### PR TITLE
docs(codegen): describe every column the reference docs render

### DIFF
--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -191,10 +191,10 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `priority` | Boolean | `TRUE` if ESPN flags the play as a priority highlight. |
 | `modified` | String | ISO timestamp the play record was last modified. |
 | `wallclock` | String | Real-world ISO timestamp of the play. |
-| `teamParticipants` | String |  |
-| `isPenalty` | Boolean |  |
+| `teamParticipants` | String | Raw ESPN team-level participants payload carried through from the plays feed (stringified). |
+| `isPenalty` | Boolean | ESPN's per-play flag that a penalty occurred on the play. |
 | `statYardage` | Int64 | Yardage ESPN credits to the play for statistical purposes. |
-| `isTurnover` | Boolean |  |
+| `isTurnover` | Boolean | ESPN's per-play turnover flag as shipped in the plays feed (broader than the giveaway-based is_turnover derivation). |
 | `type.id` | String | ESPN's numeric identifier for the play type. |
 | `type.text` | String | ESPN's text label for the play type. |
 | `type.abbreviation` | String | ESPN's abbreviation for the play type. |
@@ -219,10 +219,10 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `scoringType.name` | String | ESPN's name for the scoring type (e.g. touchdown, field goal). |
 | `scoringType.displayName` | String | ESPN's display label for the scoring type. |
 | `scoringType.abbreviation` | String | ESPN's abbreviation for the scoring type. |
-| `pointAfterAttempt.id` | Float64 |  |
-| `pointAfterAttempt.text` | String |  |
-| `pointAfterAttempt.abbreviation` | String |  |
-| `pointAfterAttempt.value` | Float64 |  |
+| `pointAfterAttempt.id` | Float64 | ESPN identifier for the point-after attempt type on the scoring play. |
+| `pointAfterAttempt.text` | String | ESPN description of the point-after attempt and its result. |
+| `pointAfterAttempt.abbreviation` | String | ESPN abbreviation of the point-after attempt type; drives the extra-point / two-point result derivation. |
+| `pointAfterAttempt.value` | Float64 | Points ESPN credits for the point-after attempt (1.0 made extra point, 2.0 made two-point try). |
 | `drive.id` | String | ESPN's `id` field for the drive containing this play. |
 | `drive.displayResult` | String | ESPN's `displayResult` field for the drive containing this play. |
 | `drive.isScore` | Boolean | ESPN's `isScore` field for the drive containing this play. |
@@ -276,7 +276,7 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `lead_start_distance` | Int64 | Value of start_distance on the next play, used for sequence-aware derivations. |
 | `lead_scoringPlay` | Boolean | Value of scoringPlay on the next play, used for sequence-aware derivations. |
 | `text_dupe` | Boolean | True when the play description duplicates the previous row's text. |
-| `end_state_missing` | Boolean |  |
+| `end_state_missing` | Boolean | Flag that ESPN's end-of-play state (end.team.id) was absent and the end state was imputed. |
 | `start.pos_team.id` | Int64 | ESPN's `pos_team.id` value for the play state at the start of the play. |
 | `start.def_pos_team.id` | Int64 | ESPN's `def_pos_team.id` value for the play state at the start of the play. |
 | `end.def_pos_team.id` | Int64 | ESPN's `def_pos_team.id` value for the play state at the end of the play. |
@@ -335,17 +335,17 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `end.pos_team_receives_2H_kickoff` | Boolean | ESPN's `pos_team_receives_2H_kickoff` value for the play state at the end of the play. |
 | `penalty_in_text` | Boolean | True when the play description mentions a penalty. |
 | `pass_breakup` | Boolean | True when a defender broke up the pass. |
-| `pass_depth` | String |  |
-| `pass_direction` | String |  |
-| `rush_direction` | String |  |
-| `qb_hurry` | Boolean |  |
+| `pass_depth` | String | Thrown-pass depth parsed from ESPN play text ("short" or "deep"); null when the text omits it (sacks, screens, pre-2025 text). |
+| `pass_direction` | String | Pass direction parsed from ESPN play text ("left", "middle", or "right"); null when the text omits it. |
+| `rush_direction` | String | Rush direction parsed from ESPN play text ("left", "middle", or "right"); null when the text omits it. |
+| `qb_hurry` | Boolean | Whether ESPN's play text says the quarterback was hurried into the throw ("hurried by ..."). |
 | `fg_attempt` | Boolean | True when the play was a field-goal attempt. |
 | `pos_unit` | String | Possession-team unit label (offense or special teams). |
 | `def_pos_unit` | String | Defensive possession-team unit label (defense or special teams). |
 | `sp` | Boolean | Binary indicator for whether or not a score occurred on the play. |
 | `play` | Boolean | Binary flag indicating the row is a counted play (excludes end markers/timeouts/penalties). |
-| `cleaned_text` | String |  |
-| `kneel_down` | Boolean |  |
+| `cleaned_text` | String | Play description with overturned-call prefixes stripped; the text the name and team extractors run against. |
+| `kneel_down` | Boolean | Whether the play is an offensive kneel, from explicit kneel text plus an end-of-half TEAM-rush heuristic. |
 | `scrimmage_play` | Boolean | True when the play is a play from scrimmage rather than a special-teams or administrative row. |
 | `pos_score_diff_end` | Int64 | Score differential from the possessing team's perspective at the end of the play. |
 | `fumble_lost` | Boolean | Binary indicator for if the fumble was lost. |
@@ -353,39 +353,39 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `field_goal_result` | String | String indicator for result of field goal attempt: made, missed, or blocked. |
 | `extra_point_result` | String | String indicator for the result of the extra point attempt: good, failed, blocked, safety (touchback in defensive endzone is 1 point apparently), or aborted. |
 | `two_point_conv_result` | String | String indicator for result of two point conversion attempt: success, failure, safety (touchback in defensive endzone is 1 point apparently), or return. |
-| `air_yardsToEndzone` | Int64 |  |
+| `air_yardsToEndzone` | Int64 | Yards to the endzone at the catch spot, parsed from the 2025+ vendor catch-spot text; null before 2025 or when unresolvable. |
 | `air_yards` | Int64 | Numeric value for distance in yards perpendicular to the line of scrimmage at where the targeted receiver either caught or didn't catch the ball. |
 | `yards_after_catch` | Int64 | Numeric value for distance in yards perpendicular to the yard line where the receiver made the reception to where the play ended. |
-| `kicking_team` | Int64 |  |
+| `kicking_team` | Int64 | Team id of the kicking team on kickoff, punt, and field-goal plays. |
 | `return_team` | Int64 | String abbreviation of the return team. Returns may occur on any of: interception, fumble, kickoff, punt, or blocked kicks. |
-| `fumble_or_muff` | Boolean |  |
-| `recovery_team` | Int64 |  |
-| `recovery_team_2` | Int64 |  |
-| `fumbling_team` | Int64 |  |
-| `int_turnover` | Boolean |  |
-| `pos_fumble_lost` | Boolean |  |
-| `def_fumble_lost` | Boolean |  |
-| `is_pos_team_turnover` | Boolean |  |
-| `is_def_pos_team_turnover` | Boolean |  |
+| `fumble_or_muff` | Boolean | Whether the play includes a fumble or a muffed kick or punt (widened beyond ESPN's fumble play types). |
+| `recovery_team` | Int64 | Team id parsed from the play text as recovering the fumble or muff. |
+| `recovery_team_2` | Int64 | Team id of the second recovery in a multi-recovery scramble, parsed from the play text. |
+| `fumbling_team` | Int64 | Team id of the side that fumbled or muffed the ball, parsed from the play text. |
+| `int_turnover` | Boolean | Whether the play is an interception giveaway. |
+| `pos_fumble_lost` | Boolean | Whether the possession team fumbled and lost the ball. |
+| `def_fumble_lost` | Boolean | Whether the defending team (e.g. a returner after a takeaway) fumbled and lost the ball back. |
+| `is_pos_team_turnover` | Boolean | Whether the possession team committed a giveaway (interception or fumble lost). |
+| `is_def_pos_team_turnover` | Boolean | Whether the defending team gave the ball back via a lost fumble. |
 | `is_turnover` | Boolean | `TRUE` if the play was a turnover. |
-| `turnover_team` | Int64 |  |
-| `is_st_turnover` | Boolean |  |
-| `is_blocked_punt_turnover` | Boolean |  |
-| `is_blocked_fg_turnover` | Boolean |  |
-| `sack_team` | Int64 |  |
-| `interception_team` | Int64 |  |
-| `pass_breakup_team` | Int64 |  |
-| `forced_fumble_team` | Int64 |  |
-| `fumble_recovery_team` | Int64 |  |
-| `punt_return_team` | Int64 |  |
-| `kick_return_team` | Int64 |  |
-| `fg_team` | Int64 |  |
-| `punt_team` | Int64 |  |
-| `penalized_team` | Int64 |  |
-| `penalty_yards_signed` | Int64 |  |
+| `turnover_team` | Int64 | Team id charged with the giveaway on the play. |
+| `is_st_turnover` | Boolean | Whether the giveaway happened on a special-teams play (kick or punt snap, or a return). |
+| `is_blocked_punt_turnover` | Boolean | Blocked-punt possession loss (blocked-punt TD, or the defense recovered); kept out of is_turnover to match ESPN's giveaway-only box. |
+| `is_blocked_fg_turnover` | Boolean | Blocked-field-goal possession loss (blocked-FG TD, or the defense recovered); kept out of is_turnover to match ESPN's giveaway-only box. |
+| `sack_team` | Int64 | Team id credited with the sack (the defense). |
+| `interception_team` | Int64 | Team id credited with the interception (the defense). |
+| `pass_breakup_team` | Int64 | Team id credited with the pass breakup (the defense). |
+| `forced_fumble_team` | Int64 | Team id credited with forcing the fumble -- the side opposite the fumbling player (the covering team on returns). |
+| `fumble_recovery_team` | Int64 | Team id that recovered the fumble or muff, from parsed text with a giveaway / own-recovery fallback. |
+| `punt_return_team` | Int64 | Team id of the punt-returning side. |
+| `kick_return_team` | Int64 | Team id of the kick-returning side. |
+| `fg_team` | Int64 | Team id attempting the field goal (the kicking team). |
+| `punt_team` | Int64 | Team id punting the ball (the kicking team). |
+| `penalized_team` | Int64 | Team id the penalty was assessed against, from the home/away text resolver with a foul-direction fallback. |
+| `penalty_yards_signed` | Int64 | Penalty yardage parsed from the play text with era-aware bounds; the printed sign is retained but is not a reliable enforcement direction. |
 | `new_down` | Int64 | Down after the play, including any penalty enforcement. |
 | `new_distance` | Int64 | Distance to go after the play, including any penalty enforcement. |
-| `under_2` | Boolean |  |
+| `under_2` | Boolean | Whether the play began with two minutes or less remaining in the half. |
 | `goal_to_go` | Boolean | Binary indicator for whether or not the posteam is in a goal down situation. |
 | `stopped_run` | Boolean | True when the rush was stopped at or behind the line of scrimmage. |
 | `opportunity_run` | Boolean | True when a rush reached 4 yards -- the carries on which the blocking did its job. Matches cfbfastR's espn_cfb_15 definition. Assets published before the 2026-08 fix carry the inverted (4 yards or fewer) flag. |
@@ -418,7 +418,7 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `end.pos_team_spread` | Float64 | ESPN's `pos_team_spread` value for the play state at the end of the play. |
 | `end.elapsed_share` | Float64 | ESPN's `elapsed_share` value for the play state at the end of the play. |
 | `end.spread_time` | Float64 | ESPN's `spread_time` value for the play state at the end of the play. |
-| `penalty_assessed_on_kickoff` | Boolean |  |
+| `penalty_assessed_on_kickoff` | Boolean | Whether a penalty was assessed on a kickoff; such plays take the kickoff/touchback win-probability handling. |
 | `start.yardsToEndzone.touchback` | Int64 | ESPN's `yardsToEndzone.touchback` value for the play state at the start of the play. |
 | `EP_start_touchback` | Float64 | Expected points the offense would have had from a touchback on this play. |
 | `EP_start` | Float64 | Expected points for the offense at the start of the play. |
@@ -464,18 +464,18 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `end.ExpScoreDiff` | Float64 | ESPN's `ExpScoreDiff` value for the play state at the end of the play. |
 | `end.ExpScoreDiff_Time_Ratio` | Float64 | ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the end of the play. |
 | `wp_touchback` | Float64 | Win probability the offense would have had starting from a touchback. |
-| `wp_before_naive` | Float64 |  |
-| `wp_touchback_naive` | Float64 |  |
-| `wp_after_naive` | Float64 |  |
-| `def_wp_before_naive` | Float64 |  |
-| `home_wp_before_naive` | Float64 |  |
-| `away_wp_before_naive` | Float64 |  |
-| `lead_wp_before_naive` | Float64 |  |
-| `lead_wp_before2_naive` | Float64 |  |
-| `def_wp_after_naive` | Float64 |  |
-| `home_wp_after_naive` | Float64 |  |
-| `away_wp_after_naive` | Float64 |  |
-| `wpa_naive` | Float64 |  |
+| `wp_before_naive` | Float64 | Pre-snap possession-team win probability from the spread-free (naive) WP model. |
+| `wp_touchback_naive` | Float64 | Naive-model win probability for the kickoff-touchback substitute state, used as the pre-snap WP on kickoffs. |
+| `wp_after_naive` | Float64 | End-of-play possession-team win probability from the naive model, after the game-logic adjustment chain. |
+| `def_wp_before_naive` | Float64 | Pre-snap defense win probability under the naive model (1 - wp_before_naive). |
+| `home_wp_before_naive` | Float64 | Pre-snap naive win probability mapped to the home team. |
+| `away_wp_before_naive` | Float64 | Pre-snap naive win probability mapped to the away team. |
+| `lead_wp_before_naive` | Float64 | Next play's pre-snap naive win probability, used in the end-of-half and change-of-possession adjustments. |
+| `lead_wp_before2_naive` | Float64 | Pre-snap naive win probability two plays ahead, used where the immediately following row is a non-play. |
+| `def_wp_after_naive` | Float64 | End-of-play defense win probability under the naive model. |
+| `home_wp_after_naive` | Float64 | End-of-play naive win probability mapped to the home team. |
+| `away_wp_after_naive` | Float64 | End-of-play naive win probability mapped to the away team. |
+| `wpa_naive` | Float64 | Win probability added on the play under the spread-free (naive) model. |
 | `cp` | Float64 | Numeric value indicating the probability for a complete pass based on comparable game situations. |
 | `cpoe` | Float64 | For a single pass play this is 1 - cp when the pass was completed or 0 - cp when the pass was incomplete. Analyzed for a whole game or season an indicator for the passer how much over or under expectation his completion percentage was. |
 | `era` | Int64 | one of pre2018 (2006-2017) or post2018 (2018+) |
@@ -507,38 +507,38 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `receiver_player_id` | Int64 | Unique identifier for the receiver that was targeted on the pass. |
 | `fumble_player_id` | Int64 | CFBD athlete_id of the player who fumbled. |
 | `sack_player_id` | Int64 | Comma-separated CFBD athlete_id(s) of the sacking defender(s). |
-| `sack_player_id2` | Int64 |  |
+| `sack_player_id2` | Int64 | ESPN athlete id of the second sacker on a split sack (regex fallback for an ESPN sidecar blind spot). |
 | `interception_player_id` | Int64 | CFBD athlete_id of the defender credited with an interception. |
 | `pass_breakup_player_id` | Int64 | CFBD athlete_id of the defender credited with the pass breakup (PBU). |
 | `fumble_forced_player_id` | Int64 | CFBD athlete_id of the defender credited with forcing the fumble. |
 | `fumble_recovered_player_id` | Int64 | CFBD athlete_id of the player recovering the fumble. |
-| `fg_kicker_player_id` | Int64 |  |
+| `fg_kicker_player_id` | Int64 | ESPN athlete id of the field-goal kicker. |
 | `punter_player_id` | Int64 | Unique identifier for the punter. |
-| `kickoff_player_id` | Int64 |  |
-| `kickoff_return_player_id` | Int64 |  |
-| `punt_return_player_id` | Int64 |  |
-| `fg_block_player_id` | Int64 |  |
-| `punt_block_player_id` | Int64 |  |
-| `fg_return_player_id` | Int64 |  |
-| `punt_block_return_player_id` | Null |  |
-| `go_wp` | Float64 |  |
-| `first_down_prob` | Float64 |  |
-| `wp_succeed` | Float64 |  |
-| `wp_fail` | Float64 |  |
-| `make_fg_wp` | Float64 |  |
-| `miss_fg_wp` | Float64 |  |
-| `fg_wp` | Float64 |  |
-| `punt_wp` | Float64 |  |
-| `go_boost` | Float64 |  |
-| `go_wp_diff` | Float64 |  |
-| `fg_wp_diff` | Float64 |  |
-| `punt_wp_diff` | Float64 |  |
-| `fourth_down_recommendation` | String |  |
-| `two_pt_wp` | Float64 |  |
-| `xp_wp` | Float64 |  |
-| `prob_2pt` | Float64 |  |
-| `two_pt_recommendation` | String |  |
-| `two_pt_wp_diff` | Float64 |  |
+| `kickoff_player_id` | Int64 | ESPN athlete id of the player kicking off. |
+| `kickoff_return_player_id` | Int64 | ESPN athlete id of the kickoff returner. |
+| `punt_return_player_id` | Int64 | ESPN athlete id of the punt returner. |
+| `fg_block_player_id` | Int64 | ESPN athlete id of the player who blocked the field goal. |
+| `punt_block_player_id` | Int64 | ESPN athlete id of the player who blocked the punt. |
+| `fg_return_player_id` | Int64 | ESPN athlete id of the player who returned the blocked or missed field goal. |
+| `punt_block_return_player_id` | Null | ESPN athlete id of the player who returned the blocked punt. |
+| `go_wp` | Float64 | Win probability from going for it on fourth down: conversion-probability-weighted mean of the success and failure states (cfb4th port). |
+| `first_down_prob` | Float64 | Modeled probability of converting the fourth down when going for it. |
+| `wp_succeed` | Float64 | Mean win probability across yardage outcomes given the fourth-down attempt converts. |
+| `wp_fail` | Float64 | Mean win probability given the fourth-down attempt fails. |
+| `make_fg_wp` | Float64 | Win probability given the field-goal attempt is made. |
+| `miss_fg_wp` | Float64 | Win probability given the field-goal attempt misses. |
+| `fg_wp` | Float64 | Make-probability-weighted win probability of attempting the field goal. |
+| `punt_wp` | Float64 | Win probability of punting, from the bundled punt-outcome distribution. |
+| `go_boost` | Float64 | cfb4th's headline number: 100 * (go_wp - max(fg_wp, punt_wp)), in percentage points. |
+| `go_wp_diff` | Float64 | go_wp minus the recommended option's WP (0 when going for it is the recommendation, otherwise <= 0). |
+| `fg_wp_diff` | Float64 | fg_wp minus the recommended option's WP (0 when the field goal is the recommendation, otherwise <= 0). |
+| `punt_wp_diff` | Float64 | punt_wp minus the recommended option's WP (0 when punting is the recommendation, otherwise <= 0). |
+| `fourth_down_recommendation` | String | Max-WP fourth-down choice among "go", "punt", and "field_goal". |
+| `two_pt_wp` | Float64 | Win probability of going for two: conversion-probability-weighted mean of the 2-point and 0-point outcomes (cfb4th port). |
+| `xp_wp` | Float64 | Win probability of kicking the extra point, weighting the make by the empirical CFB extra-point make rate. |
+| `prob_2pt` | Float64 | Two-point conversion probability from the bundled CFB two-point model. |
+| `two_pt_recommendation` | String | Point-after recommendation: "go_for_2" when two_pt_wp exceeds xp_wp, otherwise "kick_xp". |
+| `two_pt_wp_diff` | Float64 | two_pt_wp minus xp_wp; positive favors going for two. |
 
 ```python
 load_cfb_pbp(seasons=2024)
@@ -597,7 +597,7 @@ Release: [cfb_recruits](https://github.com/sportsdataverse/sportsdataverse-data/
 |---|---|---|
 | `season` | Int64 | Season (4-digit year). |
 | `team_id` | Int64 | ESPN team id. |
-| `team_id_247` | String |  |
+| `team_id_247` | String | 247Sports' own team key for the recruit's committed or signed school; not interchangeable with the ESPN/CFBD team id. |
 | `team` | String | Team name. |
 | `recruit_id` | String | ESPN recruit id. |
 | `player_name` | String | Full name of player |
@@ -618,10 +618,10 @@ Release: [cfb_returning_production](https://github.com/sportsdataverse/sportsdat
 |---|---|---|
 | `season` | Int64 | Season (4-digit year). |
 | `team_id` | Int64 | ESPN team id. |
-| `off_returning` | Float64 |  |
-| `def_returning` | Float64 |  |
-| `overall_returning` | Float64 |  |
-| `n_returning` | Int64 |  |
+| `off_returning` | Float64 | Share of the team's prior-season offensive production returning for the season. |
+| `def_returning` | Float64 | Share of the team's prior-season defensive production returning for the season. |
+| `overall_returning` | Float64 | Usage-weighted blend of the offensive and defensive returning-production shares. |
+| `n_returning` | Int64 | Number of returning players counted in the returning-production calculation. |
 
 ```python
 load_cfb_returning_production(seasons=2024)
@@ -828,20 +828,20 @@ Release: [cfb_team_info](https://github.com/sportsdataverse/sportsdataverse-data
 | `alt_color` | String | Team color (alternate). |
 | `logo` | String | Team or league logo URL. |
 | `logo_2` | String | URL of the team's alternate dark-background 500-pixel logo on ESPN's CDN, null for programs with no dark variant. |
-| `logos_3` | String |  |
-| `logos_4` | String |  |
-| `logos_5` | String |  |
-| `logos_6` | String |  |
-| `logos_7` | String |  |
-| `logos_8` | String |  |
-| `logos_9` | String |  |
-| `logos_10` | String |  |
-| `logos_11` | String |  |
-| `logos_12` | String |  |
-| `logos_13` | String |  |
-| `logos_14` | String |  |
-| `logos_15` | String |  |
-| `logos_16` | String |  |
+| `logos_3` | String | URL of the team's logo variant in slot 3 of ESPN's team-info logo list; null when the team publishes fewer variants. |
+| `logos_4` | String | URL of the team's logo variant in slot 4 of ESPN's team-info logo list; null when the team publishes fewer variants. |
+| `logos_5` | String | URL of the team's logo variant in slot 5 of ESPN's team-info logo list; null when the team publishes fewer variants. |
+| `logos_6` | String | URL of the team's logo variant in slot 6 of ESPN's team-info logo list; null when the team publishes fewer variants. |
+| `logos_7` | String | URL of the team's logo variant in slot 7 of ESPN's team-info logo list; null when the team publishes fewer variants. |
+| `logos_8` | String | URL of the team's logo variant in slot 8 of ESPN's team-info logo list; null when the team publishes fewer variants. |
+| `logos_9` | String | URL of the team's logo variant in slot 9 of ESPN's team-info logo list; null when the team publishes fewer variants. |
+| `logos_10` | String | URL of the team's logo variant in slot 10 of ESPN's team-info logo list; null when the team publishes fewer variants. |
+| `logos_11` | String | URL of the team's logo variant in slot 11 of ESPN's team-info logo list; null when the team publishes fewer variants. |
+| `logos_12` | String | URL of the team's logo variant in slot 12 of ESPN's team-info logo list; null when the team publishes fewer variants. |
+| `logos_13` | String | URL of the team's logo variant in slot 13 of ESPN's team-info logo list; null when the team publishes fewer variants. |
+| `logos_14` | String | URL of the team's logo variant in slot 14 of ESPN's team-info logo list; null when the team publishes fewer variants. |
+| `logos_15` | String | URL of the team's logo variant in slot 15 of ESPN's team-info logo list; null when the team publishes fewer variants. |
+| `logos_16` | String | URL of the team's logo variant in slot 16 of ESPN's team-info logo list; null when the team publishes fewer variants. |
 | `twitter` | String | The football program's Twitter/X handle including the leading at sign, populated for only a minority of listed teams. |
 | `venue_id` | Int32 | Referencing venue id. |
 | `venue_name` | String | Full name of the franchise's venue. |
@@ -938,10 +938,10 @@ Release: [cfb_team_talent](https://github.com/sportsdataverse/sportsdataverse-da
 | `season` | Int64 | Season (4-digit year). |
 | `team_id` | Int64 | ESPN team id. |
 | `team` | String | Team name. |
-| `talent_composite` | Float64 |  |
-| `talent_rank` | Int64 |  |
-| `blue_chip_ratio` | Float64 |  |
-| `n_recruits` | Int64 |  |
+| `talent_composite` | Float64 | Sum of composite recruiting ratings across the counted signing classes (the Team Talent measure). |
+| `talent_rank` | Int64 | Dense rank of talent_composite within the season (1 = most talented roster). |
+| `blue_chip_ratio` | Float64 | Share of the team's counted signees rated four or five stars over the rolling class window. |
+| `n_recruits` | Int64 | Number of signees counted in the blue-chip-ratio window. |
 
 ```python
 load_cfb_team_talent(seasons=2024)
@@ -1053,14 +1053,14 @@ Release: [espn_cfb_player_box](https://github.com/sportsdataverse/sportsdatavers
 | `yardsPerReception` | String | Yards gained per reception. |
 | `receivingTouchdowns` | String | Receiving touchdowns. |
 | `longReception` | String | Longest reception of the game, in yards. |
-| `fumbles` | String |  |
-| `fumblesLost` | String |  |
-| `fumblesRecovered` | String |  |
-| `kickReturns` | String |  |
-| `kickReturnYards` | String |  |
-| `yardsPerKickReturn` | String |  |
-| `longKickReturn` | String |  |
-| `kickReturnTouchdowns` | String |  |
+| `fumbles` | String | Number of times the player fumbled in the game (ESPN box score). |
+| `fumblesLost` | String | Number of the player's fumbles lost to the opponent (ESPN box score). |
+| `fumblesRecovered` | String | Number of fumbles the player recovered (ESPN box score). |
+| `kickReturns` | String | Number of kickoff returns by the player (ESPN box score). |
+| `kickReturnYards` | String | Total kickoff-return yards by the player (ESPN box score). |
+| `yardsPerKickReturn` | String | Average yards per kickoff return for the player (ESPN box score). |
+| `longKickReturn` | String | Player's longest kickoff return of the game, in yards (ESPN box score). |
+| `kickReturnTouchdowns` | String | Kickoff returns the player took for touchdowns (ESPN box score). |
 | `puntReturns` | String | Punt returns attempted. |
 | `puntReturnYards` | String | Yards gained on punt returns. |
 | `yardsPerPuntReturn` | String | Yards gained per punt return. |
@@ -1082,13 +1082,13 @@ Release: [espn_cfb_player_box](https://github.com/sportsdataverse/sportsdatavers
 | `interceptions` | String | Passing interceptions. |
 | `interceptionYards` | String | Yards returned on interceptions. |
 | `interceptionTouchdowns` | String | Touchdowns scored on interception returns. |
-| `totalTackles` | String |  |
-| `soloTackles` | String |  |
+| `totalTackles` | String | Player's total tackles, solo plus assisted (ESPN box score). |
+| `soloTackles` | String | Player's solo (unassisted) tackles (ESPN box score). |
 | `sacks` | String | Team sacks. |
-| `tacklesForLoss` | String |  |
-| `passesDefended` | String |  |
-| `hurries` | String |  |
-| `defensiveTouchdowns` | String |  |
+| `tacklesForLoss` | String | Player's tackles made behind the line of scrimmage (ESPN box score). |
+| `passesDefended` | String | Passes the player broke up or defended (ESPN box score). |
+| `hurries` | String | Quarterback hurries credited to the player (ESPN box score). |
+| `defensiveTouchdowns` | String | Touchdowns the player scored on defense (ESPN box score). |
 | `completions/passingAttempts` | String | Completions and pass attempts, as ESPN's combined string. |
 | `passingYards` | String | Net passing yards gained. |
 | `yardsPerPassAttempt` | String | Yards gained per pass attempt. |
@@ -1195,13 +1195,13 @@ Release: [espn_cfb_play_participants](https://github.com/sportsdataverse/sportsd
 | `pass_defender_player_names` | String | List of the display names of EVERY participant credited as the defender credited with defending the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
 | `pass_defender_player_ids` | String | List of the athlete ids of EVERY participant credited as the defender credited with defending the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
 | `recoverer_player_name` | String | Display name of the player who recovered the fumble -- the FIRST participant in that role on the play. |
-| `fumbler_player_name` | String |  |
+| `fumbler_player_name` | String | Display name of the first (primary) player who fumbled on the play, from ESPN's per-play participants. |
 | `recoverer_player_id` | String | ESPN athlete id of the player who recovered the fumble -- the FIRST participant in that role on the play. |
-| `fumbler_player_id` | String |  |
+| `fumbler_player_id` | String | ESPN athlete id of the first (primary) player who fumbled on the play. |
 | `recoverer_player_names` | String | List of the display names of EVERY participant credited as the player who recovered the fumble on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
-| `fumbler_player_names` | String |  |
+| `fumbler_player_names` | String | Display names of every player who fumbled on the play, as a list. |
 | `recoverer_player_ids` | String | List of the athlete ids of EVERY participant credited as the player who recovered the fumble on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
-| `fumbler_player_ids` | String |  |
+| `fumbler_player_ids` | String | ESPN athlete ids of every player who fumbled on the play, as a list. |
 | `forced_by_player_name` | String | Display name of the defender who forced the fumble -- the FIRST participant in that role on the play. |
 | `forced_by_player_id` | String | ESPN athlete id of the defender who forced the fumble -- the FIRST participant in that role on the play. |
 | `forced_by_player_names` | String | List of the display names of EVERY participant credited as the defender who forced the fumble on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
@@ -1262,7 +1262,7 @@ Release: [espn_cfb_game_rosters](https://github.com/sportsdataverse/sportsdatave
 | `status_abbreviation` | String | Status abbreviation. |
 | `middle_name` | String | Middle name of the player. |
 | `starter` | Boolean | `TRUE` if the athlete started the game. |
-| `jersey_right` | String |  |
+| `jersey_right` | String | Secondary or alternate jersey number display string from ESPN's roster record, distinct from the primary jersey number. |
 | `valid` | Boolean | `TRUE` if the roster entry is flagged valid by ESPN. |
 | `did_not_play` | Boolean | `TRUE` if the athlete did not play. |
 | `display_name` | String | Human-readable metric name. |
@@ -3138,12 +3138,12 @@ Release: [cfbfastR_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-d
 | `home_team` | String | Home team name. |
 | `home_team_division` | String | Home team NCAA division (1, 2, 3). |
 | `home_team_conference` | String | Conference name of the home team. |
-| `home_team_pregame_elo` | Int32 |  |
+| `home_team_pregame_elo` | Int32 | Home team's pregame Elo rating, carried on the cfbfastR-shaped schema. |
 | `away_team_id` | Int32 | ESPN away team id (parsed from `away_team_ref`). |
 | `away_team` | String | Away team name. |
 | `away_team_division` | String | Away team NCAA division (1, 2, 3). |
 | `away_team_conference` | String | Conference name of the away team. |
-| `away_team_pregame_elo` | Int32 |  |
+| `away_team_pregame_elo` | Int32 | Away team's pregame Elo rating, carried on the cfbfastR-shaped schema. |
 | `season` | Int32 | Season (4-digit year). |
 | `team` | String | Team name. |
 | `conference` | String | Conference of the team. |
@@ -3301,20 +3301,20 @@ Release: [cfbfastR_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-d
 | `Opp_TD_after` | Float64 | Post-play predicted probability of a defteam touchdown next (0-1). |
 | `Safety_after` | Float64 | Post-play predicted probability of a posteam safety next (0-1). |
 | `TD_after` | Float64 | Post-play predicted probability of a posteam touchdown next (0-1). |
-| `position_reception` | String |  |
-| `position_target` | String |  |
-| `position_completion` | String |  |
-| `position_incompletion` | String |  |
-| `position_sack_taken` | String |  |
-| `position_sack` | String |  |
-| `position_interception_thrown` | String |  |
-| `position_interception` | String |  |
-| `position_fumble` | String |  |
-| `position_fumble_forced` | String |  |
-| `position_fumble_recovered` | String |  |
-| `position_pass_breakup` | String |  |
-| `position_rush` | String |  |
-| `position_touchdown` | String |  |
+| `position_reception` | String | Position of the player credited with the reception on the play (cfbfastR-shaped player-position column). |
+| `position_target` | String | Position of the receiver targeted on the play (cfbfastR-shaped player-position column). |
+| `position_completion` | String | Position of the passer credited with the completion (cfbfastR-shaped player-position column). |
+| `position_incompletion` | String | Position of the passer charged with the incompletion (cfbfastR-shaped player-position column). |
+| `position_sack_taken` | String | Position of the quarterback who took the sack (cfbfastR-shaped player-position column). |
+| `position_sack` | String | Position of the defender credited with the sack (cfbfastR-shaped player-position column). |
+| `position_interception_thrown` | String | Position of the passer who threw the interception (cfbfastR-shaped player-position column). |
+| `position_interception` | String | Position of the defender who made the interception (cfbfastR-shaped player-position column). |
+| `position_fumble` | String | Position of the player who fumbled (cfbfastR-shaped player-position column). |
+| `position_fumble_forced` | String | Position of the defender who forced the fumble (cfbfastR-shaped player-position column). |
+| `position_fumble_recovered` | String | Position of the player who recovered the fumble (cfbfastR-shaped player-position column). |
+| `position_pass_breakup` | String | Position of the defender credited with the pass breakup (cfbfastR-shaped player-position column). |
+| `position_rush` | String | Position of the player credited with the rush on the play (cfbfastR-shaped player-position column). |
+| `position_touchdown` | String | Position of the player who scored the touchdown (cfbfastR-shaped player-position column). |
 | `rush_player_id` | Float64 | CFBD athlete_id of the player credited with a rush attempt. |
 | `rush_player` | String | Name of the player credited with a rush attempt. |
 | `rush_yds` | Int32 | Rushing yards gained on the play. |

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -352,12 +352,12 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `fumble_recovered` | Boolean | True when a fumble on the play was recovered. |
 | `field_goal_result` | String | String indicator for result of field goal attempt: made, missed, or blocked. |
 | `extra_point_result` | String | String indicator for the result of the extra point attempt: good, failed, blocked, safety (touchback in defensive endzone is 1 point apparently), or aborted. |
-| `two_point_conv_result` | String | String indicator for result of two point conversion attempt: success, failure, safety (touchback in defensive endzone is 1 point apparently), or return. |
+| `two_point_conv_result` | String | String result of the two-point conversion attempt: success, failure, or safety (touchback in the defensive end zone). |
 | `air_yardsToEndzone` | Int64 | Yards to the endzone at the catch spot, parsed from the 2025+ vendor catch-spot text; null before 2025 or when unresolvable. |
 | `air_yards` | Int64 | Numeric value for distance in yards perpendicular to the line of scrimmage at where the targeted receiver either caught or didn't catch the ball. |
 | `yards_after_catch` | Int64 | Numeric value for distance in yards perpendicular to the yard line where the receiver made the reception to where the play ended. |
 | `kicking_team` | Int64 | Team id of the kicking team on kickoff, punt, and field-goal plays. |
-| `return_team` | Int64 | String abbreviation of the return team. Returns may occur on any of: interception, fumble, kickoff, punt, or blocked kicks. |
+| `return_team` | Int64 | Team id of the returning side; set on interception, fumble, kickoff, punt, and blocked-kick returns. |
 | `fumble_or_muff` | Boolean | Whether the play includes a fumble or a muffed kick or punt (widened beyond ESPN's fumble play types). |
 | `recovery_team` | Int64 | Team id parsed from the play text as recovering the fumble or muff. |
 | `recovery_team_2` | Int64 | Team id of the second recovery in a multi-recovery scramble, parsed from the play text. |
@@ -367,7 +367,7 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `def_fumble_lost` | Boolean | Whether the defending team (e.g. a returner after a takeaway) fumbled and lost the ball back. |
 | `is_pos_team_turnover` | Boolean | Whether the possession team committed a giveaway (interception or fumble lost). |
 | `is_def_pos_team_turnover` | Boolean | Whether the defending team gave the ball back via a lost fumble. |
-| `is_turnover` | Boolean | `TRUE` if the play was a turnover. |
+| `is_turnover` | Boolean | True when the play is a giveaway-based turnover (interception thrown or fumble lost); blocked kicks recovered by the defense are carried by the blocked-kick fields instead. |
 | `turnover_team` | Int64 | Team id charged with the giveaway on the play. |
 | `is_st_turnover` | Boolean | Whether the giveaway happened on a special-teams play (kick or punt snap, or a return). |
 | `is_blocked_punt_turnover` | Boolean | Blocked-punt possession loss (blocked-punt TD, or the defense recovered); kept out of is_turnover to match ESPN's giveaway-only box. |
@@ -846,7 +846,7 @@ Release: [cfb_team_info](https://github.com/sportsdataverse/sportsdataverse-data
 | `venue_id` | Int32 | Referencing venue id. |
 | `venue_name` | String | Full name of the franchise's venue. |
 | `city` | String | Venue city. |
-| `state` | String | Venue state. |
+| `state` | String | U.S. state where the school is located. |
 | `zip` | String | Team/venue zip code. |
 | `country_code` | String | Team/venue country code. |
 | `timezone` | String | Time zone in which the venue resides (i.e. Eastern Time -> "America/New_York"). |
@@ -1084,7 +1084,7 @@ Release: [espn_cfb_player_box](https://github.com/sportsdataverse/sportsdatavers
 | `interceptionTouchdowns` | String | Touchdowns scored on interception returns. |
 | `totalTackles` | String | Player's total tackles, solo plus assisted (ESPN box score). |
 | `soloTackles` | String | Player's solo (unassisted) tackles (ESPN box score). |
-| `sacks` | String | Team sacks. |
+| `sacks` | String | Sacks credited to the player (ESPN box score). |
 | `tacklesForLoss` | String | Player's tackles made behind the line of scrimmage (ESPN box score). |
 | `passesDefended` | String | Passes the player broke up or defended (ESPN box score). |
 | `hurries` | String | Quarterback hurries credited to the player (ESPN box score). |

--- a/docs/docs/cfb/reference/on3.md
+++ b/docs/docs/cfb/reference/on3.md
@@ -180,7 +180,7 @@ GET /rdb/v1/collective-groups/{key}/deals
 | `agent` | character | Listed player agent. |
 | `collective_group` | character | Nested On3 record for the collective brokering the deal (stringified). |
 | `amount` | numeric | Reported dollar amount of the NIL deal. |
-| `date` | character | Date of the poll release. |
+| `date` | character | Date of the NIL collective deal, per On3. |
 | `verified` | logical | Whether On3 verified the deal. |
 | `source_url` | character | URL of the source reporting the deal. |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
@@ -470,7 +470,7 @@ GET /rdb/v1/drafts
 | `high_school_organization` | character | Nested On3 organization object for the player's high school (stringified). |
 | `college_organization` | character | Nested On3 organization object for the college the player attended (stringified). |
 | `hometown` | character | Prospect hometown. |
-| `state` | character | Venue state. |
+| `state` | character | Home state of the drafted player, per On3. |
 | `pick` | integer | Pick number of the NFL draftee within the round they were picked in. |
 | `compensatory` | logical | Whether the selection was a compensatory draft pick. |
 | `supplementary` | logical | Whether the selection came in a supplemental draft. |
@@ -517,7 +517,7 @@ GET /rdb/v1/drafts-by-stars
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `state` | character | Venue state. |
+| `state` | character | Home state associated with the draft row, per On3. |
 | `blue_chip_percent` | numeric | Percent of the drafted group who were blue-chip (four- or five-star) recruits. |
 | `population_percent` | numeric | Percent of the overall recruit population holding this star rating. |
 | `talent_ratio` | numeric | Ratio of the star tier's draft share to its population share (On3's talent ratio). |
@@ -596,7 +596,7 @@ GET /rdb/v1/drafts/{orgKey}/players
 | `high_school_organization` | character | Nested On3 organization object for the player's high school (stringified). |
 | `college_organization` | character | Nested On3 organization object for the college the player attended (stringified). |
 | `hometown` | character | Prospect hometown. |
-| `state` | character | Venue state. |
+| `state` | character | Home state of the drafted player, per On3. |
 | `pick` | integer | Pick number of the NFL draftee within the round they were picked in. |
 | `compensatory` | logical | Whether the selection was a compensatory draft pick. |
 | `supplementary` | logical | Whether the selection came in a supplemental draft. |
@@ -907,7 +907,7 @@ GET /rdb/v1/nil-compliances/state
 | `key` | integer | On3 RDB key for the state NIL-compliance record. |
 | `organization_type` | character | Organization type. |
 | `state_key` | integer | On3 key of the U.S. state the compliance record covers. |
-| `state` | character | Venue state. |
+| `state` | character | U.S. state whose NIL compliance rules the record describes. |
 | `monetization_allowed` | logical | Whether the state allows high-school athletes to monetize their NIL. |
 | `governing_rule_label` | character | Name of the governing body or rule for NIL in the state. |
 | `governing_rule_url` | character | URL of the governing NIL rule or policy document. |
@@ -977,7 +977,7 @@ GET /rdb/v1/organizations/{organizationKey}/draft-class-by-state
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `state` | character | Venue state. |
+| `state` | character | U.S. state the draft-class grouping covers. |
 | `count` | integer | Total number of players in the season index. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1150,7 +1150,7 @@ GET /rdb/v1/organizations/{organizationKey}/drafted-players
 | `high_school_organization` | character | Nested On3 organization object for the player's high school (stringified). |
 | `college_organization` | character | Nested On3 organization object for the college the player attended (stringified). |
 | `hometown` | character | Prospect hometown. |
-| `state` | character | Venue state. |
+| `state` | character | Home state of the drafted player, per On3. |
 | `pick` | integer | Pick number of the NFL draftee within the round they were picked in. |
 | `compensatory` | logical | Whether the selection was a compensatory draft pick. |
 | `supplementary` | logical | Whether the selection came in a supplemental draft. |
@@ -1628,7 +1628,7 @@ GET /rdb/v1/people/{personKey}/valuation-growth
 | `nil_status` | character | Status of the athlete's On3 NIL valuation at the snapshot (e.g. active, inactive). |
 | `valuation` | integer | Athlete's On3 NIL valuation in dollars at the snapshot. |
 | `valuation_change` | integer | Change in the NIL valuation versus the previous snapshot, in dollars. |
-| `date` | character | Date of the poll release. |
+| `date` | character | Date of the On3 NIL valuation snapshot. |
 | `date_unix` | integer | Unix timestamp of the valuation snapshot. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -2303,7 +2303,7 @@ GET /rdb/v1/player/{personKey}/videos
 | `description` | character | ESPN's description of the stat. |
 | `person_sport` | character | Nested athlete-sport profile the video is attached to (stringified). |
 | `is_featured` | logical | Whether the video is featured on the player's On3 profile. |
-| `date` | integer | Date of the poll release. |
+| `date` | integer | Publication date of the video, per On3. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3132,7 +3132,7 @@ GET /rdb/v1/videos/{videoKey}
 | `description` | character | ESPN's description of the stat. |
 | `person_sport` | character | Nested athlete-sport profile the video is attached to (stringified). |
 | `is_featured` | logical | Whether the video is featured on the player's On3 profile. |
-| `date` | integer | Date of the poll release. |
+| `date` | integer | Publication date of the video, per On3. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 

--- a/docs/docs/cfb/reference/on3.md
+++ b/docs/docs/cfb/reference/on3.md
@@ -27,16 +27,16 @@ GET /rdb/v1/coaches/{personKey}/history
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `start_pso_key` | integer |  |
-| `latest_pso_key` | integer |  |
+| `start_pso_key` | integer | On3 player-sport-organization (PSO) key for the first season of the coaching stint. |
+| `latest_pso_key` | integer | On3 player-sport-organization (PSO) key for the most recent season of the stint. |
 | `start_year` | integer | Span starting year. |
-| `latest_year` | integer |  |
-| `fired` | logical |  |
-| `promoted` | logical |  |
-| `resigned` | logical |  |
-| `end_of_team` | logical |  |
+| `latest_year` | integer | Most recent year of the coaching stint. |
+| `fired` | logical | Whether the stint ended with the coach being fired. |
+| `promoted` | logical | Whether the stint ended with the coach being promoted within the organization. |
+| `resigned` | logical | Whether the stint ended with the coach resigning. |
+| `end_of_team` | logical | On3 RDB flag that the stint ended because the team or program itself ended. |
 | `deceased` | logical | Whether the player is deceased. |
-| `is_present` | logical |  |
+| `is_present` | logical | Whether this is the coach's current (ongoing) stint. |
 | `organization` | character | Organization. |
 | `position` | character | Athlete position. |
 
@@ -70,22 +70,22 @@ GET /rdb/v1/coaches/{personKey}/profile
 | `salary` | numeric | Total cap-counting salary for the season ($). |
 | `age` | integer | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 | `high_school_name` | character | Recruit high-school name. |
-| `home_town_name` | character |  |
+| `home_town_name` | character | Coach's hometown, as listed by On3. |
 | `description` | character | ESPN's description of the stat. |
-| `alma_mater` | character |  |
-| `alma_mater_class_year` | integer |  |
-| `degree` | character |  |
-| `key` | integer |  |
+| `alma_mater` | character | School the coach graduated from. |
+| `alma_mater_class_year` | integer | Coach's graduating class year at their alma mater. |
+| `degree` | character | Degree the coach earned, when listed. |
+| `key` | integer | On3 RDB key for the coach profile. |
 | `first_name` | character | Athlete first name. |
 | `last_name` | character | Athlete last name. |
-| `known_as_name` | character |  |
+| `known_as_name` | character | Name the coach publicly goes by, when it differs from the legal name. |
 | `full_name` | character | Venue full name (e.g. `Tenney Stadium`). |
 | `slug` | character | URL slug for the team. |
-| `default_asset` | character |  |
+| `default_asset` | character | Nested On3 asset object for the coach's headshot (stringified). |
 | `organization` | character | Organization. |
-| `primary_position` | character |  |
-| `org_season_count` | integer |  |
-| `years_active` | integer |  |
+| `primary_position` | character | Nested On3 object for the coach's primary coaching role (stringified). |
+| `org_season_count` | integer | Number of seasons the coach has spent with the current organization. |
+| `years_active` | integer | Span of years the coach has been active, per On3. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -118,32 +118,32 @@ GET /rdb/v1/collective-groups
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
+| `key` | integer | On3 RDB key for the NIL collective group. |
 | `name` | character | Position name (e.g. `Quarterback`). |
-| `default_asset_key` | integer |  |
-| `default_asset` | character |  |
-| `social_asset_key` | integer |  |
-| `social_asset` | character |  |
-| `organization_key` | integer |  |
+| `default_asset_key` | integer | On3 asset key for the collective's primary logo image. |
+| `default_asset` | character | Nested On3 asset object for the collective's primary logo (stringified). |
+| `social_asset_key` | integer | On3 asset key for the collective's social-media image. |
+| `social_asset` | character | Nested On3 asset object for the collective's social-media image (stringified). |
+| `organization_key` | integer | On3 organization key of the school the collective supports. |
 | `organization` | character | Organization. |
-| `launch_date` | character |  |
+| `launch_date` | character | Date the NIL collective launched. |
 | `organization_type` | character | Organization type. |
-| `twitter_handle` | character |  |
-| `instagram_handle` | character |  |
-| `tik_tok_handle` | character |  |
-| `youtube_handle` | character |  |
-| `linked_in_handle` | character |  |
-| `website_name` | character |  |
-| `website_url` | character |  |
-| `mission_statement` | character |  |
+| `twitter_handle` | character | Collective's Twitter/X account handle. |
+| `instagram_handle` | character | Collective's Instagram account handle. |
+| `tik_tok_handle` | character | Collective's TikTok account handle. |
+| `youtube_handle` | character | Collective's YouTube channel handle. |
+| `linked_in_handle` | character | Collective's LinkedIn account handle. |
+| `website_name` | character | Display name of the collective's website. |
+| `website_url` | character | URL of the collective's website. |
+| `mission_statement` | character | Collective's stated mission, as published to On3. |
 | `description` | character | ESPN's description of the stat. |
-| `annual_goal_amount` | numeric |  |
-| `confirmed_raised_amount` | numeric |  |
-| `merged_into_group_key` | integer |  |
-| `merged_into_group` | character |  |
+| `annual_goal_amount` | numeric | Collective's annual fundraising goal in dollars, as reported to On3. |
+| `confirmed_raised_amount` | numeric | Dollar amount the collective has confirmed raising, per On3. |
+| `merged_into_group_key` | integer | On3 key of the collective this group merged into, when applicable. |
+| `merged_into_group` | character | Nested On3 record for the collective this group merged into (stringified). |
 | `slug` | character | URL slug for the team. |
-| `founders` | character |  |
-| `sports` | character |  |
+| `founders` | character | Founders of the collective, as a stringified list. |
+| `sports` | character | Sports the collective funds, as a stringified list. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -174,21 +174,21 @@ GET /rdb/v1/collective-groups/{key}/deals
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `person` | character |  |
-| `company` | character |  |
+| `key` | integer | On3 RDB key for the NIL deal record. |
+| `person` | character | Nested On3 person object for the athlete in the deal (stringified). |
+| `company` | character | Nested On3 record for the company on the other side of the NIL deal (stringified). |
 | `agent` | character | Listed player agent. |
-| `collective_group` | character |  |
-| `amount` | numeric |  |
+| `collective_group` | character | Nested On3 record for the collective brokering the deal (stringified). |
+| `amount` | numeric | Reported dollar amount of the NIL deal. |
 | `date` | character | Date of the poll release. |
-| `verified` | logical |  |
-| `source_url` | character |  |
+| `verified` | logical | Whether On3 verified the deal. |
+| `source_url` | character | URL of the source reporting the deal. |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
-| `roster_rating` | character |  |
+| `roster_rating` | character | Nested On3 roster rating object for the athlete at deal time (stringified). |
 | `status` | character | Game status (e.g. "scheduled", "in_progress", "completed"). |
-| `rpm` | character |  |
-| `nil_status` | character |  |
-| `nil_value` | integer |  |
+| `rpm` | character | Nested On3 Recruiting Prediction Machine (RPM) data for the athlete (stringified). |
+| `nil_status` | character | Status of the athlete's On3 NIL valuation (e.g. active, inactive). |
+| `nil_value` | integer | Athlete's On3 NIL valuation in dollars. |
 | `detail` | character | Detailed status text. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -218,32 +218,32 @@ GET /rdb/v1/collective-groups/{key}
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
+| `key` | integer | On3 RDB key for the NIL collective group. |
 | `name` | character | Position name (e.g. `Quarterback`). |
-| `default_asset_key` | integer |  |
-| `default_asset` | character |  |
-| `social_asset_key` | integer |  |
-| `social_asset` | character |  |
-| `organization_key` | integer |  |
+| `default_asset_key` | integer | On3 asset key for the collective's primary logo image. |
+| `default_asset` | character | Nested On3 asset object for the collective's primary logo (stringified). |
+| `social_asset_key` | integer | On3 asset key for the collective's social-media image. |
+| `social_asset` | character | Nested On3 asset object for the collective's social-media image (stringified). |
+| `organization_key` | integer | On3 organization key of the school the collective supports. |
 | `organization` | character | Organization. |
-| `launch_date` | character |  |
+| `launch_date` | character | Date the NIL collective launched. |
 | `organization_type` | character | Organization type. |
-| `twitter_handle` | character |  |
-| `instagram_handle` | character |  |
-| `tik_tok_handle` | character |  |
-| `youtube_handle` | character |  |
-| `linked_in_handle` | character |  |
-| `website_name` | character |  |
-| `website_url` | character |  |
-| `mission_statement` | character |  |
+| `twitter_handle` | character | Collective's Twitter/X account handle. |
+| `instagram_handle` | character | Collective's Instagram account handle. |
+| `tik_tok_handle` | character | Collective's TikTok account handle. |
+| `youtube_handle` | character | Collective's YouTube channel handle. |
+| `linked_in_handle` | character | Collective's LinkedIn account handle. |
+| `website_name` | character | Display name of the collective's website. |
+| `website_url` | character | URL of the collective's website. |
+| `mission_statement` | character | Collective's stated mission, as published to On3. |
 | `description` | character | ESPN's description of the stat. |
-| `annual_goal_amount` | numeric |  |
-| `confirmed_raised_amount` | numeric |  |
-| `merged_into_group_key` | integer |  |
-| `merged_into_group` | character |  |
+| `annual_goal_amount` | numeric | Collective's annual fundraising goal in dollars, as reported to On3. |
+| `confirmed_raised_amount` | numeric | Dollar amount the collective has confirmed raising, per On3. |
+| `merged_into_group_key` | integer | On3 key of the collective this group merged into, when applicable. |
+| `merged_into_group` | character | Nested On3 record for the collective this group merged into (stringified). |
 | `slug` | character | URL slug for the team. |
-| `founders` | character |  |
-| `sports` | character |  |
+| `founders` | character | Founders of the collective, as a stringified list. |
+| `sports` | character | Sports the collective funds, as a stringified list. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -326,7 +326,7 @@ GET /rdb/v1/commits/organizations/{orgKey}/latest-commits
 | col_name | type | description |
 |---|---|---|
 | `status_type` | character | Status type. |
-| `commits` | character | Number of commits in the position group. |
+| `commits` | character | Number of commitments in the organization's latest recruiting class. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -356,7 +356,7 @@ GET /rdb/v1/commits/organizations/{orgKey}
 | col_name | type | description |
 |---|---|---|
 | `status_type` | character | Status type. |
-| `commits` | character | Number of commits in the position group. |
+| `commits` | character | Number of commitments in the organization's recruiting class for the season. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -390,12 +390,12 @@ GET /rdb/v1/draft-organization-rank
 |---|---|---|
 | `organization` | character | Organization. |
 | `rank` | integer | Position of the school within the poll for the given week (1 = top-ranked). |
-| `five_stars` | integer |  |
-| `four_stars` | integer |  |
-| `three_stars` | integer | Whether three stars data is available. |
+| `five_stars` | integer | Number of five-star recruits the organization signed over the ranking window. |
+| `four_stars` | integer | Number of four-star recruits the organization signed over the ranking window. |
+| `three_stars` | integer | Number of three-star recruits the organization signed over the ranking window. |
 | `total` | integer | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
-| `percent_drafted` | numeric |  |
-| `draft_rate` | numeric |  |
+| `percent_drafted` | numeric | Share of the organization's recruits who went on to be drafted. |
+| `draft_rate` | numeric | Organization's draft-production rate used in On3's draft ranking. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -429,10 +429,10 @@ GET /rdb/v1/draft-pick-organization-rank
 |---|---|---|
 | `organization` | character | Organization. |
 | `rank` | integer | Position of the school within the poll for the given week (1 = top-ranked). |
-| `first_round` | integer |  |
-| `second_round` | integer |  |
-| `third_round` | integer |  |
-| `fourth_through_seventh_round` | integer |  |
+| `first_round` | integer | Number of the organization's players drafted in the first round. |
+| `second_round` | integer | Number of the organization's players drafted in the second round. |
+| `third_round` | integer | Number of the organization's players drafted in the third round. |
+| `fourth_through_seventh_round` | integer | Number of the organization's players drafted in rounds four through seven. |
 | `total` | integer | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -464,26 +464,26 @@ GET /rdb/v1/drafts
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `recruitment_key` | integer |  |
+| `recruitment_key` | integer | On3 RDB recruitment key linking the draft pick back to the player's recruitment record. |
 | `organization` | character | Organization. |
-| `drafted_from_organization` | character |  |
-| `high_school_organization` | character |  |
-| `college_organization` | character |  |
+| `drafted_from_organization` | character | Nested On3 organization object for the school the player was drafted out of (stringified). |
+| `high_school_organization` | character | Nested On3 organization object for the player's high school (stringified). |
+| `college_organization` | character | Nested On3 organization object for the college the player attended (stringified). |
 | `hometown` | character | Prospect hometown. |
 | `state` | character | Venue state. |
 | `pick` | integer | Pick number of the NFL draftee within the round they were picked in. |
-| `compensatory` | logical |  |
-| `supplementary` | logical |  |
+| `compensatory` | logical | Whether the selection was a compensatory draft pick. |
+| `supplementary` | logical | Whether the selection came in a supplemental draft. |
 | `traded` | logical | Whether the pick was traded. |
-| `forfeited` | logical |  |
-| `trading_organization` | character |  |
-| `through_organization_one` | character |  |
-| `through_organization_two` | character |  |
-| `through_organization_three` | character |  |
-| `key` | integer |  |
+| `forfeited` | logical | Whether the pick was forfeited. |
+| `trading_organization` | character | Pro organization that traded the pick away, when it changed hands (On3 RDB). |
+| `through_organization_one` | character | First intermediate organization the pick passed through in trades before being exercised (On3 RDB). |
+| `through_organization_two` | character | Second intermediate organization the pick passed through in trades before being exercised (On3 RDB). |
+| `through_organization_three` | character | Third intermediate organization the pick passed through in trades before being exercised (On3 RDB). |
+| `key` | integer | On3 RDB key for the draft-pick record. |
 | `round` | integer | Round of NFL draft the draftee was picked in. |
 | `overall_pick` | integer | Overall pick number in the draft. |
-| `person` | character |  |
+| `person` | character | Nested On3 person object for the drafted player (stringified). |
 | `position` | character | Athlete position. |
 | `age` | numeric | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
@@ -518,13 +518,13 @@ GET /rdb/v1/drafts-by-stars
 | col_name | type | description |
 |---|---|---|
 | `state` | character | Venue state. |
-| `blue_chip_percent` | numeric |  |
-| `population_percent` | numeric |  |
-| `talent_ratio` | numeric |  |
-| `five_stars` | integer |  |
-| `four_stars` | integer |  |
-| `three_stars` | integer | Whether three stars data is available. |
-| `zero_stars` | integer |  |
+| `blue_chip_percent` | numeric | Percent of the drafted group who were blue-chip (four- or five-star) recruits. |
+| `population_percent` | numeric | Percent of the overall recruit population holding this star rating. |
+| `talent_ratio` | numeric | Ratio of the star tier's draft share to its population share (On3's talent ratio). |
+| `five_stars` | integer | Number of drafted players who were five-star recruits. |
+| `four_stars` | integer | Number of drafted players who were four-star recruits. |
+| `three_stars` | integer | Number of drafted players who were three-star recruits. |
+| `zero_stars` | integer | Number of drafted players who were unrated (zero-star) recruits. |
 | `total` | integer | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -555,12 +555,12 @@ GET /rdb/v1/drafts-by-stars-summary
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `five_stars` | character |  |
-| `four_stars` | character |  |
-| `three_stars` | character | Whether three stars data is available. |
-| `zero_stars` | character |  |
-| `total_drafted` | integer |  |
-| `total_recruited` | integer |  |
+| `five_stars` | character | Number of drafted players who were five-star recruits. |
+| `four_stars` | character | Number of drafted players who were four-star recruits. |
+| `three_stars` | character | Number of drafted players who were three-star recruits. |
+| `zero_stars` | character | Number of drafted players who were unrated (zero-star) recruits. |
+| `total_drafted` | integer | Total number of players drafted in the summarized group. |
+| `total_recruited` | integer | Total number of recruits in the summarized group. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -590,26 +590,26 @@ GET /rdb/v1/drafts/{orgKey}/players
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `recruitment_key` | integer |  |
+| `recruitment_key` | integer | On3 RDB recruitment key linking the draft pick back to the player's recruitment record. |
 | `organization` | character | Organization. |
-| `drafted_from_organization` | character |  |
-| `high_school_organization` | character |  |
-| `college_organization` | character |  |
+| `drafted_from_organization` | character | Nested On3 organization object for the school the player was drafted out of (stringified). |
+| `high_school_organization` | character | Nested On3 organization object for the player's high school (stringified). |
+| `college_organization` | character | Nested On3 organization object for the college the player attended (stringified). |
 | `hometown` | character | Prospect hometown. |
 | `state` | character | Venue state. |
 | `pick` | integer | Pick number of the NFL draftee within the round they were picked in. |
-| `compensatory` | logical |  |
-| `supplementary` | logical |  |
+| `compensatory` | logical | Whether the selection was a compensatory draft pick. |
+| `supplementary` | logical | Whether the selection came in a supplemental draft. |
 | `traded` | logical | Whether the pick was traded. |
-| `forfeited` | logical |  |
-| `trading_organization` | character |  |
-| `through_organization_one` | character |  |
-| `through_organization_two` | character |  |
-| `through_organization_three` | character |  |
-| `key` | integer |  |
+| `forfeited` | logical | Whether the pick was forfeited. |
+| `trading_organization` | character | Pro organization that traded the pick away, when it changed hands (On3 RDB). |
+| `through_organization_one` | character | First intermediate organization the pick passed through in trades before being exercised (On3 RDB). |
+| `through_organization_two` | character | Second intermediate organization the pick passed through in trades before being exercised (On3 RDB). |
+| `through_organization_three` | character | Third intermediate organization the pick passed through in trades before being exercised (On3 RDB). |
+| `key` | integer | On3 RDB key for the draft-pick record. |
 | `round` | integer | Round of NFL draft the draftee was picked in. |
 | `overall_pick` | integer | Overall pick number in the draft. |
-| `person` | character |  |
+| `person` | character | Nested On3 person object for the drafted player (stringified). |
 | `position` | character | Athlete position. |
 | `age` | numeric | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
@@ -642,7 +642,7 @@ GET /rdb/v1/filters/conferences
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
+| `key` | integer | On3 RDB key for the conference filter option. |
 | `name` | character | Position name (e.g. `Quarterback`). |
 | `abbreviation` | character | Metric abbreviation. |
 
@@ -700,7 +700,7 @@ GET /rdb/v1/filters/positions
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
+| `key` | integer | On3 RDB key for the position filter option. |
 | `name` | character | Position name (e.g. `Quarterback`). |
 | `abbreviation` | character | Metric abbreviation. |
 
@@ -730,7 +730,7 @@ GET /rdb/v1/filters/sports
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
+| `key` | integer | On3 RDB key for the sport filter option. |
 | `name` | character | Position name (e.g. `Quarterback`). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -786,7 +786,7 @@ GET /rdb/v1/filters/teams
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `conference_key` | integer |  |
+| `conference_key` | integer | On3 RDB key of the conference the team belongs to. |
 | `conference_abbr` | character | Conference abbreviation. |
 | `teams` | character | Nested list of member-team membership spans. |
 
@@ -841,8 +841,8 @@ GET /rdb/v1/nil-100
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `person` | character |  |
-| `valuation` | character |  |
+| `person` | character | Nested On3 person object for the ranked athlete (stringified). |
+| `valuation` | character | Athlete's On3 NIL valuation in dollars. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -874,8 +874,8 @@ GET /rdb/v2/nil-100
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `person` | character |  |
-| `valuation` | character |  |
+| `person` | character | Nested On3 person object for the ranked athlete (stringified). |
+| `valuation` | character | Athlete's On3 NIL valuation in dollars. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -904,14 +904,14 @@ GET /rdb/v1/nil-compliances/state
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
+| `key` | integer | On3 RDB key for the state NIL-compliance record. |
 | `organization_type` | character | Organization type. |
-| `state_key` | integer |  |
+| `state_key` | integer | On3 key of the U.S. state the compliance record covers. |
 | `state` | character | Venue state. |
-| `monetization_allowed` | logical |  |
-| `governing_rule_label` | character |  |
-| `governing_rule_url` | character |  |
-| `current_rules` | character |  |
+| `monetization_allowed` | logical | Whether the state allows high-school athletes to monetize their NIL. |
+| `governing_rule_label` | character | Name of the governing body or rule for NIL in the state. |
+| `governing_rule_url` | character | URL of the governing NIL rule or policy document. |
+| `current_rules` | character | Text of the state's current NIL rules, as tracked by On3. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -945,8 +945,8 @@ GET /rdb/v1/nil-rankings
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `person` | character |  |
-| `valuation` | character |  |
+| `person` | character | Nested On3 person object for the ranked athlete (stringified). |
+| `valuation` | character | Athlete's On3 NIL valuation in dollars. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1039,10 +1039,10 @@ GET /rdb/v1/organizations/{organizationKey}/draft-count-by-stars
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `five_stars` | integer |  |
-| `four_stars` | integer |  |
-| `three_stars` | integer | Whether three stars data is available. |
-| `zero_stars` | integer |  |
+| `five_stars` | integer | Number of the organization's drafted players who were five-star recruits. |
+| `four_stars` | integer | Number of the organization's drafted players who were four-star recruits. |
+| `three_stars` | integer | Number of the organization's drafted players who were three-star recruits. |
+| `zero_stars` | integer | Number of the organization's drafted players who were unrated (zero-star) recruits. |
 | `total` | integer | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1075,12 +1075,12 @@ GET /rdb/v1/organizations/{organizationKey}/draft-count-by-year
 | col_name | type | description |
 |---|---|---|
 | `year` | integer | Four-digit season year (e.g. 2019). |
-| `blue_chip_percent` | numeric |  |
-| `talent_ratio` | numeric |  |
-| `five_stars` | integer |  |
-| `four_stars` | integer |  |
-| `three_stars` | integer | Whether three stars data is available. |
-| `zero_stars` | integer |  |
+| `blue_chip_percent` | numeric | Percent of the year's drafted players who were blue-chip (four- or five-star) recruits. |
+| `talent_ratio` | numeric | Ratio of the group's draft share to its recruit-population share for the year (On3's talent ratio). |
+| `five_stars` | integer | Number of the organization's players drafted that year who were five-star recruits. |
+| `four_stars` | integer | Number of the organization's players drafted that year who were four-star recruits. |
+| `three_stars` | integer | Number of the organization's players drafted that year who were three-star recruits. |
+| `zero_stars` | integer | Number of the organization's players drafted that year who were unrated (zero-star) recruits. |
 | `total` | integer | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1112,8 +1112,8 @@ GET /rdb/v1/organizations/{organizationKey}/draft-ranking-summary
 | col_name | type | description |
 |---|---|---|
 | `conference` | character | Conference of the team. |
-| `year_summary` | character |  |
-| `span_summary` | character |  |
+| `year_summary` | character | Nested summary of the organization's draft ranking for the single year (stringified). |
+| `span_summary` | character | Nested summary of the organization's draft ranking over the multi-year span (stringified). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1144,26 +1144,26 @@ GET /rdb/v1/organizations/{organizationKey}/drafted-players
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `recruitment_key` | integer |  |
+| `recruitment_key` | integer | On3 RDB recruitment key linking the draft pick back to the player's recruitment record. |
 | `organization` | character | Organization. |
-| `drafted_from_organization` | character |  |
-| `high_school_organization` | character |  |
-| `college_organization` | character |  |
+| `drafted_from_organization` | character | Nested On3 organization object for the school the player was drafted out of (stringified). |
+| `high_school_organization` | character | Nested On3 organization object for the player's high school (stringified). |
+| `college_organization` | character | Nested On3 organization object for the college the player attended (stringified). |
 | `hometown` | character | Prospect hometown. |
 | `state` | character | Venue state. |
 | `pick` | integer | Pick number of the NFL draftee within the round they were picked in. |
-| `compensatory` | logical |  |
-| `supplementary` | logical |  |
+| `compensatory` | logical | Whether the selection was a compensatory draft pick. |
+| `supplementary` | logical | Whether the selection came in a supplemental draft. |
 | `traded` | logical | Whether the pick was traded. |
-| `forfeited` | logical |  |
-| `trading_organization` | character |  |
-| `through_organization_one` | character |  |
-| `through_organization_two` | character |  |
-| `through_organization_three` | character |  |
-| `key` | integer |  |
+| `forfeited` | logical | Whether the pick was forfeited. |
+| `trading_organization` | character | Pro organization that traded the pick away, when it changed hands (On3 RDB). |
+| `through_organization_one` | character | First intermediate organization the pick passed through in trades before being exercised (On3 RDB). |
+| `through_organization_two` | character | Second intermediate organization the pick passed through in trades before being exercised (On3 RDB). |
+| `through_organization_three` | character | Third intermediate organization the pick passed through in trades before being exercised (On3 RDB). |
+| `key` | integer | On3 RDB key for the draft-pick record. |
 | `round` | integer | Round of NFL draft the draftee was picked in. |
 | `overall_pick` | integer | Overall pick number in the draft. |
-| `person` | character |  |
+| `person` | character | Nested On3 person object for the drafted player (stringified). |
 | `position` | character | Athlete position. |
 | `age` | numeric | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
@@ -1196,14 +1196,14 @@ GET /rdb/v1/organizations/{organizationKey}/drafts-by-stars-summary
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `nat_total_drafted` | integer |  |
-| `total_drafted` | integer |  |
-| `draft_rank` | integer |  |
+| `nat_total_drafted` | integer | National total of drafted players in the comparison set. |
+| `total_drafted` | integer | Total number of the organization's players drafted. |
+| `draft_rank` | integer | Organization's national rank by draft production. |
 | `organization` | character | Organization. |
-| `overall_star_summary` | character |  |
-| `five_star_summary` | character |  |
-| `four_star_summary` | character |  |
-| `three_star_summary` | character |  |
+| `overall_star_summary` | character | Nested draft summary across all star tiers (stringified). |
+| `five_star_summary` | character | Nested draft summary for the organization's five-star recruits (stringified). |
+| `four_star_summary` | character | Nested draft summary for the organization's four-star recruits (stringified). |
+| `three_star_summary` | character | Nested draft summary for the organization's three-star recruits (stringified). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1236,15 +1236,15 @@ GET /rdb/v1/organizations/{organizationKey}/roster
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `pso_key` | integer |  |
+| `pso_key` | integer | On3 player-sport-organization (PSO) key for the roster entry. |
 | `player` | character | Player name. |
 | `organization` | character | Organization. |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
-| `roster_rating` | character |  |
+| `roster_rating` | character | Nested On3 roster rating object for the player (stringified). |
 | `status` | character | Game status (e.g. "scheduled", "in_progress", "completed"). |
-| `nil_value` | character |  |
-| `rpm` | character |  |
-| `industry_comparison` | character |  |
+| `nil_value` | character | Player's On3 NIL valuation in dollars. |
+| `rpm` | character | Nested On3 Recruiting Prediction Machine (RPM) data for the player (stringified). |
+| `industry_comparison` | character | Nested comparison of the player's On3 rating against the industry-consensus rating (stringified). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1275,15 +1275,15 @@ GET /rdb/v1/organizations/{organizationKey}/roster-header
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `head_coach` | character |  |
-| `talent_rank` | character |  |
-| `prev_talent_rank` | character |  |
-| `conference_rank` | character |  |
-| `prev_conference_rank` | character |  |
-| `average_rating` | character |  |
-| `prev_average_rating` | character |  |
-| `average_nil_value` | numeric |  |
-| `total_nil_value` | integer |  |
+| `head_coach` | character | Nested On3 person object for the program's head coach (stringified). |
+| `talent_rank` | character | Program's current national roster-talent rank per On3. |
+| `prev_talent_rank` | character | Program's roster-talent rank in the previous cycle. |
+| `conference_rank` | character | Program's roster-talent rank within its conference. |
+| `prev_conference_rank` | character | Program's conference roster-talent rank in the previous cycle. |
+| `average_rating` | character | Average On3 rating across the roster. |
+| `prev_average_rating` | character | Average On3 roster rating in the previous cycle. |
+| `average_nil_value` | numeric | Average On3 NIL valuation across the roster, in dollars. |
+| `total_nil_value` | integer | Total On3 NIL valuation across the roster, in dollars. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1312,8 +1312,8 @@ GET /rdb/v1/people/{personKey}/combine-measurements
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `measurement_type_key` | integer |  |
-| `measurement_type` | character |  |
+| `measurement_type_key` | integer | On3 key for the measurement category. |
+| `measurement_type` | character | Measurement category (e.g. height, weight, 40-yard dash) per On3's measurement taxonomy. |
 | `value` | numeric | Metric value. |
 | `is_verified` | logical | Whether the player profile is verified. |
 
@@ -1344,13 +1344,13 @@ GET /rdb/v1/people/{personKey}/latest-valuation
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `nil_status` | character |  |
-| `valuation` | integer |  |
-| `valuation_change` | integer |  |
-| `followers` | integer |  |
+| `nil_status` | character | Status of the athlete's On3 NIL valuation (e.g. active, inactive). |
+| `valuation` | integer | Athlete's latest On3 NIL valuation in dollars. |
+| `valuation_change` | integer | Change in the NIL valuation since the previous update, in dollars. |
+| `followers` | integer | Total social-media followers counted toward the valuation. |
 | `rank` | integer | Position of the school within the poll for the given week (1 = top-ranked). |
 | `last_updated` | integer | Timestamp ESPN last refreshed the power index. |
-| `social_valuations` | character |  |
+| `social_valuations` | character | Per-platform breakdown of the social components of the valuation (stringified list). |
 | `group_rank` | integer | League/season rank for group. |
 | `group_name` | character | Group name (conference / division). |
 
@@ -1381,30 +1381,30 @@ GET /rdb/v1/people/{personKey}/measurements
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `measurement_type` | character |  |
-| `measurement_type_key` | integer |  |
+| `key` | integer | On3 RDB key for the measurement record. |
+| `measurement_type` | character | Measurement category (e.g. height, weight, 40-yard dash) per On3's measurement taxonomy. |
+| `measurement_type_key` | integer | On3 key for the measurement category. |
 | `type` | character | Record-type category (e.g. `total`, `home`, `road`). |
 | `value` | numeric | Metric value. |
-| `delta` | numeric |  |
-| `person_key` | integer |  |
-| `verified` | logical |  |
-| `verified_by_user_key` | integer |  |
-| `elite` | logical |  |
-| `event_key` | integer |  |
+| `delta` | numeric | Change in the measured value versus the player's previous measurement of the same type. |
+| `person_key` | integer | On3 person key of the measured athlete. |
+| `verified` | logical | Whether On3 verified the measurement. |
+| `verified_by_user_key` | integer | On3 user key of the staffer who verified the measurement. |
+| `elite` | logical | Whether On3 flags the result as elite for this measurement type. |
+| `event_key` | integer | On3 key of the camp or combine event where the measurement was taken. |
 | `event_name` | character | Event name (e.g. 'All-Star Workout Day: Home Run Derby'). |
 | `event` | character | Binary flag indicating the row is a counted game event (excludes end markers). |
-| `age_measurement_occurred` | numeric |  |
-| `top300_average` | numeric |  |
-| `top_average_change_percent` | numeric |  |
-| `drafted_average` | numeric |  |
+| `age_measurement_occurred` | numeric | Athlete's age when the measurement was taken. |
+| `top300_average` | numeric | Average value of this measurement among On3 Top300-ranked players. |
+| `top_average_change_percent` | numeric | Percent difference between the athlete's value and the Top300 average. |
+| `drafted_average` | numeric | Average value of this measurement among drafted players at the combine. |
 | `record` | character | Team win-loss record for the season. |
-| `draft_change_percent` | numeric |  |
-| `date_added` | integer |  |
+| `draft_change_percent` | numeric | Percent difference between the athlete's value and the drafted-player average. |
+| `date_added` | integer | Date the measurement record was added to the On3 database. |
 | `date_modified` | integer | Date and time that injury information was updated |
-| `date_occurred` | integer |  |
-| `is_current` | logical |  |
-| `person_sport_org_key` | integer |  |
+| `date_occurred` | integer | Date the measurement was actually taken. |
+| `is_current` | logical | Whether this is the athlete's current (most recent) measurement of the type. |
+| `person_sport_org_key` | integer | On3 player-sport-organization (PSO) key the measurement is attached to. |
 | `organization` | character | Organization. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1436,16 +1436,16 @@ GET /rdb/v1/people/{personKey}/measurements/averages
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `measurement_key` | integer |  |
-| `measurement_name` | character |  |
-| `current_person_measurement` | numeric |  |
-| `current_measurement_verified` | logical |  |
-| `top300_difference` | numeric |  |
-| `top300_average` | numeric |  |
-| `combine_drafted_average` | numeric |  |
-| `combine_drafted_difference` | numeric |  |
-| `sort` | character |  |
-| `measurement_record` | character |  |
+| `measurement_key` | integer | On3 key for the measurement category being averaged. |
+| `measurement_name` | character | Name of the measurement category (e.g. height, 40-yard dash). |
+| `current_person_measurement` | numeric | Athlete's current value for the measurement. |
+| `current_measurement_verified` | logical | Whether the athlete's current measurement is verified by On3. |
+| `top300_difference` | numeric | Difference between the athlete's value and the On3 Top300 average. |
+| `top300_average` | numeric | Average value of the measurement among On3 Top300-ranked players. |
+| `combine_drafted_average` | numeric | Average combine value of the measurement among drafted players. |
+| `combine_drafted_difference` | numeric | Difference between the athlete's value and the drafted-player combine average. |
+| `sort` | character | Display sort order of the measurement row on the On3 profile. |
+| `measurement_record` | character | Nested On3 record for the athlete's underlying measurement (stringified). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1476,12 +1476,12 @@ GET /rdb/v1/people/{personKey}/person-connections
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `connection` | character |  |
-| `connected_player` | character |  |
-| `connected_roster_rating` | character |  |
-| `connected_rating` | character |  |
-| `connected_college_organization` | character |  |
-| `connected_draft` | character |  |
+| `connection` | character | Relationship type linking the two people (e.g. sibling, parent, teammate) per On3. |
+| `connected_player` | character | Nested On3 person object for the connected player (stringified). |
+| `connected_roster_rating` | character | Nested On3 roster rating object for the connected player (stringified). |
+| `connected_rating` | character | Nested On3 recruiting rating object for the connected player (stringified). |
+| `connected_college_organization` | character | Nested On3 organization object for the connected player's college (stringified). |
+| `connected_draft` | character | Nested On3 draft record for the connected player, when drafted (stringified). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1511,8 +1511,8 @@ GET /rdb/v1/people/{personKey}/social
 | col_name | type | description |
 |---|---|---|
 | `type` | character | Record-type category (e.g. `total`, `home`, `road`). |
-| `handle` | character |  |
-| `handshake` | logical |  |
+| `handle` | character | Athlete's account handle on the social platform. |
+| `handshake` | logical | On3 RDB handshake field on the social-account record (platform link/verification metadata). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1541,9 +1541,9 @@ GET /rdb/v1/people/{personKey}/social-post-summary
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `social_type` | character |  |
+| `social_type` | character | Social platform the post summary covers (e.g. Twitter/X, Instagram). |
 | `type` | character | Record-type category (e.g. `total`, `home`, `road`). |
-| `followers` | integer |  |
+| `followers` | integer | Athlete's follower count on the platform. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1572,30 +1572,30 @@ GET /rdb/v1/people/{personKey}/track-and-field-measurements
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `measurement_type` | character |  |
-| `measurement_type_key` | integer |  |
+| `key` | integer | On3 RDB key for the measurement record. |
+| `measurement_type` | character | Measurement category (e.g. height, weight, 40-yard dash) per On3's measurement taxonomy. |
+| `measurement_type_key` | integer | On3 key for the measurement category. |
 | `type` | character | Record-type category (e.g. `total`, `home`, `road`). |
 | `value` | numeric | Metric value. |
-| `delta` | numeric |  |
-| `person_key` | integer |  |
-| `verified` | logical |  |
-| `verified_by_user_key` | integer |  |
-| `elite` | logical |  |
-| `event_key` | integer |  |
+| `delta` | numeric | Change in the measured value versus the player's previous measurement of the same type. |
+| `person_key` | integer | On3 person key of the measured athlete. |
+| `verified` | logical | Whether On3 verified the measurement. |
+| `verified_by_user_key` | integer | On3 user key of the staffer who verified the measurement. |
+| `elite` | logical | Whether On3 flags the result as elite for this measurement type. |
+| `event_key` | integer | On3 key of the camp or combine event where the measurement was taken. |
 | `event_name` | character | Event name (e.g. 'All-Star Workout Day: Home Run Derby'). |
 | `event` | character | Binary flag indicating the row is a counted game event (excludes end markers). |
-| `age_measurement_occurred` | numeric |  |
-| `top300_average` | numeric |  |
-| `top_average_change_percent` | numeric |  |
-| `drafted_average` | numeric |  |
+| `age_measurement_occurred` | numeric | Athlete's age when the measurement was taken. |
+| `top300_average` | numeric | Average value of this measurement among On3 Top300-ranked players. |
+| `top_average_change_percent` | numeric | Percent difference between the athlete's value and the Top300 average. |
+| `drafted_average` | numeric | Average value of this measurement among drafted players at the combine. |
 | `record` | character | Team win-loss record for the season. |
-| `draft_change_percent` | numeric |  |
-| `date_added` | integer |  |
+| `draft_change_percent` | numeric | Percent difference between the athlete's value and the drafted-player average. |
+| `date_added` | integer | Date the measurement record was added to the On3 database. |
 | `date_modified` | integer | Date and time that injury information was updated |
-| `date_occurred` | integer |  |
-| `is_current` | logical |  |
-| `person_sport_org_key` | integer |  |
+| `date_occurred` | integer | Date the measurement was actually taken. |
+| `is_current` | logical | Whether this is the athlete's current (most recent) measurement of the type. |
+| `person_sport_org_key` | integer | On3 player-sport-organization (PSO) key the measurement is attached to. |
 | `organization` | character | Organization. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1625,11 +1625,11 @@ GET /rdb/v1/people/{personKey}/valuation-growth
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `nil_status` | character |  |
-| `valuation` | integer |  |
-| `valuation_change` | integer |  |
+| `nil_status` | character | Status of the athlete's On3 NIL valuation at the snapshot (e.g. active, inactive). |
+| `valuation` | integer | Athlete's On3 NIL valuation in dollars at the snapshot. |
+| `valuation_change` | integer | Change in the NIL valuation versus the previous snapshot, in dollars. |
 | `date` | character | Date of the poll release. |
-| `date_unix` | integer |  |
+| `date_unix` | integer | Unix timestamp of the valuation snapshot. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1658,12 +1658,12 @@ GET /rdb/v1/person-connections/{connectionKey}
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `person_key` | integer |  |
-| `connected_person_key` | integer |  |
-| `sport_key` | integer |  |
+| `key` | integer | On3 RDB key for the person-connection record. |
+| `person_key` | integer | On3 person key of the profile the connection belongs to. |
+| `connected_person_key` | integer | On3 person key of the connected person. |
+| `sport_key` | integer | On3 sport key the connection is scoped to. |
 | `description` | character | ESPN's description of the stat. |
-| `connected_person_sport` | character |  |
+| `connected_person_sport` | character | Nested athlete-sport profile of the connected person (stringified). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1692,19 +1692,19 @@ GET /rdb/v1/person/{personKey}/primary-recruitment-evaluation
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `recruitment_key` | integer |  |
-| `author_key` | integer |  |
-| `author_name` | character |  |
-| `author_title` | character |  |
+| `key` | integer | On3 RDB key for the scouting evaluation. |
+| `recruitment_key` | integer | On3 recruitment key the evaluation is attached to. |
+| `author_key` | integer | On3 user key of the evaluation's author. |
+| `author_name` | character | Name of the On3 scout who wrote the evaluation. |
+| `author_title` | character | Job title of the On3 scout who wrote the evaluation. |
 | `title` | character | Specific role title for the assignment. |
 | `premium` | logical | Whether the article is premium content. |
-| `body` | character |  |
-| `primary` | logical |  |
+| `body` | character | Full text of the scouting evaluation. |
+| `primary` | logical | Whether this is the primary (featured) evaluation for the recruitment. |
 | `category` | character | CFBD stats category name (e.g. passing, rushing, defensive). |
-| `date_updated_unix` | integer |  |
-| `date_added` | character |  |
-| `date_updated` | character |  |
+| `date_updated_unix` | integer | Unix timestamp of the evaluation's last update. |
+| `date_added` | character | Date the evaluation was added. |
+| `date_updated` | character | Date the evaluation was last updated. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1733,19 +1733,19 @@ GET /rdb/v1/person/{personKey}/recruitment-evaluations
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `recruitment_key` | integer |  |
-| `author_key` | integer |  |
-| `author_name` | character |  |
-| `author_title` | character |  |
+| `key` | integer | On3 RDB key for the scouting evaluation. |
+| `recruitment_key` | integer | On3 recruitment key the evaluation is attached to. |
+| `author_key` | integer | On3 user key of the evaluation's author. |
+| `author_name` | character | Name of the On3 scout who wrote the evaluation. |
+| `author_title` | character | Job title of the On3 scout who wrote the evaluation. |
 | `title` | character | Specific role title for the assignment. |
 | `premium` | logical | Whether the article is premium content. |
-| `body` | character |  |
-| `primary` | logical |  |
+| `body` | character | Full text of the scouting evaluation. |
+| `primary` | logical | Whether this is the primary (featured) evaluation for the recruitment. |
 | `category` | character | CFBD stats category name (e.g. passing, rushing, defensive). |
-| `date_updated_unix` | integer |  |
-| `date_added` | character |  |
-| `date_updated` | character |  |
+| `date_updated_unix` | integer | Unix timestamp of the evaluation's last update. |
+| `date_added` | character | Date the evaluation was added. |
+| `date_updated` | character | Date the evaluation was last updated. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1774,24 +1774,24 @@ GET /rdb/v1/person-sport/{psKey}/profile-recruit
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `ranking_key` | integer |  |
+| `key` | integer | On3 RDB key for the player's ranking row. |
+| `ranking_key` | integer | On3 key of the ranking cycle the row belongs to. |
 | `rating` | numeric | Overall SP+ rating (Bill Connelly methodology, in points per game). |
 | `state_rank` | integer | State ranking. |
-| `state_abbr` | character |  |
+| `state_abbr` | character | Two-letter abbreviation of the player's home state. |
 | `position_rank` | integer | Position ranking. |
 | `position_abbr` | character | Position abbreviation. |
 | `overall_rank` | integer | Overall recruit ranking (top recruits only; may be `NA`). |
 | `stars` | integer | Recruit star rating on the 247Sports scale (2-5). |
-| `change` | character |  |
-| `consensus_rating` | numeric |  |
-| `consensus_state_rank` | integer |  |
-| `consensus_position_rank` | integer |  |
-| `consensus_overall_rank` | integer |  |
-| `consensus_stars` | integer |  |
-| `consensus_change` | character |  |
+| `change` | character | Rank movement since the previous ranking cycle. |
+| `consensus_rating` | numeric | Player's industry-consensus rating (blend of the major recruiting services). |
+| `consensus_state_rank` | integer | Player's consensus rank within their home state. |
+| `consensus_position_rank` | integer | Player's consensus rank at their position. |
+| `consensus_overall_rank` | integer | Player's national consensus rank. |
+| `consensus_stars` | integer | Player's star rating under the industry consensus. |
+| `consensus_change` | character | Consensus rank movement since the previous cycle. |
 | `strength` | integer | Strength label (Even, Power Play, Shorthanded). |
-| `five_star_plus` | logical |  |
+| `five_star_plus` | logical | Whether On3 designates the player a Five-Star Plus+ prospect. |
 | `ranking_type` | character | Poll type code (e.g. `ap`, `coaches`, `cfp`). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1824,9 +1824,9 @@ GET /rdb/v1/person-sport-rankings
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `ratings` | character |  |
-| `person` | character |  |
-| `nil_value` | integer |  |
+| `ratings` | character | Athlete's ratings across ranking cycles, as a stringified list. |
+| `person` | character | Nested On3 person object for the ranked athlete (stringified). |
+| `nil_value` | integer | Athlete's On3 NIL valuation in dollars. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1857,20 +1857,20 @@ GET /rdb/v1/player/{personKey}/all-rankings
 |---|---|---|
 | `type` | character | Record-type category (e.g. `total`, `home`, `road`). |
 | `link` | character | API link to the game feed. |
-| `ranking_key` | integer |  |
+| `ranking_key` | integer | On3 key of the ranking cycle the row belongs to. |
 | `ranking_type` | character | Poll type code (e.g. `ap`, `coaches`, `cfp`). |
 | `rating` | numeric | Overall SP+ rating (Bill Connelly methodology, in points per game). |
-| `sport` | character |  |
-| `class_year` | integer |  |
+| `sport` | character | Nested On3 sport object for the ranking row (stringified). |
+| `class_year` | integer | Recruiting class year the ranking covers. |
 | `state_rank` | integer | State ranking. |
-| `state_abbr` | character |  |
+| `state_abbr` | character | Two-letter abbreviation of the player's home state. |
 | `position_rank` | integer | Position ranking. |
 | `position_abbr` | character | Position abbreviation. |
 | `overall_rank` | integer | Overall recruit ranking (top recruits only; may be `NA`). |
 | `stars` | integer | Recruit star rating on the 247Sports scale (2-5). |
-| `five_star_plus` | logical |  |
-| `nearly_five_star_plus` | logical |  |
-| `change` | character |  |
+| `five_star_plus` | logical | Whether On3 designates the player a Five-Star Plus+ prospect. |
+| `nearly_five_star_plus` | logical | On3 flag that the player narrowly missed the Five-Star Plus+ designation. |
+| `change` | character | Rank movement since the previous ranking cycle. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1899,17 +1899,17 @@ GET /rdb/v1/player/{personKey}/database-updates
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
+| `key` | integer | On3 RDB key for the database-update entry. |
 | `type` | character | Record-type category (e.g. `total`, `home`, `road`). |
 | `text` | character | Full play description. |
-| `replacement_text` | character |  |
+| `replacement_text` | character | Rendered text of the update entry (with references substituted in). |
 | `link` | character | API link to the game feed. |
-| `date_added` | integer |  |
-| `date_occurred` | integer |  |
-| `object_key` | integer |  |
-| `sport_key` | integer |  |
-| `person_key` | integer |  |
-| `organization_key` | integer |  |
+| `date_added` | integer | Date the update entry was logged. |
+| `date_occurred` | integer | Date the underlying event occurred. |
+| `object_key` | integer | On3 key of the object the update refers to. |
+| `sport_key` | integer | On3 sport key the update is scoped to. |
+| `person_key` | integer | On3 person key of the player the update concerns. |
+| `organization_key` | integer | On3 organization key involved in the update, when any. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1938,25 +1938,25 @@ GET /rdb/v1/player/{personKey}/images
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `domain_override` | character |  |
-| `domain` | character |  |
-| `source_override` | character |  |
+| `key` | integer | On3 asset key for the image. |
+| `domain_override` | character | Override CDN domain for serving the image, when set. |
+| `domain` | character | CDN domain the image is served from. |
+| `source_override` | character | Override source attribution for the image, when set. |
 | `source` | character | News source. |
 | `title` | character | Specific role title for the assignment. |
 | `description` | character | ESPN's description of the stat. |
-| `caption` | character |  |
+| `caption` | character | Caption text for the image. |
 | `category` | character | CFBD stats category name (e.g. passing, rushing, defensive). |
-| `alt_text` | character |  |
+| `alt_text` | character | Alt text for the image. |
 | `height` | integer | Listed height (inches). |
-| `width` | integer |  |
-| `asset_type` | character |  |
-| `file_system` | character |  |
-| `path` | character |  |
+| `width` | integer | Image width in pixels. |
+| `asset_type` | character | Type of the asset (e.g. image) in On3's asset system. |
+| `file_system` | character | Storage file system the asset lives on (On3 asset metadata). |
+| `path` | character | Storage path of the image file. |
 | `type` | character | Record-type category (e.g. `total`, `home`, `road`). |
-| `thumbnail` | character |  |
+| `thumbnail` | character | URL or path of the image's thumbnail rendition. |
 | `duration` | integer | Duration. |
-| `mime_type` | character |  |
+| `mime_type` | character | MIME type of the image file (e.g. image/jpeg). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1985,8 +1985,8 @@ GET /rdb/v1/player/{personKey}/organizations
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `organizations` | character |  |
-| `draft` | character |  |
+| `organizations` | character | Player's organization stints (high school, college, pro) as a stringified list of nested objects. |
+| `draft` | character | Nested On3 draft record for the player, when drafted (stringified). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2019,8 +2019,8 @@ GET /rdb/v1/player/{playerKey}/organizations/{orgKey}
 | `organization` | character | Organization. |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
 | `position_abbr` | character | Position abbreviation. |
-| `exp_min` | integer |  |
-| `exp_max` | integer |  |
+| `exp_min` | integer | Minimum years of experience listed for the player's stint with the organization (On3 RDB). |
+| `exp_max` | integer | Maximum years of experience listed for the player's stint with the organization (On3 RDB). |
 | `year` | character | Four-digit season year (e.g. 2019). |
 | `age` | integer | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 
@@ -2051,24 +2051,24 @@ GET /rdb/v1/player/{personKey}/rankings
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `ranking_key` | integer |  |
+| `key` | integer | On3 RDB key for the player's ranking row. |
+| `ranking_key` | integer | On3 key of the ranking cycle the row belongs to. |
 | `rating` | numeric | Overall SP+ rating (Bill Connelly methodology, in points per game). |
 | `state_rank` | integer | State ranking. |
-| `state_abbr` | character |  |
+| `state_abbr` | character | Two-letter abbreviation of the player's home state. |
 | `position_rank` | integer | Position ranking. |
 | `position_abbr` | character | Position abbreviation. |
 | `overall_rank` | integer | Overall recruit ranking (top recruits only; may be `NA`). |
 | `stars` | integer | Recruit star rating on the 247Sports scale (2-5). |
-| `change` | character |  |
-| `consensus_rating` | numeric |  |
-| `consensus_state_rank` | integer |  |
-| `consensus_position_rank` | integer |  |
-| `consensus_overall_rank` | integer |  |
-| `consensus_stars` | integer |  |
-| `consensus_change` | character |  |
+| `change` | character | Rank movement since the previous ranking cycle. |
+| `consensus_rating` | numeric | Player's industry-consensus rating (blend of the major recruiting services). |
+| `consensus_state_rank` | integer | Player's consensus rank within their home state. |
+| `consensus_position_rank` | integer | Player's consensus rank at their position. |
+| `consensus_overall_rank` | integer | Player's national consensus rank. |
+| `consensus_stars` | integer | Player's star rating under the industry consensus. |
+| `consensus_change` | character | Consensus rank movement since the previous cycle. |
 | `strength` | integer | Strength label (Even, Power Play, Shorthanded). |
-| `five_star_plus` | logical |  |
+| `five_star_plus` | logical | Whether On3 designates the player a Five-Star Plus+ prospect. |
 | `ranking_type` | character | Poll type code (e.g. `ap`, `coaches`, `cfp`). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -2098,53 +2098,53 @@ GET /rdb/v1/player/{personKey}/profile
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `class_year_recruitment_key` | character |  |
-| `recruitment_key` | integer |  |
-| `person_can_manage_recruitment` | character |  |
-| `ranking_key` | integer |  |
-| `person_sport_key` | integer |  |
+| `key` | integer | On3 RDB key for the player profile. |
+| `class_year_recruitment_key` | character | On3 recruitment key for the player's recruiting-class cycle. |
+| `recruitment_key` | integer | On3 key of the player's active recruitment record. |
+| `person_can_manage_recruitment` | character | Whether the athlete can self-manage the recruitment on On3. |
+| `ranking_key` | integer | On3 key of the ranking cycle the profile's rating belongs to. |
+| `person_sport_key` | integer | On3 key of the athlete-sport profile (person x sport). |
 | `ranking` | character | National rank of the team's overall SP+ rating (1 = best). |
-| `oracle_key` | character |  |
+| `oracle_key` | character | On3's internal oracle identifier for the player record. |
 | `name` | character | Position name (e.g. `Quarterback`). |
 | `slug` | character | URL slug for the team. |
 | `high_school_name` | character | Recruit high-school name. |
 | `high_school` | character | High school |
-| `hometown_name` | character |  |
+| `hometown_name` | character | Player's hometown, as listed by On3. |
 | `hometown_state` | character | Recruit hometown state. |
 | `current_state` | character | Current home venue state. |
-| `default_asset` | character |  |
+| `default_asset` | character | Nested On3 asset object for the player's headshot (stringified). |
 | `position_abbreviation` | character | Position abbreviation (e.g. `QB`); `position_detail = TRUE` only. |
-| `primary_position` | character |  |
-| `class_rank` | character |  |
+| `primary_position` | character | Nested On3 object for the player's primary position (stringified). |
+| `class_rank` | character | Player's rank within their recruiting class. |
 | `height` | character | Listed height (inches). |
 | `weight` | integer | Listed weight (lbs). |
-| `class_year` | integer |  |
-| `degree` | character |  |
+| `class_year` | integer | Player's recruiting class year. |
+| `degree` | character | Degree the player earned or is pursuing, when listed. |
 | `age` | integer | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
-| `default_sport` | character |  |
-| `sports` | character |  |
+| `default_sport` | character | Nested On3 object for the player's primary sport (stringified). |
+| `sports` | character | Sports the player is profiled in, as a stringified list. |
 | `description` | character | ESPN's description of the stat. |
-| `bio_pro_prospect` | character |  |
-| `bio_college_recruit` | character |  |
-| `organization_level` | character |  |
-| `high_school_org_key` | integer |  |
-| `prep_school_org_key` | character |  |
-| `junior_college_org_key` | character |  |
-| `college_org_key` | character |  |
-| `nil_value` | integer |  |
-| `athlete_verified` | logical |  |
-| `prospect_verified` | logical |  |
-| `player_status` | character |  |
-| `is_coach` | logical |  |
-| `is_athlete` | logical |  |
-| `visibility` | character |  |
-| `tier` | character |  |
-| `review_status` | character |  |
+| `bio_pro_prospect` | character | Bio text framing the player as a pro prospect (On3 RDB). |
+| `bio_college_recruit` | character | Bio text framing the player as a college recruit (On3 RDB). |
+| `organization_level` | character | Level of the player's current organization (e.g. high school, college, professional). |
+| `high_school_org_key` | integer | On3 organization key of the player's high school. |
+| `prep_school_org_key` | character | On3 organization key of the player's prep school, when attended. |
+| `junior_college_org_key` | character | On3 organization key of the player's junior college, when attended. |
+| `college_org_key` | character | On3 organization key of the player's college. |
+| `nil_value` | integer | Player's On3 NIL valuation in dollars. |
+| `athlete_verified` | logical | Whether the athlete has verified their own On3 profile. |
+| `prospect_verified` | logical | Whether On3 has verified the prospect's profile information. |
+| `player_status` | character | Player's current status per On3 (e.g. active, transfer portal). |
+| `is_coach` | logical | Whether the person record is a coach. |
+| `is_athlete` | logical | Whether the person record is an athlete. |
+| `visibility` | character | Profile visibility setting on On3. |
+| `tier` | character | On3 profile tier classification for the player. |
+| `review_status` | character | Editorial review status of the profile in the On3 database. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `badge` | character |  |
-| `ncaa_id` | character |  |
-| `managed_by_user` | logical |  |
+| `badge` | character | Profile badge assigned by On3, when any. |
+| `ncaa_id` | character | Player's NCAA identifier, when known to On3. |
+| `managed_by_user` | logical | On3 user account that manages the player's profile, when claimed. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2175,20 +2175,20 @@ GET /rdb/v1/player/{playerKey}/team-targets
 |---|---|---|
 | `team` | character | Team name. |
 | `year` | integer | Four-digit season year (e.g. 2019). |
-| `sport` | character |  |
-| `coaches` | character |  |
+| `sport` | character | Nested On3 sport object for the target entry (stringified). |
+| `coaches` | character | Recruiting coaches at the target school tied to the recruitment (stringified list). |
 | `status` | character | Game status (e.g. "scheduled", "in_progress", "completed"). |
-| `interest` | integer |  |
+| `interest` | integer | Recruit's interest level in the target school, per On3. |
 | `distance` | numeric | Yards to gain for a first down (or to the goal line in goal-to-go situations). |
-| `class_rank` | integer |  |
-| `official_visit_count` | integer |  |
-| `un_official_visit_count` | integer |  |
+| `class_rank` | integer | Recruit's rank within their recruiting class. |
+| `official_visit_count` | integer | Number of official visits the recruit has taken to the school. |
+| `un_official_visit_count` | integer | Number of unofficial visits the recruit has taken to the school. |
 | `prediction` | numeric | Pre-game prediction (favorite, score, win %). |
-| `committed_date` | character |  |
-| `draft_position_count` | integer |  |
-| `draft_total` | integer |  |
+| `committed_date` | character | Date the recruit committed to the school, when applicable. |
+| `draft_position_count` | integer | Number of players at the recruit's position the school has had drafted. |
+| `draft_total` | integer | Total number of players the school has had drafted. |
 | `position_abbreviation` | character | Position abbreviation (e.g. `QB`); `position_detail = TRUE` only. |
-| `position_key` | integer |  |
+| `position_key` | integer | On3 key of the recruit's position. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2219,53 +2219,53 @@ GET /rdb/v1/player/verified
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `class_year_recruitment_key` | character |  |
-| `recruitment_key` | integer |  |
-| `person_can_manage_recruitment` | character |  |
-| `ranking_key` | integer |  |
-| `person_sport_key` | integer |  |
+| `key` | integer | On3 RDB key for the player profile. |
+| `class_year_recruitment_key` | character | On3 recruitment key for the player's recruiting-class cycle. |
+| `recruitment_key` | integer | On3 key of the player's active recruitment record. |
+| `person_can_manage_recruitment` | character | Whether the athlete can self-manage the recruitment on On3. |
+| `ranking_key` | integer | On3 key of the ranking cycle the profile's rating belongs to. |
+| `person_sport_key` | integer | On3 key of the athlete-sport profile (person x sport). |
 | `ranking` | character | National rank of the team's overall SP+ rating (1 = best). |
-| `oracle_key` | character |  |
+| `oracle_key` | character | On3's internal oracle identifier for the player record. |
 | `name` | character | Position name (e.g. `Quarterback`). |
 | `slug` | character | URL slug for the team. |
 | `high_school_name` | character | Recruit high-school name. |
 | `high_school` | character | High school |
-| `hometown_name` | character |  |
+| `hometown_name` | character | Player's hometown, as listed by On3. |
 | `hometown_state` | character | Recruit hometown state. |
 | `current_state` | character | Current home venue state. |
-| `default_asset` | character |  |
+| `default_asset` | character | Nested On3 asset object for the player's headshot (stringified). |
 | `position_abbreviation` | character | Position abbreviation (e.g. `QB`); `position_detail = TRUE` only. |
-| `primary_position` | character |  |
-| `class_rank` | character |  |
+| `primary_position` | character | Nested On3 object for the player's primary position (stringified). |
+| `class_rank` | character | Player's rank within their recruiting class. |
 | `height` | character | Listed height (inches). |
 | `weight` | integer | Listed weight (lbs). |
-| `class_year` | integer |  |
-| `degree` | character |  |
+| `class_year` | integer | Player's recruiting class year. |
+| `degree` | character | Degree the player earned or is pursuing, when listed. |
 | `age` | integer | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
-| `default_sport` | character |  |
-| `sports` | character |  |
+| `default_sport` | character | Nested On3 object for the player's primary sport (stringified). |
+| `sports` | character | Sports the player is profiled in, as a stringified list. |
 | `description` | character | ESPN's description of the stat. |
-| `bio_pro_prospect` | character |  |
-| `bio_college_recruit` | character |  |
-| `organization_level` | character |  |
-| `high_school_org_key` | integer |  |
-| `prep_school_org_key` | character |  |
-| `junior_college_org_key` | character |  |
-| `college_org_key` | character |  |
-| `nil_value` | integer |  |
-| `athlete_verified` | logical |  |
-| `prospect_verified` | logical |  |
-| `player_status` | character |  |
-| `is_coach` | logical |  |
-| `is_athlete` | logical |  |
-| `visibility` | character |  |
-| `tier` | character |  |
-| `review_status` | character |  |
+| `bio_pro_prospect` | character | Bio text framing the player as a pro prospect (On3 RDB). |
+| `bio_college_recruit` | character | Bio text framing the player as a college recruit (On3 RDB). |
+| `organization_level` | character | Level of the player's current organization (e.g. high school, college, professional). |
+| `high_school_org_key` | integer | On3 organization key of the player's high school. |
+| `prep_school_org_key` | character | On3 organization key of the player's prep school, when attended. |
+| `junior_college_org_key` | character | On3 organization key of the player's junior college, when attended. |
+| `college_org_key` | character | On3 organization key of the player's college. |
+| `nil_value` | integer | Player's On3 NIL valuation in dollars. |
+| `athlete_verified` | logical | Whether the athlete has verified their own On3 profile. |
+| `prospect_verified` | logical | Whether On3 has verified the prospect's profile information. |
+| `player_status` | character | Player's current status per On3 (e.g. active, transfer portal). |
+| `is_coach` | logical | Whether the person record is a coach. |
+| `is_athlete` | logical | Whether the person record is an athlete. |
+| `visibility` | character | Profile visibility setting on On3. |
+| `tier` | character | On3 profile tier classification for the player. |
+| `review_status` | character | Editorial review status of the profile in the On3 database. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `badge` | character |  |
-| `ncaa_id` | character |  |
-| `managed_by_user` | logical |  |
+| `badge` | character | Profile badge assigned by On3, when any. |
+| `ncaa_id` | character | Player's NCAA identifier, when known to On3. |
+| `managed_by_user` | logical | On3 user account that manages the player's profile, when claimed. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2294,15 +2294,15 @@ GET /rdb/v1/player/{personKey}/videos
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `person_key` | integer |  |
-| `source_url` | character |  |
+| `key` | integer | On3 RDB key for the video record. |
+| `person_key` | integer | On3 person key of the featured athlete. |
+| `source_url` | character | Source URL of the hosted video. |
 | `title` | character | Specific role title for the assignment. |
-| `thumbnail` | character |  |
+| `thumbnail` | character | URL of the video's thumbnail image. |
 | `category` | character | CFBD stats category name (e.g. passing, rushing, defensive). |
 | `description` | character | ESPN's description of the stat. |
-| `person_sport` | character |  |
-| `is_featured` | logical |  |
+| `person_sport` | character | Nested athlete-sport profile the video is attached to (stringified). |
+| `is_featured` | logical | Whether the video is featured on the player's On3 profile. |
 | `date` | integer | Date of the poll release. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -2332,10 +2332,10 @@ GET /rdb/v1/player/{playerKey}/visit-center
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `sport` | character |  |
+| `sport` | character | Nested On3 sport object for the visit-center entry (stringified). |
 | `year` | integer | Four-digit season year (e.g. 2019). |
-| `total_visits` | integer |  |
-| `visits` | character |  |
+| `total_visits` | integer | Total number of school visits logged for the recruit. |
+| `visits` | character | The recruit's school visits with dates and types, as a stringified list. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2403,9 +2403,9 @@ GET /rdb/v1/players/industry-comparision-list
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `ratings` | character |  |
-| `person` | character |  |
-| `nil_value` | integer |  |
+| `ratings` | character | Player's ratings across the industry services, as a stringified list. |
+| `person` | character | Nested On3 person object for the compared player (stringified). |
+| `nil_value` | integer | Player's On3 NIL valuation in dollars. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2462,13 +2462,13 @@ GET /rdb/v1/quotes
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `body` | character |  |
+| `key` | integer | On3 RDB key for the quote record. |
+| `body` | character | Full text of the quote. |
 | `category` | character | CFBD stats category name (e.g. passing, rushing, defensive). |
-| `person_key` | integer |  |
-| `person` | character |  |
-| `date_added` | character |  |
-| `date_updated` | character |  |
+| `person_key` | integer | On3 person key of the person quoted or quoted about. |
+| `person` | character | Nested On3 person object for the quote's subject (stringified). |
+| `date_added` | character | Date the quote was added to the On3 database. |
+| `date_updated` | character | Date the quote was last updated. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2497,13 +2497,13 @@ GET /rdb/v1/quotes/{key}
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `body` | character |  |
+| `key` | integer | On3 RDB key for the quote record. |
+| `body` | character | Full text of the quote. |
 | `category` | character | CFBD stats category name (e.g. passing, rushing, defensive). |
-| `person_key` | integer |  |
-| `person` | character |  |
-| `date_added` | character |  |
-| `date_updated` | character |  |
+| `person_key` | integer | On3 person key of the person quoted or quoted about. |
+| `person` | character | Nested On3 person object for the quote's subject (stringified). |
+| `date_added` | character | Date the quote was added to the On3 database. |
+| `date_updated` | character | Date the quote was last updated. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2532,19 +2532,19 @@ GET /rdb/v1/recruitment/{recruitmentKey}/primary-recruitment-evaluation
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `recruitment_key` | integer |  |
-| `author_key` | integer |  |
-| `author_name` | character |  |
-| `author_title` | character |  |
+| `key` | integer | On3 RDB key for the scouting evaluation. |
+| `recruitment_key` | integer | On3 recruitment key the evaluation is attached to. |
+| `author_key` | integer | On3 user key of the evaluation's author. |
+| `author_name` | character | Name of the On3 scout who wrote the evaluation. |
+| `author_title` | character | Job title of the On3 scout who wrote the evaluation. |
 | `title` | character | Specific role title for the assignment. |
 | `premium` | logical | Whether the article is premium content. |
-| `body` | character |  |
-| `primary` | logical |  |
+| `body` | character | Full text of the scouting evaluation. |
+| `primary` | logical | Whether this is the primary (featured) evaluation for the recruitment. |
 | `category` | character | CFBD stats category name (e.g. passing, rushing, defensive). |
-| `date_updated_unix` | integer |  |
-| `date_added` | character |  |
-| `date_updated` | character |  |
+| `date_updated_unix` | integer | Unix timestamp of the evaluation's last update. |
+| `date_added` | character | Date the evaluation was added. |
+| `date_updated` | character | Date the evaluation was last updated. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2573,19 +2573,19 @@ GET /rdb/v1/recruitment/{recruitmentKey}/recruitment-evaluations
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `recruitment_key` | integer |  |
-| `author_key` | integer |  |
-| `author_name` | character |  |
-| `author_title` | character |  |
+| `key` | integer | On3 RDB key for the scouting evaluation. |
+| `recruitment_key` | integer | On3 recruitment key the evaluation is attached to. |
+| `author_key` | integer | On3 user key of the evaluation's author. |
+| `author_name` | character | Name of the On3 scout who wrote the evaluation. |
+| `author_title` | character | Job title of the On3 scout who wrote the evaluation. |
 | `title` | character | Specific role title for the assignment. |
 | `premium` | logical | Whether the article is premium content. |
-| `body` | character |  |
-| `primary` | logical |  |
+| `body` | character | Full text of the scouting evaluation. |
+| `primary` | logical | Whether this is the primary (featured) evaluation for the recruitment. |
 | `category` | character | CFBD stats category name (e.g. passing, rushing, defensive). |
-| `date_updated_unix` | integer |  |
-| `date_added` | character |  |
-| `date_updated` | character |  |
+| `date_updated_unix` | integer | Unix timestamp of the evaluation's last update. |
+| `date_added` | character | Date the evaluation was added. |
+| `date_updated` | character | Date the evaluation was last updated. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2648,10 +2648,10 @@ GET /rdb/v1/recruitments/{recKey}/profile
 | col_name | type | description |
 |---|---|---|
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
-| `class_year` | integer |  |
-| `committed_status` | character |  |
+| `class_year` | integer | Recruiting class year of the recruitment. |
+| `committed_status` | character | Nested commitment status of the recruitment (stringified). |
 | `high_school` | character | High school |
-| `high_school_org` | character |  |
+| `high_school_org` | character | Nested On3 organization object for the recruit's high school (stringified). |
 | `home_town` | character | Player home town. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -2681,21 +2681,21 @@ GET /rdb/v1/recruitments/{recKey}/rpm-picks
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
+| `key` | integer | On3 RDB key for the RPM pick. |
 | `organization` | character | Organization. |
-| `date_added` | character |  |
-| `expert` | character |  |
-| `confidence` | numeric |  |
+| `date_added` | character | Date the expert logged the RPM pick. |
+| `expert` | character | Nested On3 record for the expert who logged the pick (stringified). |
+| `confidence` | numeric | Expert's confidence level in the prediction. |
 | `description` | character | ESPN's description of the stat. |
-| `article_link` | character |  |
+| `article_link` | character | Link to the On3 article accompanying the pick, when any. |
 | `premium` | logical | Whether the article is premium content. |
-| `correct` | logical |  |
-| `days_correct` | numeric |  |
-| `flipped_from_organization` | character |  |
-| `previous_confidence` | numeric |  |
-| `previous_date_added` | character |  |
+| `correct` | logical | Whether the pick proved correct. |
+| `days_correct` | numeric | Number of days the pick stood as correct. |
+| `flipped_from_organization` | character | Organization the expert's pick flipped from, when the prediction changed (stringified). |
+| `previous_confidence` | numeric | Expert's confidence level on their previous pick for this recruitment. |
+| `previous_date_added` | character | Date the expert's previous pick was logged. |
 | `type` | character | Record-type category (e.g. `total`, `home`, `road`). |
-| `top_teams` | character |  |
+| `top_teams` | character | Teams currently leading for the recruit per the pick, as a stringified list. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2724,8 +2724,8 @@ GET /rdb/v1/recruitments/{recKey}/rpm-summary
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `predictions` | character |  |
-| `locked` | logical |  |
+| `predictions` | character | Per-team RPM prediction percentages for the recruitment, as a stringified list. |
+| `locked` | logical | Whether the RPM prediction for the recruitment is locked (no longer updating). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2757,29 +2757,29 @@ GET /rdb/v1/team-ranking
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
+| `key` | integer | On3 RDB key for the team's class-ranking row. |
 | `organization` | character | Organization. |
-| `applied_total_rating` | numeric |  |
-| `applied_total_consensus_rating` | numeric |  |
-| `applied_average_rating` | numeric |  |
-| `applied_average_consensus_rating` | numeric |  |
-| `commits` | integer | Number of commits in the position group. |
-| `applied_commits` | integer |  |
-| `deductions` | numeric |  |
-| `deductions_description` | character |  |
-| `five_stars` | integer |  |
-| `consensus_five_stars` | integer |  |
-| `four_stars` | integer |  |
-| `consensus_four_stars` | integer |  |
-| `three_stars` | integer | Whether three stars data is available. |
-| `consensus_three_stars` | integer |  |
+| `applied_total_rating` | numeric | Sum of counted commits' On3 ratings applied to the class score. |
+| `applied_total_consensus_rating` | numeric | Sum of counted commits' industry-consensus ratings applied to the class score. |
+| `applied_average_rating` | numeric | Average On3 rating across the counted commits. |
+| `applied_average_consensus_rating` | numeric | Average industry-consensus rating across the counted commits. |
+| `commits` | integer | Number of commits in the team's recruiting class. |
+| `applied_commits` | integer | Number of commits counted toward the class score. |
+| `deductions` | numeric | Points deducted from the team's class score (On3 ranking formula). |
+| `deductions_description` | character | Explanation of the deductions applied to the class score. |
+| `five_stars` | integer | Number of five-star commits by On3's own rating. |
+| `consensus_five_stars` | integer | Number of five-star commits by industry-consensus rating. |
+| `four_stars` | integer | Number of four-star commits by On3's own rating. |
+| `consensus_four_stars` | integer | Number of four-star commits by industry-consensus rating. |
+| `three_stars` | integer | Number of three-star commits by On3's own rating. |
+| `consensus_three_stars` | integer | Number of three-star commits by industry-consensus rating. |
 | `overall_rank` | integer | Overall recruit ranking (top recruits only; may be `NA`). |
-| `overall_consensus_rank` | integer |  |
-| `dispay_consensus_score` | numeric |  |
-| `dispay_on3_score` | numeric |  |
-| `average_nil_value` | numeric |  |
-| `conference_rank` | integer |  |
-| `conference_consensus_rank` | integer |  |
+| `overall_consensus_rank` | integer | Team's national class rank by industry-consensus score. |
+| `dispay_consensus_score` | numeric | Display-formatted consensus class score (the 'dispay' spelling is On3's own field name). |
+| `dispay_on3_score` | numeric | Display-formatted On3 class score (the 'dispay' spelling is On3's own field name). |
+| `average_nil_value` | numeric | Average On3 NIL valuation across the class's commits, in dollars. |
+| `conference_rank` | integer | Team's class rank within its conference by On3 score. |
+| `conference_consensus_rank` | integer | Team's class rank within its conference by consensus score. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2811,13 +2811,13 @@ GET /rdb/v1/team-ranking/{sport}-{year}/bluechips-team-rankings
 |---|---|---|
 | `organization` | character | Organization. |
 | `overall_rank` | integer | Overall recruit ranking (top recruits only; may be `NA`). |
-| `conference_rank` | integer |  |
-| `in_state_count` | numeric |  |
-| `average_distance` | numeric |  |
-| `blue_chips` | numeric |  |
-| `social_nil_values` | numeric |  |
+| `conference_rank` | integer | Team's blue-chip class rank within its conference. |
+| `in_state_count` | numeric | Number of commits from the school's home state. |
+| `average_distance` | numeric | Average distance from the commits' hometowns to campus, in miles. |
+| `blue_chips` | numeric | Number of blue-chip (four- or five-star) commits in the class. |
+| `social_nil_values` | numeric | Nested aggregate of the class's social/NIL values (stringified). |
 | `score` | numeric | Final score string. |
-| `total_commits` | integer |  |
+| `total_commits` | integer | Total number of commits in the class. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2847,29 +2847,29 @@ GET /rdb/v1/team-ranking/{sport}-{year}/consensus-team-rankings
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
+| `key` | integer | On3 RDB key for the team's class-ranking row. |
 | `organization` | character | Organization. |
-| `applied_total_rating` | numeric |  |
-| `applied_total_consensus_rating` | numeric |  |
-| `applied_average_rating` | numeric |  |
-| `applied_average_consensus_rating` | numeric |  |
-| `commits` | integer | Number of commits in the position group. |
-| `applied_commits` | integer |  |
-| `deductions` | numeric |  |
-| `deductions_description` | character |  |
-| `five_stars` | integer |  |
-| `consensus_five_stars` | integer |  |
-| `four_stars` | integer |  |
-| `consensus_four_stars` | integer |  |
-| `three_stars` | integer | Whether three stars data is available. |
-| `consensus_three_stars` | integer |  |
+| `applied_total_rating` | numeric | Sum of counted commits' On3 ratings applied to the class score. |
+| `applied_total_consensus_rating` | numeric | Sum of counted commits' industry-consensus ratings applied to the class score. |
+| `applied_average_rating` | numeric | Average On3 rating across the counted commits. |
+| `applied_average_consensus_rating` | numeric | Average industry-consensus rating across the counted commits. |
+| `commits` | integer | Number of commits in the team's recruiting class. |
+| `applied_commits` | integer | Number of commits counted toward the class score. |
+| `deductions` | numeric | Points deducted from the team's class score (On3 ranking formula). |
+| `deductions_description` | character | Explanation of the deductions applied to the class score. |
+| `five_stars` | integer | Number of five-star commits by On3's own rating. |
+| `consensus_five_stars` | integer | Number of five-star commits by industry-consensus rating. |
+| `four_stars` | integer | Number of four-star commits by On3's own rating. |
+| `consensus_four_stars` | integer | Number of four-star commits by industry-consensus rating. |
+| `three_stars` | integer | Number of three-star commits by the On3 consensus rating. |
+| `consensus_three_stars` | integer | Number of three-star commits by industry-consensus rating. |
 | `overall_rank` | integer | Overall recruit ranking (top recruits only; may be `NA`). |
-| `overall_consensus_rank` | integer |  |
-| `dispay_consensus_score` | numeric |  |
-| `dispay_on3_score` | numeric |  |
-| `average_nil_value` | numeric |  |
-| `conference_rank` | integer |  |
-| `conference_consensus_rank` | integer |  |
+| `overall_consensus_rank` | integer | Team's national class rank by industry-consensus score. |
+| `dispay_consensus_score` | numeric | Display-formatted consensus class score (the 'dispay' spelling is On3's own field name). |
+| `dispay_on3_score` | numeric | Display-formatted On3 class score (the 'dispay' spelling is On3's own field name). |
+| `average_nil_value` | numeric | Average On3 NIL valuation across the class's commits, in dollars. |
+| `conference_rank` | integer | Team's class rank within its conference by On3 score. |
+| `conference_consensus_rank` | integer | Team's class rank within its conference by consensus score. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2900,25 +2900,25 @@ GET /rdb/v1/team-ranking/organizations/{orgKey}/summary
 |---|---|---|
 | `conference` | character | Conference of the team. |
 | `year` | integer | Four-digit season year (e.g. 2019). |
-| `total_commits` | integer |  |
-| `class_rating_current` | numeric |  |
-| `class_rating_previous` | numeric |  |
-| `class_rating_change` | character |  |
-| `national_rank_current` | integer |  |
-| `national_rank_previous` | integer |  |
-| `national_rank_change` | character |  |
-| `conference_rank_current` | integer |  |
-| `conference_rank_previous` | integer |  |
-| `conference_rank_change` | character |  |
-| `conference_consensus_rank_current` | integer |  |
-| `conference_consensus_rank_previous` | integer |  |
-| `conference_consensus_rank_change` | character |  |
-| `in_state` | numeric |  |
+| `total_commits` | integer | Total number of commits in the class. |
+| `class_rating_current` | numeric | Team's current On3 class rating. |
+| `class_rating_previous` | numeric | Team's class rating in the previous cycle. |
+| `class_rating_change` | character | Change in the class rating versus the previous cycle. |
+| `national_rank_current` | integer | Team's current national class rank. |
+| `national_rank_previous` | integer | Team's national class rank in the previous cycle. |
+| `national_rank_change` | character | Change in national class rank versus the previous cycle. |
+| `conference_rank_current` | integer | Team's current class rank within its conference. |
+| `conference_rank_previous` | integer | Team's conference class rank in the previous cycle. |
+| `conference_rank_change` | character | Change in conference class rank versus the previous cycle. |
+| `conference_consensus_rank_current` | integer | Team's current conference class rank by consensus score. |
+| `conference_consensus_rank_previous` | integer | Team's conference consensus class rank in the previous cycle. |
+| `conference_consensus_rank_change` | character | Change in conference consensus class rank versus the previous cycle. |
+| `in_state` | numeric | Number of commits from the school's home state. |
 | `avg_distance` | numeric | Average batted-ball distance (feet). |
-| `blue_chips` | numeric |  |
-| `head_coach` | character |  |
-| `director_personnel` | character |  |
-| `average_nil_value` | numeric |  |
+| `blue_chips` | numeric | Number of blue-chip (four- or five-star) commits in the class. |
+| `head_coach` | character | Nested On3 person object for the program's head coach (stringified). |
+| `director_personnel` | character | Nested On3 person object for the program's director of player personnel (stringified). |
+| `average_nil_value` | numeric | Average On3 NIL valuation across the class's commits, in dollars. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3007,33 +3007,33 @@ GET /rdb/v1/transfers/best-available
 | col_name | type | description |
 |---|---|---|
 | `eligibility` | character | Eligibility status. |
-| `last_team` | character |  |
-| `entered_article` | character |  |
-| `committed_article` | character |  |
-| `exited_article` | character |  |
-| `key` | integer |  |
-| `recruitment_key` | integer |  |
+| `last_team` | character | Nested On3 record for the team the player is transferring from (stringified). |
+| `entered_article` | character | On3 article link covering the player entering the transfer portal (stringified). |
+| `committed_article` | character | On3 article link covering the player's transfer commitment (stringified). |
+| `exited_article` | character | On3 article link covering the player exiting the portal (stringified). |
+| `key` | integer | On3 RDB key for the transfer entry. |
+| `recruitment_key` | integer | On3 recruitment key of the player's transfer recruitment. |
 | `name` | character | Position name (e.g. `Quarterback`). |
 | `slug` | character | URL slug for the team. |
 | `high_school_name` | character | Recruit high-school name. |
-| `home_town_name` | character |  |
-| `early_enrollee` | logical |  |
-| `early_signee` | logical |  |
-| `default_asset_url` | character |  |
-| `class_year` | integer |  |
-| `athlete_verified` | logical |  |
-| `prospect_verified` | logical |  |
-| `default_asset` | character |  |
+| `home_town_name` | character | Player's hometown, as listed by On3. |
+| `early_enrollee` | logical | Whether the player is an early enrollee. |
+| `early_signee` | logical | Whether the player signed in the early signing period. |
+| `default_asset_url` | character | URL of the player's headshot image. |
+| `class_year` | integer | Player's original recruiting class year. |
+| `athlete_verified` | logical | Whether the athlete has verified their own On3 profile. |
+| `prospect_verified` | logical | Whether On3 has verified the prospect's profile information. |
+| `default_asset` | character | Nested On3 asset object for the player's headshot (stringified). |
 | `position_abbreviation` | character | Position abbreviation (e.g. `QB`); `position_detail = TRUE` only. |
 | `height` | character | Listed height (inches). |
 | `weight` | numeric | Listed weight (lbs). |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
-| `roster_rating` | character |  |
-| `commit_status` | character |  |
-| `predictions` | character |  |
-| `nil_status` | character |  |
-| `nil_value` | numeric |  |
-| `sport` | character |  |
+| `roster_rating` | character | Nested On3 roster rating object for the player (stringified). |
+| `commit_status` | character | Nested commitment status of the transfer recruitment (stringified). |
+| `predictions` | character | RPM prediction entries for the transfer destination, as a stringified list. |
+| `nil_status` | character | Status of the player's On3 NIL valuation (e.g. active, inactive). |
+| `nil_value` | numeric | Player's On3 NIL valuation in dollars. |
+| `sport` | character | Nested On3 sport object for the transfer entry (stringified). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3068,33 +3068,33 @@ GET /rdb/v1/transfers/latest
 | col_name | type | description |
 |---|---|---|
 | `eligibility` | character | Eligibility status. |
-| `last_team` | character |  |
-| `entered_article` | character |  |
-| `committed_article` | character |  |
-| `exited_article` | character |  |
-| `key` | integer |  |
-| `recruitment_key` | integer |  |
+| `last_team` | character | Nested On3 record for the team the player is transferring from (stringified). |
+| `entered_article` | character | On3 article link covering the player entering the transfer portal (stringified). |
+| `committed_article` | character | On3 article link covering the player's transfer commitment (stringified). |
+| `exited_article` | character | On3 article link covering the player exiting the portal (stringified). |
+| `key` | integer | On3 RDB key for the transfer entry. |
+| `recruitment_key` | integer | On3 recruitment key of the player's transfer recruitment. |
 | `name` | character | Position name (e.g. `Quarterback`). |
 | `slug` | character | URL slug for the team. |
 | `high_school_name` | character | Recruit high-school name. |
-| `home_town_name` | character |  |
-| `early_enrollee` | logical |  |
-| `early_signee` | logical |  |
-| `default_asset_url` | character |  |
-| `class_year` | integer |  |
-| `athlete_verified` | logical |  |
-| `prospect_verified` | logical |  |
-| `default_asset` | character |  |
+| `home_town_name` | character | Player's hometown, as listed by On3. |
+| `early_enrollee` | logical | Whether the player is an early enrollee. |
+| `early_signee` | logical | Whether the player signed in the early signing period. |
+| `default_asset_url` | character | URL of the player's headshot image. |
+| `class_year` | integer | Player's original recruiting class year. |
+| `athlete_verified` | logical | Whether the athlete has verified their own On3 profile. |
+| `prospect_verified` | logical | Whether On3 has verified the prospect's profile information. |
+| `default_asset` | character | Nested On3 asset object for the player's headshot (stringified). |
 | `position_abbreviation` | character | Position abbreviation (e.g. `QB`); `position_detail = TRUE` only. |
 | `height` | character | Listed height (inches). |
 | `weight` | numeric | Listed weight (lbs). |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
-| `roster_rating` | character |  |
-| `commit_status` | character |  |
-| `predictions` | character |  |
-| `nil_status` | character |  |
-| `nil_value` | numeric |  |
-| `sport` | character |  |
+| `roster_rating` | character | Nested On3 roster rating object for the player (stringified). |
+| `commit_status` | character | Nested commitment status of the transfer recruitment (stringified). |
+| `predictions` | character | RPM prediction entries for the transfer destination, as a stringified list. |
+| `nil_status` | character | Status of the player's On3 NIL valuation (e.g. active, inactive). |
+| `nil_value` | numeric | Player's On3 NIL valuation in dollars. |
+| `sport` | character | Nested On3 sport object for the transfer entry (stringified). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3123,15 +3123,15 @@ GET /rdb/v1/videos/{videoKey}
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `key` | integer |  |
-| `person_key` | integer |  |
-| `source_url` | character |  |
+| `key` | integer | On3 RDB key for the video record. |
+| `person_key` | integer | On3 person key of the featured athlete. |
+| `source_url` | character | Source URL of the hosted video. |
 | `title` | character | Specific role title for the assignment. |
-| `thumbnail` | character |  |
+| `thumbnail` | character | URL of the video's thumbnail image. |
 | `category` | character | CFBD stats category name (e.g. passing, rushing, defensive). |
 | `description` | character | ESPN's description of the stat. |
-| `person_sport` | character |  |
-| `is_featured` | logical |  |
+| `person_sport` | character | Nested athlete-sport profile the video is attached to (stringified). |
+| `is_featured` | logical | Whether the video is featured on the player's On3 profile. |
 | `date` | integer | Date of the poll release. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.

--- a/docs/docs/cfb/reference/sports247_site_pages.md
+++ b/docs/docs/cfb/reference/sports247_site_pages.md
@@ -644,7 +644,7 @@ Player detail (identity + primary-sport rating/ranks).
 | `url` | character | RotoWire player page URL. |
 | `last_recruitment_player_institution` | integer | Nested player-institution record from the player's most recent recruitment (stringified). |
 | `current_player_institution` | integer | FK -> PlayerInstitution (current school). |
-| `twitter_contact` | integer | Player's Twitter/X handle on the 247Sports profile. |
+| `twitter_contact` | integer | Nested 247Sports contact record for the player's Twitter/X account (stringified). |
 | `mobile_phone_contact` | character | Player's mobile phone contact field on the 247Sports record. |
 | `primary_player_sport` | integer | FK -> PlayerSport (`/PlayerSport/{id}.json`). |
 | `primary_recruitment` | integer | Nested 247Sports record for the player's primary recruitment (stringified). |
@@ -987,7 +987,7 @@ Player name search.
 | `url` | character | RotoWire player page URL. |
 | `last_recruitment_player_institution` | integer | Nested player-institution record from the player's most recent recruitment (stringified). |
 | `current_player_institution` | integer | FK -> PlayerInstitution (current school). |
-| `twitter_contact` | integer | Player's Twitter/X handle on the 247Sports profile. |
+| `twitter_contact` | integer | Nested 247Sports contact record for the player's Twitter/X account (stringified). |
 | `mobile_phone_contact` | character | Player's mobile phone contact field on the 247Sports record. |
 | `primary_player_sport` | integer | FK -> PlayerSport (`/PlayerSport/{id}.json`). |
 | `primary_recruitment` | integer | Nested 247Sports record for the player's primary recruitment (stringified). |
@@ -1778,7 +1778,7 @@ Recruit class rankings for a season (rich per-recruit rows with inlined Player).
 | `player_url` | character | Full stats.ncaa.org url for the player page. |
 | `player_last_recruitment_player_institution` | integer | Nested player-institution record from the player's most recent recruitment (stringified). |
 | `player_current_player_institution` | integer | FK -> PlayerInstitution (current school). |
-| `player_twitter_contact` | integer | Player's Twitter/X handle on the 247Sports profile. |
+| `player_twitter_contact` | integer | Nested 247Sports contact record for the player's Twitter/X account (stringified). |
 | `player_mobile_phone_contact` | character | Player's mobile phone contact field on the 247Sports record. |
 | `player_primary_player_sport` | integer | FK -> PlayerSport (`/PlayerSport/{id}.json`). |
 | `player_primary_recruitment` | integer | Nested 247Sports record for the player's primary recruitment (stringified). |

--- a/docs/docs/cfb/reference/sports247_site_pages.md
+++ b/docs/docs/cfb/reference/sports247_site_pages.md
@@ -120,7 +120,7 @@ Coach hometown Location.
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `postal_code` | character | Postal code of the venue. |
 | `city` | character | Venue city. |
-| `state` | integer | Venue state. |
+| `state` | integer | U.S. state of the location record, per 247Sports. |
 | `latitude` | character | Venue latitude in decimal degrees. |
 | `longitude` | character | Venue longitude in decimal degrees. |
 | `county_tax_rate` | character | County income-tax rate for the location, carried on the 247Sports location record. |
@@ -163,11 +163,11 @@ Single CoachRanking row.
 | `ranking` | integer | FK -> the Ranking snapshot this row belongs to. |
 | `sport` | integer | Nested 247Sports sport the ranking covers (stringified). |
 | `recruitment` | character | Nested 247Sports recruitment record credited to the coach on this row (stringified). |
-| `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
+| `rating` | character | Overall rating score for the coach's recruiting haul in the 247Sports coach ranking. |
 | `scout_rating` | character | Total 247Sports in-house (scout) rating points credited to the coach's commits. |
 | `composite_rating` | character | Composite class rating for the coach's haul. |
 | `commits` | character | Number of commits credited to the coach in the ranking. |
-| `total` | character | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
+| `total` | character | Total ranking score for the coach's class, as reported by 247Sports. |
 | `composite_total` | character | Total 247Sports Composite rating points credited to the coach's commits. |
 | `five_stars` | character | Number of five-star commits credited to the coach. |
 | `scout_five_stars` | character | Number of five-star commits by 247Sports' own (scout) rating. |
@@ -230,11 +230,11 @@ Coach's recruiting-ranking history (one row per Ranking snapshot).
 | `ranking` | integer | FK -> the Ranking snapshot this row belongs to. |
 | `sport` | integer | Nested 247Sports sport the ranking covers (stringified). |
 | `recruitment` | character | Nested 247Sports recruitment record credited to the coach on this row (stringified). |
-| `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
+| `rating` | character | Overall rating score for the coach's recruiting haul in the 247Sports coach ranking. |
 | `scout_rating` | character | Total 247Sports in-house (scout) rating points credited to the coach's commits. |
 | `composite_rating` | character | Composite class rating for the coach's haul. |
 | `commits` | character | Number of commits credited to the coach in the ranking. |
-| `total` | character | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
+| `total` | character | Total ranking score for the coach's class, as reported by 247Sports. |
 | `composite_total` | character | Total 247Sports Composite rating points credited to the coach's commits. |
 | `five_stars` | character | Number of five-star commits credited to the coach. |
 | `scout_five_stars` | character | Number of five-star commits by 247Sports' own (scout) rating. |
@@ -293,7 +293,7 @@ Recruiting event detail (camp/combine/regional).
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `name` | character | Position name (e.g. `Quarterback`). |
 | `event_group` | integer | Grouping or series the event belongs to (e.g. a camp circuit) on 247Sports. |
-| `event_type` | integer | Event / play type code (V2 PBP). |
+| `event_type` | integer | Numeric code for the kind of 247Sports recruiting event on this row. |
 | `event_date` | character | Event date-time in ISO 8601 (e.g. '2017-07-11T00:00:00Z'). |
 | `default_asset` | integer | Nested 247Sports image asset for the event (stringified). |
 | `primary_color` | character | Primary team color (hex). |
@@ -428,7 +428,7 @@ Institution location (city/state/coords/tax).
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `postal_code` | character | Postal code of the venue. |
 | `city` | character | Venue city. |
-| `state` | integer | Venue state. |
+| `state` | integer | U.S. state of the location record, per 247Sports. |
 | `latitude` | character | Venue latitude in decimal degrees. |
 | `longitude` | character | Venue longitude in decimal degrees. |
 | `county_tax_rate` | character | County income-tax rate for the location, carried on the 247Sports location record. |
@@ -466,7 +466,7 @@ Institution recruiting timeline (site-authored event blurbs).
 | col_name | type | description |
 |---|---|---|
 | `body` | character | Text body of the timeline entry. |
-| `date` | character | Date of the poll release. |
+| `date` | character | Date of the institution timeline entry, per 247Sports. |
 | `author_first_name` | character | First name of the entry's author. |
 | `author_last_name` | character | Last name of the entry's author. |
 | `author_affiliation` | character | Outlet or site the author writes for, per 247Sports. |
@@ -697,7 +697,7 @@ Player's current PlayerInstitution (committed/enrolled school).
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
 | `institution` | integer | Nested 247Sports institution for the stint (stringified). |
-| `state` | integer | Venue state. |
+| `state` | integer | Nested 247Sports state record for the institution's location (stringified). |
 | `agent` | character | Listed player agent. |
 | `end_year` | character | Span ending year. |
 | `end_date` | character | Season end timestamp (ISO 8601, UTC). |
@@ -755,7 +755,7 @@ Player's high-school PlayerInstitution row.
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
 | `institution` | integer | Nested 247Sports institution for the stint (stringified). |
-| `state` | integer | Venue state. |
+| `state` | integer | Nested 247Sports state record for the institution's location (stringified). |
 | `agent` | character | Listed player agent. |
 | `end_year` | character | Span ending year. |
 | `end_date` | character | Season end timestamp (ISO 8601, UTC). |
@@ -813,7 +813,7 @@ Player-at-institution association detail.
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
 | `institution` | integer | Nested 247Sports institution for the stint (stringified). |
-| `state` | integer | Venue state. |
+| `state` | integer | Nested 247Sports state record for the institution's location (stringified). |
 | `agent` | character | Listed player agent. |
 | `end_year` | character | Span ending year. |
 | `end_date` | character | Season end timestamp (ISO 8601, UTC). |
@@ -909,7 +909,7 @@ Player's primary PlayerSport (rating/class/positions).
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
 | `player_institution` | integer | Nested player-institution stint the player-sport profile points to (stringified). |
-| `state` | integer | Venue state. |
+| `state` | integer | Home state of the recruit, per 247Sports. |
 | `sport` | integer | Nested 247Sports sport for the profile (stringified). |
 | `rating` | character | 247Sports rating string (0-1). |
 | `rating_or_default` | character | 247Sports in-house rating, falling back to a default value when unrated. |
@@ -1040,7 +1040,7 @@ PlayerSport detail (note lowercase route segment).
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
 | `player_institution` | integer | Nested player-institution stint the player-sport profile points to (stringified). |
-| `state` | integer | Venue state. |
+| `state` | integer | Home state of the recruit, per 247Sports. |
 | `sport` | integer | Nested 247Sports sport for the profile (stringified). |
 | `rating` | character | 247Sports rating string (0-1). |
 | `rating_or_default` | character | 247Sports in-house rating, falling back to a default value when unrated. |
@@ -1105,7 +1105,7 @@ PlayerInstitution linked to a PlayerSport.
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
 | `institution` | integer | Nested 247Sports institution for the stint (stringified). |
-| `state` | integer | Venue state. |
+| `state` | integer | Nested 247Sports state record for the institution's location (stringified). |
 | `agent` | character | Listed player agent. |
 | `end_year` | character | Span ending year. |
 | `end_date` | character | Season end timestamp (ISO 8601, UTC). |
@@ -1165,15 +1165,15 @@ Ranking history for a PlayerSport (one row per Ranking snapshot).
 | `sport` | integer | Nested 247Sports sport the ranking row covers (stringified). |
 | `player_sport` | integer | Nested player-sport profile the ranking row belongs to (stringified). |
 | `committed_institution` | integer | FK -> committed Institution (null if uncommitted). |
-| `order` | character | Team order within the competition (0 = first). |
+| `order` | character | Display order of the entry within the 247Sports ranking list. |
 | `position` | integer | Athlete position. |
 | `position_group` | integer | Position group of the recruits (e.g. Offensive Line, Defensive Back). |
 | `platoon` | integer | 247Sports platoon (side-of-ball grouping) identifier on the ranking row. |
-| `state` | integer | Venue state. |
-| `region` | integer | Broadcast region code. |
+| `state` | integer | Nested 247Sports state record for the recruit's home state (stringified). |
+| `region` | integer | Nested 247Sports region record for the recruit's home region (stringified). |
 | `institution` | integer | Nested institution the player was committed or signed to at ranking time (stringified). |
 | `institution_group` | character | Grouping (e.g. conference/division) of the player's institution, per 247Sports. |
-| `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
+| `rating` | character | Nested 247Sports rating record attached to the ranking row (stringified). |
 | `composite_strength` | character | 247Sports field describing the strength of the industry inputs behind the Composite rating. |
 | `composite_rating` | character | Player's 247Sports Composite rating, blending the major services' ratings. |
 | `overall_rank` | character | Overall national rank in the snapshot. |
@@ -1221,15 +1221,15 @@ Player-sport rankings for a position.
 | `sport` | integer | Nested 247Sports sport the ranking row covers (stringified). |
 | `player_sport` | integer | Nested player-sport profile the ranking row belongs to (stringified). |
 | `committed_institution` | integer | FK -> committed Institution (null if uncommitted). |
-| `order` | character | Team order within the competition (0 = first). |
+| `order` | character | Display order of the entry within the 247Sports ranking list. |
 | `position` | integer | Athlete position. |
 | `position_group` | integer | Position group of the recruits (e.g. Offensive Line, Defensive Back). |
 | `platoon` | integer | 247Sports platoon (side-of-ball grouping) identifier on the ranking row. |
-| `state` | integer | Venue state. |
-| `region` | integer | Broadcast region code. |
+| `state` | integer | Nested 247Sports state record for the recruit's home state (stringified). |
+| `region` | integer | Nested 247Sports region record for the recruit's home region (stringified). |
 | `institution` | integer | Nested institution the player was committed or signed to at ranking time (stringified). |
 | `institution_group` | character | Grouping (e.g. conference/division) of the player's institution, per 247Sports. |
-| `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
+| `rating` | character | Nested 247Sports rating record attached to the ranking row (stringified). |
 | `composite_strength` | character | 247Sports field describing the strength of the industry inputs behind the Composite rating. |
 | `composite_rating` | character | Player's 247Sports Composite rating, blending the major services' ratings. |
 | `overall_rank` | character | Overall national rank in the snapshot. |
@@ -1331,7 +1331,7 @@ Final-choice PlayerSport/commit for a recruitment.
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
 | `player_institution` | integer | Nested player-institution stint the player-sport profile points to (stringified). |
-| `state` | integer | Venue state. |
+| `state` | integer | Home state of the recruit, per 247Sports. |
 | `sport` | integer | Nested 247Sports sport for the profile (stringified). |
 | `rating` | character | 247Sports rating string (0-1). |
 | `rating_or_default` | character | 247Sports in-house rating, falling back to a default value when unrated. |
@@ -1543,7 +1543,7 @@ PlayerSport underlying a recruitment.
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
 | `player_institution` | integer | Nested player-institution stint the player-sport profile points to (stringified). |
-| `state` | integer | Venue state. |
+| `state` | integer | Home state of the recruit, per 247Sports. |
 | `sport` | integer | Nested 247Sports sport for the profile (stringified). |
 | `rating` | character | 247Sports rating string (0-1). |
 | `rating_or_default` | character | 247Sports in-house rating, falling back to a default value when unrated. |
@@ -1651,7 +1651,7 @@ Recruit-interest timeline events for a season (offers/visits/commits).
 | `recruitment` | integer | Nested 247Sports recruitment the event belongs to (stringified). |
 | `recruit_interest` | integer | Nested recruit-interest record the event belongs to (stringified). |
 | `type` | character | Record-type category (e.g. `total`, `home`, `road`). |
-| `date` | character | Date of the poll release. |
+| `date` | character | Date of the recruiting-interest event, per 247Sports. |
 | `default_name` | character | Server-rendered display label for the entity. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1748,7 +1748,7 @@ Recruit class rankings for a season (rich per-recruit rows with inlined Player).
 | `signed_institution` | integer | Nested institution the recruit signed with (stringified). |
 | `position` | integer | Athlete position. |
 | `institution` | integer | Nested institution the recruit row is scoped to (stringified). |
-| `state` | integer | Venue state. |
+| `state` | integer | Home state of the recruit, per 247Sports. |
 | `player_sport` | integer | Nested player-sport profile for the recruit (stringified). |
 | `composite_strength` | character | Composite strength points contributed to team ranking. |
 | `final_choice` | integer | Whether this entry represents the recruit's final school choice. |
@@ -1831,7 +1831,7 @@ Signed-class roster embed (PlayerSport rows). Accuracy can lag.
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
 | `player_institution` | integer | Nested player-institution stint the player-sport profile points to (stringified). |
-| `state` | integer | Venue state. |
+| `state` | integer | Home state of the recruit, per 247Sports. |
 | `sport` | integer | Nested 247Sports sport for the profile (stringified). |
 | `rating` | character | 247Sports rating string (0-1). |
 | `rating_or_default` | character | 247Sports in-house rating, falling back to a default value when unrated. |

--- a/docs/docs/cfb/reference/sports247_site_pages.md
+++ b/docs/docs/cfb/reference/sports247_site_pages.md
@@ -31,14 +31,14 @@ Coach identity detail.
 | `full_name` | character | Venue full name (e.g. `Tenney Stadium`). |
 | `birthdate` | character | Birthdate |
 | `hometown` | integer | Prospect hometown. |
-| `alma_mater` | integer |  |
-| `cbs_key` | character |  |
-| `twitter_contact` | character |  |
-| `predictions_locked` | character |  |
-| `primary_coach_job` | integer |  |
-| `default_asset` | integer |  |
-| `hero_asset` | character |  |
-| `quote_asset` | character |  |
+| `alma_mater` | integer | School the coach graduated from, per 247Sports. |
+| `cbs_key` | character | CBS Sports identifier for the coach (247Sports is a CBS Sports property). |
+| `twitter_contact` | character | Coach's Twitter/X handle on the 247Sports profile. |
+| `predictions_locked` | character | 247Sports flag that Crystal Ball prediction entries tied to the coach are locked. |
+| `primary_coach_job` | integer | Nested 247Sports record for the coach's current job (stringified). |
+| `default_asset` | integer | Nested 247Sports image asset for the coach's headshot (stringified). |
+| `hero_asset` | character | Nested 247Sports hero (banner) image asset for the coach page (stringified). |
+| `quote_asset` | character | Nested 247Sports image asset used alongside the coach's quote block (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -81,14 +81,14 @@ Coach alma-mater Institution.
 | `abbreviation` | character | Metric abbreviation. |
 | `primary_color` | character | Primary team color (hex). |
 | `secondary_color` | character | Secondary team color (hex). |
-| `is_foreign` | character |  |
+| `is_foreign` | character | Whether the institution is located outside the United States. |
 | `site` | integer | FK -> team Site (network site key). |
-| `default_asset` | integer |  |
-| `alternate_asset` | integer |  |
-| `light_asset` | integer |  |
+| `default_asset` | integer | Nested 247Sports image asset for the institution's primary logo (stringified). |
+| `alternate_asset` | integer | Nested 247Sports image asset for the institution's alternate logo (stringified). |
+| `light_asset` | integer | Nested 247Sports image asset for the light-background logo variant (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `address` | character |  |
-| `telephone` | character |  |
+| `address` | character | Institution's street address. |
+| `telephone` | character | Institution's telephone number. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -123,10 +123,10 @@ Coach hometown Location.
 | `state` | integer | Venue state. |
 | `latitude` | character | Venue latitude in decimal degrees. |
 | `longitude` | character | Venue longitude in decimal degrees. |
-| `county_tax_rate` | character |  |
-| `city_tax_rate` | character |  |
-| `special_tax_rate` | character |  |
-| `region_name` | character |  |
+| `county_tax_rate` | character | County income-tax rate for the location, carried on the 247Sports location record. |
+| `city_tax_rate` | character | City income-tax rate for the location, carried on the 247Sports location record. |
+| `special_tax_rate` | character | Special-district tax rate for the location, carried on the 247Sports location record. |
+| `region_name` | character | Name of the region (state/province) for the location. |
 | `default_name` | character | Server-rendered display label for the entity. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -158,42 +158,42 @@ Single CoachRanking row.
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `coach` | integer | Coach. |
-| `institution` | integer |  |
+| `institution` | integer | Nested 247Sports institution the coach recruited for during the ranking cycle (stringified). |
 | `conference` | integer | Conference of the team. |
 | `ranking` | integer | FK -> the Ranking snapshot this row belongs to. |
-| `sport` | integer |  |
-| `recruitment` | character |  |
+| `sport` | integer | Nested 247Sports sport the ranking covers (stringified). |
+| `recruitment` | character | Nested 247Sports recruitment record credited to the coach on this row (stringified). |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
-| `scout_rating` | character |  |
+| `scout_rating` | character | Total 247Sports in-house (scout) rating points credited to the coach's commits. |
 | `composite_rating` | character | Composite class rating for the coach's haul. |
-| `commits` | character | Number of commits in the position group. |
+| `commits` | character | Number of commits credited to the coach in the ranking. |
 | `total` | character | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
-| `composite_total` | character |  |
-| `five_stars` | character |  |
-| `scout_five_stars` | character |  |
-| `composite_five_stars` | character |  |
-| `four_stars` | character |  |
-| `scout_four_stars` | character |  |
-| `composite_four_stars` | character |  |
-| `three_stars` | character | Whether three stars data is available. |
-| `scout_three_stars` | character |  |
-| `composite_three_stars` | character |  |
-| `two_stars` | character |  |
-| `scout_two_stars` | character |  |
-| `composite_two_stars` | character |  |
-| `average_rating` | character |  |
-| `average_scout_rating` | character |  |
-| `composite_average_rating` | character |  |
+| `composite_total` | character | Total 247Sports Composite rating points credited to the coach's commits. |
+| `five_stars` | character | Number of five-star commits credited to the coach. |
+| `scout_five_stars` | character | Number of five-star commits by 247Sports' own (scout) rating. |
+| `composite_five_stars` | character | Number of five-star commits by the 247Sports Composite rating. |
+| `four_stars` | character | Number of four-star commits credited to the coach. |
+| `scout_four_stars` | character | Number of four-star commits by 247Sports' own (scout) rating. |
+| `composite_four_stars` | character | Number of four-star commits by the 247Sports Composite rating. |
+| `three_stars` | character | Number of three-star commits credited to the coach. |
+| `scout_three_stars` | character | Number of three-star commits by 247Sports' own (scout) rating. |
+| `composite_three_stars` | character | Number of three-star commits by the 247Sports Composite rating. |
+| `two_stars` | character | Number of two-star commits credited to the coach. |
+| `scout_two_stars` | character | Number of two-star commits by 247Sports' own (scout) rating. |
+| `composite_two_stars` | character | Number of two-star commits by the 247Sports Composite rating. |
+| `average_rating` | character | Average rating across the coach's credited commits. |
+| `average_scout_rating` | character | Average 247Sports in-house (scout) rating across the credited commits. |
+| `composite_average_rating` | character | Average 247Sports Composite rating across the credited commits. |
 | `overall_rank` | character | Overall national coach-recruiting rank. |
-| `composite_overall_rank` | character |  |
-| `scout_overall_rank` | character |  |
-| `division_rank` | character |  |
-| `scout_division_rank` | character |  |
-| `composite_division_rank` | character |  |
+| `composite_overall_rank` | character | Coach's national recruiter rank by Composite points. |
+| `scout_overall_rank` | character | Coach's national recruiter rank by 247Sports' own (scout) points. |
+| `division_rank` | character | Coach's recruiter rank within the division. |
+| `scout_division_rank` | character | Coach's division recruiter rank by 247Sports' own (scout) points. |
+| `composite_division_rank` | character | Coach's division recruiter rank by Composite points. |
 | `conference_rank` | character | Rank within conference. |
-| `scout_conference_rank` | character |  |
-| `composite_conference_rank` | character |  |
-| `previous_coach_ranking` | integer |  |
+| `scout_conference_rank` | character | Coach's conference recruiter rank by 247Sports' own (scout) points. |
+| `composite_conference_rank` | character | Coach's conference recruiter rank by Composite points. |
+| `previous_coach_ranking` | integer | Nested prior-cycle recruiter-ranking row for the coach (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -225,42 +225,42 @@ Coach's recruiting-ranking history (one row per Ranking snapshot).
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `coach` | integer | Coach. |
-| `institution` | integer |  |
+| `institution` | integer | Nested 247Sports institution the coach recruited for during the ranking cycle (stringified). |
 | `conference` | integer | Conference of the team. |
 | `ranking` | integer | FK -> the Ranking snapshot this row belongs to. |
-| `sport` | integer |  |
-| `recruitment` | character |  |
+| `sport` | integer | Nested 247Sports sport the ranking covers (stringified). |
+| `recruitment` | character | Nested 247Sports recruitment record credited to the coach on this row (stringified). |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
-| `scout_rating` | character |  |
+| `scout_rating` | character | Total 247Sports in-house (scout) rating points credited to the coach's commits. |
 | `composite_rating` | character | Composite class rating for the coach's haul. |
-| `commits` | character | Number of commits in the position group. |
+| `commits` | character | Number of commits credited to the coach in the ranking. |
 | `total` | character | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
-| `composite_total` | character |  |
-| `five_stars` | character |  |
-| `scout_five_stars` | character |  |
-| `composite_five_stars` | character |  |
-| `four_stars` | character |  |
-| `scout_four_stars` | character |  |
-| `composite_four_stars` | character |  |
-| `three_stars` | character | Whether three stars data is available. |
-| `scout_three_stars` | character |  |
-| `composite_three_stars` | character |  |
-| `two_stars` | character |  |
-| `scout_two_stars` | character |  |
-| `composite_two_stars` | character |  |
-| `average_rating` | character |  |
-| `average_scout_rating` | character |  |
-| `composite_average_rating` | character |  |
+| `composite_total` | character | Total 247Sports Composite rating points credited to the coach's commits. |
+| `five_stars` | character | Number of five-star commits credited to the coach. |
+| `scout_five_stars` | character | Number of five-star commits by 247Sports' own (scout) rating. |
+| `composite_five_stars` | character | Number of five-star commits by the 247Sports Composite rating. |
+| `four_stars` | character | Number of four-star commits credited to the coach. |
+| `scout_four_stars` | character | Number of four-star commits by 247Sports' own (scout) rating. |
+| `composite_four_stars` | character | Number of four-star commits by the 247Sports Composite rating. |
+| `three_stars` | character | Number of three-star commits credited to the coach. |
+| `scout_three_stars` | character | Number of three-star commits by 247Sports' own (scout) rating. |
+| `composite_three_stars` | character | Number of three-star commits by the 247Sports Composite rating. |
+| `two_stars` | character | Number of two-star commits credited to the coach. |
+| `scout_two_stars` | character | Number of two-star commits by 247Sports' own (scout) rating. |
+| `composite_two_stars` | character | Number of two-star commits by the 247Sports Composite rating. |
+| `average_rating` | character | Average rating across the coach's credited commits. |
+| `average_scout_rating` | character | Average 247Sports in-house (scout) rating across the credited commits. |
+| `composite_average_rating` | character | Average 247Sports Composite rating across the credited commits. |
 | `overall_rank` | character | Overall national coach-recruiting rank. |
-| `composite_overall_rank` | character |  |
-| `scout_overall_rank` | character |  |
-| `division_rank` | character |  |
-| `scout_division_rank` | character |  |
-| `composite_division_rank` | character |  |
+| `composite_overall_rank` | character | Coach's national recruiter rank by Composite points. |
+| `scout_overall_rank` | character | Coach's national recruiter rank by 247Sports' own (scout) points. |
+| `division_rank` | character | Coach's recruiter rank within the division. |
+| `scout_division_rank` | character | Coach's division recruiter rank by 247Sports' own (scout) points. |
+| `composite_division_rank` | character | Coach's division recruiter rank by Composite points. |
 | `conference_rank` | character | Rank within conference. |
-| `scout_conference_rank` | character |  |
-| `composite_conference_rank` | character |  |
-| `previous_coach_ranking` | integer |  |
+| `scout_conference_rank` | character | Coach's conference recruiter rank by 247Sports' own (scout) points. |
+| `composite_conference_rank` | character | Coach's conference recruiter rank by Composite points. |
+| `previous_coach_ranking` | integer | Nested prior-cycle recruiter-ranking row for the coach (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -292,10 +292,10 @@ Recruiting event detail (camp/combine/regional).
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `name` | character | Position name (e.g. `Quarterback`). |
-| `event_group` | integer |  |
+| `event_group` | integer | Grouping or series the event belongs to (e.g. a camp circuit) on 247Sports. |
 | `event_type` | integer | Event / play type code (V2 PBP). |
 | `event_date` | character | Event date-time in ISO 8601 (e.g. '2017-07-11T00:00:00Z'). |
-| `default_asset` | integer |  |
+| `default_asset` | integer | Nested 247Sports image asset for the event (stringified). |
 | `primary_color` | character | Primary team color (hex). |
 | `year` | integer | Four-digit season year (e.g. 2019). |
 | `default_name` | character | Server-rendered display label for the entity. |
@@ -340,14 +340,14 @@ Institution (school/team) detail.
 | `abbreviation` | character | Metric abbreviation. |
 | `primary_color` | character | Primary team color (hex). |
 | `secondary_color` | character | Secondary team color (hex). |
-| `is_foreign` | character |  |
+| `is_foreign` | character | Whether the institution is located outside the United States. |
 | `site` | integer | FK -> team Site (network site key). |
-| `default_asset` | integer |  |
-| `alternate_asset` | integer |  |
-| `light_asset` | integer |  |
+| `default_asset` | integer | Nested 247Sports image asset for the institution's primary logo (stringified). |
+| `alternate_asset` | integer | Nested 247Sports image asset for the institution's alternate logo (stringified). |
+| `light_asset` | integer | Nested 247Sports image asset for the light-background logo variant (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `address` | character |  |
-| `telephone` | character |  |
+| `address` | character | Institution's street address. |
+| `telephone` | character | Institution's telephone number. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -389,14 +389,14 @@ Institution directory (paginated list).
 | `abbreviation` | character | Metric abbreviation. |
 | `primary_color` | character | Primary team color (hex). |
 | `secondary_color` | character | Secondary team color (hex). |
-| `is_foreign` | character |  |
+| `is_foreign` | character | Whether the institution is located outside the United States. |
 | `site` | integer | FK -> team Site (network site key). |
-| `default_asset` | integer |  |
-| `alternate_asset` | integer |  |
-| `light_asset` | integer |  |
+| `default_asset` | integer | Nested 247Sports image asset for the institution's primary logo (stringified). |
+| `alternate_asset` | integer | Nested 247Sports image asset for the institution's alternate logo (stringified). |
+| `light_asset` | integer | Nested 247Sports image asset for the light-background logo variant (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `address` | character |  |
-| `telephone` | character |  |
+| `address` | character | Institution's street address. |
+| `telephone` | character | Institution's telephone number. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -431,10 +431,10 @@ Institution location (city/state/coords/tax).
 | `state` | integer | Venue state. |
 | `latitude` | character | Venue latitude in decimal degrees. |
 | `longitude` | character | Venue longitude in decimal degrees. |
-| `county_tax_rate` | character |  |
-| `city_tax_rate` | character |  |
-| `special_tax_rate` | character |  |
-| `region_name` | character |  |
+| `county_tax_rate` | character | County income-tax rate for the location, carried on the 247Sports location record. |
+| `city_tax_rate` | character | City income-tax rate for the location, carried on the 247Sports location record. |
+| `special_tax_rate` | character | Special-district tax rate for the location, carried on the 247Sports location record. |
+| `region_name` | character | Name of the region (state/province) for the location. |
 | `default_name` | character | Server-rendered display label for the entity. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -465,11 +465,11 @@ Institution recruiting timeline (site-authored event blurbs).
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `body` | character |  |
+| `body` | character | Text body of the timeline entry. |
 | `date` | character | Date of the poll release. |
-| `author_first_name` | character |  |
-| `author_last_name` | character |  |
-| `author_affiliation` | character |  |
+| `author_first_name` | character | First name of the entry's author. |
+| `author_last_name` | character | Last name of the entry's author. |
+| `author_affiliation` | character | Outlet or site the author writes for, per 247Sports. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -501,8 +501,8 @@ Pro-draft picks embed for a league/year/round.
 | col_name | type | description |
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
-| `pro_team` | integer |  |
-| `pro_team_name` | character |  |
+| `pro_team` | integer | Nested 247Sports record for the professional team that made the pick (stringified). |
+| `pro_team_name` | character | Name of the professional team that made the pick. |
 | `year` | character | Four-digit season year (e.g. 2019). |
 | `round` | character | Draft round number (1-based) the pick belongs to. |
 | `pick` | character | Pick number within the round. |
@@ -511,10 +511,10 @@ Pro-draft picks embed for a league/year/round.
 | `player_first_name` | character | Player's first name |
 | `player_last_name` | character | Player's last name |
 | `college_team` | integer | College team name. |
-| `college_team_name` | character |  |
+| `college_team_name` | character | Name of the college the player was drafted out of. |
 | `position_abbreviation` | character | Player's position at draft. |
-| `traded_from_team` | character |  |
-| `pick_type` | character |  |
+| `traded_from_team` | character | Team the pick was traded from, when it changed hands. |
+| `pick_type` | character | Type of the selection (e.g. regular, compensatory, supplemental). |
 | `league` | integer | League slug. |
 | `mock` | character | Whether this is a mock-draft projection vs an actual pick. |
 | `default_name` | character | Server-rendered display label for the entity. |
@@ -560,14 +560,14 @@ Institutions belonging to a league.
 | `abbreviation` | character | Metric abbreviation. |
 | `primary_color` | character | Primary team color (hex). |
 | `secondary_color` | character | Secondary team color (hex). |
-| `is_foreign` | character |  |
+| `is_foreign` | character | Whether the institution is located outside the United States. |
 | `site` | integer | FK -> team Site (network site key). |
-| `default_asset` | integer |  |
-| `alternate_asset` | integer |  |
-| `light_asset` | integer |  |
+| `default_asset` | integer | Nested 247Sports image asset for the institution's primary logo (stringified). |
+| `alternate_asset` | integer | Nested 247Sports image asset for the institution's alternate logo (stringified). |
+| `light_asset` | integer | Nested 247Sports image asset for the light-background logo variant (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `address` | character |  |
-| `telephone` | character |  |
+| `address` | character | Institution's street address. |
+| `telephone` | character | Institution's telephone number. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -597,10 +597,10 @@ News/headline feed items for a site Page.
 | col_name | type | description |
 |---|---|---|
 | `uid` | character | ESPN global unique identifier. |
-| `update_date` | character |  |
-| `title_text` | character |  |
-| `main_text` | character |  |
-| `redirection_url` | character |  |
+| `update_date` | character | Date the feed item was published or updated. |
+| `title_text` | character | Headline text of the feed item. |
+| `main_text` | character | Body text of the feed item. |
+| `redirection_url` | character | URL the feed item links out to. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -635,28 +635,28 @@ Player detail (identity + primary-sport rating/ranks).
 | `full_name` | character | Venue full name (e.g. `Tenney Stadium`). |
 | `height` | character | Listed height (inches). |
 | `weight` | numeric | Listed weight (lbs). |
-| `bio` | character |  |
-| `scout_evaluation` | character |  |
+| `bio` | character | Player biography text authored on 247Sports. |
+| `scout_evaluation` | character | 247Sports scouting evaluation text for the player. |
 | `birthdate` | character | Birthdate |
-| `modified_user` | character |  |
-| `modified_date` | character |  |
+| `modified_user` | character | 247Sports user who last modified the player record. |
+| `modified_date` | character | Date the player record was last modified. |
 | `cbs_key` | integer | Cross-reference key into the CBS Sports id space. |
 | `url` | character | RotoWire player page URL. |
-| `last_recruitment_player_institution` | integer |  |
+| `last_recruitment_player_institution` | integer | Nested player-institution record from the player's most recent recruitment (stringified). |
 | `current_player_institution` | integer | FK -> PlayerInstitution (current school). |
-| `twitter_contact` | integer |  |
-| `mobile_phone_contact` | character |  |
+| `twitter_contact` | integer | Player's Twitter/X handle on the 247Sports profile. |
+| `mobile_phone_contact` | character | Player's mobile phone contact field on the 247Sports record. |
 | `primary_player_sport` | integer | FK -> PlayerSport (`/PlayerSport/{id}.json`). |
-| `primary_recruitment` | integer |  |
+| `primary_recruitment` | integer | Nested 247Sports record for the player's primary recruitment (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `default_asset` | integer |  |
-| `default_asset_url` | character |  |
-| `hero_asset` | character |  |
-| `quote_asset` | character |  |
-| `user` | character |  |
-| `pro_stat_player` | integer |  |
-| `college_stat_player` | integer |  |
-| `bio_or_default` | character |  |
+| `default_asset` | integer | Nested 247Sports image asset for the player's headshot (stringified). |
+| `default_asset_url` | character | URL of the player's headshot image. |
+| `hero_asset` | character | Nested 247Sports hero (banner) image asset for the player page (stringified). |
+| `quote_asset` | character | Nested 247Sports image asset used alongside the player's quote block (stringified). |
+| `user` | character | 247Sports user account linked to the player profile (nested, stringified). |
+| `pro_stat_player` | integer | Reference tying the profile to a professional stats player record (247Sports field). |
+| `college_stat_player` | integer | Reference tying the profile to a college stats player record (247Sports field). |
+| `bio_or_default` | character | Player bio text, falling back to a default blurb when none is authored. |
 | `rating` | integer | 247Sports numeric rating (0-1 scale) for the primary sport. |
 | `star_rating` | integer | Star tier (2-5) derived from the rating. |
 | `national_rank` | integer | Overall national rank in the recruit's class. |
@@ -664,8 +664,8 @@ Player detail (identity + primary-sport rating/ranks).
 | `state_rank` | integer | Rank within home state for the class. |
 | `hometown_state` | integer | Recruit hometown state. |
 | `hometown_city` | character | Recruit hometown city. |
-| `player_high_school_name` | character |  |
-| `primary_player_position_abbreviation` | character |  |
+| `player_high_school_name` | character | Name of the player's high school. |
+| `primary_player_position_abbreviation` | character | Abbreviation of the player's primary position. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -696,32 +696,32 @@ Player's current PlayerInstitution (committed/enrolled school).
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
-| `institution` | integer |  |
+| `institution` | integer | Nested 247Sports institution for the stint (stringified). |
 | `state` | integer | Venue state. |
 | `agent` | character | Listed player agent. |
 | `end_year` | character | Span ending year. |
 | `end_date` | character | Season end timestamp (ISO 8601, UTC). |
-| `early_enrollee` | character |  |
-| `early_signee` | character |  |
+| `early_enrollee` | character | Whether the player enrolled early at the institution. |
+| `early_signee` | character | Whether the player signed in the early signing period. |
 | `height` | character | Listed height (inches). |
 | `weight` | character | Listed weight (lbs). |
-| `transfer_institution` | character |  |
-| `transfer_season` | character |  |
-| `transfer_eligibility` | character |  |
-| `created_date` | character |  |
-| `modified_date` | character |  |
-| `lead_expert` | integer |  |
-| `player_institution_evaluation` | integer |  |
-| `primary_player_sport` | integer |  |
-| `default_asset` | integer |  |
-| `hero_asset` | character |  |
-| `primary_recruitment` | integer |  |
+| `transfer_institution` | character | Nested institution involved in the player's transfer, for transfer-portal stints (stringified). |
+| `transfer_season` | character | Season of the player's transfer, when applicable. |
+| `transfer_eligibility` | character | Player's eligibility status for the transfer, per 247Sports. |
+| `created_date` | character | Date the player-institution record was created. |
+| `modified_date` | character | Date the player-institution record was last modified. |
+| `lead_expert` | integer | 247Sports expert assigned as the lead on the recruitment (nested, stringified). |
+| `player_institution_evaluation` | integer | Nested 247Sports evaluation attached to this player-institution stint (stringified). |
+| `primary_player_sport` | integer | Nested 247Sports player-sport profile the stint belongs to (stringified). |
+| `default_asset` | integer | Nested 247Sports image asset for the stint (stringified). |
+| `hero_asset` | character | Nested 247Sports hero (banner) image asset for the stint (stringified). |
+| `primary_recruitment` | integer | Nested 247Sports record for the recruitment behind the stint (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `end_year_or_current` | character |  |
-| `start_year_or_expected` | character |  |
-| `end_year_or_expected` | character |  |
-| `next_institution_type` | character |  |
-| `next_institution_group` | character |  |
+| `end_year_or_current` | character | Stint's end year, or the current year for an active stint. |
+| `start_year_or_expected` | character | Stint's start year, or the expected start year for a future stint. |
+| `end_year_or_expected` | character | Stint's end year, or the expected end year for an active stint. |
+| `next_institution_type` | character | Level of the player's next institution (e.g. college, professional), per 247Sports. |
+| `next_institution_group` | character | Grouping (e.g. conference/division) of the player's next institution, per 247Sports. |
 | `start_year` | character | Span starting year. |
 | `start_date` | character | Season start timestamp (ISO 8601, UTC). |
 
@@ -754,32 +754,32 @@ Player's high-school PlayerInstitution row.
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
-| `institution` | integer |  |
+| `institution` | integer | Nested 247Sports institution for the stint (stringified). |
 | `state` | integer | Venue state. |
 | `agent` | character | Listed player agent. |
 | `end_year` | character | Span ending year. |
 | `end_date` | character | Season end timestamp (ISO 8601, UTC). |
-| `early_enrollee` | character |  |
-| `early_signee` | character |  |
+| `early_enrollee` | character | Whether the player enrolled early at the institution. |
+| `early_signee` | character | Whether the player signed in the early signing period. |
 | `height` | character | Listed height (inches). |
 | `weight` | character | Listed weight (lbs). |
-| `transfer_institution` | character |  |
-| `transfer_season` | character |  |
-| `transfer_eligibility` | character |  |
-| `created_date` | character |  |
-| `modified_date` | character |  |
-| `lead_expert` | integer |  |
-| `player_institution_evaluation` | integer |  |
-| `primary_player_sport` | integer |  |
-| `default_asset` | integer |  |
-| `hero_asset` | character |  |
-| `primary_recruitment` | integer |  |
+| `transfer_institution` | character | Nested institution involved in the player's transfer, for transfer-portal stints (stringified). |
+| `transfer_season` | character | Season of the player's transfer, when applicable. |
+| `transfer_eligibility` | character | Player's eligibility status for the transfer, per 247Sports. |
+| `created_date` | character | Date the player-institution record was created. |
+| `modified_date` | character | Date the player-institution record was last modified. |
+| `lead_expert` | integer | 247Sports expert assigned as the lead on the recruitment (nested, stringified). |
+| `player_institution_evaluation` | integer | Nested 247Sports evaluation attached to this player-institution stint (stringified). |
+| `primary_player_sport` | integer | Nested 247Sports player-sport profile the stint belongs to (stringified). |
+| `default_asset` | integer | Nested 247Sports image asset for the stint (stringified). |
+| `hero_asset` | character | Nested 247Sports hero (banner) image asset for the stint (stringified). |
+| `primary_recruitment` | integer | Nested 247Sports record for the recruitment behind the stint (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `end_year_or_current` | character |  |
-| `start_year_or_expected` | character |  |
-| `end_year_or_expected` | character |  |
-| `next_institution_type` | character |  |
-| `next_institution_group` | character |  |
+| `end_year_or_current` | character | Stint's end year, or the current year for an active stint. |
+| `start_year_or_expected` | character | Stint's start year, or the expected start year for a future stint. |
+| `end_year_or_expected` | character | Stint's end year, or the expected end year for an active stint. |
+| `next_institution_type` | character | Level of the player's next institution (e.g. college, professional), per 247Sports. |
+| `next_institution_group` | character | Grouping (e.g. conference/division) of the player's next institution, per 247Sports. |
 | `start_year` | character | Span starting year. |
 | `start_date` | character | Season start timestamp (ISO 8601, UTC). |
 
@@ -812,32 +812,32 @@ Player-at-institution association detail.
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
-| `institution` | integer |  |
+| `institution` | integer | Nested 247Sports institution for the stint (stringified). |
 | `state` | integer | Venue state. |
 | `agent` | character | Listed player agent. |
 | `end_year` | character | Span ending year. |
 | `end_date` | character | Season end timestamp (ISO 8601, UTC). |
-| `early_enrollee` | character |  |
-| `early_signee` | character |  |
+| `early_enrollee` | character | Whether the player enrolled early at the institution. |
+| `early_signee` | character | Whether the player signed in the early signing period. |
 | `height` | character | Listed height (inches). |
 | `weight` | character | Listed weight (lbs). |
-| `transfer_institution` | character |  |
-| `transfer_season` | character |  |
-| `transfer_eligibility` | character |  |
-| `created_date` | character |  |
-| `modified_date` | character |  |
-| `lead_expert` | integer |  |
-| `player_institution_evaluation` | integer |  |
-| `primary_player_sport` | integer |  |
-| `default_asset` | integer |  |
-| `hero_asset` | character |  |
-| `primary_recruitment` | integer |  |
+| `transfer_institution` | character | Nested institution involved in the player's transfer, for transfer-portal stints (stringified). |
+| `transfer_season` | character | Season of the player's transfer, when applicable. |
+| `transfer_eligibility` | character | Player's eligibility status for the transfer, per 247Sports. |
+| `created_date` | character | Date the player-institution record was created. |
+| `modified_date` | character | Date the player-institution record was last modified. |
+| `lead_expert` | integer | 247Sports expert assigned as the lead on the recruitment (nested, stringified). |
+| `player_institution_evaluation` | integer | Nested 247Sports evaluation attached to this player-institution stint (stringified). |
+| `primary_player_sport` | integer | Nested 247Sports player-sport profile the stint belongs to (stringified). |
+| `default_asset` | integer | Nested 247Sports image asset for the stint (stringified). |
+| `hero_asset` | character | Nested 247Sports hero (banner) image asset for the stint (stringified). |
+| `primary_recruitment` | integer | Nested 247Sports record for the recruitment behind the stint (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `end_year_or_current` | character |  |
-| `start_year_or_expected` | character |  |
-| `end_year_or_expected` | character |  |
-| `next_institution_type` | character |  |
-| `next_institution_group` | character |  |
+| `end_year_or_current` | character | Stint's end year, or the current year for an active stint. |
+| `start_year_or_expected` | character | Stint's start year, or the expected start year for a future stint. |
+| `end_year_or_expected` | character | Stint's end year, or the expected end year for an active stint. |
+| `next_institution_type` | character | Level of the player's next institution (e.g. college, professional), per 247Sports. |
+| `next_institution_group` | character | Grouping (e.g. conference/division) of the player's next institution, per 247Sports. |
 | `start_year` | character | Span starting year. |
 | `start_date` | character | Season start timestamp (ISO 8601, UTC). |
 
@@ -869,13 +869,13 @@ Scout evaluation of a player-institution fit.
 | col_name | type | description |
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
-| `player_institution` | integer |  |
-| `user` | integer |  |
-| `evaluated_date` | character |  |
-| `comparison_player` | integer |  |
-| `projection` | character |  |
-| `primary` | character |  |
-| `scout_evaluation` | character |  |
+| `player_institution` | integer | Nested player-institution stint the evaluation is attached to (stringified). |
+| `user` | integer | 247Sports user account of the evaluator (nested, stringified). |
+| `evaluated_date` | character | Date the evaluation was written. |
+| `comparison_player` | integer | Established player the evaluator compares the prospect to. |
+| `projection` | character | Evaluator's projection for the player (e.g. draft round or college level). |
+| `primary` | character | Whether this is the primary (featured) evaluation for the stint. |
+| `scout_evaluation` | character | Full text of the 247Sports scouting evaluation. |
 | `event` | character | Binary flag indicating the row is a counted game event (excludes end markers). |
 | `default_name` | character | Server-rendered display label for the entity. |
 
@@ -908,40 +908,40 @@ Player's primary PlayerSport (rating/class/positions).
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
-| `player_institution` | integer |  |
+| `player_institution` | integer | Nested player-institution stint the player-sport profile points to (stringified). |
 | `state` | integer | Venue state. |
-| `sport` | integer |  |
+| `sport` | integer | Nested 247Sports sport for the profile (stringified). |
 | `rating` | character | 247Sports rating string (0-1). |
-| `rating_or_default` | character |  |
-| `local_index` | character |  |
+| `rating_or_default` | character | 247Sports in-house rating, falling back to a default value when unrated. |
+| `local_index` | character | 247Sports' own industry-index value for the player, alongside the Rivals and ESPN indexes. |
 | `rivals_grade` | character | Rivals source grade (industry composite input). |
-| `rivals_rank` | character |  |
-| `rivals_index` | character |  |
+| `rivals_rank` | character | Player's rank in the Rivals industry ranking, as tracked by 247Sports. |
+| `rivals_index` | character | Rivals index value for the player, as tracked by 247Sports. |
 | `espn_grade` | character | ESPN source grade (industry composite input). |
-| `espn_rank` | character |  |
-| `espn_index` | character |  |
+| `espn_rank` | character | Player's rank in the ESPN industry ranking, as tracked by 247Sports. |
+| `espn_index` | character | ESPN index value for the player, as tracked by 247Sports. |
 | `composite_strength` | character | Composite strength points (team-ranking weight). |
 | `composite_rating` | character | 247Sports Composite rating (industry blend). |
-| `composite_rating_or_default` | character |  |
-| `average_rank` | character |  |
-| `previous_recruitment` | integer |  |
-| `primary` | character |  |
-| `class_year_override` | character |  |
+| `composite_rating_or_default` | character | 247Sports Composite rating, falling back to a default value when unrated. |
+| `average_rank` | character | Player's average rank across the tracked industry services. |
+| `previous_recruitment` | integer | Nested record for the player's previous recruitment (stringified). |
+| `primary` | character | Whether this is the player's primary sport. |
+| `class_year_override` | character | Override of the player's recruiting class year, when 247Sports reassigns it. |
 | `class_year` | character | Recruiting class year. |
 | `recruitment` | integer | FK -> Recruitment aggregate for this player-sport. |
-| `primary_institution_prediction` | integer |  |
-| `secondary_institution_prediction` | integer |  |
-| `primary_institution_prediction_percentage` | character |  |
-| `show_unranked_rating` | character |  |
-| `current_player_sport_year` | integer |  |
-| `unpublished_player_sport_ranking` | integer |  |
-| `current_player_sport_ranking` | integer |  |
-| `primary_player_position` | integer |  |
-| `primary_position` | integer |  |
-| `primary_position_group` | integer |  |
+| `primary_institution_prediction` | integer | Nested leading Crystal Ball institution prediction for the player (stringified). |
+| `secondary_institution_prediction` | integer | Nested second-place Crystal Ball institution prediction (stringified). |
+| `primary_institution_prediction_percentage` | character | Share of Crystal Ball predictions favoring the leading institution. |
+| `show_unranked_rating` | character | 247Sports display flag to show the rating even while the player is unranked. |
+| `current_player_sport_year` | integer | Current ranking-cycle year for the player-sport profile. |
+| `unpublished_player_sport_ranking` | integer | Nested not-yet-published ranking row for the player (stringified). |
+| `current_player_sport_ranking` | integer | Nested current published ranking row for the player (stringified). |
+| `primary_player_position` | integer | Nested 247Sports record for the player's primary position (stringified). |
+| `primary_position` | integer | Player's primary position on the 247Sports profile. |
+| `primary_position_group` | integer | Position group the player's primary position belongs to. |
 | `default_name` | character | Server-rendered display label for the entity. |
 | `star_rating` | character | Star tier (2-5). |
-| `secondary_institution_prediction_percentage` | character |  |
+| `secondary_institution_prediction_percentage` | character | Share of Crystal Ball predictions favoring the second-place institution. |
 | `jersey` | character | Jersey number. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -978,28 +978,28 @@ Player name search.
 | `full_name` | character | Venue full name (e.g. `Tenney Stadium`). |
 | `height` | character | Listed height (inches). |
 | `weight` | numeric | Listed weight (lbs). |
-| `bio` | character |  |
-| `scout_evaluation` | character |  |
+| `bio` | character | Player biography text authored on 247Sports. |
+| `scout_evaluation` | character | 247Sports scouting evaluation text for the player. |
 | `birthdate` | character | Birthdate |
-| `modified_user` | character |  |
-| `modified_date` | character |  |
+| `modified_user` | character | 247Sports user who last modified the player record. |
+| `modified_date` | character | Date the player record was last modified. |
 | `cbs_key` | integer | Cross-reference key into the CBS Sports id space. |
 | `url` | character | RotoWire player page URL. |
-| `last_recruitment_player_institution` | integer |  |
+| `last_recruitment_player_institution` | integer | Nested player-institution record from the player's most recent recruitment (stringified). |
 | `current_player_institution` | integer | FK -> PlayerInstitution (current school). |
-| `twitter_contact` | integer |  |
-| `mobile_phone_contact` | character |  |
+| `twitter_contact` | integer | Player's Twitter/X handle on the 247Sports profile. |
+| `mobile_phone_contact` | character | Player's mobile phone contact field on the 247Sports record. |
 | `primary_player_sport` | integer | FK -> PlayerSport (`/PlayerSport/{id}.json`). |
-| `primary_recruitment` | integer |  |
+| `primary_recruitment` | integer | Nested 247Sports record for the player's primary recruitment (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `default_asset` | integer |  |
-| `default_asset_url` | character |  |
-| `hero_asset` | character |  |
-| `quote_asset` | character |  |
-| `user` | character |  |
-| `pro_stat_player` | integer |  |
-| `college_stat_player` | integer |  |
-| `bio_or_default` | character |  |
+| `default_asset` | integer | Nested 247Sports image asset for the player's headshot (stringified). |
+| `default_asset_url` | character | URL of the player's headshot image. |
+| `hero_asset` | character | Nested 247Sports hero (banner) image asset for the player page (stringified). |
+| `quote_asset` | character | Nested 247Sports image asset used alongside the player's quote block (stringified). |
+| `user` | character | 247Sports user account linked to the player profile (nested, stringified). |
+| `pro_stat_player` | integer | Reference tying the profile to a professional stats player record (247Sports field). |
+| `college_stat_player` | integer | Reference tying the profile to a college stats player record (247Sports field). |
+| `bio_or_default` | character | Player bio text, falling back to a default blurb when none is authored. |
 | `rating` | integer | 247Sports numeric rating (0-1 scale) for the primary sport. |
 | `star_rating` | integer | Star tier (2-5) derived from the rating. |
 | `national_rank` | integer | Overall national rank in the recruit's class. |
@@ -1007,8 +1007,8 @@ Player name search.
 | `state_rank` | integer | Rank within home state for the class. |
 | `hometown_state` | integer | Recruit hometown state. |
 | `hometown_city` | character | Recruit hometown city. |
-| `player_high_school_name` | character |  |
-| `primary_player_position_abbreviation` | character |  |
+| `player_high_school_name` | character | Name of the player's high school. |
+| `primary_player_position_abbreviation` | character | Abbreviation of the player's primary position. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1039,40 +1039,40 @@ PlayerSport detail (note lowercase route segment).
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
-| `player_institution` | integer |  |
+| `player_institution` | integer | Nested player-institution stint the player-sport profile points to (stringified). |
 | `state` | integer | Venue state. |
-| `sport` | integer |  |
+| `sport` | integer | Nested 247Sports sport for the profile (stringified). |
 | `rating` | character | 247Sports rating string (0-1). |
-| `rating_or_default` | character |  |
-| `local_index` | character |  |
+| `rating_or_default` | character | 247Sports in-house rating, falling back to a default value when unrated. |
+| `local_index` | character | 247Sports' own industry-index value for the player, alongside the Rivals and ESPN indexes. |
 | `rivals_grade` | character | Rivals source grade (industry composite input). |
-| `rivals_rank` | character |  |
-| `rivals_index` | character |  |
+| `rivals_rank` | character | Player's rank in the Rivals industry ranking, as tracked by 247Sports. |
+| `rivals_index` | character | Rivals index value for the player, as tracked by 247Sports. |
 | `espn_grade` | character | ESPN source grade (industry composite input). |
-| `espn_rank` | character |  |
-| `espn_index` | character |  |
+| `espn_rank` | character | Player's rank in the ESPN industry ranking, as tracked by 247Sports. |
+| `espn_index` | character | ESPN index value for the player, as tracked by 247Sports. |
 | `composite_strength` | character | Composite strength points (team-ranking weight). |
 | `composite_rating` | character | 247Sports Composite rating (industry blend). |
-| `composite_rating_or_default` | character |  |
-| `average_rank` | character |  |
-| `previous_recruitment` | integer |  |
-| `primary` | character |  |
-| `class_year_override` | character |  |
+| `composite_rating_or_default` | character | 247Sports Composite rating, falling back to a default value when unrated. |
+| `average_rank` | character | Player's average rank across the tracked industry services. |
+| `previous_recruitment` | integer | Nested record for the player's previous recruitment (stringified). |
+| `primary` | character | Whether this is the player's primary sport. |
+| `class_year_override` | character | Override of the player's recruiting class year, when 247Sports reassigns it. |
 | `class_year` | character | Recruiting class year. |
 | `recruitment` | integer | FK -> Recruitment aggregate for this player-sport. |
-| `primary_institution_prediction` | integer |  |
-| `secondary_institution_prediction` | integer |  |
-| `primary_institution_prediction_percentage` | character |  |
-| `show_unranked_rating` | character |  |
-| `current_player_sport_year` | integer |  |
-| `unpublished_player_sport_ranking` | integer |  |
-| `current_player_sport_ranking` | integer |  |
-| `primary_player_position` | integer |  |
-| `primary_position` | integer |  |
-| `primary_position_group` | integer |  |
+| `primary_institution_prediction` | integer | Nested leading Crystal Ball institution prediction for the player (stringified). |
+| `secondary_institution_prediction` | integer | Nested second-place Crystal Ball institution prediction (stringified). |
+| `primary_institution_prediction_percentage` | character | Share of Crystal Ball predictions favoring the leading institution. |
+| `show_unranked_rating` | character | 247Sports display flag to show the rating even while the player is unranked. |
+| `current_player_sport_year` | integer | Current ranking-cycle year for the player-sport profile. |
+| `unpublished_player_sport_ranking` | integer | Nested not-yet-published ranking row for the player (stringified). |
+| `current_player_sport_ranking` | integer | Nested current published ranking row for the player (stringified). |
+| `primary_player_position` | integer | Nested 247Sports record for the player's primary position (stringified). |
+| `primary_position` | integer | Player's primary position on the 247Sports profile. |
+| `primary_position_group` | integer | Position group the player's primary position belongs to. |
 | `default_name` | character | Server-rendered display label for the entity. |
 | `star_rating` | character | Star tier (2-5). |
-| `secondary_institution_prediction_percentage` | character |  |
+| `secondary_institution_prediction_percentage` | character | Share of Crystal Ball predictions favoring the second-place institution. |
 | `jersey` | character | Jersey number. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1104,32 +1104,32 @@ PlayerInstitution linked to a PlayerSport.
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
-| `institution` | integer |  |
+| `institution` | integer | Nested 247Sports institution for the stint (stringified). |
 | `state` | integer | Venue state. |
 | `agent` | character | Listed player agent. |
 | `end_year` | character | Span ending year. |
 | `end_date` | character | Season end timestamp (ISO 8601, UTC). |
-| `early_enrollee` | character |  |
-| `early_signee` | character |  |
+| `early_enrollee` | character | Whether the player enrolled early at the institution. |
+| `early_signee` | character | Whether the player signed in the early signing period. |
 | `height` | character | Listed height (inches). |
 | `weight` | character | Listed weight (lbs). |
-| `transfer_institution` | character |  |
-| `transfer_season` | character |  |
-| `transfer_eligibility` | character |  |
-| `created_date` | character |  |
-| `modified_date` | character |  |
-| `lead_expert` | integer |  |
-| `player_institution_evaluation` | integer |  |
-| `primary_player_sport` | integer |  |
-| `default_asset` | integer |  |
-| `hero_asset` | character |  |
-| `primary_recruitment` | integer |  |
+| `transfer_institution` | character | Nested institution involved in the player's transfer, for transfer-portal stints (stringified). |
+| `transfer_season` | character | Season of the player's transfer, when applicable. |
+| `transfer_eligibility` | character | Player's eligibility status for the transfer, per 247Sports. |
+| `created_date` | character | Date the player-institution record was created. |
+| `modified_date` | character | Date the player-institution record was last modified. |
+| `lead_expert` | integer | 247Sports expert assigned as the lead on the recruitment (nested, stringified). |
+| `player_institution_evaluation` | integer | Nested 247Sports evaluation attached to this player-institution stint (stringified). |
+| `primary_player_sport` | integer | Nested 247Sports player-sport profile the stint belongs to (stringified). |
+| `default_asset` | integer | Nested 247Sports image asset for the stint (stringified). |
+| `hero_asset` | character | Nested 247Sports hero (banner) image asset for the stint (stringified). |
+| `primary_recruitment` | integer | Nested 247Sports record for the recruitment behind the stint (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `end_year_or_current` | character |  |
-| `start_year_or_expected` | character |  |
-| `end_year_or_expected` | character |  |
-| `next_institution_type` | character |  |
-| `next_institution_group` | character |  |
+| `end_year_or_current` | character | Stint's end year, or the current year for an active stint. |
+| `start_year_or_expected` | character | Stint's start year, or the expected start year for a future stint. |
+| `end_year_or_expected` | character | Stint's end year, or the expected end year for an active stint. |
+| `next_institution_type` | character | Level of the player's next institution (e.g. college, professional), per 247Sports. |
+| `next_institution_group` | character | Grouping (e.g. conference/division) of the player's next institution, per 247Sports. |
 | `start_year` | character | Span starting year. |
 | `start_date` | character | Season start timestamp (ISO 8601, UTC). |
 
@@ -1162,31 +1162,31 @@ Ranking history for a PlayerSport (one row per Ranking snapshot).
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `ranking` | integer | FK -> Ranking snapshot. |
-| `sport` | integer |  |
-| `player_sport` | integer |  |
+| `sport` | integer | Nested 247Sports sport the ranking row covers (stringified). |
+| `player_sport` | integer | Nested player-sport profile the ranking row belongs to (stringified). |
 | `committed_institution` | integer | FK -> committed Institution (null if uncommitted). |
 | `order` | character | Team order within the competition (0 = first). |
 | `position` | integer | Athlete position. |
 | `position_group` | integer | Position group of the recruits (e.g. Offensive Line, Defensive Back). |
-| `platoon` | integer |  |
+| `platoon` | integer | 247Sports platoon (side-of-ball grouping) identifier on the ranking row. |
 | `state` | integer | Venue state. |
 | `region` | integer | Broadcast region code. |
-| `institution` | integer |  |
-| `institution_group` | character |  |
+| `institution` | integer | Nested institution the player was committed or signed to at ranking time (stringified). |
+| `institution_group` | character | Grouping (e.g. conference/division) of the player's institution, per 247Sports. |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
-| `composite_strength` | character |  |
-| `composite_rating` | character |  |
+| `composite_strength` | character | 247Sports field describing the strength of the industry inputs behind the Composite rating. |
+| `composite_rating` | character | Player's 247Sports Composite rating, blending the major services' ratings. |
 | `overall_rank` | character | Overall national rank in the snapshot. |
-| `composite_overall_rank` | character |  |
+| `composite_overall_rank` | character | Player's national rank by 247Sports Composite rating. |
 | `group_rank` | character | League/season rank for group. |
-| `composite_group_rank` | character |  |
+| `composite_group_rank` | character | Player's rank within their position group by Composite rating. |
 | `position_rank` | character | Rank within position. |
-| `previous_player_sport_ranking` | integer |  |
-| `composite_position_rank` | character |  |
+| `previous_player_sport_ranking` | integer | Nested prior-cycle ranking row for the player (stringified). |
+| `composite_position_rank` | character | Player's rank at their position by Composite rating. |
 | `state_rank` | character | Rank within home state. |
-| `composite_state_rank` | character |  |
+| `composite_state_rank` | character | Player's rank within their home state by Composite rating. |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `position_group_rank` | character |  |
+| `position_group_rank` | character | Player's rank within their position group in the 247Sports ranking. |
 | `region_rank` | character | Region ranking. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1218,31 +1218,31 @@ Player-sport rankings for a position.
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `ranking` | integer | FK -> Ranking snapshot. |
-| `sport` | integer |  |
-| `player_sport` | integer |  |
+| `sport` | integer | Nested 247Sports sport the ranking row covers (stringified). |
+| `player_sport` | integer | Nested player-sport profile the ranking row belongs to (stringified). |
 | `committed_institution` | integer | FK -> committed Institution (null if uncommitted). |
 | `order` | character | Team order within the competition (0 = first). |
 | `position` | integer | Athlete position. |
 | `position_group` | integer | Position group of the recruits (e.g. Offensive Line, Defensive Back). |
-| `platoon` | integer |  |
+| `platoon` | integer | 247Sports platoon (side-of-ball grouping) identifier on the ranking row. |
 | `state` | integer | Venue state. |
 | `region` | integer | Broadcast region code. |
-| `institution` | integer |  |
-| `institution_group` | character |  |
+| `institution` | integer | Nested institution the player was committed or signed to at ranking time (stringified). |
+| `institution_group` | character | Grouping (e.g. conference/division) of the player's institution, per 247Sports. |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
-| `composite_strength` | character |  |
-| `composite_rating` | character |  |
+| `composite_strength` | character | 247Sports field describing the strength of the industry inputs behind the Composite rating. |
+| `composite_rating` | character | Player's 247Sports Composite rating, blending the major services' ratings. |
 | `overall_rank` | character | Overall national rank in the snapshot. |
-| `composite_overall_rank` | character |  |
+| `composite_overall_rank` | character | Player's national rank by 247Sports Composite rating. |
 | `group_rank` | character | League/season rank for group. |
-| `composite_group_rank` | character |  |
+| `composite_group_rank` | character | Player's rank within their position group by Composite rating. |
 | `position_rank` | character | Rank within position. |
-| `previous_player_sport_ranking` | integer |  |
-| `composite_position_rank` | character |  |
+| `previous_player_sport_ranking` | integer | Nested prior-cycle ranking row for the player (stringified). |
+| `composite_position_rank` | character | Player's rank at their position by Composite rating. |
 | `state_rank` | character | Rank within home state. |
-| `composite_state_rank` | character |  |
+| `composite_state_rank` | character | Player's rank within their home state by Composite rating. |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `position_group_rank` | character |  |
+| `position_group_rank` | character | Player's rank within their position group in the 247Sports ranking. |
 | `region_rank` | character | Region ranking. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1274,30 +1274,30 @@ Single recruit-interest (school<->recruit link) detail.
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `recruitment` | integer | FK -> parent Recruitment. |
-| `player_sport` | integer |  |
-| `recruit_state` | integer |  |
+| `player_sport` | integer | Nested player-sport profile the interest entry belongs to (stringified). |
+| `recruit_state` | integer | 247Sports status of the recruit's interest entry for the school (e.g. committed, signed, decommitted). |
 | `institution` | integer | FK -> the interested/interesting Institution. |
-| `lock_prediction` | character |  |
-| `recruits_interest` | character |  |
-| `primary_coach` | integer |  |
-| `secondary_coach` | character |  |
-| `keeper_coach` | character |  |
-| `institutions_interest` | character |  |
+| `lock_prediction` | character | Crystal Ball lock-prediction value for the school on this recruitment (247Sports field). |
+| `recruits_interest` | character | Recruit's stated interest level in the school, per 247Sports. |
+| `primary_coach` | integer | Lead recruiting coach at the school for this recruit. |
+| `secondary_coach` | character | Secondary recruiting coach at the school for this recruit. |
+| `keeper_coach` | character | Coach designated as the keeper contact for the recruitment (247Sports field). |
+| `institutions_interest` | character | School's interest level in the recruit, per 247Sports. |
 | `position` | integer | Athlete position. |
 | `position_group` | integer | Position group of the recruits (e.g. Offensive Line, Defensive Back). |
-| `platoon` | integer |  |
+| `platoon` | integer | 247Sports platoon (side-of-ball grouping) identifier on the interest entry. |
 | `offered` | character | Whether the school has extended an offer. |
-| `gray_shirt` | character |  |
-| `walk_on` | character |  |
-| `official_visit` | integer |  |
-| `second_official_visit` | character |  |
-| `soft_commit` | character |  |
+| `gray_shirt` | character | Whether the offer or commitment is a grayshirt (delayed enrollment) arrangement. |
+| `walk_on` | character | Whether the recruit would join the program as a walk-on. |
+| `official_visit` | integer | Date of the recruit's official visit to the school. |
+| `second_official_visit` | character | Date of the recruit's second official visit to the school. |
+| `soft_commit` | character | Whether 247Sports marks the commitment as a soft commit. |
 | `hard_commit` | integer | FK -> the RecruitInterestEvent marking a hard commit. |
-| `signing_date` | integer |  |
-| `enrollment_date` | integer |  |
-| `decommit` | character |  |
-| `offer` | character |  |
-| `highest_recruit_interest_event` | integer |  |
+| `signing_date` | integer | Date the recruit signed with the school. |
+| `enrollment_date` | integer | Date the recruit enrolled at the school. |
+| `decommit` | character | Date the recruit decommitted from the school, when applicable. |
+| `offer` | character | Whether the school has extended a scholarship offer to the recruit. |
+| `highest_recruit_interest_event` | integer | Nested highest-signal event on the interest timeline (e.g. commitment) (stringified). |
 | `commit_status` | character | Commitment status label (e.g. Committed, Signed). |
 | `default_name` | character | Server-rendered display label for the entity. |
 
@@ -1330,40 +1330,40 @@ Final-choice PlayerSport/commit for a recruitment.
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
-| `player_institution` | integer |  |
+| `player_institution` | integer | Nested player-institution stint the player-sport profile points to (stringified). |
 | `state` | integer | Venue state. |
-| `sport` | integer |  |
+| `sport` | integer | Nested 247Sports sport for the profile (stringified). |
 | `rating` | character | 247Sports rating string (0-1). |
-| `rating_or_default` | character |  |
-| `local_index` | character |  |
+| `rating_or_default` | character | 247Sports in-house rating, falling back to a default value when unrated. |
+| `local_index` | character | 247Sports' own industry-index value for the player, alongside the Rivals and ESPN indexes. |
 | `rivals_grade` | character | Rivals source grade (industry composite input). |
-| `rivals_rank` | character |  |
-| `rivals_index` | character |  |
+| `rivals_rank` | character | Player's rank in the Rivals industry ranking, as tracked by 247Sports. |
+| `rivals_index` | character | Rivals index value for the player, as tracked by 247Sports. |
 | `espn_grade` | character | ESPN source grade (industry composite input). |
-| `espn_rank` | character |  |
-| `espn_index` | character |  |
+| `espn_rank` | character | Player's rank in the ESPN industry ranking, as tracked by 247Sports. |
+| `espn_index` | character | ESPN index value for the player, as tracked by 247Sports. |
 | `composite_strength` | character | Composite strength points (team-ranking weight). |
 | `composite_rating` | character | 247Sports Composite rating (industry blend). |
-| `composite_rating_or_default` | character |  |
-| `average_rank` | character |  |
-| `previous_recruitment` | integer |  |
-| `primary` | character |  |
-| `class_year_override` | character |  |
+| `composite_rating_or_default` | character | 247Sports Composite rating, falling back to a default value when unrated. |
+| `average_rank` | character | Player's average rank across the tracked industry services. |
+| `previous_recruitment` | integer | Nested record for the player's previous recruitment (stringified). |
+| `primary` | character | Whether this is the player's primary sport. |
+| `class_year_override` | character | Override of the player's recruiting class year, when 247Sports reassigns it. |
 | `class_year` | character | Recruiting class year. |
 | `recruitment` | integer | FK -> Recruitment aggregate for this player-sport. |
-| `primary_institution_prediction` | integer |  |
-| `secondary_institution_prediction` | integer |  |
-| `primary_institution_prediction_percentage` | character |  |
-| `show_unranked_rating` | character |  |
-| `current_player_sport_year` | integer |  |
-| `unpublished_player_sport_ranking` | integer |  |
-| `current_player_sport_ranking` | integer |  |
-| `primary_player_position` | integer |  |
-| `primary_position` | integer |  |
-| `primary_position_group` | integer |  |
+| `primary_institution_prediction` | integer | Nested leading Crystal Ball institution prediction for the player (stringified). |
+| `secondary_institution_prediction` | integer | Nested second-place Crystal Ball institution prediction (stringified). |
+| `primary_institution_prediction_percentage` | character | Share of Crystal Ball predictions favoring the leading institution. |
+| `show_unranked_rating` | character | 247Sports display flag to show the rating even while the player is unranked. |
+| `current_player_sport_year` | integer | Current ranking-cycle year for the player-sport profile. |
+| `unpublished_player_sport_ranking` | integer | Nested not-yet-published ranking row for the player (stringified). |
+| `current_player_sport_ranking` | integer | Nested current published ranking row for the player (stringified). |
+| `primary_player_position` | integer | Nested 247Sports record for the player's primary position (stringified). |
+| `primary_position` | integer | Player's primary position on the 247Sports profile. |
+| `primary_position_group` | integer | Position group the player's primary position belongs to. |
 | `default_name` | character | Server-rendered display label for the entity. |
 | `star_rating` | character | Star tier (2-5). |
-| `secondary_institution_prediction_percentage` | character |  |
+| `secondary_institution_prediction_percentage` | character | Share of Crystal Ball predictions favoring the second-place institution. |
 | `jersey` | character | Jersey number. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1406,14 +1406,14 @@ Committed institution for a recruitment.
 | `abbreviation` | character | Metric abbreviation. |
 | `primary_color` | character | Primary team color (hex). |
 | `secondary_color` | character | Secondary team color (hex). |
-| `is_foreign` | character |  |
+| `is_foreign` | character | Whether the institution is located outside the United States. |
 | `site` | integer | FK -> team Site (network site key). |
-| `default_asset` | integer |  |
-| `alternate_asset` | integer |  |
-| `light_asset` | integer |  |
+| `default_asset` | integer | Nested 247Sports image asset for the institution's primary logo (stringified). |
+| `alternate_asset` | integer | Nested 247Sports image asset for the institution's alternate logo (stringified). |
+| `light_asset` | integer | Nested 247Sports image asset for the light-background logo variant (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `address` | character |  |
-| `telephone` | character |  |
+| `address` | character | Institution's street address. |
+| `telephone` | character | Institution's telephone number. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1455,14 +1455,14 @@ All institutions the recruit has interest links with.
 | `abbreviation` | character | Metric abbreviation. |
 | `primary_color` | character | Primary team color (hex). |
 | `secondary_color` | character | Secondary team color (hex). |
-| `is_foreign` | character |  |
+| `is_foreign` | character | Whether the institution is located outside the United States. |
 | `site` | integer | FK -> team Site (network site key). |
-| `default_asset` | integer |  |
-| `alternate_asset` | integer |  |
-| `light_asset` | integer |  |
+| `default_asset` | integer | Nested 247Sports image asset for the institution's primary logo (stringified). |
+| `alternate_asset` | integer | Nested 247Sports image asset for the institution's alternate logo (stringified). |
+| `light_asset` | integer | Nested 247Sports image asset for the light-background logo variant (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `address` | character |  |
-| `telephone` | character |  |
+| `address` | character | Institution's street address. |
+| `telephone` | character | Institution's telephone number. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1504,14 +1504,14 @@ Institutions that have offered the recruit.
 | `abbreviation` | character | Metric abbreviation. |
 | `primary_color` | character | Primary team color (hex). |
 | `secondary_color` | character | Secondary team color (hex). |
-| `is_foreign` | character |  |
+| `is_foreign` | character | Whether the institution is located outside the United States. |
 | `site` | integer | FK -> team Site (network site key). |
-| `default_asset` | integer |  |
-| `alternate_asset` | integer |  |
-| `light_asset` | integer |  |
+| `default_asset` | integer | Nested 247Sports image asset for the institution's primary logo (stringified). |
+| `alternate_asset` | integer | Nested 247Sports image asset for the institution's alternate logo (stringified). |
+| `light_asset` | integer | Nested 247Sports image asset for the light-background logo variant (stringified). |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `address` | character |  |
-| `telephone` | character |  |
+| `address` | character | Institution's street address. |
+| `telephone` | character | Institution's telephone number. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1542,40 +1542,40 @@ PlayerSport underlying a recruitment.
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
-| `player_institution` | integer |  |
+| `player_institution` | integer | Nested player-institution stint the player-sport profile points to (stringified). |
 | `state` | integer | Venue state. |
-| `sport` | integer |  |
+| `sport` | integer | Nested 247Sports sport for the profile (stringified). |
 | `rating` | character | 247Sports rating string (0-1). |
-| `rating_or_default` | character |  |
-| `local_index` | character |  |
+| `rating_or_default` | character | 247Sports in-house rating, falling back to a default value when unrated. |
+| `local_index` | character | 247Sports' own industry-index value for the player, alongside the Rivals and ESPN indexes. |
 | `rivals_grade` | character | Rivals source grade (industry composite input). |
-| `rivals_rank` | character |  |
-| `rivals_index` | character |  |
+| `rivals_rank` | character | Player's rank in the Rivals industry ranking, as tracked by 247Sports. |
+| `rivals_index` | character | Rivals index value for the player, as tracked by 247Sports. |
 | `espn_grade` | character | ESPN source grade (industry composite input). |
-| `espn_rank` | character |  |
-| `espn_index` | character |  |
+| `espn_rank` | character | Player's rank in the ESPN industry ranking, as tracked by 247Sports. |
+| `espn_index` | character | ESPN index value for the player, as tracked by 247Sports. |
 | `composite_strength` | character | Composite strength points (team-ranking weight). |
 | `composite_rating` | character | 247Sports Composite rating (industry blend). |
-| `composite_rating_or_default` | character |  |
-| `average_rank` | character |  |
-| `previous_recruitment` | integer |  |
-| `primary` | character |  |
-| `class_year_override` | character |  |
+| `composite_rating_or_default` | character | 247Sports Composite rating, falling back to a default value when unrated. |
+| `average_rank` | character | Player's average rank across the tracked industry services. |
+| `previous_recruitment` | integer | Nested record for the player's previous recruitment (stringified). |
+| `primary` | character | Whether this is the player's primary sport. |
+| `class_year_override` | character | Override of the player's recruiting class year, when 247Sports reassigns it. |
 | `class_year` | character | Recruiting class year. |
 | `recruitment` | integer | FK -> Recruitment aggregate for this player-sport. |
-| `primary_institution_prediction` | integer |  |
-| `secondary_institution_prediction` | integer |  |
-| `primary_institution_prediction_percentage` | character |  |
-| `show_unranked_rating` | character |  |
-| `current_player_sport_year` | integer |  |
-| `unpublished_player_sport_ranking` | integer |  |
-| `current_player_sport_ranking` | integer |  |
-| `primary_player_position` | integer |  |
-| `primary_position` | integer |  |
-| `primary_position_group` | integer |  |
+| `primary_institution_prediction` | integer | Nested leading Crystal Ball institution prediction for the player (stringified). |
+| `secondary_institution_prediction` | integer | Nested second-place Crystal Ball institution prediction (stringified). |
+| `primary_institution_prediction_percentage` | character | Share of Crystal Ball predictions favoring the leading institution. |
+| `show_unranked_rating` | character | 247Sports display flag to show the rating even while the player is unranked. |
+| `current_player_sport_year` | integer | Current ranking-cycle year for the player-sport profile. |
+| `unpublished_player_sport_ranking` | integer | Nested not-yet-published ranking row for the player (stringified). |
+| `current_player_sport_ranking` | integer | Nested current published ranking row for the player (stringified). |
+| `primary_player_position` | integer | Nested 247Sports record for the player's primary position (stringified). |
+| `primary_position` | integer | Player's primary position on the 247Sports profile. |
+| `primary_position_group` | integer | Position group the player's primary position belongs to. |
 | `default_name` | character | Server-rendered display label for the entity. |
 | `star_rating` | character | Star tier (2-5). |
-| `secondary_institution_prediction_percentage` | character |  |
+| `secondary_institution_prediction_percentage` | character | Share of Crystal Ball predictions favoring the second-place institution. |
 | `jersey` | character | Jersey number. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1606,17 +1606,17 @@ Current expert 'crystal ball' predictions for a season.
 | col_name | type | description |
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
-| `player_institution` | integer |  |
+| `player_institution` | integer | Nested player-institution stint the Crystal Ball prediction targets (stringified). |
 | `institution` | integer | FK -> predicted destination Institution. |
-| `user` | integer |  |
-| `updated_on` | character |  |
+| `user` | integer | 247Sports user account of the predictor (nested, stringified). |
+| `updated_on` | character | Date the prediction was last updated. |
 | `prediction_status` | character | Crystal-ball prediction status code. |
-| `days_correct` | character |  |
+| `days_correct` | character | Number of days the prediction has stood as correct. |
 | `premium` | character | Whether the article is premium content. |
 | `score` | character | Expert accuracy score at time of prediction. |
 | `confidence` | character | Expert confidence 1-10. |
-| `parent` | character |  |
-| `is_zero_zone` | character |  |
+| `parent` | character | Parent prediction record this entry updates (247Sports field). |
+| `is_zero_zone` | character | Whether the prediction fell in 247Sports' zero zone (logged too close to the announcement to earn accuracy credit). |
 | `default_name` | character | Server-rendered display label for the entity. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1647,9 +1647,9 @@ Recruit-interest timeline events for a season (offers/visits/commits).
 | col_name | type | description |
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
-| `institution` | integer |  |
-| `recruitment` | integer |  |
-| `recruit_interest` | integer |  |
+| `institution` | integer | Nested 247Sports institution the interest event involves (stringified). |
+| `recruitment` | integer | Nested 247Sports recruitment the event belongs to (stringified). |
+| `recruit_interest` | integer | Nested recruit-interest record the event belongs to (stringified). |
 | `type` | character | Record-type category (e.g. `total`, `home`, `road`). |
 | `date` | character | Date of the poll release. |
 | `default_name` | character | Server-rendered display label for the entity. |
@@ -1683,30 +1683,30 @@ All recruit interests for a season (paginated).
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `recruitment` | integer | FK -> parent Recruitment. |
-| `player_sport` | integer |  |
-| `recruit_state` | integer |  |
+| `player_sport` | integer | Nested player-sport profile the interest entry belongs to (stringified). |
+| `recruit_state` | integer | 247Sports status of the recruit's interest entry for the school (e.g. committed, signed, decommitted). |
 | `institution` | integer | FK -> the interested/interesting Institution. |
-| `lock_prediction` | character |  |
-| `recruits_interest` | character |  |
-| `primary_coach` | integer |  |
-| `secondary_coach` | character |  |
-| `keeper_coach` | character |  |
-| `institutions_interest` | character |  |
+| `lock_prediction` | character | Crystal Ball lock-prediction value for the school on this recruitment (247Sports field). |
+| `recruits_interest` | character | Recruit's stated interest level in the school, per 247Sports. |
+| `primary_coach` | integer | Lead recruiting coach at the school for this recruit. |
+| `secondary_coach` | character | Secondary recruiting coach at the school for this recruit. |
+| `keeper_coach` | character | Coach designated as the keeper contact for the recruitment (247Sports field). |
+| `institutions_interest` | character | School's interest level in the recruit, per 247Sports. |
 | `position` | integer | Athlete position. |
 | `position_group` | integer | Position group of the recruits (e.g. Offensive Line, Defensive Back). |
-| `platoon` | integer |  |
+| `platoon` | integer | 247Sports platoon (side-of-ball grouping) identifier on the interest entry. |
 | `offered` | character | Whether the school has extended an offer. |
-| `gray_shirt` | character |  |
-| `walk_on` | character |  |
-| `official_visit` | integer |  |
-| `second_official_visit` | character |  |
-| `soft_commit` | character |  |
+| `gray_shirt` | character | Whether the offer or commitment is a grayshirt (delayed enrollment) arrangement. |
+| `walk_on` | character | Whether the recruit would join the program as a walk-on. |
+| `official_visit` | integer | Date of the recruit's official visit to the school. |
+| `second_official_visit` | character | Date of the recruit's second official visit to the school. |
+| `soft_commit` | character | Whether 247Sports marks the commitment as a soft commit. |
 | `hard_commit` | integer | FK -> the RecruitInterestEvent marking a hard commit. |
-| `signing_date` | integer |  |
-| `enrollment_date` | integer |  |
-| `decommit` | character |  |
-| `offer` | character |  |
-| `highest_recruit_interest_event` | integer |  |
+| `signing_date` | integer | Date the recruit signed with the school. |
+| `enrollment_date` | integer | Date the recruit enrolled at the school. |
+| `decommit` | character | Date the recruit decommitted from the school, when applicable. |
+| `offer` | character | Whether the school has extended a scholarship offer to the recruit. |
+| `highest_recruit_interest_event` | integer | Nested highest-signal event on the interest timeline (e.g. commitment) (stringified). |
 | `commit_status` | character | Commitment status label (e.g. Committed, Signed). |
 | `default_name` | character | Server-rendered display label for the entity. |
 
@@ -1742,25 +1742,25 @@ Recruit class rankings for a season (rich per-recruit rows with inlined Player).
 | col_name | type | description |
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
-| `player_institution` | integer |  |
+| `player_institution` | integer | Nested player-institution stint behind the recruit row (stringified). |
 | `year` | integer | Four-digit season year (e.g. 2019). |
-| `announcement_date` | character |  |
-| `signed_institution` | integer |  |
+| `announcement_date` | character | Date the recruit announced their decision. |
+| `signed_institution` | integer | Nested institution the recruit signed with (stringified). |
 | `position` | integer | Athlete position. |
-| `institution` | integer |  |
+| `institution` | integer | Nested institution the recruit row is scoped to (stringified). |
 | `state` | integer | Venue state. |
-| `player_sport` | integer |  |
+| `player_sport` | integer | Nested player-sport profile for the recruit (stringified). |
 | `composite_strength` | character | Composite strength points contributed to team ranking. |
-| `final_choice` | integer |  |
-| `highest_recruit_interest_event_type` | character |  |
-| `highest_recruit_interest_event` | integer |  |
-| `committed_recruit_interest` | integer |  |
+| `final_choice` | integer | Whether this entry represents the recruit's final school choice. |
+| `highest_recruit_interest_event_type` | character | Type of the highest-signal event on the recruit's interest timeline (e.g. commit, signing). |
+| `highest_recruit_interest_event` | integer | Nested highest-signal event on the recruit's interest timeline (stringified). |
+| `committed_recruit_interest` | integer | Nested interest record for the school the recruit committed to (stringified). |
 | `committed_institution` | integer | FK -> committed Institution. |
-| `highest_recruit_interest` | integer |  |
-| `primary_player_position` | integer |  |
-| `primary_position` | integer |  |
+| `highest_recruit_interest` | integer | Nested interest record carrying the recruit's highest interest signal (stringified). |
+| `primary_player_position` | integer | Nested 247Sports record for the recruit's primary position (stringified). |
+| `primary_position` | integer | Recruit's primary position on the 247Sports profile. |
 | `default_name` | character | Server-rendered display label for the entity. |
-| `commited_institution_team_image` | character |  |
+| `commited_institution_team_image` | character | Team image asset for the committed institution (the 'commited' spelling is 247Sports' own field name). |
 | `recruit_interest_count` | integer | Number of tracked school interests. |
 | `recruit_interests_url` | character | Site URL to the recruit's interest timeline. |
 | `player_key` | integer | Primary key of this entity (the id used in its `.json` route). |
@@ -1769,37 +1769,37 @@ Recruit class rankings for a season (rich per-recruit rows with inlined Player).
 | `player_full_name` | character | Player full name. |
 | `player_height` | character | Participant height (e.g. "6' 5\""). |
 | `player_weight` | numeric | Participant weight in pounds. |
-| `player_bio` | character |  |
-| `player_scout_evaluation` | character |  |
-| `player_birthdate` | character |  |
-| `player_modified_user` | character |  |
-| `player_modified_date` | character |  |
+| `player_bio` | character | Player biography text authored on 247Sports. |
+| `player_scout_evaluation` | character | 247Sports scouting evaluation text for the player. |
+| `player_birthdate` | character | Player's date of birth, per 247Sports. |
+| `player_modified_user` | character | 247Sports user who last modified the player record. |
+| `player_modified_date` | character | Date the player record was last modified. |
 | `player_cbs_key` | integer | Cross-reference key into the CBS Sports id space. |
 | `player_url` | character | Full stats.ncaa.org url for the player page. |
-| `player_last_recruitment_player_institution` | integer |  |
+| `player_last_recruitment_player_institution` | integer | Nested player-institution record from the player's most recent recruitment (stringified). |
 | `player_current_player_institution` | integer | FK -> PlayerInstitution (current school). |
-| `player_twitter_contact` | integer |  |
-| `player_mobile_phone_contact` | character |  |
+| `player_twitter_contact` | integer | Player's Twitter/X handle on the 247Sports profile. |
+| `player_mobile_phone_contact` | character | Player's mobile phone contact field on the 247Sports record. |
 | `player_primary_player_sport` | integer | FK -> PlayerSport (`/PlayerSport/{id}.json`). |
-| `player_primary_recruitment` | integer |  |
+| `player_primary_recruitment` | integer | Nested 247Sports record for the player's primary recruitment (stringified). |
 | `player_default_name` | character | Server-rendered display label for the entity. |
-| `player_default_asset` | integer |  |
-| `player_default_asset_url` | character |  |
-| `player_hero_asset` | character |  |
-| `player_quote_asset` | character |  |
-| `player_user` | character |  |
-| `player_pro_stat_player` | integer |  |
-| `player_college_stat_player` | integer |  |
-| `player_bio_or_default` | character |  |
+| `player_default_asset` | integer | Nested 247Sports image asset for the player's headshot (stringified). |
+| `player_default_asset_url` | character | URL of the player's headshot image. |
+| `player_hero_asset` | character | Nested 247Sports hero (banner) image asset for the player page (stringified). |
+| `player_quote_asset` | character | Nested 247Sports image asset used alongside the player's quote block (stringified). |
+| `player_user` | character | 247Sports user account linked to the player profile (nested, stringified). |
+| `player_pro_stat_player` | integer | Reference tying the profile to a professional stats player record (247Sports field). |
+| `player_college_stat_player` | integer | Reference tying the profile to a college stats player record (247Sports field). |
+| `player_bio_or_default` | character | Player bio text, falling back to a default blurb when none is authored. |
 | `player_rating` | integer | 247Sports numeric rating (0-1 scale) for the primary sport. |
 | `player_star_rating` | integer | Star tier (2-5) derived from the rating. |
 | `player_national_rank` | integer | Overall national rank in the recruit's class. |
 | `player_position_rank` | integer | Rank within position for the class. |
 | `player_state_rank` | integer | Rank within home state for the class. |
-| `player_hometown_state` | integer |  |
-| `player_hometown_city` | character |  |
-| `player_player_high_school_name` | character |  |
-| `player_primary_player_position_abbreviation` | character |  |
+| `player_hometown_state` | integer | State of the player's hometown. |
+| `player_hometown_city` | character | City of the player's hometown. |
+| `player_player_high_school_name` | character | Name of the player's high school. |
+| `player_primary_player_position_abbreviation` | character | Abbreviation of the player's primary position. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1830,40 +1830,40 @@ Signed-class roster embed (PlayerSport rows). Accuracy can lag.
 |---|---|---|
 | `key` | integer | Primary key of this entity (the id used in its `.json` route). |
 | `player` | integer | Player name. |
-| `player_institution` | integer |  |
+| `player_institution` | integer | Nested player-institution stint the player-sport profile points to (stringified). |
 | `state` | integer | Venue state. |
-| `sport` | integer |  |
+| `sport` | integer | Nested 247Sports sport for the profile (stringified). |
 | `rating` | character | 247Sports rating string (0-1). |
-| `rating_or_default` | character |  |
-| `local_index` | character |  |
+| `rating_or_default` | character | 247Sports in-house rating, falling back to a default value when unrated. |
+| `local_index` | character | 247Sports' own industry-index value for the player, alongside the Rivals and ESPN indexes. |
 | `rivals_grade` | character | Rivals source grade (industry composite input). |
-| `rivals_rank` | character |  |
-| `rivals_index` | character |  |
+| `rivals_rank` | character | Player's rank in the Rivals industry ranking, as tracked by 247Sports. |
+| `rivals_index` | character | Rivals index value for the player, as tracked by 247Sports. |
 | `espn_grade` | character | ESPN source grade (industry composite input). |
-| `espn_rank` | character |  |
-| `espn_index` | character |  |
+| `espn_rank` | character | Player's rank in the ESPN industry ranking, as tracked by 247Sports. |
+| `espn_index` | character | ESPN index value for the player, as tracked by 247Sports. |
 | `composite_strength` | character | Composite strength points (team-ranking weight). |
 | `composite_rating` | character | 247Sports Composite rating (industry blend). |
-| `composite_rating_or_default` | character |  |
-| `average_rank` | character |  |
-| `previous_recruitment` | integer |  |
-| `primary` | character |  |
-| `class_year_override` | character |  |
+| `composite_rating_or_default` | character | 247Sports Composite rating, falling back to a default value when unrated. |
+| `average_rank` | character | Player's average rank across the tracked industry services. |
+| `previous_recruitment` | integer | Nested record for the player's previous recruitment (stringified). |
+| `primary` | character | Whether this is the player's primary sport. |
+| `class_year_override` | character | Override of the player's recruiting class year, when 247Sports reassigns it. |
 | `class_year` | character | Recruiting class year. |
 | `recruitment` | integer | FK -> Recruitment aggregate for this player-sport. |
-| `primary_institution_prediction` | integer |  |
-| `secondary_institution_prediction` | integer |  |
-| `primary_institution_prediction_percentage` | character |  |
-| `show_unranked_rating` | character |  |
-| `current_player_sport_year` | integer |  |
-| `unpublished_player_sport_ranking` | integer |  |
-| `current_player_sport_ranking` | integer |  |
-| `primary_player_position` | integer |  |
-| `primary_position` | integer |  |
-| `primary_position_group` | integer |  |
+| `primary_institution_prediction` | integer | Nested leading Crystal Ball institution prediction for the player (stringified). |
+| `secondary_institution_prediction` | integer | Nested second-place Crystal Ball institution prediction (stringified). |
+| `primary_institution_prediction_percentage` | character | Share of Crystal Ball predictions favoring the leading institution. |
+| `show_unranked_rating` | character | 247Sports display flag to show the rating even while the player is unranked. |
+| `current_player_sport_year` | integer | Current ranking-cycle year for the player-sport profile. |
+| `unpublished_player_sport_ranking` | integer | Nested not-yet-published ranking row for the player (stringified). |
+| `current_player_sport_ranking` | integer | Nested current published ranking row for the player (stringified). |
+| `primary_player_position` | integer | Nested 247Sports record for the player's primary position (stringified). |
+| `primary_position` | integer | Player's primary position on the 247Sports profile. |
+| `primary_position_group` | integer | Position group the player's primary position belongs to. |
 | `default_name` | character | Server-rendered display label for the entity. |
 | `star_rating` | character | Star tier (2-5). |
-| `secondary_institution_prediction_percentage` | character |  |
+| `secondary_institution_prediction_percentage` | character | Share of Crystal Ball predictions favoring the second-place institution. |
 | `jersey` | character | Jersey number. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.

--- a/docs/docs/mbb/reference/loaders.md
+++ b/docs/docs/mbb/reference/loaders.md
@@ -69,8 +69,8 @@ Release: [espn_mens_college_basketball_pbp](https://github.com/sportsdataverse/s
 | `shooting_play` | Boolean | TRUE if the play was a shooting attempt. |
 | `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
 | `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
-| `points_attempted` | Int32 |  |
-| `short_description` | String |  |
+| `points_attempted` | Int32 | Point value at stake on the shot attempt (3 for threes, 2 for other field goals, 1 for free throws), from the ESPN play type. |
+| `short_description` | String | Shortened version of ESPN's play description text, without score context. |
 | `team_id` | Int32 | Unique team identifier. |
 | `athlete_id_1` | Int32 | Primary athlete identifier (e.g. shooter). |
 | `athlete_id_2` | Int32 | Secondary athlete identifier (e.g. assister / fouler). |
@@ -109,9 +109,9 @@ Release: [espn_mens_college_basketball_pbp](https://github.com/sportsdataverse/s
 | `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
 | `game_date` | Date | Game date (YYYY-MM-DD). |
 | `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
-| `athlete_name_1` | String |  |
-| `athlete_name_2` | String |  |
-| `athlete_name_3` | String |  |
+| `athlete_name_1` | String | Display name of the first athlete in the ESPN play participants (e.g., the shooter on a shot attempt). |
+| `athlete_name_2` | String | Display name of the second athlete in the ESPN play participants (e.g., the assisting player), when present. |
+| `athlete_name_3` | String | Display name of the third athlete in the ESPN play participants, when present. |
 
 ```python
 load_mbb_pbp(seasons=2024)
@@ -240,9 +240,9 @@ Release: [espn_mens_college_basketball_schedules](https://github.com/sportsdatav
 | `home_conference_id` | Int32 | Unique identifier for home conference. |
 | `home_score` | Int32 | Home team score at the time of the play. |
 | `home_winner` | Boolean | Home team's winner. |
-| `home_current_rank` | Float64 |  |
-| `home_linescores` | String |  |
-| `home_records` | String |  |
+| `home_current_rank` | Float64 | Poll ranking ESPN listed for the home team at game time (unranked teams carry a sentinel value). |
+| `home_linescores` | String | Period-by-period scores for the home team as a delimited string from ESPN's schedule feed. |
+| `home_records` | String | Record strings (overall and split records) for the home team from ESPN's schedule feed. |
 | `away_id` | Int32 | Unique identifier for away. |
 | `away_uid` | String | Away team's uid. |
 | `away_location` | String | Away team's location. |
@@ -258,9 +258,9 @@ Release: [espn_mens_college_basketball_schedules](https://github.com/sportsdatav
 | `away_conference_id` | Int32 | Unique identifier for away conference. |
 | `away_score` | Int32 | Away team score at the time of the play. |
 | `away_winner` | Boolean | Away team's winner. |
-| `away_current_rank` | Float64 |  |
-| `away_linescores` | String |  |
-| `away_records` | String |  |
+| `away_current_rank` | Float64 | Poll ranking ESPN listed for the away team at game time (unranked teams carry a sentinel value). |
+| `away_linescores` | String | Period-by-period scores for the away team as a delimited string from ESPN's schedule feed. |
+| `away_records` | String | Record strings (overall and split records) for the away team from ESPN's schedule feed. |
 | `game_id` | Int32 | Unique game identifier. |
 | `season` | Int32 | Season year. |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
@@ -347,7 +347,7 @@ Release: [espn_mens_college_basketball_team_boxscores](https://github.com/sports
 | `opponent_team_logo` | String | Opponent team logo URL. |
 | `opponent_team_score` | Int32 | Opponent team's score. |
 | `lead_changes` | String | Lead changes. |
-| `lead_percentage` | String |  |
+| `lead_percentage` | String | Share of game time the team held the lead, as reported in ESPN's team boxscore. |
 
 ```python
 load_mbb_team_boxscore(seasons=2024)
@@ -418,10 +418,10 @@ Release: [espn_mens_college_basketball_shots](https://github.com/sportsdataverse
 | `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
 | `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
 | `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
-| `athlete_name_1` | String |  |
-| `athlete_name_2` | String |  |
+| `athlete_name_1` | String | Display name of the shooter credited on the attempt in ESPN's play participants. |
+| `athlete_name_2` | String | Display name of the second athlete tied to the attempt (typically the assister), when present. |
 | `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
-| `team_mascot` | String |  |
+| `team_mascot` | String | Mascot/nickname of the shooting team from ESPN's team record. |
 | `team_abbrev` | String | Abbreviation for team. |
 
 ```python
@@ -774,81 +774,81 @@ Release: [ncaa_mbb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `away_score` | Int64 | Away team score at the time of the play. |
 | `event_team` | String | Team associated with the shift change. |
 | `event_description` | String | Human-readable event description. |
-| `player_1` | String |  |
-| `player_2` | String |  |
+| `player_1` | String | Name of the primary player credited on the event (shooter, fouler, rebounder, etc.), as scraped from stats.ncaa.org. |
+| `player_2` | String | Name of the secondary player on the event (e.g., the assister or the player subbed for), when present. |
 | `event_type` | String | Event / play type code (V2 PBP). |
-| `event_result` | String |  |
+| `event_result` | String | Outcome of the event, e.g. made or missed for shot attempts. |
 | `shot_value` | Int64 | Point value of the shot (2 or 3). |
-| `event_length` | Int64 |  |
-| `poss_num` | Int64 |  |
-| `poss_team` | String |  |
-| `poss_length` | Int64 |  |
-| `is_transition` | Boolean |  |
-| `home_1` | String |  |
-| `home_2` | String |  |
-| `home_3` | String |  |
-| `home_4` | String |  |
-| `home_5` | String |  |
-| `away_1` | String |  |
-| `away_2` | String |  |
-| `away_3` | String |  |
-| `away_4` | String |  |
-| `away_5` | String |  |
+| `event_length` | Int64 | Seconds elapsed between this event and the previous event in the game. |
+| `poss_num` | Int64 | Sequential possession number within the game that the event belongs to. |
+| `poss_team` | String | Name of the team in possession when the event occurred. |
+| `poss_length` | Int64 | Duration of the enclosing possession in seconds. |
+| `is_transition` | Boolean | Flag marking events that occurred in transition, within the opening seconds of the possession. |
+| `home_1` | String | Name of the home team's on-floor player in lineup slot 1 for the event, from the substitution walk-forward. |
+| `home_2` | String | Name of the home team's on-floor player in lineup slot 2 for the event, from the substitution walk-forward. |
+| `home_3` | String | Name of the home team's on-floor player in lineup slot 3 for the event, from the substitution walk-forward. |
+| `home_4` | String | Name of the home team's on-floor player in lineup slot 4 for the event, from the substitution walk-forward. |
+| `home_5` | String | Name of the home team's on-floor player in lineup slot 5 for the event, from the substitution walk-forward. |
+| `away_1` | String | Name of the away team's on-floor player in lineup slot 1 for the event, from the substitution walk-forward. |
+| `away_2` | String | Name of the away team's on-floor player in lineup slot 2 for the event, from the substitution walk-forward. |
+| `away_3` | String | Name of the away team's on-floor player in lineup slot 3 for the event, from the substitution walk-forward. |
+| `away_4` | String | Name of the away team's on-floor player in lineup slot 4 for the event, from the substitution walk-forward. |
+| `away_5` | String | Name of the away team's on-floor player in lineup slot 5 for the event, from the substitution walk-forward. |
 | `status` | String | Status label. |
-| `is_garbage_time` | Boolean |  |
-| `sub_deviate` | Int64 |  |
+| `is_garbage_time` | Boolean | Flag marking events in garbage time under the score-margin and clock rule of the pbp builder. |
+| `sub_deviate` | Int64 | Per-game count of substitution-tracking deviations found while walking lineups forward; nonzero flags imperfect substitution data. |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
-| `home_ncaa_team_id` | String |  |
+| `home_ncaa_team_id` | String | stats.ncaa.org team identifier for the home team. |
 | `home_espn_team_id` | String | ESPN home team id (NA for bart-only rows). |
-| `away_ncaa_team_id` | String |  |
+| `away_ncaa_team_id` | String | stats.ncaa.org team identifier for the away team. |
 | `away_espn_team_id` | String | ESPN away team id (NA for bart-only rows). |
-| `event_team_ncaa_team_id` | String |  |
-| `event_team_espn_team_id` | String |  |
-| `poss_team_ncaa_team_id` | String |  |
-| `poss_team_espn_team_id` | String |  |
-| `player_1_id` | String |  |
-| `player_1_clean_name` | String |  |
-| `player_2_id` | String |  |
-| `player_2_clean_name` | String |  |
-| `home_1_player_id` | String |  |
-| `home_1_clean_name` | String |  |
-| `home_2_player_id` | String |  |
-| `home_2_clean_name` | String |  |
-| `home_3_player_id` | String |  |
-| `home_3_clean_name` | String |  |
-| `home_4_player_id` | String |  |
-| `home_4_clean_name` | String |  |
-| `home_5_player_id` | String |  |
-| `home_5_clean_name` | String |  |
-| `away_1_player_id` | String |  |
-| `away_1_clean_name` | String |  |
-| `away_2_player_id` | String |  |
-| `away_2_clean_name` | String |  |
-| `away_3_player_id` | String |  |
-| `away_3_clean_name` | String |  |
-| `away_4_player_id` | String |  |
-| `away_4_clean_name` | String |  |
-| `away_5_player_id` | String |  |
-| `away_5_clean_name` | String |  |
+| `event_team_ncaa_team_id` | String | stats.ncaa.org team identifier of the team credited with the event. |
+| `event_team_espn_team_id` | String | ESPN team identifier of the team credited with the event, via the NCAA-to-ESPN crosswalk. |
+| `poss_team_ncaa_team_id` | String | stats.ncaa.org team identifier of the team in possession. |
+| `poss_team_espn_team_id` | String | ESPN team identifier of the team in possession, via the NCAA-to-ESPN crosswalk. |
+| `player_1_id` | String | stats.ncaa.org player identifier for player_1, resolved through the roster name matcher. |
+| `player_1_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name for player_1. |
+| `player_2_id` | String | stats.ncaa.org player identifier for player_2, resolved through the roster name matcher. |
+| `player_2_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name for player_2. |
+| `home_1_player_id` | String | stats.ncaa.org player identifier for the home slot-1 on-floor player. |
+| `home_1_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-1 on-floor player. |
+| `home_2_player_id` | String | stats.ncaa.org player identifier for the home slot-2 on-floor player. |
+| `home_2_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-2 on-floor player. |
+| `home_3_player_id` | String | stats.ncaa.org player identifier for the home slot-3 on-floor player. |
+| `home_3_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-3 on-floor player. |
+| `home_4_player_id` | String | stats.ncaa.org player identifier for the home slot-4 on-floor player. |
+| `home_4_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-4 on-floor player. |
+| `home_5_player_id` | String | stats.ncaa.org player identifier for the home slot-5 on-floor player. |
+| `home_5_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-5 on-floor player. |
+| `away_1_player_id` | String | stats.ncaa.org player identifier for the away slot-1 on-floor player. |
+| `away_1_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-1 on-floor player. |
+| `away_2_player_id` | String | stats.ncaa.org player identifier for the away slot-2 on-floor player. |
+| `away_2_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-2 on-floor player. |
+| `away_3_player_id` | String | stats.ncaa.org player identifier for the away slot-3 on-floor player. |
+| `away_3_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-3 on-floor player. |
+| `away_4_player_id` | String | stats.ncaa.org player identifier for the away slot-4 on-floor player. |
+| `away_4_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-4 on-floor player. |
+| `away_5_player_id` | String | stats.ncaa.org player identifier for the away slot-5 on-floor player. |
+| `away_5_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-5 on-floor player. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
-| `is_fastbreak` | Boolean |  |
-| `is_from_turnover` | Boolean |  |
-| `is_paint` | Boolean |  |
-| `is_second_chance` | Boolean |  |
-| `assist_player` | String |  |
-| `ft_number` | Int64 |  |
-| `ft_attempts` | Int64 |  |
-| `foul_class` | String |  |
-| `is_shooting_foul` | Boolean |  |
-| `is_looseball_foul` | Boolean |  |
-| `is_one_and_one` | Boolean |  |
-| `is_flagrant` | Boolean |  |
-| `foul_tech_class` | String |  |
-| `ft_awarded` | Int64 |  |
-| `turnover_type` | String |  |
-| `is_team_turnover` | Boolean |  |
-| `timeout_type` | String |  |
-| `challenge_outcome` | String |  |
+| `is_fastbreak` | Boolean | Flag marking the shot as a fast-break attempt, from the stats.ncaa.org play text. |
+| `is_from_turnover` | Boolean | Flag marking an attempt generated off an opponent turnover. |
+| `is_paint` | Boolean | Flag marking the shot as attempted in the paint. |
+| `is_second_chance` | Boolean | Flag marking a second-chance attempt following an offensive rebound. |
+| `assist_player` | String | Name of the player credited with the assist on a made shot, when present. |
+| `ft_number` | Int64 | Which free throw of the trip this attempt is (1 of 2, 2 of 2, etc.). |
+| `ft_attempts` | Int64 | Total free throws in the trip this attempt belongs to. |
+| `foul_class` | String | Parsed category of the foul event (e.g. personal, offensive). |
+| `is_shooting_foul` | Boolean | Flag marking the foul as a shooting foul. |
+| `is_looseball_foul` | Boolean | Flag marking the foul as a loose-ball foul. |
+| `is_one_and_one` | Boolean | Flag marking a bonus one-and-one free-throw trip. |
+| `is_flagrant` | Boolean | Flag marking the foul as flagrant. |
+| `foul_tech_class` | String | Parsed technical-foul class for technical foul events, when present. |
+| `ft_awarded` | Int64 | Number of free throws awarded by the foul. |
+| `turnover_type` | String | Parsed turnover subtype (e.g. lost ball, bad pass, travel). |
+| `is_team_turnover` | Boolean | Flag marking a turnover charged to the team rather than an individual player. |
+| `timeout_type` | String | Type of timeout called (e.g. full, 30-second, media). |
+| `challenge_outcome` | String | Outcome of a coach's challenge or video-review event, when present. |
 | `season` | Int64 | Season year. |
 
 ```python
@@ -886,124 +886,124 @@ Release: [ncaa_mbb_player_box](https://github.com/sportsdataverse/sportsdatavers
 | `away` | String | Away record. |
 | `team` | String | Team-side label or team identifier. |
 | `player` | String | Player name. |
-| `mins` | Float64 |  |
-| `o_poss` | Float64 |  |
+| `mins` | Float64 | Minutes played, derived from the lineup walk-forward through the play-by-play. |
+| `o_poss` | Float64 | Offensive possessions the player was on the floor for. |
 | `pts` | Float64 | Points scored. |
-| `orb` | Float64 |  |
-| `drb` | Float64 |  |
+| `orb` | Float64 | Offensive rebounds. |
+| `drb` | Float64 | Defensive rebounds. |
 | `ast` | Float64 | Assists. |
 | `stl` | Float64 | Steals. |
 | `blk` | Float64 | Blocks. |
 | `tov` | Float64 | Turnovers. |
 | `pf` | Float64 | Personal fouls. |
 | `ts_pct` | Float64 | True shooting percentage (0-1). |
-| `efg_pct` | Float64 |  |
+| `efg_pct` | Float64 | Effective field-goal percentage, weighting made threes at 1.5. |
 | `fgm` | Float64 | Field goals made. |
 | `fga` | Float64 | Field goal attempts. |
 | `fg_pct` | Float64 | Field goal percentage (0-1). |
-| `tpm` | Float64 |  |
-| `tpa` | Float64 |  |
-| `tp_pct` | Float64 |  |
+| `tpm` | Float64 | Three-point field goals made. |
+| `tpa` | Float64 | Three-point field goals attempted. |
+| `tp_pct` | Float64 | Three-point field-goal percentage. |
 | `ftm` | Float64 | Free throws made. |
 | `fta` | Float64 | Free throw attempts. |
 | `ft_pct` | Float64 | Free throw percentage (0-1). |
-| `rimm` | Float64 |  |
-| `rima` | Float64 |  |
-| `rim_pct` | Float64 |  |
-| `midm` | Float64 |  |
-| `mida` | Float64 |  |
-| `mid_pct` | Float64 |  |
-| `pbackm` | Float64 |  |
-| `pbacka` | Float64 |  |
-| `pback_pct` | Float64 |  |
-| `blk_rim` | Float64 |  |
-| `blk_mid` | Float64 |  |
-| `blk_three` | Float64 |  |
-| `pct_fga_trans` | Float64 |  |
-| `pct_tpa_trans` | Float64 |  |
-| `pct_rima_trans` | Float64 |  |
-| `pct_fgm_trans` | Float64 |  |
-| `pct_tpm_trans` | Float64 |  |
-| `pct_rimm_trans` | Float64 |  |
-| `pct_fgm_ast` | Float64 |  |
-| `pct_tpm_ast` | Float64 |  |
-| `pct_rimm_ast` | Float64 |  |
-| `pts_trans` | Float64 |  |
-| `orb_trans` | Float64 |  |
-| `drb_trans` | Float64 |  |
-| `ast_trans` | Float64 |  |
-| `stl_trans` | Float64 |  |
-| `blk_trans` | Float64 |  |
-| `tov_trans` | Float64 |  |
-| `ts_pct_trans` | Float64 |  |
-| `efg_pct_trans` | Float64 |  |
-| `fgm_trans` | Float64 |  |
-| `fga_trans` | Float64 |  |
-| `fg_pct_trans` | Float64 |  |
-| `tpm_trans` | Float64 |  |
-| `tpa_trans` | Float64 |  |
-| `tp_pct_trans` | Float64 |  |
-| `ftm_trans` | Float64 |  |
-| `fta_trans` | Float64 |  |
-| `ft_pct_trans` | Float64 |  |
-| `rimm_trans` | Float64 |  |
-| `rima_trans` | Float64 |  |
-| `rim_pct_trans` | Float64 |  |
-| `midm_trans` | Float64 |  |
-| `mida_trans` | Float64 |  |
-| `mid_pct_trans` | Float64 |  |
-| `pts_half` | Float64 |  |
-| `orb_half` | Float64 |  |
-| `drb_half` | Float64 |  |
-| `ast_half` | Float64 |  |
-| `stl_half` | Float64 |  |
-| `blk_half` | Float64 |  |
-| `tov_half` | Float64 |  |
-| `ts_pct_half` | Float64 |  |
-| `efg_pct_half` | Float64 |  |
-| `fgm_half` | Float64 |  |
-| `fga_half` | Float64 |  |
-| `fg_pct_half` | Float64 |  |
-| `tpm_half` | Float64 |  |
-| `tpa_half` | Float64 |  |
-| `tp_pct_half` | Float64 |  |
-| `ftm_half` | Float64 |  |
-| `fta_half` | Float64 |  |
-| `ft_pct_half` | Float64 |  |
-| `rimm_half` | Float64 |  |
-| `rima_half` | Float64 |  |
-| `rim_pct_half` | Float64 |  |
-| `midm_half` | Float64 |  |
-| `mida_half` | Float64 |  |
-| `mid_pct_half` | Float64 |  |
-| `pts_ast` | Float64 |  |
-| `fgm_ast` | Float64 |  |
-| `tpm_ast` | Float64 |  |
-| `rimm_ast` | Float64 |  |
-| `midm_ast` | Float64 |  |
-| `pts_unast` | Float64 |  |
-| `efg_pct_unast` | Float64 |  |
-| `fgm_unast` | Float64 |  |
-| `fga_unast` | Float64 |  |
-| `fg_pct_unast` | Float64 |  |
-| `tpm_unast` | Float64 |  |
-| `tpa_unast` | Float64 |  |
-| `tp_pct_unast` | Float64 |  |
-| `rimm_unast` | Float64 |  |
-| `rima_unast` | Float64 |  |
-| `rim_pct_unast` | Float64 |  |
-| `midm_unast` | Float64 |  |
-| `mida_unast` | Float64 |  |
-| `mid_pct_unast` | Float64 |  |
+| `rimm` | Float64 | Rim shots (dunks, layups, hooks, tip-ins) made. |
+| `rima` | Float64 | Rim shots (dunks, layups, hooks, tip-ins) attempted. |
+| `rim_pct` | Float64 | Field-goal percentage on rim attempts. |
+| `midm` | Float64 | Mid-range (non-rim two-point) shots made. |
+| `mida` | Float64 | Mid-range (non-rim two-point) shots attempted. |
+| `mid_pct` | Float64 | Field-goal percentage on mid-range attempts. |
+| `pbackm` | Float64 | Putbacks made — rim shots immediately following an offensive rebound. |
+| `pbacka` | Float64 | Putbacks attempted — rim shots immediately following an offensive rebound. |
+| `pback_pct` | Float64 | Field-goal percentage on putback attempts. |
+| `blk_rim` | Float64 | Blocks recorded against opponent rim attempts. |
+| `blk_mid` | Float64 | Blocks recorded against opponent mid-range attempts. |
+| `blk_three` | Float64 | Blocks recorded against opponent three-point attempts. |
+| `pct_fga_trans` | Float64 | Share of the player's field-goal attempts taken in transition. |
+| `pct_tpa_trans` | Float64 | Share of the player's three-point attempts taken in transition. |
+| `pct_rima_trans` | Float64 | Share of the player's rim attempts taken in transition. |
+| `pct_fgm_trans` | Float64 | Share of the player's field-goal makes that came in transition. |
+| `pct_tpm_trans` | Float64 | Share of the player's three-point makes that came in transition. |
+| `pct_rimm_trans` | Float64 | Share of the player's rim makes that came in transition. |
+| `pct_fgm_ast` | Float64 | Share of the player's made field goals that were assisted. |
+| `pct_tpm_ast` | Float64 | Share of the player's made threes that were assisted. |
+| `pct_rimm_ast` | Float64 | Share of the player's made rim shots that were assisted. |
+| `pts_trans` | Float64 | Points scored in transition possessions. |
+| `orb_trans` | Float64 | Offensive rebounds in transition possessions. |
+| `drb_trans` | Float64 | Defensive rebounds in transition possessions. |
+| `ast_trans` | Float64 | Assists in transition possessions. |
+| `stl_trans` | Float64 | Steals in transition possessions. |
+| `blk_trans` | Float64 | Blocks in transition possessions. |
+| `tov_trans` | Float64 | Turnovers in transition possessions. |
+| `ts_pct_trans` | Float64 | True-shooting percentage in transition possessions. |
+| `efg_pct_trans` | Float64 | Effective field-goal percentage in transition possessions. |
+| `fgm_trans` | Float64 | Field goals made in transition possessions. |
+| `fga_trans` | Float64 | Field goals attempted in transition possessions. |
+| `fg_pct_trans` | Float64 | Field-goal percentage in transition possessions. |
+| `tpm_trans` | Float64 | Three-pointers made in transition possessions. |
+| `tpa_trans` | Float64 | Three-pointers attempted in transition possessions. |
+| `tp_pct_trans` | Float64 | Three-point percentage in transition possessions. |
+| `ftm_trans` | Float64 | Free throws made in transition possessions. |
+| `fta_trans` | Float64 | Free throws attempted in transition possessions. |
+| `ft_pct_trans` | Float64 | Free-throw percentage in transition possessions. |
+| `rimm_trans` | Float64 | Rim shots made in transition possessions. |
+| `rima_trans` | Float64 | Rim shots attempted in transition possessions. |
+| `rim_pct_trans` | Float64 | Rim field-goal percentage in transition possessions. |
+| `midm_trans` | Float64 | Mid-range shots made in transition possessions. |
+| `mida_trans` | Float64 | Mid-range shots attempted in transition possessions. |
+| `mid_pct_trans` | Float64 | Mid-range field-goal percentage in transition possessions. |
+| `pts_half` | Float64 | Points scored in halfcourt possessions. |
+| `orb_half` | Float64 | Offensive rebounds in halfcourt possessions. |
+| `drb_half` | Float64 | Defensive rebounds in halfcourt possessions. |
+| `ast_half` | Float64 | Assists in halfcourt possessions. |
+| `stl_half` | Float64 | Steals in halfcourt possessions. |
+| `blk_half` | Float64 | Blocks in halfcourt possessions. |
+| `tov_half` | Float64 | Turnovers in halfcourt possessions. |
+| `ts_pct_half` | Float64 | True-shooting percentage in halfcourt possessions. |
+| `efg_pct_half` | Float64 | Effective field-goal percentage in halfcourt possessions. |
+| `fgm_half` | Float64 | Field goals made in halfcourt possessions. |
+| `fga_half` | Float64 | Field goals attempted in halfcourt possessions. |
+| `fg_pct_half` | Float64 | Field-goal percentage in halfcourt possessions. |
+| `tpm_half` | Float64 | Three-pointers made in halfcourt possessions. |
+| `tpa_half` | Float64 | Three-pointers attempted in halfcourt possessions. |
+| `tp_pct_half` | Float64 | Three-point percentage in halfcourt possessions. |
+| `ftm_half` | Float64 | Free throws made in halfcourt possessions. |
+| `fta_half` | Float64 | Free throws attempted in halfcourt possessions. |
+| `ft_pct_half` | Float64 | Free-throw percentage in halfcourt possessions. |
+| `rimm_half` | Float64 | Rim shots made in halfcourt possessions. |
+| `rima_half` | Float64 | Rim shots attempted in halfcourt possessions. |
+| `rim_pct_half` | Float64 | Rim field-goal percentage in halfcourt possessions. |
+| `midm_half` | Float64 | Mid-range shots made in halfcourt possessions. |
+| `mida_half` | Float64 | Mid-range shots attempted in halfcourt possessions. |
+| `mid_pct_half` | Float64 | Mid-range field-goal percentage in halfcourt possessions. |
+| `pts_ast` | Float64 | Points from the player's assisted field-goal makes. |
+| `fgm_ast` | Float64 | Assisted field-goal makes. |
+| `tpm_ast` | Float64 | Assisted three-point makes. |
+| `rimm_ast` | Float64 | Assisted rim makes. |
+| `midm_ast` | Float64 | Assisted mid-range makes. |
+| `pts_unast` | Float64 | Points from the player's unassisted field-goal makes. |
+| `efg_pct_unast` | Float64 | Effective field-goal percentage in the unassisted split (makes not credited with an assist). |
+| `fgm_unast` | Float64 | Field goals made in the unassisted split (makes not credited with an assist). |
+| `fga_unast` | Float64 | Field goals attempted in the unassisted split (makes not credited with an assist). |
+| `fg_pct_unast` | Float64 | Field-goal percentage in the unassisted split (makes not credited with an assist). |
+| `tpm_unast` | Float64 | Three-pointers made in the unassisted split (makes not credited with an assist). |
+| `tpa_unast` | Float64 | Three-pointers attempted in the unassisted split (makes not credited with an assist). |
+| `tp_pct_unast` | Float64 | Three-point percentage in the unassisted split (makes not credited with an assist). |
+| `rimm_unast` | Float64 | Rim shots made in the unassisted split (makes not credited with an assist). |
+| `rima_unast` | Float64 | Rim shots attempted in the unassisted split (makes not credited with an assist). |
+| `rim_pct_unast` | Float64 | Rim field-goal percentage in the unassisted split (makes not credited with an assist). |
+| `midm_unast` | Float64 | Mid-range shots made in the unassisted split (makes not credited with an assist). |
+| `mida_unast` | Float64 | Mid-range shots attempted in the unassisted split (makes not credited with an assist). |
+| `mid_pct_unast` | Float64 | Mid-range field-goal percentage in the unassisted split (makes not credited with an assist). |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
-| `home_ncaa_team_id` | String |  |
+| `home_ncaa_team_id` | String | stats.ncaa.org team identifier for the home team. |
 | `home_espn_team_id` | String | ESPN home team id (NA for bart-only rows). |
-| `away_ncaa_team_id` | String |  |
+| `away_ncaa_team_id` | String | stats.ncaa.org team identifier for the away team. |
 | `away_espn_team_id` | String | ESPN away team id (NA for bart-only rows). |
-| `team_ncaa_team_id` | String |  |
-| `team_espn_team_id` | String |  |
+| `team_ncaa_team_id` | String | stats.ncaa.org team identifier of the player's team. |
+| `team_espn_team_id` | String | ESPN team identifier of the player's team, via the NCAA-to-ESPN crosswalk. |
 | `player_id` | String | Unique player identifier. |
-| `clean_name` | String |  |
+| `clean_name` | String | Normalized (diacritics- and punctuation-cleaned) player name used to join across the NCAA datasets. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
 | `season` | Int64 | Season year. |
 
@@ -1021,82 +1021,82 @@ Release: [ncaa_mbb_team_box](https://github.com/sportsdataverse/sportsdataverse-
 | `home` | String | Home. |
 | `away` | String | Away record. |
 | `team` | String | Team-side label or team identifier. |
-| `mins` | Float64 |  |
-| `o_mins` | Float64 |  |
-| `d_mins` | Float64 |  |
-| `o_poss` | Float64 |  |
-| `d_poss` | Float64 |  |
-| `ortg` | Float64 |  |
-| `drtg` | Float64 |  |
-| `netrtg` | Float64 |  |
+| `mins` | Float64 | Minutes covered by the team's tracked lineups in the game. |
+| `o_mins` | Float64 | Minutes spent on tracked offensive possessions. |
+| `d_mins` | Float64 | Minutes spent on tracked defensive possessions. |
+| `o_poss` | Float64 | Offensive possessions. |
+| `d_poss` | Float64 | Defensive possessions. |
+| `ortg` | Float64 | Offensive rating — points scored per 100 possessions. |
+| `drtg` | Float64 | Defensive rating — points allowed per 100 possessions. |
+| `netrtg` | Float64 | Net rating — offensive rating minus defensive rating. |
 | `pts` | Float64 | Points scored. |
-| `d_pts` | Float64 |  |
+| `d_pts` | Float64 | Points allowed. |
 | `fga` | Float64 | Field goal attempts. |
-| `d_fga` | Float64 |  |
+| `d_fga` | Float64 | Opponent field-goal attempts. |
 | `fgm` | Float64 | Field goals made. |
-| `d_fgm` | Float64 |  |
-| `tpa` | Float64 |  |
-| `d_tpa` | Float64 |  |
-| `tpm` | Float64 |  |
-| `d_tpm` | Float64 |  |
+| `d_fgm` | Float64 | Opponent field goals made. |
+| `tpa` | Float64 | Three-point attempts. |
+| `d_tpa` | Float64 | Opponent three-point attempts. |
+| `tpm` | Float64 | Three-pointers made. |
+| `d_tpm` | Float64 | Opponent three-pointers made. |
 | `fta` | Float64 | Free throw attempts. |
-| `d_fta` | Float64 |  |
+| `d_fta` | Float64 | Opponent free-throw attempts. |
 | `ftm` | Float64 | Free throws made. |
-| `d_ftm` | Float64 |  |
-| `rima` | Float64 |  |
-| `d_rima` | Float64 |  |
-| `rimm` | Float64 |  |
-| `d_rimm` | Float64 |  |
-| `orb` | Float64 |  |
-| `d_orb` | Float64 |  |
-| `drb` | Float64 |  |
-| `d_drb` | Float64 |  |
+| `d_ftm` | Float64 | Opponent free throws made. |
+| `rima` | Float64 | Rim shots (dunks, layups, hooks, tip-ins) attempted. |
+| `d_rima` | Float64 | Opponent rim shots attempted. |
+| `rimm` | Float64 | Rim shots made. |
+| `d_rimm` | Float64 | Opponent rim shots made. |
+| `orb` | Float64 | Offensive rebounds. |
+| `d_orb` | Float64 | Opponent offensive rebounds. |
+| `drb` | Float64 | Defensive rebounds. |
+| `d_drb` | Float64 | Opponent defensive rebounds. |
 | `blk` | Float64 | Blocks. |
-| `d_blk` | Float64 |  |
+| `d_blk` | Float64 | Opponent blocks (own shots blocked). |
 | `to` | Float64 | To. |
-| `d_to` | Float64 |  |
+| `d_to` | Float64 | Opponent turnovers forced. |
 | `ast` | Float64 | Assists. |
-| `d_ast` | Float64 |  |
-| `e_poss` | Float64 |  |
+| `d_ast` | Float64 | Opponent assists allowed. |
+| `e_poss` | Float64 | Estimated possessions — the average of the team's and the opponent's raw possession counts. |
 | `fg_pct` | Float64 | Field goal percentage (0-1). |
-| `d_fg_pct` | Float64 |  |
-| `tpp` | Float64 |  |
-| `d_tpp` | Float64 |  |
-| `ftp` | Float64 |  |
-| `d_ftp` | Float64 |  |
-| `efg_pct` | Float64 |  |
-| `d_efg_pct` | Float64 |  |
+| `d_fg_pct` | Float64 | Opponent field-goal percentage. |
+| `tpp` | Float64 | Three-point percentage. |
+| `d_tpp` | Float64 | Opponent three-point percentage. |
+| `ftp` | Float64 | Free-throw percentage. |
+| `d_ftp` | Float64 | Opponent free-throw percentage. |
+| `efg_pct` | Float64 | Effective field-goal percentage, weighting made threes at 1.5. |
+| `d_efg_pct` | Float64 | Opponent effective field-goal percentage. |
 | `ts_pct` | Float64 | True shooting percentage (0-1). |
-| `d_ts_pct` | Float64 |  |
-| `rim_pct` | Float64 |  |
-| `d_rim_pct` | Float64 |  |
-| `mid_pct` | Float64 |  |
-| `d_mid_pct` | Float64 |  |
-| `tp_rate` | Float64 |  |
-| `d_tp_rate` | Float64 |  |
-| `rim_rate` | Float64 |  |
-| `d_rim_rate` | Float64 |  |
-| `mid_rate` | Float64 |  |
-| `d_mid_rate` | Float64 |  |
+| `d_ts_pct` | Float64 | Opponent true-shooting percentage. |
+| `rim_pct` | Float64 | Field-goal percentage on rim attempts. |
+| `d_rim_pct` | Float64 | Opponent field-goal percentage on rim attempts. |
+| `mid_pct` | Float64 | Field-goal percentage on mid-range attempts. |
+| `d_mid_pct` | Float64 | Opponent field-goal percentage on mid-range attempts. |
+| `tp_rate` | Float64 | Three-point attempts as a share of field-goal attempts. |
+| `d_tp_rate` | Float64 | Opponent three-point attempts as a share of their field-goal attempts. |
+| `rim_rate` | Float64 | Rim attempts as a share of field-goal attempts. |
+| `d_rim_rate` | Float64 | Opponent rim attempts as a share of their field-goal attempts. |
+| `mid_rate` | Float64 | Mid-range attempts as a share of field-goal attempts. |
+| `d_mid_rate` | Float64 | Opponent mid-range attempts as a share of their field-goal attempts. |
 | `ft_rate` | Float64 | Ft rate. |
-| `d_ft_rate` | Float64 |  |
-| `ast_rate` | Float64 |  |
-| `d_ast_rate` | Float64 |  |
+| `d_ft_rate` | Float64 | Opponent free-throw attempts relative to their field-goal attempts. |
+| `ast_rate` | Float64 | Share of the team's made field goals that were assisted. |
+| `d_ast_rate` | Float64 | Share of opponent made field goals that were assisted. |
 | `to_rate` | Float64 | To rate. |
-| `d_to_rate` | Float64 |  |
-| `blk_rate` | Float64 |  |
-| `o_blk_rate` | Float64 |  |
+| `d_to_rate` | Float64 | Opponent turnovers as a share of their possessions (forced-turnover rate). |
+| `blk_rate` | Float64 | Share of opponent two-point attempts the team blocked. |
+| `o_blk_rate` | Float64 | Share of the team's own two-point attempts blocked by the opponent. |
 | `orb_pct` | Float64 | Offensive rebound percentage. |
 | `drb_pct` | Float64 | Defensive rebound percentage. |
-| `time_per_poss` | Float64 |  |
-| `d_time_per_poss` | Float64 |  |
+| `time_per_poss` | Float64 | Average seconds per offensive possession. |
+| `d_time_per_poss` | Float64 | Average seconds per defensive possession. |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
-| `home_ncaa_team_id` | String |  |
+| `home_ncaa_team_id` | String | stats.ncaa.org team identifier for the home team. |
 | `home_espn_team_id` | String | ESPN home team id (NA for bart-only rows). |
-| `away_ncaa_team_id` | String |  |
+| `away_ncaa_team_id` | String | stats.ncaa.org team identifier for the away team. |
 | `away_espn_team_id` | String | ESPN away team id (NA for bart-only rows). |
-| `team_ncaa_team_id` | String |  |
-| `team_espn_team_id` | String |  |
+| `team_ncaa_team_id` | String | stats.ncaa.org team identifier of the team the row belongs to. |
+| `team_espn_team_id` | String | ESPN team identifier of the team, via the NCAA-to-ESPN crosswalk. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
 | `season` | Int64 | Season year. |
 
@@ -1132,13 +1132,13 @@ Release: [ncaa_mbb_team_rosters](https://github.com/sportsdataverse/sportsdatave
 | `team` | String | Team-side label or team identifier. |
 | `player_id` | String | Unique player identifier. |
 | `player` | String | Player name. |
-| `clean_name` | String |  |
+| `clean_name` | String | Normalized (diacritics- and punctuation-cleaned) player name used to join across the NCAA datasets. |
 | `name` | String | Display name. |
 | `jersey` | String | Jersey number worn by the player. |
 | `class` | String | College class / draft eligibility note. |
 | `position` | String | Listed roster position (G, F, C, etc.). |
 | `height` | String | Player height (string e.g. '6-2' or inches). |
-| `ht_inches` | Int64 |  |
+| `ht_inches` | Int64 | Player height converted to total inches from the stats.ncaa.org roster listing. |
 | `hometown` | String | Player hometown. |
 | `high_school` | String | High school |
 | `gp` | String | Games played. |
@@ -1175,56 +1175,56 @@ Release: [ncaa_mbb_possessions](https://github.com/sportsdataverse/sportsdataver
 | `home` | String | Home. |
 | `away` | String | Away record. |
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
-| `poss_num` | Int64 |  |
-| `poss_team` | String |  |
-| `home_1` | String |  |
-| `home_2` | String |  |
-| `home_3` | String |  |
-| `home_4` | String |  |
-| `home_5` | String |  |
-| `away_1` | String |  |
-| `away_2` | String |  |
-| `away_3` | String |  |
-| `away_4` | String |  |
-| `away_5` | String |  |
+| `poss_num` | Int64 | Sequential possession number within the game. |
+| `poss_team` | String | Name of the team in possession. |
+| `home_1` | String | Name of the home team's on-floor player in lineup slot 1 for the possession, from the substitution walk-forward. |
+| `home_2` | String | Name of the home team's on-floor player in lineup slot 2 for the possession, from the substitution walk-forward. |
+| `home_3` | String | Name of the home team's on-floor player in lineup slot 3 for the possession, from the substitution walk-forward. |
+| `home_4` | String | Name of the home team's on-floor player in lineup slot 4 for the possession, from the substitution walk-forward. |
+| `home_5` | String | Name of the home team's on-floor player in lineup slot 5 for the possession, from the substitution walk-forward. |
+| `away_1` | String | Name of the away team's on-floor player in lineup slot 1 for the possession, from the substitution walk-forward. |
+| `away_2` | String | Name of the away team's on-floor player in lineup slot 2 for the possession, from the substitution walk-forward. |
+| `away_3` | String | Name of the away team's on-floor player in lineup slot 3 for the possession, from the substitution walk-forward. |
+| `away_4` | String | Name of the away team's on-floor player in lineup slot 4 for the possession, from the substitution walk-forward. |
+| `away_5` | String | Name of the away team's on-floor player in lineup slot 5 for the possession, from the substitution walk-forward. |
 | `home_score` | Int64 | Home team score at the time of the play. |
 | `away_score` | Int64 | Away team score at the time of the play. |
 | `pts` | Int64 | Points scored. |
-| `is_assisted` | Int64 |  |
-| `is_transition` | Int64 |  |
-| `is_garbage_time` | Int64 |  |
-| `start_event_type` | String |  |
-| `first_shot_time` | Int64 |  |
-| `first_shot_type` | String |  |
-| `last_event_time` | Int64 |  |
-| `last_event_type` | String |  |
+| `is_assisted` | Int64 | 1 when the possession's made field goal was assisted, else 0. |
+| `is_transition` | Int64 | 1 for transition possessions, else 0. |
+| `is_garbage_time` | Int64 | 1 for possessions in garbage time under the score-margin and clock rule, else 0. |
+| `start_event_type` | String | Event type that opened the possession (e.g., a defensive rebound or a made-basket inbound). |
+| `first_shot_time` | Int64 | Clock time in seconds at the possession's first shot attempt, from the possession segmentation engine. |
+| `first_shot_type` | String | Shot class of the possession's first attempt (rim, mid-range, or three). |
+| `last_event_time` | Int64 | Clock time in seconds at the possession's final event. |
+| `last_event_type` | String | Event type that ended the possession (e.g., a made shot, turnover, or defensive rebound). |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
-| `home_ncaa_team_id` | String |  |
+| `home_ncaa_team_id` | String | stats.ncaa.org team identifier for the home team. |
 | `home_espn_team_id` | String | ESPN home team id (NA for bart-only rows). |
-| `away_ncaa_team_id` | String |  |
+| `away_ncaa_team_id` | String | stats.ncaa.org team identifier for the away team. |
 | `away_espn_team_id` | String | ESPN away team id (NA for bart-only rows). |
-| `poss_team_ncaa_team_id` | String |  |
-| `poss_team_espn_team_id` | String |  |
-| `home_1_player_id` | String |  |
-| `home_1_clean_name` | String |  |
-| `home_2_player_id` | String |  |
-| `home_2_clean_name` | String |  |
-| `home_3_player_id` | String |  |
-| `home_3_clean_name` | String |  |
-| `home_4_player_id` | String |  |
-| `home_4_clean_name` | String |  |
-| `home_5_player_id` | String |  |
-| `home_5_clean_name` | String |  |
-| `away_1_player_id` | String |  |
-| `away_1_clean_name` | String |  |
-| `away_2_player_id` | String |  |
-| `away_2_clean_name` | String |  |
-| `away_3_player_id` | String |  |
-| `away_3_clean_name` | String |  |
-| `away_4_player_id` | String |  |
-| `away_4_clean_name` | String |  |
-| `away_5_player_id` | String |  |
-| `away_5_clean_name` | String |  |
+| `poss_team_ncaa_team_id` | String | stats.ncaa.org team identifier of the team in possession. |
+| `poss_team_espn_team_id` | String | ESPN team identifier of the team in possession, via the NCAA-to-ESPN crosswalk. |
+| `home_1_player_id` | String | stats.ncaa.org player identifier for the home slot-1 on-floor player. |
+| `home_1_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-1 on-floor player. |
+| `home_2_player_id` | String | stats.ncaa.org player identifier for the home slot-2 on-floor player. |
+| `home_2_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-2 on-floor player. |
+| `home_3_player_id` | String | stats.ncaa.org player identifier for the home slot-3 on-floor player. |
+| `home_3_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-3 on-floor player. |
+| `home_4_player_id` | String | stats.ncaa.org player identifier for the home slot-4 on-floor player. |
+| `home_4_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-4 on-floor player. |
+| `home_5_player_id` | String | stats.ncaa.org player identifier for the home slot-5 on-floor player. |
+| `home_5_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-5 on-floor player. |
+| `away_1_player_id` | String | stats.ncaa.org player identifier for the away slot-1 on-floor player. |
+| `away_1_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-1 on-floor player. |
+| `away_2_player_id` | String | stats.ncaa.org player identifier for the away slot-2 on-floor player. |
+| `away_2_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-2 on-floor player. |
+| `away_3_player_id` | String | stats.ncaa.org player identifier for the away slot-3 on-floor player. |
+| `away_3_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-3 on-floor player. |
+| `away_4_player_id` | String | stats.ncaa.org player identifier for the away slot-4 on-floor player. |
+| `away_4_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-4 on-floor player. |
+| `away_5_player_id` | String | stats.ncaa.org player identifier for the away slot-5 on-floor player. |
+| `away_5_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-5 on-floor player. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
 | `season` | Int64 | Season year. |
 
@@ -1239,81 +1239,81 @@ Release: [ncaa_mbb_lineups](https://github.com/sportsdataverse/sportsdataverse-d
 
 | col_name | type | description |
 |---|---|---|
-| `lineup_key` | String |  |
+| `lineup_key` | String | Sorted player-code key identifying the five-player unit on the floor (hoop-explorer convention). |
 | `date` | String | Date in YYYY-MM-DD format. |
-| `location_type` | String |  |
+| `location_type` | String | Whether the lineup's team was the Home or Away side in the game. |
 | `team` | String | Team-side label or team identifier. |
-| `team_year` | Int64 |  |
+| `team_year` | Int64 | Season year of the team-season the lineup row belongs to. |
 | `opponent` | String | Opponent. |
-| `lineup_id` | String |  |
-| `start_min` | Float64 |  |
-| `end_min` | Float64 |  |
-| `duration_mins` | Float64 |  |
-| `player_1` | String |  |
-| `player_2` | String |  |
-| `player_3` | String |  |
-| `player_4` | String |  |
-| `player_5` | String |  |
-| `players_in` | String |  |
-| `players_out` | String |  |
-| `start_scored` | Int64 |  |
-| `start_allowed` | Int64 |  |
-| `end_scored` | Int64 |  |
-| `end_allowed` | Int64 |  |
-| `start_diff` | Int64 |  |
-| `end_diff` | Int64 |  |
-| `player_count_error` | Null |  |
+| `lineup_id` | String | Sorted-name identifier of the five-player lineup, joined from the on-floor player names. |
+| `start_min` | Float64 | Game minute at which the stint began. |
+| `end_min` | Float64 | Game minute at which the stint ended. |
+| `duration_mins` | Float64 | Length of the stint in minutes. |
+| `player_1` | String | Name of the first player (in sorted order) of the five-player lineup. |
+| `player_2` | String | Name of the second player (in sorted order) of the five-player lineup. |
+| `player_3` | String | Name of the third player (in sorted order) of the five-player lineup. |
+| `player_4` | String | Name of the fourth player (in sorted order) of the five-player lineup. |
+| `player_5` | String | Name of the fifth player (in sorted order) of the five-player lineup. |
+| `players_in` | String | Delimited names of the players substituted in at the start of the stint. |
+| `players_out` | String | Delimited names of the players substituted out at the end of the stint. |
+| `start_scored` | Int64 | Team points scored at the moment the stint began. |
+| `start_allowed` | Int64 | Points allowed at the moment the stint began. |
+| `end_scored` | Int64 | Team points scored at the moment the stint ended. |
+| `end_allowed` | Int64 | Points allowed at the moment the stint ended. |
+| `start_diff` | Int64 | Score margin (scored minus allowed) when the stint began. |
+| `end_diff` | Int64 | Score margin (scored minus allowed) when the stint ended. |
+| `player_count_error` | Null | Flag marking stints where the reconciled on-floor count was not exactly five players (all-null when clean). |
 | `poss` | Int64 | Poss. |
 | `pts` | Int64 | Points scored. |
 | `plus_minus` | Int64 | Plus/minus point differential while on court. |
 | `fga` | Int64 | Field goal attempts. |
 | `fgm` | Int64 | Field goals made. |
-| `rima` | Int64 |  |
-| `rimm` | Int64 |  |
-| `rim_ast` | Int64 |  |
-| `mida` | Int64 |  |
-| `midm` | Int64 |  |
-| `mid_ast` | Int64 |  |
-| `fg2a` | Int64 |  |
-| `fg2m` | Int64 |  |
-| `tpa` | Int64 |  |
-| `tpm` | Int64 |  |
-| `tp_ast` | Int64 |  |
+| `rima` | Int64 | Rim shots (dunks, layups, hooks, tip-ins) attempted by the lineup during the stint. |
+| `rimm` | Int64 | Rim shots made by the lineup during the stint. |
+| `rim_ast` | Int64 | Assisted rim makes by the lineup during the stint. |
+| `mida` | Int64 | Mid-range shots attempted by the lineup during the stint. |
+| `midm` | Int64 | Mid-range shots made by the lineup during the stint. |
+| `mid_ast` | Int64 | Assisted mid-range makes by the lineup during the stint. |
+| `fg2a` | Int64 | Two-point field goals attempted by the lineup during the stint. |
+| `fg2m` | Int64 | Two-point field goals made by the lineup during the stint. |
+| `tpa` | Int64 | Three-pointers attempted by the lineup during the stint. |
+| `tpm` | Int64 | Three-pointers made by the lineup during the stint. |
+| `tp_ast` | Int64 | Assisted three-point makes by the lineup during the stint. |
 | `fta` | Int64 | Free throw attempts. |
 | `ftm` | Int64 | Free throws made. |
-| `orb` | Int64 |  |
-| `drb` | Int64 |  |
+| `orb` | Int64 | Offensive rebounds by the lineup during the stint. |
+| `drb` | Int64 | Defensive rebounds by the lineup during the stint. |
 | `to` | Int64 | To. |
 | `stl` | Int64 | Steals. |
 | `blk` | Int64 | Blocks. |
 | `ast` | Int64 | Assists. |
-| `foul` | Int64 |  |
-| `opp_poss` | Int64 |  |
+| `foul` | Int64 | Fouls committed by the lineup during the stint. |
+| `opp_poss` | Int64 | Opponent possessions while the lineup was on the floor during the stint. |
 | `opp_pts` | Int64 | Opponent points. |
-| `opp_plus_minus` | Int64 |  |
-| `opp_fga` | Int64 |  |
-| `opp_fgm` | Int64 |  |
-| `opp_rima` | Int64 |  |
-| `opp_rimm` | Int64 |  |
-| `opp_rim_ast` | Int64 |  |
-| `opp_mida` | Int64 |  |
-| `opp_midm` | Int64 |  |
-| `opp_mid_ast` | Int64 |  |
-| `opp_fg2a` | Int64 |  |
-| `opp_fg2m` | Int64 |  |
-| `opp_tpa` | Int64 |  |
-| `opp_tpm` | Int64 |  |
-| `opp_tp_ast` | Int64 |  |
-| `opp_fta` | Int64 |  |
-| `opp_ftm` | Int64 |  |
-| `opp_orb` | Int64 |  |
-| `opp_drb` | Int64 |  |
-| `opp_to` | Int64 |  |
-| `opp_stl` | Int64 |  |
-| `opp_blk` | Int64 |  |
-| `opp_ast` | Int64 |  |
-| `opp_foul` | Int64 |  |
-| `stint_num` | Int64 |  |
+| `opp_plus_minus` | Int64 | Opponent scoring margin while the lineup was on the floor during the stint. |
+| `opp_fga` | Int64 | Opponent field-goal attempts while the lineup was on the floor during the stint. |
+| `opp_fgm` | Int64 | Opponent field goals made while the lineup was on the floor during the stint. |
+| `opp_rima` | Int64 | Opponent rim shots attempted while the lineup was on the floor during the stint. |
+| `opp_rimm` | Int64 | Opponent rim shots made while the lineup was on the floor during the stint. |
+| `opp_rim_ast` | Int64 | Opponent assisted rim makes while the lineup was on the floor during the stint. |
+| `opp_mida` | Int64 | Opponent mid-range shots attempted while the lineup was on the floor during the stint. |
+| `opp_midm` | Int64 | Opponent mid-range shots made while the lineup was on the floor during the stint. |
+| `opp_mid_ast` | Int64 | Opponent assisted mid-range makes while the lineup was on the floor during the stint. |
+| `opp_fg2a` | Int64 | Opponent two-point attempts while the lineup was on the floor during the stint. |
+| `opp_fg2m` | Int64 | Opponent two-point makes while the lineup was on the floor during the stint. |
+| `opp_tpa` | Int64 | Opponent three-point attempts while the lineup was on the floor during the stint. |
+| `opp_tpm` | Int64 | Opponent three-point makes while the lineup was on the floor during the stint. |
+| `opp_tp_ast` | Int64 | Opponent assisted three-point makes while the lineup was on the floor during the stint. |
+| `opp_fta` | Int64 | Opponent free-throw attempts while the lineup was on the floor during the stint. |
+| `opp_ftm` | Int64 | Opponent free throws made while the lineup was on the floor during the stint. |
+| `opp_orb` | Int64 | Opponent offensive rebounds while the lineup was on the floor during the stint. |
+| `opp_drb` | Int64 | Opponent defensive rebounds while the lineup was on the floor during the stint. |
+| `opp_to` | Int64 | Opponent turnovers while the lineup was on the floor during the stint. |
+| `opp_stl` | Int64 | Opponent steals while the lineup was on the floor during the stint. |
+| `opp_blk` | Int64 | Opponent blocks while the lineup was on the floor during the stint. |
+| `opp_ast` | Int64 | Opponent assists while the lineup was on the floor during the stint. |
+| `opp_foul` | Int64 | Opponent fouls committed while the lineup was on the floor during the stint. |
+| `stint_num` | Int64 | Sequential on-floor stint number for the lineup within the game. |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
 | `season` | Int64 | Season year. |
 
@@ -1333,34 +1333,34 @@ Release: [ncaa_mbb_matchup_stints](https://github.com/sportsdataverse/sportsdata
 | `game_date` | String | Game date (YYYY-MM-DD). |
 | `home` | String | Home. |
 | `away` | String | Away record. |
-| `game_stint_num` | Int64 |  |
+| `game_stint_num` | Int64 | Sequential stint number within the game, incremented at every substitution by either team. |
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
-| `start_seconds` | Int64 |  |
-| `end_seconds` | Int64 |  |
+| `start_seconds` | Int64 | Elapsed game seconds at which the stint began. |
+| `end_seconds` | Int64 | Elapsed game seconds at which the stint ended. |
 | `duration_seconds` | Int64 | Streak duration in seconds. |
-| `matchup_key` | String |  |
-| `home_lineup_key` | String |  |
-| `away_lineup_key` | String |  |
-| `home_lineup` | String |  |
-| `away_lineup` | String |  |
-| `end_home_score` | Int64 |  |
-| `end_away_score` | Int64 |  |
-| `n_events` | Int64 |  |
-| `n_possessions` | Int64 |  |
-| `start_home_score` | Int64 |  |
-| `start_away_score` | Int64 |  |
-| `home_pts` | Int64 |  |
-| `away_pts` | Int64 |  |
-| `home_1` | String |  |
-| `home_2` | String |  |
-| `home_3` | String |  |
-| `home_4` | String |  |
-| `home_5` | String |  |
-| `away_1` | String |  |
-| `away_2` | String |  |
-| `away_3` | String |  |
-| `away_4` | String |  |
-| `away_5` | String |  |
+| `matchup_key` | String | Combined home-plus-away lineup key identifying the ten-player matchup on the floor. |
+| `home_lineup_key` | String | Sorted player-code key for the home five on the floor. |
+| `away_lineup_key` | String | Sorted player-code key for the away five on the floor. |
+| `home_lineup` | String | Delimited names of the home five on the floor during the stint. |
+| `away_lineup` | String | Delimited names of the away five on the floor during the stint. |
+| `end_home_score` | Int64 | Home team score when the stint ended. |
+| `end_away_score` | Int64 | Away team score when the stint ended. |
+| `n_events` | Int64 | Number of play-by-play events falling within the stint. |
+| `n_possessions` | Int64 | Number of possessions falling within the stint. |
+| `start_home_score` | Int64 | Home team score when the stint began. |
+| `start_away_score` | Int64 | Away team score when the stint began. |
+| `home_pts` | Int64 | Points scored by the home team during the stint. |
+| `away_pts` | Int64 | Points scored by the away team during the stint. |
+| `home_1` | String | Name of the home team's on-floor player in lineup slot 1 for the stint. |
+| `home_2` | String | Name of the home team's on-floor player in lineup slot 2 for the stint. |
+| `home_3` | String | Name of the home team's on-floor player in lineup slot 3 for the stint. |
+| `home_4` | String | Name of the home team's on-floor player in lineup slot 4 for the stint. |
+| `home_5` | String | Name of the home team's on-floor player in lineup slot 5 for the stint. |
+| `away_1` | String | Name of the away team's on-floor player in lineup slot 1 for the stint. |
+| `away_2` | String | Name of the away team's on-floor player in lineup slot 2 for the stint. |
+| `away_3` | String | Name of the away team's on-floor player in lineup slot 3 for the stint. |
+| `away_4` | String | Name of the away team's on-floor player in lineup slot 4 for the stint. |
+| `away_5` | String | Name of the away team's on-floor player in lineup slot 5 for the stint. |
 
 ```python
 load_ncaa_mbb_matchup_stints(seasons=2024)
@@ -1376,21 +1376,21 @@ Release: [ncaa_mbb_shots](https://github.com/sportsdataverse/sportsdataverse-dat
 | `season` | Int64 | Season year. |
 | `team_id` | String | Unique team identifier. |
 | `shooter_id` | String | Unique identifier for shooter. |
-| `shot_x` | Float64 |  |
-| `shot_y` | Float64 |  |
-| `dist_ft` | Float64 |  |
-| `shot_zone` | String |  |
+| `shot_x` | Float64 | Court x-coordinate of the attempt in feet, decoded from the stats.ncaa.org shot-chart map. |
+| `shot_y` | Float64 | Court y-coordinate of the attempt in feet, decoded from the stats.ncaa.org shot-chart map. |
+| `dist_ft` | Float64 | Shot distance from the basket in feet. |
+| `shot_zone` | String | Labeled zone of the attempt (rim, mid-range, or three-point). |
 | `shot_type` | String | Shot type label (e.g. 'Jump Shot', 'Layup'). |
-| `made` | Boolean |  |
-| `point_value` | Int64 |  |
+| `made` | Boolean | Whether the shot was made. |
+| `point_value` | Int64 | Point value of the attempt (2 or 3). |
 | `period` | Null | Period of the game (1-4 quarters; 5+ for OT). |
-| `sec_left` | Null |  |
+| `sec_left` | Null | Seconds remaining in the period when the shot was taken (all-null in current captures). |
 | `source` | String | News source. |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
-| `ncaa_team_id` | String |  |
+| `ncaa_team_id` | String | stats.ncaa.org team identifier of the shooting team. |
 | `espn_team_id` | String | ESPN team id (canonical key). |
-| `shooter_player_id` | String |  |
-| `shooter_clean_name` | String |  |
+| `shooter_player_id` | String | stats.ncaa.org player identifier of the shooter. |
+| `shooter_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the shooter. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
 
 ```python
@@ -1405,12 +1405,12 @@ Release: [ncaa_mbb_rapm_within_team](https://github.com/sportsdataverse/sportsda
 | col_name | type | description |
 |---|---|---|
 | `team` | String | Team-side label or team identifier. |
-| `player_code` | String |  |
-| `rapm_off` | Float64 |  |
-| `rapm_def` | Float64 |  |
-| `team_off_poss` | Float64 |  |
-| `num_players` | Int64 |  |
-| `rapm_net` | Float64 |  |
+| `player_code` | String | Short unique-within-team player code generated from the player's name (hoop-explorer convention). |
+| `rapm_off` | Float64 | Ridge-regressed offensive RAPM per 100 possessions, estimated relative to the player's own teammates. |
+| `rapm_def` | Float64 | Ridge-regressed defensive RAPM per 100 possessions relative to teammates; positive means good defense. |
+| `team_off_poss` | Float64 | Team offensive possessions underlying the within-team fit. |
+| `num_players` | Int64 | Number of players in the team's RAPM design matrix. |
+| `rapm_net` | Float64 | Net RAPM — the sum of the offensive and defensive components, per 100 possessions. |
 | `season` | Int32 | Season year. |
 | `player_id` | String | Unique player identifier. |
 | `team_id` | String | Unique team identifier. |

--- a/docs/docs/mbb/reference/loaders.md
+++ b/docs/docs/mbb/reference/loaders.md
@@ -982,19 +982,19 @@ Release: [ncaa_mbb_player_box](https://github.com/sportsdataverse/sportsdatavers
 | `rimm_ast` | Float64 | Assisted rim makes. |
 | `midm_ast` | Float64 | Assisted mid-range makes. |
 | `pts_unast` | Float64 | Points from the player's unassisted field-goal makes. |
-| `efg_pct_unast` | Float64 | Effective field-goal percentage in the unassisted split (makes not credited with an assist). |
-| `fgm_unast` | Float64 | Field goals made in the unassisted split (makes not credited with an assist). |
-| `fga_unast` | Float64 | Field goals attempted in the unassisted split (makes not credited with an assist). |
-| `fg_pct_unast` | Float64 | Field-goal percentage in the unassisted split (makes not credited with an assist). |
-| `tpm_unast` | Float64 | Three-pointers made in the unassisted split (makes not credited with an assist). |
-| `tpa_unast` | Float64 | Three-pointers attempted in the unassisted split (makes not credited with an assist). |
-| `tp_pct_unast` | Float64 | Three-point percentage in the unassisted split (makes not credited with an assist). |
-| `rimm_unast` | Float64 | Rim shots made in the unassisted split (makes not credited with an assist). |
-| `rima_unast` | Float64 | Rim shots attempted in the unassisted split (makes not credited with an assist). |
-| `rim_pct_unast` | Float64 | Rim field-goal percentage in the unassisted split (makes not credited with an assist). |
-| `midm_unast` | Float64 | Mid-range shots made in the unassisted split (makes not credited with an assist). |
-| `mida_unast` | Float64 | Mid-range shots attempted in the unassisted split (makes not credited with an assist). |
-| `mid_pct_unast` | Float64 | Mid-range field-goal percentage in the unassisted split (makes not credited with an assist). |
+| `efg_pct_unast` | Float64 | Effective field-goal percentage in the unassisted split (makes for which no assist was credited). |
+| `fgm_unast` | Float64 | Field goals made in the unassisted split (makes for which no assist was credited). |
+| `fga_unast` | Float64 | Field goals attempted in the unassisted split (makes for which no assist was credited). |
+| `fg_pct_unast` | Float64 | Field-goal percentage in the unassisted split (makes for which no assist was credited). |
+| `tpm_unast` | Float64 | Three-pointers made in the unassisted split (makes for which no assist was credited). |
+| `tpa_unast` | Float64 | Three-pointers attempted in the unassisted split (makes for which no assist was credited). |
+| `tp_pct_unast` | Float64 | Three-point percentage in the unassisted split (makes for which no assist was credited). |
+| `rimm_unast` | Float64 | Rim shots made in the unassisted split (makes for which no assist was credited). |
+| `rima_unast` | Float64 | Rim shots attempted in the unassisted split (makes for which no assist was credited). |
+| `rim_pct_unast` | Float64 | Rim field-goal percentage in the unassisted split (makes for which no assist was credited). |
+| `midm_unast` | Float64 | Mid-range shots made in the unassisted split (makes for which no assist was credited). |
+| `mida_unast` | Float64 | Mid-range shots attempted in the unassisted split (makes for which no assist was credited). |
+| `mid_pct_unast` | Float64 | Mid-range field-goal percentage in the unassisted split (makes for which no assist was credited). |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
 | `home_ncaa_team_id` | String | stats.ncaa.org team identifier for the home team. |
 | `home_espn_team_id` | String | ESPN home team id (NA for bart-only rows). |
@@ -1337,7 +1337,7 @@ Release: [ncaa_mbb_matchup_stints](https://github.com/sportsdataverse/sportsdata
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
 | `start_seconds` | Int64 | Elapsed game seconds at which the stint began. |
 | `end_seconds` | Int64 | Elapsed game seconds at which the stint ended. |
-| `duration_seconds` | Int64 | Streak duration in seconds. |
+| `duration_seconds` | Int64 | Duration of the lineup stint in seconds. |
 | `matchup_key` | String | Combined home-plus-away lineup key identifying the ten-player matchup on the floor. |
 | `home_lineup_key` | String | Sorted player-code key for the home five on the floor. |
 | `away_lineup_key` | String | Sorted player-code key for the away five on the floor. |

--- a/docs/docs/nba/reference/loaders.md
+++ b/docs/docs/nba/reference/loaders.md
@@ -80,8 +80,8 @@ Release: [espn_nba_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `shooting_play` | Boolean | TRUE if the play was a shooting attempt. |
 | `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
 | `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
-| `points_attempted` | Int32 |  |
-| `short_description` | String |  |
+| `points_attempted` | Int32 | Point value attempted on the shot (2 or 3; 1 for a free throw). |
+| `short_description` | String | Short text description of the play from ESPN. |
 | `game_id` | Int32 | Unique game identifier. |
 | `season` | Int32 | Season year. |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
@@ -103,8 +103,8 @@ Release: [espn_nba_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `time` | String | Time / clock value. |
 | `clock_minutes` | Int32 | Clock minutes split out for convenience. |
 | `clock_seconds` | Float64 | Clock seconds split out for convenience. |
-| `home_timeout_called` | Boolean |  |
-| `away_timeout_called` | Boolean |  |
+| `home_timeout_called` | Boolean | Whether the play is a timeout called by the home team. |
+| `away_timeout_called` | Boolean | Whether the play is a timeout called by the away team. |
 | `half` | Int32 | Half of the game (1 or 2). |
 | `game_half` | Int32 | Half of the game (1 or 2). |
 | `lead_qtr` | Int32 | Quarter lead (the next-play's quarter). |
@@ -122,9 +122,9 @@ Release: [espn_nba_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
 | `game_date` | Date | Game date (YYYY-MM-DD). |
 | `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
-| `athlete_name_1` | String |  |
-| `athlete_name_2` | String |  |
-| `athlete_name_3` | String |  |
+| `athlete_name_1` | String | Name of the primary athlete involved in the play (pairs with athlete_id_1). |
+| `athlete_name_2` | String | Name of the secondary athlete involved in the play (e.g. the assister or fouled player). |
+| `athlete_name_3` | String | Name of the tertiary athlete involved in the play. |
 | `type_abbreviation` | String | Type abbreviation. |
 
 ```python
@@ -254,8 +254,8 @@ Release: [espn_nba_schedules](https://github.com/sportsdataverse/sportsdataverse
 | `home_logo` | String | Home team logo URL. |
 | `home_score` | Int32 | Home team score at the time of the play. |
 | `home_winner` | Boolean | Home team's winner. |
-| `home_linescores` | String |  |
-| `home_records` | String |  |
+| `home_linescores` | String | Period-by-period points for the home team, stringified from ESPN's linescores array. |
+| `home_records` | String | Home team's records at game time (overall, home, away), stringified from ESPN. |
 | `away_id` | Int32 | Unique identifier for away. |
 | `away_uid` | String | Away team's uid. |
 | `away_location` | String | Away team's location. |
@@ -270,8 +270,8 @@ Release: [espn_nba_schedules](https://github.com/sportsdataverse/sportsdataverse
 | `away_logo` | String | Away team logo URL. |
 | `away_score` | Int32 | Away team score at the time of the play. |
 | `away_winner` | Boolean | Away team's winner. |
-| `away_linescores` | String |  |
-| `away_records` | String |  |
+| `away_linescores` | String | Period-by-period points for the away team, stringified from ESPN's linescores array. |
+| `away_records` | String | Away team's records at game time (overall, home, away), stringified from ESPN. |
 | `game_id` | Int32 | Unique game identifier. |
 | `season` | Int32 | Season year. |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
@@ -354,7 +354,7 @@ Release: [espn_nba_team_boxscores](https://github.com/sportsdataverse/sportsdata
 | `opponent_team_logo` | String | Opponent team logo URL. |
 | `opponent_team_score` | Int32 | Opponent team's score. |
 | `lead_changes` | String | Lead changes. |
-| `lead_percentage` | String |  |
+| `lead_percentage` | String | Percentage of the game the team held the lead, from ESPN's team box score stats. |
 
 ```python
 load_nba_team_boxscore(seasons=2024)
@@ -435,10 +435,10 @@ Release: [espn_nba_shots](https://github.com/sportsdataverse/sportsdataverse-dat
 | `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
 | `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
 | `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
-| `athlete_name_1` | String |  |
-| `athlete_name_2` | String |  |
+| `athlete_name_1` | String | Name of the shooter on the attempt. |
+| `athlete_name_2` | String | Name of the secondary athlete on the attempt (e.g. the assister). |
 | `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
-| `team_mascot` | String |  |
+| `team_mascot` | String | Mascot (nickname) portion of the shooting team's name. |
 | `team_abbrev` | String | Abbreviation for team. |
 
 ```python
@@ -646,13 +646,13 @@ Release: [nba_stats_schedules](https://github.com/sportsdataverse/sportsdatavers
 | `home_team_id` | Int64 | Unique identifier for the home team. |
 | `home_team_abbreviation` | String | Home team abbreviation; `team_detail = TRUE` only. |
 | `home_team_name` | String | Home team name. |
-| `home_pts` | Int64 |  |
-| `home_wl` | String |  |
+| `home_pts` | Int64 | Final points scored by the home team. |
+| `home_wl` | String | Home team's result for the game (W or L). |
 | `away_team_id` | Int64 | Unique identifier for the away team. |
 | `away_team_abbreviation` | String | Away team abbreviation; `team_detail = TRUE` only. |
 | `away_team_name` | String | Away team name. |
-| `away_pts` | Int64 |  |
-| `away_wl` | String |  |
+| `away_pts` | Int64 | Final points scored by the away team. |
+| `away_wl` | String | Away team's result for the game (W or L). |
 
 ```python
 load_nba_stats_schedules(seasons=2025)
@@ -670,11 +670,11 @@ Release: [nba_stats_coaches](https://github.com/sportsdataverse/sportsdataverse-
 | `coach_id` | Int64 | ESPN coach id. |
 | `first_name` | String | Player's first name. |
 | `last_name` | String | Player's last name. |
-| `coach_name` | String |  |
-| `is_assistant` | Int64 |  |
-| `coach_type` | String |  |
-| `sort_sequence` | Int64 |  |
-| `sub_sort_sequence` | Int64 |  |
+| `coach_name` | String | Coach's full name. |
+| `is_assistant` | Int64 | Numeric flag from the NBA Stats API distinguishing assistants from head coaches. |
+| `coach_type` | String | Coach role description (e.g. "Head Coach", "Assistant Coach"). |
+| `sort_sequence` | Int64 | Sort order of the coach within the team's staff listing. |
+| `sub_sort_sequence` | Int64 | Secondary sort order within the coach type. |
 | `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 
 ```python
@@ -710,7 +710,7 @@ Release: [nba_stats_lineups](https://github.com/sportsdataverse/sportsdataverse-
 
 | col_name | type | description |
 |---|---|---|
-| `group_set` | String |  |
+| `group_set` | String | Lineup grouping label from the NBA Stats API (e.g. "Lineups"). |
 | `group_id` | String | ESPN group id. |
 | `group_name` | String | Group name (conference / division). |
 | `team_id` | Int64 | Unique team identifier. |
@@ -720,50 +720,50 @@ Release: [nba_stats_lineups](https://github.com/sportsdataverse/sportsdataverse-
 | `l` | Int64 | Losses. |
 | `w_pct` | Float64 | Wins percentage (0-1 decimal). |
 | `min` | Float64 | Minutes played. |
-| `e_off_rating` | Float64 |  |
-| `off_rating` | Float64 |  |
-| `e_def_rating` | Float64 |  |
-| `def_rating` | Float64 |  |
-| `e_net_rating` | Float64 |  |
+| `e_off_rating` | Float64 | Estimated offensive rating (NBA Stats estimated-metrics family) over the split. |
+| `off_rating` | Float64 | Offensive rating (points scored per 100 possessions) over the split. |
+| `e_def_rating` | Float64 | Estimated defensive rating (NBA Stats estimated-metrics family) over the split. |
+| `def_rating` | Float64 | Defensive rating (points allowed per 100 possessions) over the split. |
+| `e_net_rating` | Float64 | Estimated net rating (NBA Stats estimated-metrics family) over the split. |
 | `net_rating` | Float64 | Net rating (off rating - def rating). |
 | `ast_pct` | Float64 | Assist percentage. |
-| `ast_to` | Float64 |  |
-| `ast_ratio` | Float64 |  |
-| `oreb_pct` | Float64 |  |
-| `dreb_pct` | Float64 |  |
-| `reb_pct` | Float64 |  |
-| `tm_tov_pct` | Float64 |  |
-| `efg_pct` | Float64 |  |
+| `ast_to` | Float64 | Assist-to-turnover ratio over the split. |
+| `ast_ratio` | Float64 | Assist ratio (assists per 100 possessions used) over the split. |
+| `oreb_pct` | Float64 | Offensive rebound percentage over the split, as a decimal. |
+| `dreb_pct` | Float64 | Defensive rebound percentage over the split, as a decimal. |
+| `reb_pct` | Float64 | Total rebound percentage over the split, as a decimal. |
+| `tm_tov_pct` | Float64 | Team turnover percentage (turnovers per 100 possessions) over the split, as a decimal. |
+| `efg_pct` | Float64 | Effective field goal percentage over the split, as a decimal. |
 | `ts_pct` | Float64 | True shooting percentage (0-1). |
-| `e_pace` | Float64 |  |
+| `e_pace` | Float64 | Estimated pace (NBA Stats estimated-metrics family) over the split. |
 | `pace` | Float64 | Possessions per 48 minutes. |
 | `pace_per40` | Float64 | Pace per40. |
 | `poss` | Int64 | Poss. |
 | `pie` | Float64 | Player Impact Estimate (0-1). |
-| `gp_rank` | Int64 |  |
-| `w_rank` | Int64 |  |
-| `l_rank` | Int64 |  |
-| `w_pct_rank` | Int64 |  |
-| `min_rank` | Int64 |  |
-| `off_rating_rank` | Int64 |  |
-| `def_rating_rank` | Int64 |  |
-| `net_rating_rank` | Int64 |  |
-| `ast_pct_rank` | Int64 |  |
-| `ast_to_rank` | Int64 |  |
-| `ast_ratio_rank` | Int64 |  |
-| `oreb_pct_rank` | Int64 |  |
-| `dreb_pct_rank` | Int64 |  |
-| `reb_pct_rank` | Int64 |  |
-| `tm_tov_pct_rank` | Int64 |  |
-| `efg_pct_rank` | Int64 |  |
-| `ts_pct_rank` | Int64 |  |
-| `pace_rank` | Int64 |  |
-| `pie_rank` | Int64 |  |
-| `sum_time_played` | Int64 |  |
+| `gp_rank` | Int64 | League rank of the row's games played for the season and split. |
+| `w_rank` | Int64 | League rank of the row's wins for the season and split. |
+| `l_rank` | Int64 | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | Int64 | League rank of the row's win percentage for the season and split. |
+| `min_rank` | Int64 | League rank of the row's minutes played for the season and split. |
+| `off_rating_rank` | Int64 | League rank of the row's offensive rating (points scored per 100 possessions) for the season and split. |
+| `def_rating_rank` | Int64 | League rank of the row's defensive rating (points allowed per 100 possessions) for the season and split. |
+| `net_rating_rank` | Int64 | League rank of the row's net rating (offensive minus defensive rating) for the season and split. |
+| `ast_pct_rank` | Int64 | League rank of the row's assist percentage (share of teammate field goals assisted while on the floor) for the season and split. |
+| `ast_to_rank` | Int64 | League rank of the row's assist-to-turnover ratio for the season and split. |
+| `ast_ratio_rank` | Int64 | League rank of the row's assist ratio (assists per 100 possessions used) for the season and split. |
+| `oreb_pct_rank` | Int64 | League rank of the row's offensive rebound percentage for the season and split. |
+| `dreb_pct_rank` | Int64 | League rank of the row's defensive rebound percentage for the season and split. |
+| `reb_pct_rank` | Int64 | League rank of the row's total rebound percentage for the season and split. |
+| `tm_tov_pct_rank` | Int64 | League rank of the row's team turnover percentage (turnovers per 100 possessions) for the season and split. |
+| `efg_pct_rank` | Int64 | League rank of the row's effective field goal percentage for the season and split. |
+| `ts_pct_rank` | Int64 | League rank of the row's true shooting percentage for the season and split. |
+| `pace_rank` | Int64 | League rank of the row's pace (possessions per 48 minutes) for the season and split. |
+| `pie_rank` | Int64 | League rank of the row's Player Impact Estimate (PIE, the NBA Stats catch-all impact metric) for the season and split. |
+| `sum_time_played` | Int64 | Total time the five-man lineup was on the floor across the split. |
 | `season` | Int32 | Season year. |
 | `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
-| `measure_type` | String |  |
-| `per_mode` | String |  |
+| `measure_type` | String | NBA Stats measure type the row was pulled from (e.g. Base, Advanced, Misc, Scoring, Opponent, Usage, Defense). |
+| `per_mode` | String | NBA Stats per-mode of the row values (e.g. Totals, PerGame, Per100Possessions). |
 | `fgm` | Float64 | Field goals made. |
 | `fga` | Float64 | Field goal attempts. |
 | `fg_pct` | Float64 | Field goal percentage (0-1). |
@@ -780,118 +780,118 @@ Release: [nba_stats_lineups](https://github.com/sportsdataverse/sportsdataverse-
 | `tov` | Float64 | Turnovers. |
 | `stl` | Float64 | Steals. |
 | `blk` | Float64 | Blocks. |
-| `blka` | Float64 |  |
+| `blka` | Float64 | Shot attempts blocked by opponents (blocks against). |
 | `pf` | Float64 | Personal fouls. |
-| `pfd` | Float64 |  |
+| `pfd` | Float64 | Personal fouls drawn. |
 | `pts` | Float64 | Points scored. |
 | `plus_minus` | Float64 | Plus/minus point differential while on court. |
-| `fgm_rank` | Int64 |  |
-| `fga_rank` | Int64 |  |
-| `fg_pct_rank` | Int64 |  |
-| `fg3m_rank` | Int64 |  |
-| `fg3a_rank` | Int64 |  |
-| `fg3_pct_rank` | Int64 |  |
-| `ftm_rank` | Int64 |  |
-| `fta_rank` | Int64 |  |
-| `ft_pct_rank` | Int64 |  |
-| `oreb_rank` | Int64 |  |
-| `dreb_rank` | Int64 |  |
-| `reb_rank` | Int64 |  |
-| `ast_rank` | Int64 |  |
-| `tov_rank` | Int64 |  |
-| `stl_rank` | Int64 |  |
-| `blk_rank` | Int64 |  |
-| `blka_rank` | Int64 |  |
-| `pf_rank` | Int64 |  |
-| `pfd_rank` | Int64 |  |
-| `pts_rank` | Int64 |  |
-| `plus_minus_rank` | Int64 |  |
-| `pts_off_tov` | Float64 |  |
-| `pts_2nd_chance` | Float64 |  |
-| `pts_fb` | Float64 |  |
-| `pts_paint` | Float64 |  |
-| `opp_pts_off_tov` | Float64 |  |
-| `opp_pts_2nd_chance` | Float64 |  |
-| `opp_pts_fb` | Float64 |  |
-| `opp_pts_paint` | Float64 |  |
-| `pts_off_tov_rank` | Int64 |  |
-| `pts_2nd_chance_rank` | Int64 |  |
-| `pts_fb_rank` | Int64 |  |
-| `pts_paint_rank` | Int64 |  |
-| `opp_pts_off_tov_rank` | Int64 |  |
-| `opp_pts_2nd_chance_rank` | Int64 |  |
-| `opp_pts_fb_rank` | Int64 |  |
-| `opp_pts_paint_rank` | Int64 |  |
-| `opp_fgm` | Float64 |  |
-| `opp_fga` | Float64 |  |
-| `opp_fg_pct` | Float64 |  |
-| `opp_fg3m` | Float64 |  |
-| `opp_fg3a` | Float64 |  |
-| `opp_fg3_pct` | Float64 |  |
-| `opp_ftm` | Float64 |  |
-| `opp_fta` | Float64 |  |
-| `opp_ft_pct` | Float64 |  |
-| `opp_oreb` | Float64 |  |
-| `opp_dreb` | Float64 |  |
-| `opp_reb` | Float64 |  |
-| `opp_ast` | Float64 |  |
-| `opp_tov` | Float64 |  |
-| `opp_stl` | Float64 |  |
-| `opp_blk` | Float64 |  |
-| `opp_blka` | Float64 |  |
-| `opp_pf` | Float64 |  |
-| `opp_pfd` | Float64 |  |
+| `fgm_rank` | Int64 | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | Int64 | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | Int64 | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | Int64 | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | Int64 | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | Int64 | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | Int64 | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | Int64 | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | Int64 | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | Int64 | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | Int64 | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | Int64 | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | Int64 | League rank of the row's assists for the season and split. |
+| `tov_rank` | Int64 | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | Int64 | League rank of the row's steals for the season and split. |
+| `blk_rank` | Int64 | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | Int64 | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | Int64 | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | Int64 | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | Int64 | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | Int64 | League rank of the row's plus-minus point differential while on the floor for the season and split. |
+| `pts_off_tov` | Float64 | Points scored off opponent turnovers over the split. |
+| `pts_2nd_chance` | Float64 | Second-chance points over the split. |
+| `pts_fb` | Float64 | Fast-break points over the split. |
+| `pts_paint` | Float64 | Points in the paint over the split. |
+| `opp_pts_off_tov` | Float64 | Opponent points scored off opponent turnovers allowed over the split. |
+| `opp_pts_2nd_chance` | Float64 | Opponent second-chance points allowed over the split. |
+| `opp_pts_fb` | Float64 | Opponent fast-break points allowed over the split. |
+| `opp_pts_paint` | Float64 | Opponent points in the paint allowed over the split. |
+| `pts_off_tov_rank` | Int64 | League rank of the row's points scored off opponent turnovers for the season and split. |
+| `pts_2nd_chance_rank` | Int64 | League rank of the row's second-chance points for the season and split. |
+| `pts_fb_rank` | Int64 | League rank of the row's fast-break points for the season and split. |
+| `pts_paint_rank` | Int64 | League rank of the row's points in the paint for the season and split. |
+| `opp_pts_off_tov_rank` | Int64 | League rank of the row's opponent points scored off opponent turnovers for the season and split. |
+| `opp_pts_2nd_chance_rank` | Int64 | League rank of the row's opponent second-chance points for the season and split. |
+| `opp_pts_fb_rank` | Int64 | League rank of the row's opponent fast-break points for the season and split. |
+| `opp_pts_paint_rank` | Int64 | League rank of the row's opponent points in the paint for the season and split. |
+| `opp_fgm` | Float64 | Opponent field goals made allowed over the split. |
+| `opp_fga` | Float64 | Opponent field goals attempted allowed over the split. |
+| `opp_fg_pct` | Float64 | Opponent field goal percentage allowed over the split. |
+| `opp_fg3m` | Float64 | Opponent three-point field goals made allowed over the split. |
+| `opp_fg3a` | Float64 | Opponent three-point field goals attempted allowed over the split. |
+| `opp_fg3_pct` | Float64 | Opponent three-point field goal percentage allowed over the split. |
+| `opp_ftm` | Float64 | Opponent free throws made allowed over the split. |
+| `opp_fta` | Float64 | Opponent free throws attempted allowed over the split. |
+| `opp_ft_pct` | Float64 | Opponent free throw percentage allowed over the split. |
+| `opp_oreb` | Float64 | Opponent offensive rebounds allowed over the split. |
+| `opp_dreb` | Float64 | Opponent defensive rebounds allowed over the split. |
+| `opp_reb` | Float64 | Opponent total rebounds allowed over the split. |
+| `opp_ast` | Float64 | Opponent assists allowed over the split. |
+| `opp_tov` | Float64 | Opponent turnovers allowed over the split. |
+| `opp_stl` | Float64 | Opponent steals allowed over the split. |
+| `opp_blk` | Float64 | Opponent blocked shots allowed over the split. |
+| `opp_blka` | Float64 | Opponent shot attempts blocked by opponents (blocks against) allowed over the split. |
+| `opp_pf` | Float64 | Opponent personal fouls committed allowed over the split. |
+| `opp_pfd` | Float64 | Opponent personal fouls drawn allowed over the split. |
 | `opp_pts` | Float64 | Opponent points. |
-| `opp_fgm_rank` | Int64 |  |
-| `opp_fga_rank` | Int64 |  |
-| `opp_fg_pct_rank` | Int64 |  |
-| `opp_fg3m_rank` | Int64 |  |
-| `opp_fg3a_rank` | Int64 |  |
-| `opp_fg3_pct_rank` | Int64 |  |
-| `opp_ftm_rank` | Int64 |  |
-| `opp_fta_rank` | Int64 |  |
-| `opp_ft_pct_rank` | Int64 |  |
-| `opp_oreb_rank` | Int64 |  |
-| `opp_dreb_rank` | Int64 |  |
-| `opp_reb_rank` | Int64 |  |
-| `opp_ast_rank` | Int64 |  |
-| `opp_tov_rank` | Int64 |  |
-| `opp_stl_rank` | Int64 |  |
-| `opp_blk_rank` | Int64 |  |
-| `opp_blka_rank` | Int64 |  |
-| `opp_pf_rank` | Int64 |  |
-| `opp_pfd_rank` | Int64 |  |
-| `opp_pts_rank` | Int64 |  |
-| `pct_fga_2pt` | Float64 |  |
-| `pct_fga_3pt` | Float64 |  |
-| `pct_pts_2pt` | Float64 |  |
-| `pct_pts_2pt_mr` | Float64 |  |
-| `pct_pts_3pt` | Float64 |  |
-| `pct_pts_fb` | Float64 |  |
-| `pct_pts_ft` | Float64 |  |
-| `pct_pts_off_tov` | Float64 |  |
-| `pct_pts_paint` | Float64 |  |
-| `pct_ast_2pm` | Float64 |  |
-| `pct_uast_2pm` | Float64 |  |
-| `pct_ast_3pm` | Float64 |  |
-| `pct_uast_3pm` | Float64 |  |
-| `pct_ast_fgm` | Float64 |  |
-| `pct_uast_fgm` | Float64 |  |
-| `pct_fga_2pt_rank` | Int64 |  |
-| `pct_fga_3pt_rank` | Int64 |  |
-| `pct_pts_2pt_rank` | Int64 |  |
-| `pct_pts_2pt_mr_rank` | Int64 |  |
-| `pct_pts_3pt_rank` | Int64 |  |
-| `pct_pts_fb_rank` | Int64 |  |
-| `pct_pts_ft_rank` | Int64 |  |
-| `pct_pts_off_tov_rank` | Int64 |  |
-| `pct_pts_paint_rank` | Int64 |  |
-| `pct_ast_2pm_rank` | Int64 |  |
-| `pct_uast_2pm_rank` | Int64 |  |
-| `pct_ast_3pm_rank` | Int64 |  |
-| `pct_uast_3pm_rank` | Int64 |  |
-| `pct_ast_fgm_rank` | Int64 |  |
-| `pct_uast_fgm_rank` | Int64 |  |
+| `opp_fgm_rank` | Int64 | League rank of the row's opponent field goals made for the season and split. |
+| `opp_fga_rank` | Int64 | League rank of the row's opponent field goals attempted for the season and split. |
+| `opp_fg_pct_rank` | Int64 | League rank of the row's opponent field goal percentage for the season and split. |
+| `opp_fg3m_rank` | Int64 | League rank of the row's opponent three-point field goals made for the season and split. |
+| `opp_fg3a_rank` | Int64 | League rank of the row's opponent three-point field goals attempted for the season and split. |
+| `opp_fg3_pct_rank` | Int64 | League rank of the row's opponent three-point field goal percentage for the season and split. |
+| `opp_ftm_rank` | Int64 | League rank of the row's opponent free throws made for the season and split. |
+| `opp_fta_rank` | Int64 | League rank of the row's opponent free throws attempted for the season and split. |
+| `opp_ft_pct_rank` | Int64 | League rank of the row's opponent free throw percentage for the season and split. |
+| `opp_oreb_rank` | Int64 | League rank of the row's opponent offensive rebounds for the season and split. |
+| `opp_dreb_rank` | Int64 | League rank of the row's opponent defensive rebounds for the season and split. |
+| `opp_reb_rank` | Int64 | League rank of the row's opponent total rebounds for the season and split. |
+| `opp_ast_rank` | Int64 | League rank of the row's opponent assists for the season and split. |
+| `opp_tov_rank` | Int64 | League rank of the row's opponent turnovers for the season and split. |
+| `opp_stl_rank` | Int64 | League rank of the row's opponent steals for the season and split. |
+| `opp_blk_rank` | Int64 | League rank of the row's opponent blocked shots for the season and split. |
+| `opp_blka_rank` | Int64 | League rank of the row's opponent shot attempts blocked by opponents (blocks against) for the season and split. |
+| `opp_pf_rank` | Int64 | League rank of the row's opponent personal fouls committed for the season and split. |
+| `opp_pfd_rank` | Int64 | League rank of the row's opponent personal fouls drawn for the season and split. |
+| `opp_pts_rank` | Int64 | League rank of the row's opponent points scored for the season and split. |
+| `pct_fga_2pt` | Float64 | Share of field goal attempts taken as two-pointers, as a decimal. |
+| `pct_fga_3pt` | Float64 | Share of field goal attempts taken as three-pointers, as a decimal. |
+| `pct_pts_2pt` | Float64 | Share of points scored on two-point field goals, as a decimal. |
+| `pct_pts_2pt_mr` | Float64 | Share of points scored on mid-range two-pointers, as a decimal. |
+| `pct_pts_3pt` | Float64 | Share of points scored on three-pointers, as a decimal. |
+| `pct_pts_fb` | Float64 | Share of points scored on fast breaks, as a decimal. |
+| `pct_pts_ft` | Float64 | Share of points scored at the free throw line, as a decimal. |
+| `pct_pts_off_tov` | Float64 | Share of points scored off opponent turnovers, as a decimal. |
+| `pct_pts_paint` | Float64 | Share of points scored in the paint, as a decimal. |
+| `pct_ast_2pm` | Float64 | Percentage of made two-pointers that were assisted, as a decimal. |
+| `pct_uast_2pm` | Float64 | Percentage of made two-pointers that were unassisted, as a decimal. |
+| `pct_ast_3pm` | Float64 | Percentage of made three-pointers that were assisted, as a decimal. |
+| `pct_uast_3pm` | Float64 | Percentage of made three-pointers that were unassisted, as a decimal. |
+| `pct_ast_fgm` | Float64 | Percentage of made field goals that were assisted, as a decimal. |
+| `pct_uast_fgm` | Float64 | Percentage of made field goals that were unassisted, as a decimal. |
+| `pct_fga_2pt_rank` | Int64 | League rank of the row's share of field goal attempts taken as two-pointers for the season and split. |
+| `pct_fga_3pt_rank` | Int64 | League rank of the row's share of field goal attempts taken as three-pointers for the season and split. |
+| `pct_pts_2pt_rank` | Int64 | League rank of the row's share of points scored on two-point field goals for the season and split. |
+| `pct_pts_2pt_mr_rank` | Int64 | League rank of the row's share of points scored on mid-range two-pointers for the season and split. |
+| `pct_pts_3pt_rank` | Int64 | League rank of the row's share of points scored on three-pointers for the season and split. |
+| `pct_pts_fb_rank` | Int64 | League rank of the row's share of points scored on fast breaks for the season and split. |
+| `pct_pts_ft_rank` | Int64 | League rank of the row's share of points scored at the free throw line for the season and split. |
+| `pct_pts_off_tov_rank` | Int64 | League rank of the row's share of points scored off opponent turnovers for the season and split. |
+| `pct_pts_paint_rank` | Int64 | League rank of the row's share of points scored in the paint for the season and split. |
+| `pct_ast_2pm_rank` | Int64 | League rank of the row's percentage of made two-pointers that were assisted for the season and split. |
+| `pct_uast_2pm_rank` | Int64 | League rank of the row's percentage of made two-pointers that were unassisted for the season and split. |
+| `pct_ast_3pm_rank` | Int64 | League rank of the row's percentage of made three-pointers that were assisted for the season and split. |
+| `pct_uast_3pm_rank` | Int64 | League rank of the row's percentage of made three-pointers that were unassisted for the season and split. |
+| `pct_ast_fgm_rank` | Int64 | League rank of the row's percentage of made field goals that were assisted for the season and split. |
+| `pct_uast_fgm_rank` | Int64 | League rank of the row's percentage of made field goals that were unassisted for the season and split. |
 
 ```python
 load_nba_stats_lineups(seasons=2025)
@@ -907,16 +907,16 @@ Release: [nba_stats_game_lineups](https://github.com/sportsdataverse/sportsdatav
 | `game_id` | String | Unique game identifier. |
 | `action_number` | Int64 | Sequential action number within a game (V3 PBP). |
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
-| `home_player_1` | Int64 |  |
-| `home_player_2` | Int64 |  |
-| `home_player_3` | Int64 |  |
-| `home_player_4` | Int64 |  |
-| `home_player_5` | Int64 |  |
-| `away_player_1` | Int64 |  |
-| `away_player_2` | Int64 |  |
-| `away_player_3` | Int64 |  |
-| `away_player_4` | Int64 |  |
-| `away_player_5` | Int64 |  |
+| `home_player_1` | Int64 | NBA Stats player id of the home on-court player 1 of 5 for the row. |
+| `home_player_2` | Int64 | NBA Stats player id of the home on-court player 2 of 5 for the row. |
+| `home_player_3` | Int64 | NBA Stats player id of the home on-court player 3 of 5 for the row. |
+| `home_player_4` | Int64 | NBA Stats player id of the home on-court player 4 of 5 for the row. |
+| `home_player_5` | Int64 | NBA Stats player id of the home on-court player 5 of 5 for the row. |
+| `away_player_1` | Int64 | NBA Stats player id of the away on-court player 1 of 5 for the row. |
+| `away_player_2` | Int64 | NBA Stats player id of the away on-court player 2 of 5 for the row. |
+| `away_player_3` | Int64 | NBA Stats player id of the away on-court player 3 of 5 for the row. |
+| `away_player_4` | Int64 | NBA Stats player id of the away on-court player 4 of 5 for the row. |
+| `away_player_5` | Int64 | NBA Stats player id of the away on-court player 5 of 5 for the row. |
 | `season` | Int64 | Season year. |
 
 ```python
@@ -948,7 +948,7 @@ Release: [nba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data
 
 | col_name | type | description |
 |---|---|---|
-| `order_index` | Int64 |  |
+| `order_index` | Int64 | Stable within-game ordering index for events after pbpstats-style reordering of the raw feed. |
 | `action_number` | Int64 | Sequential action number within a game (V3 PBP). |
 | `clock` | String | Game clock value. |
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
@@ -975,27 +975,27 @@ Release: [nba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data
 | `game_id` | String | Unique game identifier. |
 | `seconds_remaining` | Float64 | Seconds remaining in the period. |
 | `event_type` | String | Event / play type code (V2 PBP). |
-| `is_made_shot` | Boolean |  |
-| `is_missed_shot` | Boolean |  |
-| `is_free_throw` | Boolean |  |
-| `is_rebound` | Boolean |  |
+| `is_made_shot` | Boolean | Whether the event is a made field goal. |
+| `is_missed_shot` | Boolean | Whether the event is a missed field goal. |
+| `is_free_throw` | Boolean | Whether the event is a free throw attempt. |
+| `is_rebound` | Boolean | Whether the event is a rebound. |
 | `is_turnover` | Boolean | `TRUE` if the play was a turnover. |
-| `is_foul` | Boolean |  |
-| `is_substitution` | Boolean |  |
-| `is_jump_ball` | Boolean |  |
-| `is_timeout` | Boolean |  |
-| `is_period` | Boolean |  |
+| `is_foul` | Boolean | Whether the event is a foul. |
+| `is_substitution` | Boolean | Whether the event is a substitution. |
+| `is_jump_ball` | Boolean | Whether the event is a jump ball. |
+| `is_timeout` | Boolean | Whether the event is a timeout. |
+| `is_period` | Boolean | Whether the event is a period start or end marker. |
 | `possession_number` | Int64 | Possession number. |
-| `off_player_1` | Int64 |  |
-| `off_player_2` | Int64 |  |
-| `off_player_3` | Int64 |  |
-| `off_player_4` | Int64 |  |
-| `off_player_5` | Int64 |  |
-| `def_player_1` | Int64 |  |
-| `def_player_2` | Int64 |  |
-| `def_player_3` | Int64 |  |
-| `def_player_4` | Int64 |  |
-| `def_player_5` | Int64 |  |
+| `off_player_1` | Int64 | NBA Stats player id of offensive on-court player 1 of 5 during the event. |
+| `off_player_2` | Int64 | NBA Stats player id of offensive on-court player 2 of 5 during the event. |
+| `off_player_3` | Int64 | NBA Stats player id of offensive on-court player 3 of 5 during the event. |
+| `off_player_4` | Int64 | NBA Stats player id of offensive on-court player 4 of 5 during the event. |
+| `off_player_5` | Int64 | NBA Stats player id of offensive on-court player 5 of 5 during the event. |
+| `def_player_1` | Int64 | NBA Stats player id of defensive on-court player 1 of 5 during the event. |
+| `def_player_2` | Int64 | NBA Stats player id of defensive on-court player 2 of 5 during the event. |
+| `def_player_3` | Int64 | NBA Stats player id of defensive on-court player 3 of 5 during the event. |
+| `def_player_4` | Int64 | NBA Stats player id of defensive on-court player 4 of 5 during the event. |
+| `def_player_5` | Int64 | NBA Stats player id of defensive on-court player 5 of 5 during the event. |
 | `season` | Int64 | Season year. |
 
 ```python
@@ -1013,18 +1013,18 @@ Release: [nba_stats_possessions](https://github.com/sportsdataverse/sportsdatave
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
 | `possession_number` | Int64 | Possession number. |
 | `offense_team_id` | Int64 | Unique identifier for offense team. |
-| `defense_team_id` | Int64 |  |
-| `start_order_index` | Int64 |  |
-| `end_order_index` | Int64 |  |
-| `start_seconds_remaining` | Float64 |  |
-| `end_seconds_remaining` | Float64 |  |
+| `defense_team_id` | Int64 | NBA Stats team id of the defending team for the possession. |
+| `start_order_index` | Int64 | order_index of the play-by-play event that starts the possession. |
+| `end_order_index` | Int64 | order_index of the play-by-play event that ends the possession. |
+| `start_seconds_remaining` | Float64 | Seconds remaining in the period when the possession started. |
+| `end_seconds_remaining` | Float64 | Seconds remaining in the period when the possession ended. |
 | `points` | Int64 | Points scored. |
-| `is_second_chance` | Boolean |  |
-| `number_in_period` | Int64 |  |
-| `possession_start_type` | String |  |
-| `count_as_possession` | Boolean |  |
-| `fg2a` | Int64 |  |
-| `fg2m` | Int64 |  |
+| `is_second_chance` | Boolean | Whether the row is a second-chance continuation following an offensive rebound. |
+| `number_in_period` | Int64 | Sequential possession number for the offense within the period. |
+| `possession_start_type` | String | How the possession began (e.g. off a made shot, defensive rebound, turnover, or period start). |
+| `count_as_possession` | Boolean | Whether the row counts as a true possession for per-possession rate stats. |
+| `fg2a` | Int64 | Two-point field goal attempts during the possession. |
+| `fg2m` | Int64 | Two-point field goals made during the possession. |
 | `fg3a` | Int64 | Three-point field goal attempts. |
 | `fg3m` | Int64 | Three-point field goals made. |
 | `fta` | Int64 | Free throw attempts. |
@@ -1032,17 +1032,17 @@ Release: [nba_stats_possessions](https://github.com/sportsdataverse/sportsdatave
 | `oreb` | Int64 | Offensive rebounds. |
 | `dreb` | Int64 | Defensive rebounds. |
 | `tov` | Int64 | Turnovers. |
-| `off_player_1` | Int64 |  |
-| `off_player_2` | Int64 |  |
-| `off_player_3` | Int64 |  |
-| `off_player_4` | Int64 |  |
-| `off_player_5` | Int64 |  |
-| `def_player_1` | Int64 |  |
-| `def_player_2` | Int64 |  |
-| `def_player_3` | Int64 |  |
-| `def_player_4` | Int64 |  |
-| `def_player_5` | Int64 |  |
-| `lineup_source` | String |  |
+| `off_player_1` | Int64 | NBA Stats player id of offensive on-court player 1 of 5 for the possession. |
+| `off_player_2` | Int64 | NBA Stats player id of offensive on-court player 2 of 5 for the possession. |
+| `off_player_3` | Int64 | NBA Stats player id of offensive on-court player 3 of 5 for the possession. |
+| `off_player_4` | Int64 | NBA Stats player id of offensive on-court player 4 of 5 for the possession. |
+| `off_player_5` | Int64 | NBA Stats player id of offensive on-court player 5 of 5 for the possession. |
+| `def_player_1` | Int64 | NBA Stats player id of defensive on-court player 1 of 5 for the possession. |
+| `def_player_2` | Int64 | NBA Stats player id of defensive on-court player 2 of 5 for the possession. |
+| `def_player_3` | Int64 | NBA Stats player id of defensive on-court player 3 of 5 for the possession. |
+| `def_player_4` | Int64 | NBA Stats player id of defensive on-court player 4 of 5 for the possession. |
+| `def_player_5` | Int64 | NBA Stats player id of defensive on-court player 5 of 5 for the possession. |
+| `lineup_source` | String | Provenance of the on-court lineup identification for the row (how the five-man units were resolved). |
 | `season` | Int64 | Season year. |
 
 ```python
@@ -1059,16 +1059,16 @@ Release: [nba_stats_game_lineups](https://github.com/sportsdataverse/sportsdatav
 | `game_id` | String | Unique game identifier. |
 | `action_number` | Int64 | Sequential action number within a game (V3 PBP). |
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
-| `home_player_1` | Int64 |  |
-| `home_player_2` | Int64 |  |
-| `home_player_3` | Int64 |  |
-| `home_player_4` | Int64 |  |
-| `home_player_5` | Int64 |  |
-| `away_player_1` | Int64 |  |
-| `away_player_2` | Int64 |  |
-| `away_player_3` | Int64 |  |
-| `away_player_4` | Int64 |  |
-| `away_player_5` | Int64 |  |
+| `home_player_1` | Int64 | NBA Stats player id of the home on-court player 1 of 5 for the row. |
+| `home_player_2` | Int64 | NBA Stats player id of the home on-court player 2 of 5 for the row. |
+| `home_player_3` | Int64 | NBA Stats player id of the home on-court player 3 of 5 for the row. |
+| `home_player_4` | Int64 | NBA Stats player id of the home on-court player 4 of 5 for the row. |
+| `home_player_5` | Int64 | NBA Stats player id of the home on-court player 5 of 5 for the row. |
+| `away_player_1` | Int64 | NBA Stats player id of the away on-court player 1 of 5 for the row. |
+| `away_player_2` | Int64 | NBA Stats player id of the away on-court player 2 of 5 for the row. |
+| `away_player_3` | Int64 | NBA Stats player id of the away on-court player 3 of 5 for the row. |
+| `away_player_4` | Int64 | NBA Stats player id of the away on-court player 4 of 5 for the row. |
+| `away_player_5` | Int64 | NBA Stats player id of the away on-court player 5 of 5 for the row. |
 | `season` | Int64 | Season year. |
 
 ```python
@@ -1082,7 +1082,7 @@ Release: [nba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data
 
 | col_name | type | description |
 |---|---|---|
-| `order_index` | Int64 |  |
+| `order_index` | Int64 | Stable within-game ordering index for events after pbpstats-style reordering of the raw feed. |
 | `action_number` | Int64 | Sequential action number within a game (V3 PBP). |
 | `clock` | String | Game clock value. |
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
@@ -1109,27 +1109,27 @@ Release: [nba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data
 | `game_id` | String | Unique game identifier. |
 | `seconds_remaining` | Float64 | Seconds remaining in the period. |
 | `event_type` | String | Event / play type code (V2 PBP). |
-| `is_made_shot` | Boolean |  |
-| `is_missed_shot` | Boolean |  |
-| `is_free_throw` | Boolean |  |
-| `is_rebound` | Boolean |  |
+| `is_made_shot` | Boolean | Whether the event is a made field goal. |
+| `is_missed_shot` | Boolean | Whether the event is a missed field goal. |
+| `is_free_throw` | Boolean | Whether the event is a free throw attempt. |
+| `is_rebound` | Boolean | Whether the event is a rebound. |
 | `is_turnover` | Boolean | `TRUE` if the play was a turnover. |
-| `is_foul` | Boolean |  |
-| `is_substitution` | Boolean |  |
-| `is_jump_ball` | Boolean |  |
-| `is_timeout` | Boolean |  |
-| `is_period` | Boolean |  |
+| `is_foul` | Boolean | Whether the event is a foul. |
+| `is_substitution` | Boolean | Whether the event is a substitution. |
+| `is_jump_ball` | Boolean | Whether the event is a jump ball. |
+| `is_timeout` | Boolean | Whether the event is a timeout. |
+| `is_period` | Boolean | Whether the event is a period start or end marker. |
 | `possession_number` | Int64 | Possession number. |
-| `off_player_1` | Int64 |  |
-| `off_player_2` | Int64 |  |
-| `off_player_3` | Int64 |  |
-| `off_player_4` | Int64 |  |
-| `off_player_5` | Int64 |  |
-| `def_player_1` | Int64 |  |
-| `def_player_2` | Int64 |  |
-| `def_player_3` | Int64 |  |
-| `def_player_4` | Int64 |  |
-| `def_player_5` | Int64 |  |
+| `off_player_1` | Int64 | NBA Stats player id of offensive on-court player 1 of 5 during the event. |
+| `off_player_2` | Int64 | NBA Stats player id of offensive on-court player 2 of 5 during the event. |
+| `off_player_3` | Int64 | NBA Stats player id of offensive on-court player 3 of 5 during the event. |
+| `off_player_4` | Int64 | NBA Stats player id of offensive on-court player 4 of 5 during the event. |
+| `off_player_5` | Int64 | NBA Stats player id of offensive on-court player 5 of 5 during the event. |
+| `def_player_1` | Int64 | NBA Stats player id of defensive on-court player 1 of 5 during the event. |
+| `def_player_2` | Int64 | NBA Stats player id of defensive on-court player 2 of 5 during the event. |
+| `def_player_3` | Int64 | NBA Stats player id of defensive on-court player 3 of 5 during the event. |
+| `def_player_4` | Int64 | NBA Stats player id of defensive on-court player 4 of 5 during the event. |
+| `def_player_5` | Int64 | NBA Stats player id of defensive on-court player 5 of 5 during the event. |
 | `season` | Int64 | Season year. |
 
 ```python
@@ -1243,78 +1243,78 @@ Release: [nba_stats_player_season_stats](https://github.com/sportsdataverse/spor
 | `l` | Int64 | Losses. |
 | `w_pct` | Float64 | Wins percentage (0-1 decimal). |
 | `min` | Float64 | Minutes played. |
-| `e_off_rating` | Float64 |  |
-| `off_rating` | Float64 |  |
-| `sp_work_off_rating` | Float64 |  |
-| `e_def_rating` | Float64 |  |
-| `def_rating` | Float64 |  |
-| `sp_work_def_rating` | Float64 |  |
-| `e_net_rating` | Float64 |  |
+| `e_off_rating` | Float64 | Estimated offensive rating (NBA Stats estimated-metrics family) over the split. |
+| `off_rating` | Float64 | Offensive rating (points scored per 100 possessions) over the split. |
+| `sp_work_off_rating` | Float64 | Offensive rating carried in the stats API's SP_WORK column set (mirrors off_rating) over the split. |
+| `e_def_rating` | Float64 | Estimated defensive rating (NBA Stats estimated-metrics family) over the split. |
+| `def_rating` | Float64 | Defensive rating (points allowed per 100 possessions) over the split. |
+| `sp_work_def_rating` | Float64 | Defensive rating carried in the stats API's SP_WORK column set (mirrors def_rating) over the split. |
+| `e_net_rating` | Float64 | Estimated net rating (NBA Stats estimated-metrics family) over the split. |
 | `net_rating` | Float64 | Net rating (off rating - def rating). |
-| `sp_work_net_rating` | Float64 |  |
+| `sp_work_net_rating` | Float64 | Net rating carried in the stats API's SP_WORK column set (mirrors net_rating) over the split. |
 | `ast_pct` | Float64 | Assist percentage. |
-| `ast_to` | Float64 |  |
-| `ast_ratio` | Float64 |  |
-| `oreb_pct` | Float64 |  |
-| `dreb_pct` | Float64 |  |
-| `reb_pct` | Float64 |  |
-| `tm_tov_pct` | Float64 |  |
-| `e_tov_pct` | Float64 |  |
-| `efg_pct` | Float64 |  |
+| `ast_to` | Float64 | Assist-to-turnover ratio over the split. |
+| `ast_ratio` | Float64 | Assist ratio (assists per 100 possessions used) over the split. |
+| `oreb_pct` | Float64 | Offensive rebound percentage over the split, as a decimal. |
+| `dreb_pct` | Float64 | Defensive rebound percentage over the split, as a decimal. |
+| `reb_pct` | Float64 | Total rebound percentage over the split, as a decimal. |
+| `tm_tov_pct` | Float64 | Team turnover percentage (turnovers per 100 possessions) over the split, as a decimal. |
+| `e_tov_pct` | Float64 | Estimated turnover percentage (NBA Stats estimated-metrics family) over the split, as a decimal. |
+| `efg_pct` | Float64 | Effective field goal percentage over the split, as a decimal. |
 | `ts_pct` | Float64 | True shooting percentage (0-1). |
-| `usg_pct` | Float64 |  |
-| `e_usg_pct` | Float64 |  |
-| `e_pace` | Float64 |  |
+| `usg_pct` | Float64 | Usage percentage (share of team plays used while on the floor) over the split, as a decimal. |
+| `e_usg_pct` | Float64 | Estimated usage percentage (NBA Stats estimated-metrics family) over the split, as a decimal. |
+| `e_pace` | Float64 | Estimated pace (NBA Stats estimated-metrics family) over the split. |
 | `pace` | Float64 | Possessions per 48 minutes. |
 | `pace_per40` | Float64 | Pace per40. |
-| `sp_work_pace` | Float64 |  |
+| `sp_work_pace` | Float64 | Pace carried in the stats API's SP_WORK column set (mirrors pace) over the split. |
 | `pie` | Float64 | Player Impact Estimate (0-1). |
 | `poss` | Int64 | Poss. |
 | `fgm` | Float64 | Field goals made. |
 | `fga` | Float64 | Field goal attempts. |
-| `fgm_pg` | Float64 |  |
-| `fga_pg` | Float64 |  |
+| `fgm_pg` | Float64 | Field goals made per game over the split. |
+| `fga_pg` | Float64 | Field goals attempted per game over the split. |
 | `fg_pct` | Float64 | Field goal percentage (0-1). |
-| `gp_rank` | Int64 |  |
-| `w_rank` | Int64 |  |
-| `l_rank` | Int64 |  |
-| `w_pct_rank` | Int64 |  |
-| `min_rank` | Int64 |  |
-| `e_off_rating_rank` | Int64 |  |
-| `off_rating_rank` | Int64 |  |
-| `sp_work_off_rating_rank` | Int64 |  |
-| `e_def_rating_rank` | Int64 |  |
-| `def_rating_rank` | Int64 |  |
-| `sp_work_def_rating_rank` | Int64 |  |
-| `e_net_rating_rank` | Int64 |  |
-| `net_rating_rank` | Int64 |  |
-| `sp_work_net_rating_rank` | Int64 |  |
-| `ast_pct_rank` | Int64 |  |
-| `ast_to_rank` | Int64 |  |
-| `ast_ratio_rank` | Int64 |  |
-| `oreb_pct_rank` | Int64 |  |
-| `dreb_pct_rank` | Int64 |  |
-| `reb_pct_rank` | Int64 |  |
-| `tm_tov_pct_rank` | Int64 |  |
-| `e_tov_pct_rank` | Int64 |  |
-| `efg_pct_rank` | Int64 |  |
-| `ts_pct_rank` | Int64 |  |
-| `usg_pct_rank` | Int64 |  |
-| `e_usg_pct_rank` | Int64 |  |
-| `e_pace_rank` | Int64 |  |
-| `pace_rank` | Int64 |  |
-| `sp_work_pace_rank` | Int64 |  |
-| `pie_rank` | Int64 |  |
-| `fgm_rank` | Int64 |  |
-| `fga_rank` | Int64 |  |
-| `fgm_pg_rank` | Int64 |  |
-| `fga_pg_rank` | Int64 |  |
-| `fg_pct_rank` | Int64 |  |
-| `team_count` | Int64 |  |
+| `gp_rank` | Int64 | League rank of the row's games played for the season and split. |
+| `w_rank` | Int64 | League rank of the row's wins for the season and split. |
+| `l_rank` | Int64 | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | Int64 | League rank of the row's win percentage for the season and split. |
+| `min_rank` | Int64 | League rank of the row's minutes played for the season and split. |
+| `e_off_rating_rank` | Int64 | League rank of the row's estimated offensive rating (NBA Stats estimated-metrics family) for the season and split. |
+| `off_rating_rank` | Int64 | League rank of the row's offensive rating (points scored per 100 possessions) for the season and split. |
+| `sp_work_off_rating_rank` | Int64 | League rank of the row's offensive rating carried in the stats API's SP_WORK column set (mirrors off_rating) for the season and split. |
+| `e_def_rating_rank` | Int64 | League rank of the row's estimated defensive rating (NBA Stats estimated-metrics family) for the season and split. |
+| `def_rating_rank` | Int64 | League rank of the row's defensive rating (points allowed per 100 possessions) for the season and split. |
+| `sp_work_def_rating_rank` | Int64 | League rank of the row's defensive rating carried in the stats API's SP_WORK column set (mirrors def_rating) for the season and split. |
+| `e_net_rating_rank` | Int64 | League rank of the row's estimated net rating (NBA Stats estimated-metrics family) for the season and split. |
+| `net_rating_rank` | Int64 | League rank of the row's net rating (offensive minus defensive rating) for the season and split. |
+| `sp_work_net_rating_rank` | Int64 | League rank of the row's net rating carried in the stats API's SP_WORK column set (mirrors net_rating) for the season and split. |
+| `ast_pct_rank` | Int64 | League rank of the row's assist percentage (share of teammate field goals assisted while on the floor) for the season and split. |
+| `ast_to_rank` | Int64 | League rank of the row's assist-to-turnover ratio for the season and split. |
+| `ast_ratio_rank` | Int64 | League rank of the row's assist ratio (assists per 100 possessions used) for the season and split. |
+| `oreb_pct_rank` | Int64 | League rank of the row's offensive rebound percentage for the season and split. |
+| `dreb_pct_rank` | Int64 | League rank of the row's defensive rebound percentage for the season and split. |
+| `reb_pct_rank` | Int64 | League rank of the row's total rebound percentage for the season and split. |
+| `tm_tov_pct_rank` | Int64 | League rank of the row's team turnover percentage (turnovers per 100 possessions) for the season and split. |
+| `e_tov_pct_rank` | Int64 | League rank of the row's estimated turnover percentage (NBA Stats estimated-metrics family) for the season and split. |
+| `efg_pct_rank` | Int64 | League rank of the row's effective field goal percentage for the season and split. |
+| `ts_pct_rank` | Int64 | League rank of the row's true shooting percentage for the season and split. |
+| `usg_pct_rank` | Int64 | League rank of the row's usage percentage (share of team plays used while on the floor) for the season and split. |
+| `e_usg_pct_rank` | Int64 | League rank of the row's estimated usage percentage (NBA Stats estimated-metrics family) for the season and split. |
+| `e_pace_rank` | Int64 | League rank of the row's estimated pace (NBA Stats estimated-metrics family) for the season and split. |
+| `pace_rank` | Int64 | League rank of the row's pace (possessions per 48 minutes) for the season and split. |
+| `sp_work_pace_rank` | Int64 | League rank of the row's pace carried in the stats API's SP_WORK column set (mirrors pace) for the season and split. |
+| `pie_rank` | Int64 | League rank of the row's Player Impact Estimate (PIE, the NBA Stats catch-all impact metric) for the season and split. |
+| `fgm_rank` | Int64 | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | Int64 | League rank of the row's field goals attempted for the season and split. |
+| `fgm_pg_rank` | Int64 | League rank of the row's field goals made per game for the season and split. |
+| `fga_pg_rank` | Int64 | League rank of the row's field goals attempted per game for the season and split. |
+| `fg_pct_rank` | Int64 | League rank of the row's field goal percentage for the season and split. |
+| `team_count` | Int64 | Number of distinct teams aggregated into the split row. |
 | `season` | Int32 | Season year. |
 | `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
-| `measure_type` | String |  |
-| `per_mode` | String |  |
+| `measure_type` | String | NBA Stats measure type the row was pulled from (e.g. Base, Advanced, Misc, Scoring, Opponent, Usage, Defense). |
+| `per_mode` | String | NBA Stats per-mode of the row values (e.g. Totals, PerGame, Per100Possessions). |
 | `fg3m` | Float64 | Three-point field goals made. |
 | `fg3a` | Float64 | Three-point field goal attempts. |
 | `fg3_pct` | Float64 | Three-point field goal percentage (0-1). |
@@ -1328,120 +1328,120 @@ Release: [nba_stats_player_season_stats](https://github.com/sportsdataverse/spor
 | `tov` | Float64 | Turnovers. |
 | `stl` | Float64 | Steals. |
 | `blk` | Float64 | Blocks. |
-| `blka` | Float64 |  |
+| `blka` | Float64 | Shot attempts blocked by opponents (blocks against). |
 | `pf` | Float64 | Personal fouls. |
-| `pfd` | Float64 |  |
+| `pfd` | Float64 | Personal fouls drawn. |
 | `pts` | Float64 | Points scored. |
 | `plus_minus` | Float64 | Plus/minus point differential while on court. |
-| `nba_fantasy_pts` | Float64 |  |
-| `dd2` | Int64 |  |
-| `td3` | Int64 |  |
-| `wnba_fantasy_pts` | Float64 |  |
-| `fg3m_rank` | Int64 |  |
-| `fg3a_rank` | Int64 |  |
-| `fg3_pct_rank` | Int64 |  |
-| `ftm_rank` | Int64 |  |
-| `fta_rank` | Int64 |  |
-| `ft_pct_rank` | Int64 |  |
-| `oreb_rank` | Int64 |  |
-| `dreb_rank` | Int64 |  |
-| `reb_rank` | Int64 |  |
-| `ast_rank` | Int64 |  |
-| `tov_rank` | Int64 |  |
-| `stl_rank` | Int64 |  |
-| `blk_rank` | Int64 |  |
-| `blka_rank` | Int64 |  |
-| `pf_rank` | Int64 |  |
-| `pfd_rank` | Int64 |  |
-| `pts_rank` | Int64 |  |
-| `plus_minus_rank` | Int64 |  |
-| `nba_fantasy_pts_rank` | Int64 |  |
-| `dd2_rank` | Int64 |  |
-| `td3_rank` | Int64 |  |
-| `wnba_fantasy_pts_rank` | Int64 |  |
-| `pct_dreb` | Float64 |  |
-| `pct_stl` | Float64 |  |
-| `pct_blk` | Float64 |  |
-| `opp_pts_off_tov` | Float64 |  |
-| `opp_pts_2nd_chance` | Float64 |  |
-| `opp_pts_fb` | Float64 |  |
-| `opp_pts_paint` | Float64 |  |
-| `def_ws` | Float64 |  |
-| `def_ws_raw` | Float64 |  |
-| `pct_dreb_rank` | Int64 |  |
-| `pct_stl_rank` | Int64 |  |
-| `pct_blk_rank` | Int64 |  |
-| `opp_pts_off_tov_rank` | Int64 |  |
-| `opp_pts_2nd_chance_rank` | Int64 |  |
-| `opp_pts_fb_rank` | Int64 |  |
-| `opp_pts_paint_rank` | Int64 |  |
-| `def_ws_rank` | Int64 |  |
-| `pts_off_tov` | Float64 |  |
-| `pts_2nd_chance` | Float64 |  |
-| `pts_fb` | Float64 |  |
-| `pts_paint` | Float64 |  |
-| `pts_off_tov_rank` | Int64 |  |
-| `pts_2nd_chance_rank` | Int64 |  |
-| `pts_fb_rank` | Int64 |  |
-| `pts_paint_rank` | Int64 |  |
-| `pct_fga_2pt` | Float64 |  |
-| `pct_fga_3pt` | Float64 |  |
-| `pct_pts_2pt` | Float64 |  |
-| `pct_pts_2pt_mr` | Float64 |  |
-| `pct_pts_3pt` | Float64 |  |
-| `pct_pts_fb` | Float64 |  |
-| `pct_pts_ft` | Float64 |  |
-| `pct_pts_off_tov` | Float64 |  |
-| `pct_pts_paint` | Float64 |  |
-| `pct_ast_2pm` | Float64 |  |
-| `pct_uast_2pm` | Float64 |  |
-| `pct_ast_3pm` | Float64 |  |
-| `pct_uast_3pm` | Float64 |  |
-| `pct_ast_fgm` | Float64 |  |
-| `pct_uast_fgm` | Float64 |  |
-| `pct_fga_2pt_rank` | Int64 |  |
-| `pct_fga_3pt_rank` | Int64 |  |
-| `pct_pts_2pt_rank` | Int64 |  |
-| `pct_pts_2pt_mr_rank` | Int64 |  |
-| `pct_pts_3pt_rank` | Int64 |  |
-| `pct_pts_fb_rank` | Int64 |  |
-| `pct_pts_ft_rank` | Int64 |  |
-| `pct_pts_off_tov_rank` | Int64 |  |
-| `pct_pts_paint_rank` | Int64 |  |
-| `pct_ast_2pm_rank` | Int64 |  |
-| `pct_uast_2pm_rank` | Int64 |  |
-| `pct_ast_3pm_rank` | Int64 |  |
-| `pct_uast_3pm_rank` | Int64 |  |
-| `pct_ast_fgm_rank` | Int64 |  |
-| `pct_uast_fgm_rank` | Int64 |  |
-| `pct_fgm` | Float64 |  |
-| `pct_fga` | Float64 |  |
-| `pct_fg3m` | Float64 |  |
-| `pct_fg3a` | Float64 |  |
-| `pct_ftm` | Float64 |  |
-| `pct_fta` | Float64 |  |
-| `pct_oreb` | Float64 |  |
-| `pct_reb` | Float64 |  |
-| `pct_ast` | Float64 |  |
-| `pct_tov` | Float64 |  |
-| `pct_blka` | Float64 |  |
-| `pct_pf` | Float64 |  |
-| `pct_pfd` | Float64 |  |
-| `pct_pts` | Float64 |  |
-| `pct_fgm_rank` | Int64 |  |
-| `pct_fga_rank` | Int64 |  |
-| `pct_fg3m_rank` | Int64 |  |
-| `pct_fg3a_rank` | Int64 |  |
-| `pct_ftm_rank` | Int64 |  |
-| `pct_fta_rank` | Int64 |  |
-| `pct_oreb_rank` | Int64 |  |
-| `pct_reb_rank` | Int64 |  |
-| `pct_ast_rank` | Int64 |  |
-| `pct_tov_rank` | Int64 |  |
-| `pct_blka_rank` | Int64 |  |
-| `pct_pf_rank` | Int64 |  |
-| `pct_pfd_rank` | Int64 |  |
-| `pct_pts_rank` | Int64 |  |
+| `nba_fantasy_pts` | Float64 | Fantasy points under the NBA's fantasy scoring formula. |
+| `dd2` | Int64 | Double-doubles recorded over the split. |
+| `td3` | Int64 | Triple-doubles recorded over the split. |
+| `wnba_fantasy_pts` | Float64 | Fantasy points under the WNBA's fantasy scoring formula. |
+| `fg3m_rank` | Int64 | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | Int64 | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | Int64 | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | Int64 | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | Int64 | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | Int64 | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | Int64 | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | Int64 | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | Int64 | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | Int64 | League rank of the row's assists for the season and split. |
+| `tov_rank` | Int64 | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | Int64 | League rank of the row's steals for the season and split. |
+| `blk_rank` | Int64 | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | Int64 | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | Int64 | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | Int64 | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | Int64 | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | Int64 | League rank of the row's plus-minus point differential while on the floor for the season and split. |
+| `nba_fantasy_pts_rank` | Int64 | League rank of the row's NBA fantasy points (league scoring formula) for the season and split. |
+| `dd2_rank` | Int64 | League rank of the row's double-doubles for the season and split. |
+| `td3_rank` | Int64 | League rank of the row's triple-doubles for the season and split. |
+| `wnba_fantasy_pts_rank` | Int64 | League rank of the row's WNBA fantasy points (league scoring formula) for the season and split. |
+| `pct_dreb` | Float64 | Share of the team's defensive rebounds accounted for by the player while on the floor, as a decimal. |
+| `pct_stl` | Float64 | Share of the team's steals accounted for by the player while on the floor, as a decimal. |
+| `pct_blk` | Float64 | Share of the team's blocked shots accounted for by the player while on the floor, as a decimal. |
+| `opp_pts_off_tov` | Float64 | Opponent points scored off opponent turnovers allowed over the split. |
+| `opp_pts_2nd_chance` | Float64 | Opponent second-chance points allowed over the split. |
+| `opp_pts_fb` | Float64 | Opponent fast-break points allowed over the split. |
+| `opp_pts_paint` | Float64 | Opponent points in the paint allowed over the split. |
+| `def_ws` | Float64 | Defensive win shares credited to the player (NBA Stats defense dashboard metric). |
+| `def_ws_raw` | Float64 | Unscaled (raw) defensive win shares value carried alongside def_ws by the NBA Stats API. |
+| `pct_dreb_rank` | Int64 | League rank of the row's share of the team's defensive rebounds accounted for by the player while on the floor for the season and split. |
+| `pct_stl_rank` | Int64 | League rank of the row's share of the team's steals accounted for by the player while on the floor for the season and split. |
+| `pct_blk_rank` | Int64 | League rank of the row's share of the team's blocked shots accounted for by the player while on the floor for the season and split. |
+| `opp_pts_off_tov_rank` | Int64 | League rank of the row's opponent points scored off opponent turnovers for the season and split. |
+| `opp_pts_2nd_chance_rank` | Int64 | League rank of the row's opponent second-chance points for the season and split. |
+| `opp_pts_fb_rank` | Int64 | League rank of the row's opponent fast-break points for the season and split. |
+| `opp_pts_paint_rank` | Int64 | League rank of the row's opponent points in the paint for the season and split. |
+| `def_ws_rank` | Int64 | League rank of the row's defensive win shares (NBA Stats defense dashboard metric) for the season and split. |
+| `pts_off_tov` | Float64 | Points scored off opponent turnovers over the split. |
+| `pts_2nd_chance` | Float64 | Second-chance points over the split. |
+| `pts_fb` | Float64 | Fast-break points over the split. |
+| `pts_paint` | Float64 | Points in the paint over the split. |
+| `pts_off_tov_rank` | Int64 | League rank of the row's points scored off opponent turnovers for the season and split. |
+| `pts_2nd_chance_rank` | Int64 | League rank of the row's second-chance points for the season and split. |
+| `pts_fb_rank` | Int64 | League rank of the row's fast-break points for the season and split. |
+| `pts_paint_rank` | Int64 | League rank of the row's points in the paint for the season and split. |
+| `pct_fga_2pt` | Float64 | Share of field goal attempts taken as two-pointers, as a decimal. |
+| `pct_fga_3pt` | Float64 | Share of field goal attempts taken as three-pointers, as a decimal. |
+| `pct_pts_2pt` | Float64 | Share of points scored on two-point field goals, as a decimal. |
+| `pct_pts_2pt_mr` | Float64 | Share of points scored on mid-range two-pointers, as a decimal. |
+| `pct_pts_3pt` | Float64 | Share of points scored on three-pointers, as a decimal. |
+| `pct_pts_fb` | Float64 | Share of points scored on fast breaks, as a decimal. |
+| `pct_pts_ft` | Float64 | Share of points scored at the free throw line, as a decimal. |
+| `pct_pts_off_tov` | Float64 | Share of points scored off opponent turnovers, as a decimal. |
+| `pct_pts_paint` | Float64 | Share of points scored in the paint, as a decimal. |
+| `pct_ast_2pm` | Float64 | Percentage of made two-pointers that were assisted, as a decimal. |
+| `pct_uast_2pm` | Float64 | Percentage of made two-pointers that were unassisted, as a decimal. |
+| `pct_ast_3pm` | Float64 | Percentage of made three-pointers that were assisted, as a decimal. |
+| `pct_uast_3pm` | Float64 | Percentage of made three-pointers that were unassisted, as a decimal. |
+| `pct_ast_fgm` | Float64 | Percentage of made field goals that were assisted, as a decimal. |
+| `pct_uast_fgm` | Float64 | Percentage of made field goals that were unassisted, as a decimal. |
+| `pct_fga_2pt_rank` | Int64 | League rank of the row's share of field goal attempts taken as two-pointers for the season and split. |
+| `pct_fga_3pt_rank` | Int64 | League rank of the row's share of field goal attempts taken as three-pointers for the season and split. |
+| `pct_pts_2pt_rank` | Int64 | League rank of the row's share of points scored on two-point field goals for the season and split. |
+| `pct_pts_2pt_mr_rank` | Int64 | League rank of the row's share of points scored on mid-range two-pointers for the season and split. |
+| `pct_pts_3pt_rank` | Int64 | League rank of the row's share of points scored on three-pointers for the season and split. |
+| `pct_pts_fb_rank` | Int64 | League rank of the row's share of points scored on fast breaks for the season and split. |
+| `pct_pts_ft_rank` | Int64 | League rank of the row's share of points scored at the free throw line for the season and split. |
+| `pct_pts_off_tov_rank` | Int64 | League rank of the row's share of points scored off opponent turnovers for the season and split. |
+| `pct_pts_paint_rank` | Int64 | League rank of the row's share of points scored in the paint for the season and split. |
+| `pct_ast_2pm_rank` | Int64 | League rank of the row's percentage of made two-pointers that were assisted for the season and split. |
+| `pct_uast_2pm_rank` | Int64 | League rank of the row's percentage of made two-pointers that were unassisted for the season and split. |
+| `pct_ast_3pm_rank` | Int64 | League rank of the row's percentage of made three-pointers that were assisted for the season and split. |
+| `pct_uast_3pm_rank` | Int64 | League rank of the row's percentage of made three-pointers that were unassisted for the season and split. |
+| `pct_ast_fgm_rank` | Int64 | League rank of the row's percentage of made field goals that were assisted for the season and split. |
+| `pct_uast_fgm_rank` | Int64 | League rank of the row's percentage of made field goals that were unassisted for the season and split. |
+| `pct_fgm` | Float64 | Share of the team's field goals made accounted for by the player while on the floor, as a decimal. |
+| `pct_fga` | Float64 | Share of the team's field goals attempted accounted for by the player while on the floor, as a decimal. |
+| `pct_fg3m` | Float64 | Share of the team's three-point field goals made accounted for by the player while on the floor, as a decimal. |
+| `pct_fg3a` | Float64 | Share of the team's three-point field goals attempted accounted for by the player while on the floor, as a decimal. |
+| `pct_ftm` | Float64 | Share of the team's free throws made accounted for by the player while on the floor, as a decimal. |
+| `pct_fta` | Float64 | Share of the team's free throws attempted accounted for by the player while on the floor, as a decimal. |
+| `pct_oreb` | Float64 | Share of the team's offensive rebounds accounted for by the player while on the floor, as a decimal. |
+| `pct_reb` | Float64 | Share of the team's total rebounds accounted for by the player while on the floor, as a decimal. |
+| `pct_ast` | Float64 | Share of the team's assists accounted for by the player while on the floor, as a decimal. |
+| `pct_tov` | Float64 | Share of the team's turnovers accounted for by the player while on the floor, as a decimal. |
+| `pct_blka` | Float64 | Share of the team's shot attempts blocked by opponents (blocks against) accounted for by the player while on the floor, as a decimal. |
+| `pct_pf` | Float64 | Share of the team's personal fouls committed accounted for by the player while on the floor, as a decimal. |
+| `pct_pfd` | Float64 | Share of the team's personal fouls drawn accounted for by the player while on the floor, as a decimal. |
+| `pct_pts` | Float64 | Share of the team's points scored accounted for by the player while on the floor, as a decimal. |
+| `pct_fgm_rank` | Int64 | League rank of the row's share of the team's field goals made accounted for by the player while on the floor for the season and split. |
+| `pct_fga_rank` | Int64 | League rank of the row's share of the team's field goals attempted accounted for by the player while on the floor for the season and split. |
+| `pct_fg3m_rank` | Int64 | League rank of the row's share of the team's three-point field goals made accounted for by the player while on the floor for the season and split. |
+| `pct_fg3a_rank` | Int64 | League rank of the row's share of the team's three-point field goals attempted accounted for by the player while on the floor for the season and split. |
+| `pct_ftm_rank` | Int64 | League rank of the row's share of the team's free throws made accounted for by the player while on the floor for the season and split. |
+| `pct_fta_rank` | Int64 | League rank of the row's share of the team's free throws attempted accounted for by the player while on the floor for the season and split. |
+| `pct_oreb_rank` | Int64 | League rank of the row's share of the team's offensive rebounds accounted for by the player while on the floor for the season and split. |
+| `pct_reb_rank` | Int64 | League rank of the row's share of the team's total rebounds accounted for by the player while on the floor for the season and split. |
+| `pct_ast_rank` | Int64 | League rank of the row's share of the team's assists accounted for by the player while on the floor for the season and split. |
+| `pct_tov_rank` | Int64 | League rank of the row's share of the team's turnovers accounted for by the player while on the floor for the season and split. |
+| `pct_blka_rank` | Int64 | League rank of the row's share of the team's shot attempts blocked by opponents (blocks against) accounted for by the player while on the floor for the season and split. |
+| `pct_pf_rank` | Int64 | League rank of the row's share of the team's personal fouls committed accounted for by the player while on the floor for the season and split. |
+| `pct_pfd_rank` | Int64 | League rank of the row's share of the team's personal fouls drawn accounted for by the player while on the floor for the season and split. |
+| `pct_pts_rank` | Int64 | League rank of the row's share of the team's points scored accounted for by the player while on the floor for the season and split. |
 
 ```python
 load_nba_stats_player_season_stats(seasons=2025)
@@ -1458,18 +1458,18 @@ Release: [nba_stats_possessions](https://github.com/sportsdataverse/sportsdatave
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
 | `possession_number` | Int64 | Possession number. |
 | `offense_team_id` | Int64 | Unique identifier for offense team. |
-| `defense_team_id` | Int64 |  |
-| `start_order_index` | Int64 |  |
-| `end_order_index` | Int64 |  |
-| `start_seconds_remaining` | Float64 |  |
-| `end_seconds_remaining` | Float64 |  |
+| `defense_team_id` | Int64 | NBA Stats team id of the defending team for the possession. |
+| `start_order_index` | Int64 | order_index of the play-by-play event that starts the possession. |
+| `end_order_index` | Int64 | order_index of the play-by-play event that ends the possession. |
+| `start_seconds_remaining` | Float64 | Seconds remaining in the period when the possession started. |
+| `end_seconds_remaining` | Float64 | Seconds remaining in the period when the possession ended. |
 | `points` | Int64 | Points scored. |
-| `is_second_chance` | Boolean |  |
-| `number_in_period` | Int64 |  |
-| `possession_start_type` | String |  |
-| `count_as_possession` | Boolean |  |
-| `fg2a` | Int64 |  |
-| `fg2m` | Int64 |  |
+| `is_second_chance` | Boolean | Whether the row is a second-chance continuation following an offensive rebound. |
+| `number_in_period` | Int64 | Sequential possession number for the offense within the period. |
+| `possession_start_type` | String | How the possession began (e.g. off a made shot, defensive rebound, turnover, or period start). |
+| `count_as_possession` | Boolean | Whether the row counts as a true possession for per-possession rate stats. |
+| `fg2a` | Int64 | Two-point field goal attempts during the possession. |
+| `fg2m` | Int64 | Two-point field goals made during the possession. |
 | `fg3a` | Int64 | Three-point field goal attempts. |
 | `fg3m` | Int64 | Three-point field goals made. |
 | `fta` | Int64 | Free throw attempts. |
@@ -1477,17 +1477,17 @@ Release: [nba_stats_possessions](https://github.com/sportsdataverse/sportsdatave
 | `oreb` | Int64 | Offensive rebounds. |
 | `dreb` | Int64 | Defensive rebounds. |
 | `tov` | Int64 | Turnovers. |
-| `off_player_1` | Int64 |  |
-| `off_player_2` | Int64 |  |
-| `off_player_3` | Int64 |  |
-| `off_player_4` | Int64 |  |
-| `off_player_5` | Int64 |  |
-| `def_player_1` | Int64 |  |
-| `def_player_2` | Int64 |  |
-| `def_player_3` | Int64 |  |
-| `def_player_4` | Int64 |  |
-| `def_player_5` | Int64 |  |
-| `lineup_source` | String |  |
+| `off_player_1` | Int64 | NBA Stats player id of offensive on-court player 1 of 5 for the possession. |
+| `off_player_2` | Int64 | NBA Stats player id of offensive on-court player 2 of 5 for the possession. |
+| `off_player_3` | Int64 | NBA Stats player id of offensive on-court player 3 of 5 for the possession. |
+| `off_player_4` | Int64 | NBA Stats player id of offensive on-court player 4 of 5 for the possession. |
+| `off_player_5` | Int64 | NBA Stats player id of offensive on-court player 5 of 5 for the possession. |
+| `def_player_1` | Int64 | NBA Stats player id of defensive on-court player 1 of 5 for the possession. |
+| `def_player_2` | Int64 | NBA Stats player id of defensive on-court player 2 of 5 for the possession. |
+| `def_player_3` | Int64 | NBA Stats player id of defensive on-court player 3 of 5 for the possession. |
+| `def_player_4` | Int64 | NBA Stats player id of defensive on-court player 4 of 5 for the possession. |
+| `def_player_5` | Int64 | NBA Stats player id of defensive on-court player 5 of 5 for the possession. |
+| `lineup_source` | String | Provenance of the on-court lineup identification for the row (how the five-man units were resolved). |
 | `season` | Int64 | Season year. |
 
 ```python
@@ -1516,7 +1516,7 @@ Release: [nba_stats_rosters](https://github.com/sportsdataverse/sportsdataverse-
 | `exp` | String | Years of NBA playing experience entering the season ('R' = rookie). |
 | `school` | String | Player school / pre-draft team. |
 | `player_id` | Int64 | Unique player identifier. |
-| `how_acquired` | String |  |
+| `how_acquired` | String | How the team acquired the player (e.g. draft, trade, free agency). |
 | `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 
 ```python
@@ -1571,86 +1571,86 @@ Release: [nba_stats_standings](https://github.com/sportsdataverse/sportsdatavers
 | `playoff_rank` | Int64 | League/season rank for playoff. |
 | `clinch_indicator` | String | Playoff clinch indicator (e.g. 'x' clinched playoff, 'e' eliminated). |
 | `division` | String | Team division. |
-| `division_record` | String |  |
-| `division_rank` | Int64 |  |
+| `division_record` | String | Win-loss record against division opponents. |
+| `division_rank` | Int64 | Team's rank within its division. |
 | `wins` | Int64 | Total wins. |
 | `losses` | Int64 | Total losses. |
 | `win_pct` | Float64 | Win percentage (0-1 decimal). |
-| `league_rank` | Int64 |  |
+| `league_rank` | Int64 | Team's rank in the overall league standings. |
 | `record` | String | Overall win-loss record. |
 | `home` | String | Home. |
 | `road` | String | Road. |
 | `l10` | String | Last-ten record. |
-| `last10_home` | String |  |
-| `last10_road` | String |  |
+| `last10_home` | String | Win-loss record over the team's last 10 home games. |
+| `last10_road` | String | Win-loss record over the team's last 10 road games. |
 | `ot` | String | Ot. |
-| `three_pts_or_less` | String |  |
-| `ten_pts_or_more` | String |  |
-| `long_home_streak` | Int64 |  |
-| `str_long_home_streak` | String |  |
-| `long_road_streak` | Int64 |  |
-| `str_long_road_streak` | String |  |
-| `long_win_streak` | Int64 |  |
-| `long_loss_streak` | Int64 |  |
-| `current_home_streak` | Int64 |  |
-| `str_current_home_streak` | String |  |
-| `current_road_streak` | Int64 |  |
-| `str_current_road_streak` | String |  |
-| `current_streak` | Int64 |  |
-| `str_current_streak` | String |  |
-| `conference_games_back` | Float64 |  |
-| `division_games_back` | Float64 |  |
-| `clinched_conference_title` | Int64 |  |
-| `clinched_division_title` | Int64 |  |
-| `clinched_playoff_birth` | Int64 |  |
-| `clinched_play_in` | Int64 |  |
-| `eliminated_conference` | Int64 |  |
-| `eliminated_division` | Int64 |  |
-| `ahead_at_half` | String |  |
-| `behind_at_half` | String |  |
-| `tied_at_half` | String |  |
-| `ahead_at_third` | String |  |
-| `behind_at_third` | String |  |
-| `tied_at_third` | String |  |
-| `score100_pts` | String |  |
-| `opp_score100_pts` | String |  |
-| `opp_over500` | String |  |
-| `lead_in_fgpct` | String |  |
-| `lead_in_reb` | String |  |
-| `fewer_turnovers` | String |  |
+| `three_pts_or_less` | String | Win-loss record in games decided by three points or fewer. |
+| `ten_pts_or_more` | String | Win-loss record in games decided by ten points or more. |
+| `long_home_streak` | Int64 | Longest home streak of the season (positive counts wins, negative losses). |
+| `str_long_home_streak` | String | Longest home streak of the season as display text (e.g. "W 5"). |
+| `long_road_streak` | Int64 | Longest road streak of the season (positive counts wins, negative losses). |
+| `str_long_road_streak` | String | Longest road streak of the season as display text (e.g. "W 5"). |
+| `long_win_streak` | Int64 | Longest winning streak of the season, in games. |
+| `long_loss_streak` | Int64 | Longest losing streak of the season, in games. |
+| `current_home_streak` | Int64 | Current home streak (positive counts wins, negative losses). |
+| `str_current_home_streak` | String | Current home streak as display text (e.g. "L 2"). |
+| `current_road_streak` | Int64 | Current road streak (positive counts wins, negative losses). |
+| `str_current_road_streak` | String | Current road streak as display text (e.g. "W 3"). |
+| `current_streak` | Int64 | Current overall streak (positive counts wins, negative losses). |
+| `str_current_streak` | String | Current overall streak as display text (e.g. "W 4"). |
+| `conference_games_back` | Float64 | Games behind the conference leader. |
+| `division_games_back` | Float64 | Games behind the division leader. |
+| `clinched_conference_title` | Int64 | Flag (1/0) for whether the team has clinched the conference title. |
+| `clinched_division_title` | Int64 | Flag (1/0) for whether the team has clinched its division. |
+| `clinched_playoff_birth` | Int64 | Flag (1/0) for whether the team has clinched a playoff berth. |
+| `clinched_play_in` | Int64 | Flag (1/0) for whether the team has clinched a play-in tournament spot. |
+| `eliminated_conference` | Int64 | Flag (1/0) for whether the team is eliminated from conference contention. |
+| `eliminated_division` | Int64 | Flag (1/0) for whether the team is eliminated from division contention. |
+| `ahead_at_half` | String | Win-loss record when leading at halftime. |
+| `behind_at_half` | String | Win-loss record when trailing at halftime. |
+| `tied_at_half` | String | Win-loss record when tied at halftime. |
+| `ahead_at_third` | String | Win-loss record when leading after three quarters. |
+| `behind_at_third` | String | Win-loss record when trailing after three quarters. |
+| `tied_at_third` | String | Win-loss record when tied after three quarters. |
+| `score100_pts` | String | Win-loss record when scoring 100 or more points. |
+| `opp_score100_pts` | String | Win-loss record when the opponent scores 100 or more points. |
+| `opp_over500` | String | Win-loss record against teams with winning (over .500) records. |
+| `lead_in_fgpct` | String | Win-loss record when posting the higher field goal percentage. |
+| `lead_in_reb` | String | Win-loss record when out-rebounding the opponent. |
+| `fewer_turnovers` | String | Win-loss record when committing fewer turnovers than the opponent. |
 | `points_pg` | Float64 | Points pg. |
 | `opp_points_pg` | Float64 | Opponent points pg. |
 | `diff_points_pg` | Float64 | Diff points pg. |
-| `vs_east` | String |  |
-| `vs_atlantic` | String |  |
-| `vs_central` | String |  |
-| `vs_southeast` | String |  |
-| `vs_west` | String |  |
-| `vs_northwest` | String |  |
-| `vs_pacific` | String |  |
-| `vs_southwest` | String |  |
-| `jan` | String |  |
-| `feb` | String |  |
-| `mar` | String |  |
-| `apr` | String |  |
-| `may` | Null |  |
-| `jun` | Null |  |
-| `jul` | Null |  |
-| `aug` | Null |  |
-| `sep` | Null |  |
-| `oct` | String |  |
-| `nov` | String |  |
-| `dec` | String |  |
-| `score_80_plus` | String |  |
-| `opp_score_80_plus` | String |  |
-| `score_below_80` | String |  |
-| `opp_score_below_80` | String |  |
-| `total_points` | Int64 |  |
-| `opp_total_points` | Int64 |  |
-| `diff_total_points` | Int64 |  |
-| `league_games_back` | Float64 |  |
-| `playoff_seeding` | Int64 |  |
-| `clinched_post_season` | Int64 |  |
+| `vs_east` | String | Win-loss record against Eastern Conference opponents. |
+| `vs_atlantic` | String | Win-loss record against Atlantic Division opponents. |
+| `vs_central` | String | Win-loss record against Central Division opponents. |
+| `vs_southeast` | String | Win-loss record against Southeast Division opponents. |
+| `vs_west` | String | Win-loss record against Western Conference opponents. |
+| `vs_northwest` | String | Win-loss record against Northwest Division opponents. |
+| `vs_pacific` | String | Win-loss record against Pacific Division opponents. |
+| `vs_southwest` | String | Win-loss record against Southwest Division opponents. |
+| `jan` | String | Win-loss record in games played in January. |
+| `feb` | String | Win-loss record in games played in February. |
+| `mar` | String | Win-loss record in games played in March. |
+| `apr` | String | Win-loss record in games played in April. |
+| `may` | Null | Win-loss record in games played in May. |
+| `jun` | Null | Win-loss record in games played in June. |
+| `jul` | Null | Win-loss record in games played in July. |
+| `aug` | Null | Win-loss record in games played in August. |
+| `sep` | Null | Win-loss record in games played in September. |
+| `oct` | String | Win-loss record in games played in October. |
+| `nov` | String | Win-loss record in games played in November. |
+| `dec` | String | Win-loss record in games played in December. |
+| `score_80_plus` | String | Win-loss record when scoring 80 or more points. |
+| `opp_score_80_plus` | String | Win-loss record when the opponent scores 80 or more points. |
+| `score_below_80` | String | Win-loss record when scoring fewer than 80 points. |
+| `opp_score_below_80` | String | Win-loss record when holding the opponent below 80 points. |
+| `total_points` | Int64 | Total points scored by the team over the season to date. |
+| `opp_total_points` | Int64 | Total points allowed by the team over the season to date. |
+| `diff_total_points` | Int64 | Season point differential (points scored minus points allowed). |
+| `league_games_back` | Float64 | Games behind the overall league leader. |
+| `playoff_seeding` | Int64 | Team's current playoff seed. |
+| `clinched_post_season` | Int64 | Flag (1/0) for whether the team has clinched any postseason berth. |
 | `neutral` | String | Neutral. |
 | `season` | Int32 | Season year. |
 | `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
@@ -1711,49 +1711,49 @@ Release: [nba_stats_team_season_stats](https://github.com/sportsdataverse/sports
 | `l` | Int64 | Losses. |
 | `w_pct` | Float64 | Wins percentage (0-1 decimal). |
 | `min` | Float64 | Minutes played. |
-| `e_off_rating` | Float64 |  |
-| `off_rating` | Float64 |  |
-| `e_def_rating` | Float64 |  |
-| `def_rating` | Float64 |  |
-| `e_net_rating` | Float64 |  |
+| `e_off_rating` | Float64 | Estimated offensive rating (NBA Stats estimated-metrics family) over the split. |
+| `off_rating` | Float64 | Offensive rating (points scored per 100 possessions) over the split. |
+| `e_def_rating` | Float64 | Estimated defensive rating (NBA Stats estimated-metrics family) over the split. |
+| `def_rating` | Float64 | Defensive rating (points allowed per 100 possessions) over the split. |
+| `e_net_rating` | Float64 | Estimated net rating (NBA Stats estimated-metrics family) over the split. |
 | `net_rating` | Float64 | Net rating (off rating - def rating). |
 | `ast_pct` | Float64 | Assist percentage. |
-| `ast_to` | Float64 |  |
-| `ast_ratio` | Float64 |  |
-| `oreb_pct` | Float64 |  |
-| `dreb_pct` | Float64 |  |
-| `reb_pct` | Float64 |  |
-| `tm_tov_pct` | Float64 |  |
-| `efg_pct` | Float64 |  |
+| `ast_to` | Float64 | Assist-to-turnover ratio over the split. |
+| `ast_ratio` | Float64 | Assist ratio (assists per 100 possessions used) over the split. |
+| `oreb_pct` | Float64 | Offensive rebound percentage over the split, as a decimal. |
+| `dreb_pct` | Float64 | Defensive rebound percentage over the split, as a decimal. |
+| `reb_pct` | Float64 | Total rebound percentage over the split, as a decimal. |
+| `tm_tov_pct` | Float64 | Team turnover percentage (turnovers per 100 possessions) over the split, as a decimal. |
+| `efg_pct` | Float64 | Effective field goal percentage over the split, as a decimal. |
 | `ts_pct` | Float64 | True shooting percentage (0-1). |
-| `e_pace` | Float64 |  |
+| `e_pace` | Float64 | Estimated pace (NBA Stats estimated-metrics family) over the split. |
 | `pace` | Float64 | Possessions per 48 minutes. |
 | `pace_per40` | Float64 | Pace per40. |
 | `poss` | Int64 | Poss. |
 | `pie` | Float64 | Player Impact Estimate (0-1). |
-| `gp_rank` | Int64 |  |
-| `w_rank` | Int64 |  |
-| `l_rank` | Int64 |  |
-| `w_pct_rank` | Int64 |  |
-| `min_rank` | Int64 |  |
-| `off_rating_rank` | Int64 |  |
-| `def_rating_rank` | Int64 |  |
-| `net_rating_rank` | Int64 |  |
-| `ast_pct_rank` | Int64 |  |
-| `ast_to_rank` | Int64 |  |
-| `ast_ratio_rank` | Int64 |  |
-| `oreb_pct_rank` | Int64 |  |
-| `dreb_pct_rank` | Int64 |  |
-| `reb_pct_rank` | Int64 |  |
-| `tm_tov_pct_rank` | Int64 |  |
-| `efg_pct_rank` | Int64 |  |
-| `ts_pct_rank` | Int64 |  |
-| `pace_rank` | Int64 |  |
-| `pie_rank` | Int64 |  |
+| `gp_rank` | Int64 | League rank of the row's games played for the season and split. |
+| `w_rank` | Int64 | League rank of the row's wins for the season and split. |
+| `l_rank` | Int64 | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | Int64 | League rank of the row's win percentage for the season and split. |
+| `min_rank` | Int64 | League rank of the row's minutes played for the season and split. |
+| `off_rating_rank` | Int64 | League rank of the row's offensive rating (points scored per 100 possessions) for the season and split. |
+| `def_rating_rank` | Int64 | League rank of the row's defensive rating (points allowed per 100 possessions) for the season and split. |
+| `net_rating_rank` | Int64 | League rank of the row's net rating (offensive minus defensive rating) for the season and split. |
+| `ast_pct_rank` | Int64 | League rank of the row's assist percentage (share of teammate field goals assisted while on the floor) for the season and split. |
+| `ast_to_rank` | Int64 | League rank of the row's assist-to-turnover ratio for the season and split. |
+| `ast_ratio_rank` | Int64 | League rank of the row's assist ratio (assists per 100 possessions used) for the season and split. |
+| `oreb_pct_rank` | Int64 | League rank of the row's offensive rebound percentage for the season and split. |
+| `dreb_pct_rank` | Int64 | League rank of the row's defensive rebound percentage for the season and split. |
+| `reb_pct_rank` | Int64 | League rank of the row's total rebound percentage for the season and split. |
+| `tm_tov_pct_rank` | Int64 | League rank of the row's team turnover percentage (turnovers per 100 possessions) for the season and split. |
+| `efg_pct_rank` | Int64 | League rank of the row's effective field goal percentage for the season and split. |
+| `ts_pct_rank` | Int64 | League rank of the row's true shooting percentage for the season and split. |
+| `pace_rank` | Int64 | League rank of the row's pace (possessions per 48 minutes) for the season and split. |
+| `pie_rank` | Int64 | League rank of the row's Player Impact Estimate (PIE, the NBA Stats catch-all impact metric) for the season and split. |
 | `season` | Int32 | Season year. |
 | `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
-| `measure_type` | String |  |
-| `per_mode` | String |  |
+| `measure_type` | String | NBA Stats measure type the row was pulled from (e.g. Base, Advanced, Misc, Scoring, Opponent, Usage, Defense). |
+| `per_mode` | String | NBA Stats per-mode of the row values (e.g. Totals, PerGame, Per100Possessions). |
 | `fgm` | Float64 | Field goals made. |
 | `fga` | Float64 | Field goal attempts. |
 | `fg_pct` | Float64 | Field goal percentage (0-1). |
@@ -1770,118 +1770,118 @@ Release: [nba_stats_team_season_stats](https://github.com/sportsdataverse/sports
 | `tov` | Float64 | Turnovers. |
 | `stl` | Float64 | Steals. |
 | `blk` | Float64 | Blocks. |
-| `blka` | Float64 |  |
+| `blka` | Float64 | Shot attempts blocked by opponents (blocks against). |
 | `pf` | Float64 | Personal fouls. |
-| `pfd` | Float64 |  |
+| `pfd` | Float64 | Personal fouls drawn. |
 | `pts` | Float64 | Points scored. |
 | `plus_minus` | Float64 | Plus/minus point differential while on court. |
-| `fgm_rank` | Int64 |  |
-| `fga_rank` | Int64 |  |
-| `fg_pct_rank` | Int64 |  |
-| `fg3m_rank` | Int64 |  |
-| `fg3a_rank` | Int64 |  |
-| `fg3_pct_rank` | Int64 |  |
-| `ftm_rank` | Int64 |  |
-| `fta_rank` | Int64 |  |
-| `ft_pct_rank` | Int64 |  |
-| `oreb_rank` | Int64 |  |
-| `dreb_rank` | Int64 |  |
-| `reb_rank` | Int64 |  |
-| `ast_rank` | Int64 |  |
-| `tov_rank` | Int64 |  |
-| `stl_rank` | Int64 |  |
-| `blk_rank` | Int64 |  |
-| `blka_rank` | Int64 |  |
-| `pf_rank` | Int64 |  |
-| `pfd_rank` | Int64 |  |
-| `pts_rank` | Int64 |  |
-| `plus_minus_rank` | Int64 |  |
-| `opp_pts_off_tov` | Float64 |  |
-| `opp_pts_2nd_chance` | Float64 |  |
-| `opp_pts_fb` | Float64 |  |
-| `opp_pts_paint` | Float64 |  |
-| `opp_pts_off_tov_rank` | Int64 |  |
-| `opp_pts_2nd_chance_rank` | Int64 |  |
-| `opp_pts_fb_rank` | Int64 |  |
-| `opp_pts_paint_rank` | Int64 |  |
-| `pts_off_tov` | Float64 |  |
-| `pts_2nd_chance` | Float64 |  |
-| `pts_fb` | Float64 |  |
-| `pts_paint` | Float64 |  |
-| `pts_off_tov_rank` | Int64 |  |
-| `pts_2nd_chance_rank` | Int64 |  |
-| `pts_fb_rank` | Int64 |  |
-| `pts_paint_rank` | Int64 |  |
-| `opp_fgm` | Float64 |  |
-| `opp_fga` | Float64 |  |
-| `opp_fg_pct` | Float64 |  |
-| `opp_fg3m` | Float64 |  |
-| `opp_fg3a` | Float64 |  |
-| `opp_fg3_pct` | Float64 |  |
-| `opp_ftm` | Float64 |  |
-| `opp_fta` | Float64 |  |
-| `opp_ft_pct` | Float64 |  |
-| `opp_oreb` | Float64 |  |
-| `opp_dreb` | Float64 |  |
-| `opp_reb` | Float64 |  |
-| `opp_ast` | Float64 |  |
-| `opp_tov` | Float64 |  |
-| `opp_stl` | Float64 |  |
-| `opp_blk` | Float64 |  |
-| `opp_blka` | Float64 |  |
-| `opp_pf` | Float64 |  |
-| `opp_pfd` | Float64 |  |
+| `fgm_rank` | Int64 | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | Int64 | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | Int64 | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | Int64 | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | Int64 | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | Int64 | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | Int64 | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | Int64 | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | Int64 | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | Int64 | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | Int64 | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | Int64 | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | Int64 | League rank of the row's assists for the season and split. |
+| `tov_rank` | Int64 | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | Int64 | League rank of the row's steals for the season and split. |
+| `blk_rank` | Int64 | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | Int64 | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | Int64 | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | Int64 | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | Int64 | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | Int64 | League rank of the row's plus-minus point differential while on the floor for the season and split. |
+| `opp_pts_off_tov` | Float64 | Opponent points scored off opponent turnovers allowed over the split. |
+| `opp_pts_2nd_chance` | Float64 | Opponent second-chance points allowed over the split. |
+| `opp_pts_fb` | Float64 | Opponent fast-break points allowed over the split. |
+| `opp_pts_paint` | Float64 | Opponent points in the paint allowed over the split. |
+| `opp_pts_off_tov_rank` | Int64 | League rank of the row's opponent points scored off opponent turnovers for the season and split. |
+| `opp_pts_2nd_chance_rank` | Int64 | League rank of the row's opponent second-chance points for the season and split. |
+| `opp_pts_fb_rank` | Int64 | League rank of the row's opponent fast-break points for the season and split. |
+| `opp_pts_paint_rank` | Int64 | League rank of the row's opponent points in the paint for the season and split. |
+| `pts_off_tov` | Float64 | Points scored off opponent turnovers over the split. |
+| `pts_2nd_chance` | Float64 | Second-chance points over the split. |
+| `pts_fb` | Float64 | Fast-break points over the split. |
+| `pts_paint` | Float64 | Points in the paint over the split. |
+| `pts_off_tov_rank` | Int64 | League rank of the row's points scored off opponent turnovers for the season and split. |
+| `pts_2nd_chance_rank` | Int64 | League rank of the row's second-chance points for the season and split. |
+| `pts_fb_rank` | Int64 | League rank of the row's fast-break points for the season and split. |
+| `pts_paint_rank` | Int64 | League rank of the row's points in the paint for the season and split. |
+| `opp_fgm` | Float64 | Opponent field goals made allowed over the split. |
+| `opp_fga` | Float64 | Opponent field goals attempted allowed over the split. |
+| `opp_fg_pct` | Float64 | Opponent field goal percentage allowed over the split. |
+| `opp_fg3m` | Float64 | Opponent three-point field goals made allowed over the split. |
+| `opp_fg3a` | Float64 | Opponent three-point field goals attempted allowed over the split. |
+| `opp_fg3_pct` | Float64 | Opponent three-point field goal percentage allowed over the split. |
+| `opp_ftm` | Float64 | Opponent free throws made allowed over the split. |
+| `opp_fta` | Float64 | Opponent free throws attempted allowed over the split. |
+| `opp_ft_pct` | Float64 | Opponent free throw percentage allowed over the split. |
+| `opp_oreb` | Float64 | Opponent offensive rebounds allowed over the split. |
+| `opp_dreb` | Float64 | Opponent defensive rebounds allowed over the split. |
+| `opp_reb` | Float64 | Opponent total rebounds allowed over the split. |
+| `opp_ast` | Float64 | Opponent assists allowed over the split. |
+| `opp_tov` | Float64 | Opponent turnovers allowed over the split. |
+| `opp_stl` | Float64 | Opponent steals allowed over the split. |
+| `opp_blk` | Float64 | Opponent blocked shots allowed over the split. |
+| `opp_blka` | Float64 | Opponent shot attempts blocked by opponents (blocks against) allowed over the split. |
+| `opp_pf` | Float64 | Opponent personal fouls committed allowed over the split. |
+| `opp_pfd` | Float64 | Opponent personal fouls drawn allowed over the split. |
 | `opp_pts` | Float64 | Opponent points. |
-| `opp_fgm_rank` | Int64 |  |
-| `opp_fga_rank` | Int64 |  |
-| `opp_fg_pct_rank` | Int64 |  |
-| `opp_fg3m_rank` | Int64 |  |
-| `opp_fg3a_rank` | Int64 |  |
-| `opp_fg3_pct_rank` | Int64 |  |
-| `opp_ftm_rank` | Int64 |  |
-| `opp_fta_rank` | Int64 |  |
-| `opp_ft_pct_rank` | Int64 |  |
-| `opp_oreb_rank` | Int64 |  |
-| `opp_dreb_rank` | Int64 |  |
-| `opp_reb_rank` | Int64 |  |
-| `opp_ast_rank` | Int64 |  |
-| `opp_tov_rank` | Int64 |  |
-| `opp_stl_rank` | Int64 |  |
-| `opp_blk_rank` | Int64 |  |
-| `opp_blka_rank` | Int64 |  |
-| `opp_pf_rank` | Int64 |  |
-| `opp_pfd_rank` | Int64 |  |
-| `opp_pts_rank` | Int64 |  |
-| `pct_fga_2pt` | Float64 |  |
-| `pct_fga_3pt` | Float64 |  |
-| `pct_pts_2pt` | Float64 |  |
-| `pct_pts_2pt_mr` | Float64 |  |
-| `pct_pts_3pt` | Float64 |  |
-| `pct_pts_fb` | Float64 |  |
-| `pct_pts_ft` | Float64 |  |
-| `pct_pts_off_tov` | Float64 |  |
-| `pct_pts_paint` | Float64 |  |
-| `pct_ast_2pm` | Float64 |  |
-| `pct_uast_2pm` | Float64 |  |
-| `pct_ast_3pm` | Float64 |  |
-| `pct_uast_3pm` | Float64 |  |
-| `pct_ast_fgm` | Float64 |  |
-| `pct_uast_fgm` | Float64 |  |
-| `pct_fga_2pt_rank` | Int64 |  |
-| `pct_fga_3pt_rank` | Int64 |  |
-| `pct_pts_2pt_rank` | Int64 |  |
-| `pct_pts_2pt_mr_rank` | Int64 |  |
-| `pct_pts_3pt_rank` | Int64 |  |
-| `pct_pts_fb_rank` | Int64 |  |
-| `pct_pts_ft_rank` | Int64 |  |
-| `pct_pts_off_tov_rank` | Int64 |  |
-| `pct_pts_paint_rank` | Int64 |  |
-| `pct_ast_2pm_rank` | Int64 |  |
-| `pct_uast_2pm_rank` | Int64 |  |
-| `pct_ast_3pm_rank` | Int64 |  |
-| `pct_uast_3pm_rank` | Int64 |  |
-| `pct_ast_fgm_rank` | Int64 |  |
-| `pct_uast_fgm_rank` | Int64 |  |
+| `opp_fgm_rank` | Int64 | League rank of the row's opponent field goals made for the season and split. |
+| `opp_fga_rank` | Int64 | League rank of the row's opponent field goals attempted for the season and split. |
+| `opp_fg_pct_rank` | Int64 | League rank of the row's opponent field goal percentage for the season and split. |
+| `opp_fg3m_rank` | Int64 | League rank of the row's opponent three-point field goals made for the season and split. |
+| `opp_fg3a_rank` | Int64 | League rank of the row's opponent three-point field goals attempted for the season and split. |
+| `opp_fg3_pct_rank` | Int64 | League rank of the row's opponent three-point field goal percentage for the season and split. |
+| `opp_ftm_rank` | Int64 | League rank of the row's opponent free throws made for the season and split. |
+| `opp_fta_rank` | Int64 | League rank of the row's opponent free throws attempted for the season and split. |
+| `opp_ft_pct_rank` | Int64 | League rank of the row's opponent free throw percentage for the season and split. |
+| `opp_oreb_rank` | Int64 | League rank of the row's opponent offensive rebounds for the season and split. |
+| `opp_dreb_rank` | Int64 | League rank of the row's opponent defensive rebounds for the season and split. |
+| `opp_reb_rank` | Int64 | League rank of the row's opponent total rebounds for the season and split. |
+| `opp_ast_rank` | Int64 | League rank of the row's opponent assists for the season and split. |
+| `opp_tov_rank` | Int64 | League rank of the row's opponent turnovers for the season and split. |
+| `opp_stl_rank` | Int64 | League rank of the row's opponent steals for the season and split. |
+| `opp_blk_rank` | Int64 | League rank of the row's opponent blocked shots for the season and split. |
+| `opp_blka_rank` | Int64 | League rank of the row's opponent shot attempts blocked by opponents (blocks against) for the season and split. |
+| `opp_pf_rank` | Int64 | League rank of the row's opponent personal fouls committed for the season and split. |
+| `opp_pfd_rank` | Int64 | League rank of the row's opponent personal fouls drawn for the season and split. |
+| `opp_pts_rank` | Int64 | League rank of the row's opponent points scored for the season and split. |
+| `pct_fga_2pt` | Float64 | Share of field goal attempts taken as two-pointers, as a decimal. |
+| `pct_fga_3pt` | Float64 | Share of field goal attempts taken as three-pointers, as a decimal. |
+| `pct_pts_2pt` | Float64 | Share of points scored on two-point field goals, as a decimal. |
+| `pct_pts_2pt_mr` | Float64 | Share of points scored on mid-range two-pointers, as a decimal. |
+| `pct_pts_3pt` | Float64 | Share of points scored on three-pointers, as a decimal. |
+| `pct_pts_fb` | Float64 | Share of points scored on fast breaks, as a decimal. |
+| `pct_pts_ft` | Float64 | Share of points scored at the free throw line, as a decimal. |
+| `pct_pts_off_tov` | Float64 | Share of points scored off opponent turnovers, as a decimal. |
+| `pct_pts_paint` | Float64 | Share of points scored in the paint, as a decimal. |
+| `pct_ast_2pm` | Float64 | Percentage of made two-pointers that were assisted, as a decimal. |
+| `pct_uast_2pm` | Float64 | Percentage of made two-pointers that were unassisted, as a decimal. |
+| `pct_ast_3pm` | Float64 | Percentage of made three-pointers that were assisted, as a decimal. |
+| `pct_uast_3pm` | Float64 | Percentage of made three-pointers that were unassisted, as a decimal. |
+| `pct_ast_fgm` | Float64 | Percentage of made field goals that were assisted, as a decimal. |
+| `pct_uast_fgm` | Float64 | Percentage of made field goals that were unassisted, as a decimal. |
+| `pct_fga_2pt_rank` | Int64 | League rank of the row's share of field goal attempts taken as two-pointers for the season and split. |
+| `pct_fga_3pt_rank` | Int64 | League rank of the row's share of field goal attempts taken as three-pointers for the season and split. |
+| `pct_pts_2pt_rank` | Int64 | League rank of the row's share of points scored on two-point field goals for the season and split. |
+| `pct_pts_2pt_mr_rank` | Int64 | League rank of the row's share of points scored on mid-range two-pointers for the season and split. |
+| `pct_pts_3pt_rank` | Int64 | League rank of the row's share of points scored on three-pointers for the season and split. |
+| `pct_pts_fb_rank` | Int64 | League rank of the row's share of points scored on fast breaks for the season and split. |
+| `pct_pts_ft_rank` | Int64 | League rank of the row's share of points scored at the free throw line for the season and split. |
+| `pct_pts_off_tov_rank` | Int64 | League rank of the row's share of points scored off opponent turnovers for the season and split. |
+| `pct_pts_paint_rank` | Int64 | League rank of the row's share of points scored in the paint for the season and split. |
+| `pct_ast_2pm_rank` | Int64 | League rank of the row's percentage of made two-pointers that were assisted for the season and split. |
+| `pct_uast_2pm_rank` | Int64 | League rank of the row's percentage of made two-pointers that were unassisted for the season and split. |
+| `pct_ast_3pm_rank` | Int64 | League rank of the row's percentage of made three-pointers that were assisted for the season and split. |
+| `pct_uast_3pm_rank` | Int64 | League rank of the row's percentage of made three-pointers that were unassisted for the season and split. |
+| `pct_ast_fgm_rank` | Int64 | League rank of the row's percentage of made field goals that were assisted for the season and split. |
+| `pct_uast_fgm_rank` | Int64 | League rank of the row's percentage of made field goals that were unassisted for the season and split. |
 
 ```python
 load_nba_stats_team_season_stats(seasons=2025)
@@ -1902,10 +1902,10 @@ Release: [nba_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data
 | `espn_full_name` | String | ESPN full name. |
 | `espn_jersey` | String | ESPN jersey number. |
 | `espn_position` | String | ESPN position abbreviation. |
-| `nba_player_id` | String |  |
-| `nba_player_name` | String |  |
-| `nba_jersey_num` | String |  |
-| `nba_position` | String |  |
+| `nba_player_id` | String | NBA Stats player id side of the ESPN-to-NBA player crosswalk. |
+| `nba_player_name` | String | Player name as listed by the NBA Stats API. |
+| `nba_jersey_num` | String | Player's jersey number as listed by the NBA Stats API. |
+| `nba_position` | String | Player's position as listed by the NBA Stats API. |
 | `fox_athlete_id` | String | Fox athlete id (NA if unmatched). |
 | `fox_player` | String | Fox player name (NA if unmatched). |
 | `fox_jersey` | String | Fox jersey number (NA if unmatched). |
@@ -1933,13 +1933,13 @@ Release: [nba_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data
 | `home_espn_team_id` | Int32 | ESPN home team id (NA for bart-only rows). |
 | `away_espn_team_id` | Int32 | ESPN away team id (NA for bart-only rows). |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
-| `nba_game_id` | String |  |
-| `nba_game_code` | String |  |
-| `nba_home_team_id` | String |  |
-| `nba_away_team_id` | String |  |
+| `nba_game_id` | String | NBA Stats 10-character game id matched to the ESPN game in the crosswalk. |
+| `nba_game_code` | String | NBA game code (date and matchup string) from the NBA Stats API. |
+| `nba_home_team_id` | String | NBA Stats team id of the home team. |
+| `nba_away_team_id` | String | NBA Stats team id of the away team. |
 | `fox_game_id` | String | Fox game id (NA placeholder). |
-| `fox_home_team_id` | String |  |
-| `fox_away_team_id` | String |  |
+| `fox_home_team_id` | String | FOX Sports team id of the home team in the crosswalk. |
+| `fox_away_team_id` | String | FOX Sports team id of the away team in the crosswalk. |
 | `yahoo_game_id` | String | Yahoo game id (NA placeholder). |
 | `match_method` | String | Combination of matched sources, e.g. "fox+bart" / "fox_only" / "bart_only" / "espn_only". |
 | `match_confidence` | Float64 | Jaro-Winkler score or 1 for exact (NA if none). |
@@ -1962,13 +1962,13 @@ Release: [nba_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data
 | `espn_short_name` | String | ESPN short name. |
 | `espn_location` | String | ESPN school/location only. |
 | `espn_mascot` | String | ESPN mascot/nickname. |
-| `nba_team_id` | String |  |
-| `nba_team_abbreviation` | String |  |
-| `nba_team_name` | String |  |
-| `nba_team_city` | String |  |
-| `nba_team_slug` | String |  |
-| `nba_conference` | String |  |
-| `nba_division` | String |  |
+| `nba_team_id` | String | NBA Stats team id side of the ESPN-to-NBA team crosswalk. |
+| `nba_team_abbreviation` | String | Team abbreviation as listed by the NBA Stats API. |
+| `nba_team_name` | String | Team nickname as listed by the NBA Stats API. |
+| `nba_team_city` | String | Team city as listed by the NBA Stats API. |
+| `nba_team_slug` | String | URL-friendly slug for the team's name on NBA Stats. |
+| `nba_conference` | String | Team's conference as listed by the NBA Stats API. |
+| `nba_division` | String | Team's division as listed by the NBA Stats API. |
 | `fox_team_id` | String | Fox Bifrost team id (NA if unmatched). |
 | `fox_team_name` | String | Fox team name (NA if unmatched). |
 | `yahoo_team_id` | String | Yahoo team id (NA placeholder). |

--- a/docs/docs/nba/reference/nba_stats.md
+++ b/docs/docs/nba/reference/nba_stats.md
@@ -31,8 +31,8 @@ GET /stats/alltimeleadersgrids
 | `player_id` | integer | Unique player identifier. |
 | `player_name` | character | Player name. |
 | `tov` | numeric | Turnovers. |
-| `tov_rank` | integer |  |
-| `is_active_flag` | character |  |
+| `tov_rank` | integer | All-time league rank of the player's career turnover total on the leaders grid. |
+| `is_active_flag` | character | Flag indicating whether the player is currently active in the league. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -164,42 +164,42 @@ GET /stats/boxscoreadvancedv3
 | col_name | type | description |
 |---|---|---|
 | `pie` | numeric | Player Impact Estimate (0-1). |
-| `assistpercentage` | numeric |  |
-| `assistratio` | numeric |  |
-| `assisttoturnover` | numeric |  |
+| `assistpercentage` | numeric | Percentage of teammate field goals assisted while on the floor, as a decimal. |
+| `assistratio` | numeric | Assists per 100 possessions used (assist ratio). |
+| `assisttoturnover` | numeric | Ratio of assists to turnovers. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `defensiverating` | numeric |  |
-| `defensivereboundpercentage` | numeric |  |
-| `effectivefieldgoalpercentage` | numeric |  |
-| `estimateddefensiverating` | numeric |  |
-| `estimatednetrating` | numeric |  |
-| `estimatedoffensiverating` | numeric |  |
-| `estimatedpace` | numeric |  |
-| `estimatedusagepercentage` | numeric |  |
-| `familyname` | character |  |
+| `defensiverating` | numeric | Points allowed per 100 possessions while on the floor (defensive rating). |
+| `defensivereboundpercentage` | numeric | Percentage of available defensive rebounds secured while on the floor, as a decimal. |
+| `effectivefieldgoalpercentage` | numeric | Effective field goal percentage (weights made threes at 1.5), as a decimal. |
+| `estimateddefensiverating` | numeric | Estimated defensive rating from the stats API's estimated-metrics family. |
+| `estimatednetrating` | numeric | Estimated net rating (estimated offensive minus defensive rating) from the stats API's estimated-metrics family. |
+| `estimatedoffensiverating` | numeric | Estimated offensive rating from the stats API's estimated-metrics family. |
+| `estimatedpace` | numeric | Estimated pace (possessions per 48 minutes) from the stats API's estimated-metrics family. |
+| `estimatedusagepercentage` | numeric | Estimated percentage of team plays used by the player while on the floor, as a decimal. |
+| `familyname` | character | Player's family (last) name. |
 | `firstname` | character | Firstname. |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `netrating` | numeric |  |
-| `offensiverating` | numeric |  |
-| `offensivereboundpercentage` | numeric |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `netrating` | numeric | Offensive rating minus defensive rating while on the floor (net rating). |
+| `offensiverating` | numeric | Points scored per 100 possessions while on the floor (offensive rating). |
+| `offensivereboundpercentage` | numeric | Percentage of available offensive rebounds secured while on the floor, as a decimal. |
 | `pace` | numeric | Possessions per 48 minutes. |
-| `paceper40` | numeric |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
+| `paceper40` | numeric | Pace normalized to possessions per 40 minutes. |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `possessions` | numeric | Possessions used. |
-| `reboundpercentage` | numeric |  |
+| `reboundpercentage` | numeric | Percentage of all available rebounds secured while on the floor, as a decimal. |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
-| `trueshootingpercentage` | numeric |  |
-| `turnoverratio` | numeric |  |
-| `usagepercentage` | numeric |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
+| `trueshootingpercentage` | numeric | True shooting percentage (accounts for threes and free throws), as a decimal. |
+| `turnoverratio` | numeric | Turnovers per 100 possessions used (turnover ratio). |
+| `usagepercentage` | numeric | Percentage of team plays used by the player while on the floor, as a decimal. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -291,28 +291,28 @@ GET /stats/boxscorefourfactorsv3
 | col_name | type | description |
 |---|---|---|
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `effectivefieldgoalpercentage` | numeric |  |
-| `familyname` | character |  |
+| `effectivefieldgoalpercentage` | numeric | Effective field goal percentage four-factor, as a decimal. |
+| `familyname` | character | Player's family (last) name. |
 | `firstname` | character | Firstname. |
-| `freethrowattemptrate` | numeric |  |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
+| `freethrowattemptrate` | numeric | Free throw attempts per field goal attempt (free throw rate four-factor). |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `offensivereboundpercentage` | numeric |  |
-| `oppeffectivefieldgoalpercentage` | numeric |  |
-| `oppfreethrowattemptrate` | numeric |  |
-| `oppoffensivereboundpercentage` | numeric |  |
-| `oppteamturnoverpercentage` | numeric |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `offensivereboundpercentage` | numeric | Offensive rebound percentage four-factor, as a decimal. |
+| `oppeffectivefieldgoalpercentage` | numeric | Opponent's effective field goal percentage while on the floor, as a decimal. |
+| `oppfreethrowattemptrate` | numeric | Opponent's free throw attempt rate while on the floor. |
+| `oppoffensivereboundpercentage` | numeric | Opponent's offensive rebound percentage while on the floor, as a decimal. |
+| `oppteamturnoverpercentage` | numeric | Opponent turnovers forced per 100 possessions while on the floor. |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
-| `teamturnoverpercentage` | numeric |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
+| `teamturnoverpercentage` | numeric | Turnovers committed per 100 possessions (turnover four-factor). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -341,37 +341,37 @@ GET /stats/boxscorehustlev2
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `boxoutplayerrebounds` | integer |  |
-| `boxoutplayerteamrebounds` | integer |  |
-| `boxouts` | integer |  |
-| `chargesdrawn` | integer |  |
+| `boxoutplayerrebounds` | integer | Rebounds the player secured directly off their own box-outs. |
+| `boxoutplayerteamrebounds` | integer | Team rebounds secured following the player's box-outs. |
+| `boxouts` | integer | Total box-outs recorded in the game (hustle stats tracking). |
+| `chargesdrawn` | integer | Offensive charges drawn. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `contestedshots` | integer |  |
-| `contestedshots2pt` | integer |  |
-| `contestedshots3pt` | integer |  |
-| `defensiveboxouts` | integer |  |
+| `contestedshots` | integer | Opponent shot attempts contested in the game. |
+| `contestedshots2pt` | integer | Opponent two-point attempts contested. |
+| `contestedshots3pt` | integer | Opponent three-point attempts contested. |
+| `defensiveboxouts` | integer | Box-outs recorded on the defensive glass. |
 | `deflections` | integer | Defensive deflections. |
-| `familyname` | character |  |
+| `familyname` | character | Player's family (last) name. |
 | `firstname` | character | Firstname. |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
-| `looseballsrecovereddefensive` | integer |  |
-| `looseballsrecoveredoffensive` | integer |  |
-| `looseballsrecoveredtotal` | integer |  |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
+| `looseballsrecovereddefensive` | integer | Loose balls recovered while on defense. |
+| `looseballsrecoveredoffensive` | integer | Loose balls recovered while on offense. |
+| `looseballsrecoveredtotal` | integer | Total loose balls recovered in the game. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `offensiveboxouts` | integer |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `offensiveboxouts` | integer | Box-outs recorded on the offensive glass. |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
 | `points` | integer | Points scored. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
-| `screenassistpoints` | integer |  |
-| `screenassists` | integer |  |
+| `screenassistpoints` | integer | Points teammates scored directly off the player's screen assists. |
+| `screenassists` | integer | Screens that led directly to a teammate's made field goal (screen assists). |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -448,32 +448,32 @@ GET /stats/boxscoremiscv3
 | col_name | type | description |
 |---|---|---|
 | `blocks` | integer | Total blocks. |
-| `blocksagainst` | integer |  |
+| `blocksagainst` | integer | Player's shot attempts that were blocked by opponents. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `familyname` | character |  |
+| `familyname` | character | Player's family (last) name. |
 | `firstname` | character | Firstname. |
-| `foulsdrawn` | integer |  |
-| `foulspersonal` | integer |  |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
+| `foulsdrawn` | integer | Personal fouls drawn. |
+| `foulspersonal` | integer | Personal fouls committed. |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `opppointsfastbreak` | integer |  |
-| `opppointsoffturnovers` | integer |  |
-| `opppointspaint` | integer |  |
-| `opppointssecondchance` | integer |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
-| `pointsfastbreak` | integer |  |
-| `pointsoffturnovers` | integer |  |
-| `pointspaint` | integer |  |
-| `pointssecondchance` | integer |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `opppointsfastbreak` | integer | Opponent fast-break points scored while on the floor. |
+| `opppointsoffturnovers` | integer | Opponent points off turnovers scored while on the floor. |
+| `opppointspaint` | integer | Opponent points in the paint scored while on the floor. |
+| `opppointssecondchance` | integer | Opponent second-chance points scored while on the floor. |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
+| `pointsfastbreak` | integer | Fast-break points scored. |
+| `pointsoffturnovers` | integer | Points scored off opponent turnovers. |
+| `pointspaint` | integer | Points scored in the paint. |
+| `pointssecondchance` | integer | Second-chance points scored after offensive rebounds. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -571,35 +571,35 @@ GET /stats/boxscorescoringv3
 | col_name | type | description |
 |---|---|---|
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `familyname` | character |  |
+| `familyname` | character | Player's family (last) name. |
 | `firstname` | character | Firstname. |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `percentageassisted2pt` | numeric |  |
-| `percentageassisted3pt` | numeric |  |
-| `percentageassistedfgm` | numeric |  |
-| `percentagefieldgoalsattempted2pt` | numeric |  |
-| `percentagefieldgoalsattempted3pt` | numeric |  |
-| `percentagepoints2pt` | numeric |  |
-| `percentagepoints3pt` | numeric |  |
-| `percentagepointsfastbreak` | numeric |  |
-| `percentagepointsfreethrow` | numeric |  |
-| `percentagepointsmidrange2pt` | numeric |  |
-| `percentagepointsoffturnovers` | numeric |  |
-| `percentagepointspaint` | numeric |  |
-| `percentageunassisted2pt` | numeric |  |
-| `percentageunassisted3pt` | numeric |  |
-| `percentageunassistedfgm` | numeric |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `percentageassisted2pt` | numeric | Percentage of made two-pointers that were assisted, as a decimal. |
+| `percentageassisted3pt` | numeric | Percentage of made three-pointers that were assisted, as a decimal. |
+| `percentageassistedfgm` | numeric | Percentage of made field goals that were assisted, as a decimal. |
+| `percentagefieldgoalsattempted2pt` | numeric | Share of field goal attempts taken as two-pointers, as a decimal. |
+| `percentagefieldgoalsattempted3pt` | numeric | Share of field goal attempts taken as three-pointers, as a decimal. |
+| `percentagepoints2pt` | numeric | Share of points scored on two-pointers, as a decimal. |
+| `percentagepoints3pt` | numeric | Share of points scored on three-pointers, as a decimal. |
+| `percentagepointsfastbreak` | numeric | Share of points scored on fast breaks, as a decimal. |
+| `percentagepointsfreethrow` | numeric | Share of points scored at the free throw line, as a decimal. |
+| `percentagepointsmidrange2pt` | numeric | Share of points scored on mid-range two-pointers, as a decimal. |
+| `percentagepointsoffturnovers` | numeric | Share of points scored off opponent turnovers, as a decimal. |
+| `percentagepointspaint` | numeric | Share of points scored in the paint, as a decimal. |
+| `percentageunassisted2pt` | numeric | Percentage of made two-pointers that were unassisted, as a decimal. |
+| `percentageunassisted3pt` | numeric | Percentage of made three-pointers that were unassisted, as a decimal. |
+| `percentageunassistedfgm` | numeric | Percentage of made field goals that were unassisted, as a decimal. |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -679,19 +679,19 @@ GET /stats/boxscoresummaryv3
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `dummykey` | character |  |
-| `gameid` | character |  |
-| `inbonus` | character |  |
+| `dummykey` | character | Placeholder key emitted by the stats API's box score summary payload; carries no data. |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `inbonus` | character | Whether the team is currently in the bonus (penalty) foul situation, as reported by the stats API. |
 | `score` | integer | Final score. |
-| `seed` | integer |  |
+| `seed` | integer | Team's playoff seed, populated for postseason games. |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
-| `teamlosses` | integer |  |
+| `teamlosses` | integer | Team's loss total entering the game. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
-| `teamwins` | integer |  |
-| `timeoutsremaining` | integer |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
+| `teamwins` | integer | Team's win total entering the game. |
+| `timeoutsremaining` | integer | Timeouts the team has remaining. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -732,7 +732,7 @@ GET /stats/boxscoretraditionalv2
 | `player_id` | integer | Unique player identifier. |
 | `player_name` | character | Player name. |
 | `nickname` | character | Team or athlete nickname. |
-| `start_position` | character |  |
+| `start_position` | character | Position the player started the game at (F, C, or G); empty for reserves. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
 | `min` | character | Minutes played. |
 | `fgm` | integer | Field goals made. |
@@ -788,76 +788,76 @@ GET /stats/boxscoretraditionalv3
 | col_name | type | description |
 |---|---|---|
 | `assists` | integer | Total assists. |
-| `bench_assists` | integer |  |
-| `bench_blocks` | integer |  |
-| `bench_fieldgoalsattempted` | integer |  |
-| `bench_fieldgoalsmade` | integer |  |
-| `bench_fieldgoalspercentage` | numeric |  |
-| `bench_foulspersonal` | integer |  |
-| `bench_freethrowsattempted` | integer |  |
-| `bench_freethrowsmade` | integer |  |
-| `bench_freethrowspercentage` | numeric |  |
-| `bench_minutes` | character |  |
+| `bench_assists` | integer | Total assists by the team's bench players. |
+| `bench_blocks` | integer | Total blocked shots by the team's bench players. |
+| `bench_fieldgoalsattempted` | integer | Total field goal attempts by the team's bench players. |
+| `bench_fieldgoalsmade` | integer | Total field goals made by the team's bench players. |
+| `bench_fieldgoalspercentage` | numeric | Combined field goal percentage of the team's bench players. |
+| `bench_foulspersonal` | integer | Total personal fouls by the team's bench players. |
+| `bench_freethrowsattempted` | integer | Total free throw attempts by the team's bench players. |
+| `bench_freethrowsmade` | integer | Total free throws made by the team's bench players. |
+| `bench_freethrowspercentage` | numeric | Combined free throw percentage of the team's bench players. |
+| `bench_minutes` | character | Total minutes played by the team's bench players. |
 | `bench_points` | integer | Points scored by the bench. |
-| `bench_reboundsdefensive` | integer |  |
-| `bench_reboundsoffensive` | integer |  |
-| `bench_reboundstotal` | integer |  |
-| `bench_steals` | integer |  |
-| `bench_threepointersattempted` | integer |  |
-| `bench_threepointersmade` | integer |  |
-| `bench_threepointerspercentage` | numeric |  |
-| `bench_turnovers` | integer |  |
+| `bench_reboundsdefensive` | integer | Total defensive rebounds by the team's bench players. |
+| `bench_reboundsoffensive` | integer | Total offensive rebounds by the team's bench players. |
+| `bench_reboundstotal` | integer | Total rebounds by the team's bench players. |
+| `bench_steals` | integer | Total steals by the team's bench players. |
+| `bench_threepointersattempted` | integer | Total three-point attempts by the team's bench players. |
+| `bench_threepointersmade` | integer | Total three-pointers made by the team's bench players. |
+| `bench_threepointerspercentage` | numeric | Combined three-point percentage of the team's bench players. |
+| `bench_turnovers` | integer | Total turnovers by the team's bench players. |
 | `blocks` | integer | Total blocks. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `familyname` | character |  |
-| `fieldgoalsattempted` | integer |  |
-| `fieldgoalsmade` | integer |  |
-| `fieldgoalspercentage` | numeric |  |
+| `familyname` | character | Player's family (last) name. |
+| `fieldgoalsattempted` | integer | Field goal attempts recorded in the game. |
+| `fieldgoalsmade` | integer | Field goals made recorded in the game. |
+| `fieldgoalspercentage` | numeric | Field goal percentage for the game, as a decimal. |
 | `firstname` | character | Firstname. |
-| `foulspersonal` | integer |  |
-| `freethrowsattempted` | integer |  |
-| `freethrowsmade` | integer |  |
-| `freethrowspercentage` | numeric |  |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
+| `foulspersonal` | integer | Personal fouls recorded in the game. |
+| `freethrowsattempted` | integer | Free throw attempts recorded in the game. |
+| `freethrowsmade` | integer | Free throws made recorded in the game. |
+| `freethrowspercentage` | numeric | Free throw percentage for the game, as a decimal. |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
-| `plusminuspoints` | numeric |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
+| `plusminuspoints` | numeric | Team point differential while the player was on the floor (plus-minus). |
 | `points` | integer | Points scored. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
-| `reboundsdefensive` | integer |  |
-| `reboundsoffensive` | integer |  |
-| `reboundstotal` | integer |  |
-| `starters_assists` | integer |  |
-| `starters_blocks` | integer |  |
-| `starters_fieldgoalsattempted` | integer |  |
-| `starters_fieldgoalsmade` | integer |  |
-| `starters_fieldgoalspercentage` | numeric |  |
-| `starters_foulspersonal` | integer |  |
-| `starters_freethrowsattempted` | integer |  |
-| `starters_freethrowsmade` | integer |  |
-| `starters_freethrowspercentage` | numeric |  |
-| `starters_minutes` | character |  |
-| `starters_points` | integer |  |
-| `starters_reboundsdefensive` | integer |  |
-| `starters_reboundsoffensive` | integer |  |
-| `starters_reboundstotal` | integer |  |
-| `starters_steals` | integer |  |
-| `starters_threepointersattempted` | integer |  |
-| `starters_threepointersmade` | integer |  |
-| `starters_threepointerspercentage` | numeric |  |
-| `starters_turnovers` | integer |  |
+| `reboundsdefensive` | integer | Defensive rebounds recorded in the game. |
+| `reboundsoffensive` | integer | Offensive rebounds recorded in the game. |
+| `reboundstotal` | integer | Total rebounds recorded in the game. |
+| `starters_assists` | integer | Total assists by the team's starters. |
+| `starters_blocks` | integer | Total blocked shots by the team's starters. |
+| `starters_fieldgoalsattempted` | integer | Total field goal attempts by the team's starters. |
+| `starters_fieldgoalsmade` | integer | Total field goals made by the team's starters. |
+| `starters_fieldgoalspercentage` | numeric | Combined field goal percentage of the team's starters. |
+| `starters_foulspersonal` | integer | Total personal fouls by the team's starters. |
+| `starters_freethrowsattempted` | integer | Total free throw attempts by the team's starters. |
+| `starters_freethrowsmade` | integer | Total free throws made by the team's starters. |
+| `starters_freethrowspercentage` | numeric | Combined free throw percentage of the team's starters. |
+| `starters_minutes` | character | Total minutes played by the team's starters. |
+| `starters_points` | integer | Total points by the team's starters. |
+| `starters_reboundsdefensive` | integer | Total defensive rebounds by the team's starters. |
+| `starters_reboundsoffensive` | integer | Total offensive rebounds by the team's starters. |
+| `starters_reboundstotal` | integer | Total rebounds by the team's starters. |
+| `starters_steals` | integer | Total steals by the team's starters. |
+| `starters_threepointersattempted` | integer | Total three-point attempts by the team's starters. |
+| `starters_threepointersmade` | integer | Total three-pointers made by the team's starters. |
+| `starters_threepointerspercentage` | numeric | Combined three-point percentage of the team's starters. |
+| `starters_turnovers` | integer | Total turnovers by the team's starters. |
 | `steals` | integer | Total steals. |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
-| `threepointersattempted` | integer |  |
-| `threepointersmade` | integer |  |
-| `threepointerspercentage` | numeric |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
+| `threepointersattempted` | integer | Three-point attempts recorded in the game. |
+| `threepointersmade` | integer | Three-pointers made recorded in the game. |
+| `threepointerspercentage` | numeric | Three-point percentage for the game, as a decimal. |
 | `turnovers` | integer | Total turnovers. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -893,38 +893,38 @@ GET /stats/boxscoreusagev3
 | col_name | type | description |
 |---|---|---|
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `familyname` | character |  |
+| `familyname` | character | Player's family (last) name. |
 | `firstname` | character | Firstname. |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `percentageassists` | numeric |  |
-| `percentageblocks` | numeric |  |
-| `percentageblocksallowed` | numeric |  |
-| `percentagefieldgoalsattempted` | numeric |  |
-| `percentagefieldgoalsmade` | numeric |  |
-| `percentagefreethrowsattempted` | numeric |  |
-| `percentagefreethrowsmade` | numeric |  |
-| `percentagepersonalfouls` | numeric |  |
-| `percentagepersonalfoulsdrawn` | numeric |  |
-| `percentagepoints` | numeric |  |
-| `percentagereboundsdefensive` | numeric |  |
-| `percentagereboundsoffensive` | numeric |  |
-| `percentagereboundstotal` | numeric |  |
-| `percentagesteals` | numeric |  |
-| `percentagethreepointersattempted` | numeric |  |
-| `percentagethreepointersmade` | numeric |  |
-| `percentageturnovers` | numeric |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `percentageassists` | numeric | Share of the team's assists accounted for by the player while on the floor, as a decimal. |
+| `percentageblocks` | numeric | Share of the team's blocked shots accounted for by the player while on the floor, as a decimal. |
+| `percentageblocksallowed` | numeric | Share of the team's shot attempts blocked by opponents accounted for by the player while on the floor, as a decimal. |
+| `percentagefieldgoalsattempted` | numeric | Share of the team's field goal attempts accounted for by the player while on the floor, as a decimal. |
+| `percentagefieldgoalsmade` | numeric | Share of the team's field goals made accounted for by the player while on the floor, as a decimal. |
+| `percentagefreethrowsattempted` | numeric | Share of the team's free throw attempts accounted for by the player while on the floor, as a decimal. |
+| `percentagefreethrowsmade` | numeric | Share of the team's free throws made accounted for by the player while on the floor, as a decimal. |
+| `percentagepersonalfouls` | numeric | Share of the team's personal fouls accounted for by the player while on the floor, as a decimal. |
+| `percentagepersonalfoulsdrawn` | numeric | Share of the team's personal fouls drawn accounted for by the player while on the floor, as a decimal. |
+| `percentagepoints` | numeric | Share of the team's points accounted for by the player while on the floor, as a decimal. |
+| `percentagereboundsdefensive` | numeric | Share of the team's defensive rebounds accounted for by the player while on the floor, as a decimal. |
+| `percentagereboundsoffensive` | numeric | Share of the team's offensive rebounds accounted for by the player while on the floor, as a decimal. |
+| `percentagereboundstotal` | numeric | Share of the team's total rebounds accounted for by the player while on the floor, as a decimal. |
+| `percentagesteals` | numeric | Share of the team's steals accounted for by the player while on the floor, as a decimal. |
+| `percentagethreepointersattempted` | numeric | Share of the team's three-point attempts accounted for by the player while on the floor, as a decimal. |
+| `percentagethreepointersmade` | numeric | Share of the team's three-pointers made accounted for by the player while on the floor, as a decimal. |
+| `percentageturnovers` | numeric | Share of the team's turnovers accounted for by the player while on the floor, as a decimal. |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
-| `usagepercentage` | numeric |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
+| `usagepercentage` | numeric | Percentage of team plays used by the player while on the floor, as a decimal. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -956,12 +956,12 @@ GET /stats/commonallplayers
 | col_name | type | description |
 |---|---|---|
 | `person_id` | integer | Unique player identifier (V3 endpoints). |
-| `display_last_comma_first` | character |  |
-| `display_first_last` | character |  |
-| `rosterstatus` | integer |  |
+| `display_last_comma_first` | character | Player name formatted as "Last, First". |
+| `display_first_last` | character | Player name formatted as "First Last". |
+| `rosterstatus` | integer | Roster status flag (1 = currently on a roster, 0 = not). |
 | `from_year` | character | First season. |
 | `to_year` | character | Most recent season. |
-| `playercode` | character |  |
+| `playercode` | character | URL-style player code slug used by the league's legacy stats pages. |
 | `player_slug` | character | URL-safe player identifier. |
 | `team_id` | integer | Unique team identifier. |
 | `team_city` | character | Team city or region (e.g. 'Las Vegas'). |
@@ -969,10 +969,10 @@ GET /stats/commonallplayers
 | `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
 | `team_code` | character | Internal team code. |
 | `team_slug` | character | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
-| `games_played_flag` | character |  |
-| `otherleague_experience_ch` | character |  |
-| `is_nba_assigned` | integer |  |
-| `nba_assigned_team_id` | integer |  |
+| `games_played_flag` | character | Y/N flag for whether the player has appeared in a league game. |
+| `otherleague_experience_ch` | character | Code for the player's experience in another league (e.g. G League), as reported by the stats API. |
+| `is_nba_assigned` | integer | Flag indicating whether the player is currently on an NBA roster assignment (two-way and G League assignment tracking). |
+| `nba_assigned_team_id` | integer | Team identifier of the NBA team the player is assigned to, when on assignment. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1102,7 +1102,7 @@ GET /stats/commonteamroster
 |---|---|---|
 | `teamid` | integer | Teamid. |
 | `season` | character | Season year. |
-| `leagueid` | character |  |
+| `leagueid` | character | League identifier from the stats API ("00" = NBA, "10" = WNBA, "20" = G League). |
 | `player` | character | Player name. |
 | `nickname` | character | Team or athlete nickname. |
 | `player_slug` | character | URL-safe player identifier. |
@@ -1115,7 +1115,7 @@ GET /stats/commonteamroster
 | `exp` | character | Exp. |
 | `school` | character | Player school / pre-draft team. |
 | `player_id` | integer | Unique player identifier. |
-| `how_acquired` | character |  |
+| `how_acquired` | character | How the team acquired the player (e.g. draft, trade, free agency). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1181,54 +1181,54 @@ GET /stats/cumestatsplayer
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `display_fi_last` | character |  |
+| `display_fi_last` | character | Abbreviated player name (first initial and last name). |
 | `person_id` | integer | Unique player identifier (V3 endpoints). |
 | `jersey_num` | character | Jersey number worn by the player. |
 | `gp` | integer | Games played. |
 | `gs` | integer | Games started. |
-| `actual_minutes` | integer |  |
-| `actual_seconds` | integer |  |
-| `fg` | integer |  |
+| `actual_minutes` | integer | Whole minutes of actual playing time accumulated over the aggregated games. |
+| `actual_seconds` | integer | Leftover seconds of actual playing time beyond the whole minutes. |
+| `fg` | integer | Field goals made over the aggregated games. |
 | `fga` | integer | Field goal attempts. |
 | `fg_pct` | numeric | Field goal percentage (0-1). |
-| `fg3` | integer |  |
+| `fg3` | integer | Three-point field goals made over the aggregated games. |
 | `fg3a` | integer | Three-point field goal attempts. |
 | `fg3_pct` | numeric | Three-point field goal percentage (0-1). |
-| `ft` | integer |  |
+| `ft` | integer | Free throws made over the aggregated games. |
 | `fta` | integer | Free throw attempts. |
 | `ft_pct` | numeric | Free throw percentage (0-1). |
-| `off_reb` | integer |  |
-| `def_reb` | integer |  |
-| `tot_reb` | integer |  |
+| `off_reb` | integer | Offensive rebounds over the aggregated games. |
+| `def_reb` | integer | Defensive rebounds over the aggregated games. |
+| `tot_reb` | integer | Total rebounds over the aggregated games. |
 | `ast` | integer | Assists. |
 | `pf` | integer | Personal fouls. |
-| `dq` | integer |  |
+| `dq` | integer | Disqualifications (fouled out) over the aggregated games. |
 | `stl` | integer | Steals. |
 | `turnovers` | integer | Total turnovers. |
 | `blk` | integer | Blocks. |
 | `pts` | integer | Points scored. |
-| `max_actual_minutes` | integer |  |
-| `max_actual_seconds` | integer |  |
-| `max_reb` | integer |  |
-| `max_ast` | integer |  |
-| `max_stl` | integer |  |
-| `max_turnovers` | integer |  |
-| `max_blk` | integer |  |
-| `max_pts` | integer |  |
-| `avg_actual_minutes` | integer |  |
-| `avg_actual_seconds` | numeric |  |
-| `avg_tot_reb` | numeric |  |
-| `avg_ast` | numeric |  |
-| `avg_stl` | numeric |  |
-| `avg_turnovers` | numeric |  |
-| `avg_blk` | numeric |  |
-| `avg_pts` | numeric |  |
-| `per_min_tot_reb` | numeric |  |
-| `per_min_ast` | numeric |  |
-| `per_min_stl` | numeric |  |
-| `per_min_turnovers` | numeric |  |
-| `per_min_blk` | numeric |  |
-| `per_min_pts` | numeric |  |
+| `max_actual_minutes` | integer | Most whole minutes played in any single aggregated game. |
+| `max_actual_seconds` | integer | Seconds component paired with the single-game maximum minutes. |
+| `max_reb` | integer | Most rebounds recorded in any single aggregated game. |
+| `max_ast` | integer | Most assists recorded in any single aggregated game. |
+| `max_stl` | integer | Most steals recorded in any single aggregated game. |
+| `max_turnovers` | integer | Most turnovers recorded in any single aggregated game. |
+| `max_blk` | integer | Most blocked shots recorded in any single aggregated game. |
+| `max_pts` | integer | Most points recorded in any single aggregated game. |
+| `avg_actual_minutes` | integer | Average whole minutes played per aggregated game. |
+| `avg_actual_seconds` | numeric | Average seconds component of playing time per aggregated game. |
+| `avg_tot_reb` | numeric | Average total rebounds per game over the aggregated games. |
+| `avg_ast` | numeric | Average assists per game over the aggregated games. |
+| `avg_stl` | numeric | Average steals per game over the aggregated games. |
+| `avg_turnovers` | numeric | Average turnovers per game over the aggregated games. |
+| `avg_blk` | numeric | Average blocked shots per game over the aggregated games. |
+| `avg_pts` | numeric | Average points per game over the aggregated games. |
+| `per_min_tot_reb` | numeric | Total rebounds per minute played over the aggregated games. |
+| `per_min_ast` | numeric | Assists per minute played over the aggregated games. |
+| `per_min_stl` | numeric | Steals per minute played over the aggregated games. |
+| `per_min_turnovers` | numeric | Turnovers per minute played over the aggregated games. |
+| `per_min_blk` | numeric | Blocked shots per minute played over the aggregated games. |
+| `per_min_pts` | numeric | Points per minute played over the aggregated games. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1305,49 +1305,49 @@ GET /stats/cumestatsteam
 | `team_id` | character | Unique team identifier. |
 | `gp` | character | Games played. |
 | `gs` | character | Games started. |
-| `actual_minutes` | character |  |
-| `actual_seconds` | character |  |
-| `fg` | character |  |
+| `actual_minutes` | character | Whole minutes of actual playing time accumulated over the aggregated games. |
+| `actual_seconds` | character | Leftover seconds of actual playing time beyond the whole minutes. |
+| `fg` | character | Field goals made over the aggregated games. |
 | `fga` | character | Field goal attempts. |
 | `fg_pct` | character | Field goal percentage (0-1). |
-| `fg3` | character |  |
+| `fg3` | character | Three-point field goals made over the aggregated games. |
 | `fg3a` | character | Three-point field goal attempts. |
 | `fg3_pct` | character | Three-point field goal percentage (0-1). |
-| `ft` | character |  |
+| `ft` | character | Free throws made over the aggregated games. |
 | `fta` | character | Free throw attempts. |
 | `ft_pct` | character | Free throw percentage (0-1). |
-| `off_reb` | character |  |
-| `def_reb` | character |  |
-| `tot_reb` | character |  |
+| `off_reb` | character | Offensive rebounds over the aggregated games. |
+| `def_reb` | character | Defensive rebounds over the aggregated games. |
+| `tot_reb` | character | Total rebounds over the aggregated games. |
 | `ast` | character | Assists. |
 | `pf` | character | Personal fouls. |
-| `dq` | character |  |
+| `dq` | character | Disqualifications (fouled out) over the aggregated games. |
 | `stl` | character | Steals. |
 | `turnovers` | character | Total turnovers. |
 | `blk` | character | Blocks. |
 | `pts` | character | Points scored. |
-| `max_actual_minutes` | character |  |
-| `max_actual_seconds` | character |  |
-| `max_reb` | character |  |
-| `max_ast` | character |  |
-| `max_stl` | character |  |
-| `max_turnovers` | character |  |
-| `max_blkp` | character |  |
-| `max_pts` | character |  |
-| `avg_actual_minutes` | character |  |
-| `avg_actual_seconds` | character |  |
-| `avg_reb` | character |  |
-| `avg_ast` | character |  |
-| `avg_stl` | character |  |
-| `avg_turnovers` | character |  |
-| `avg_blkp` | character |  |
-| `avg_pts` | character |  |
-| `per_min_reb` | character |  |
-| `per_min_ast` | character |  |
-| `per_min_stl` | character |  |
-| `per_min_turnovers` | character |  |
-| `per_min_blk` | character |  |
-| `per_min_pts` | character |  |
+| `max_actual_minutes` | character | Most whole minutes played in any single aggregated game. |
+| `max_actual_seconds` | character | Seconds component paired with the single-game maximum minutes. |
+| `max_reb` | character | Most rebounds recorded in any single aggregated game. |
+| `max_ast` | character | Most assists recorded in any single aggregated game. |
+| `max_stl` | character | Most steals recorded in any single aggregated game. |
+| `max_turnovers` | character | Most turnovers recorded in any single aggregated game. |
+| `max_blkp` | character | Most blocked shots recorded in any single aggregated game. |
+| `max_pts` | character | Most points recorded in any single aggregated game. |
+| `avg_actual_minutes` | character | Average whole minutes played per aggregated game. |
+| `avg_actual_seconds` | character | Average seconds component of playing time per aggregated game. |
+| `avg_reb` | character | Average rebounds per game over the aggregated games. |
+| `avg_ast` | character | Average assists per game over the aggregated games. |
+| `avg_stl` | character | Average steals per game over the aggregated games. |
+| `avg_turnovers` | character | Average turnovers per game over the aggregated games. |
+| `avg_blkp` | character | Average blocked shots per game over the aggregated games. |
+| `avg_pts` | character | Average points per game over the aggregated games. |
+| `per_min_reb` | character | Rebounds per minute played over the aggregated games. |
+| `per_min_ast` | character | Assists per minute played over the aggregated games. |
+| `per_min_stl` | character | Steals per minute played over the aggregated games. |
+| `per_min_turnovers` | character | Turnovers per minute played over the aggregated games. |
+| `per_min_blk` | character | Blocked shots per minute played over the aggregated games. |
+| `per_min_pts` | character | Points per minute played over the aggregated games. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1416,18 +1416,18 @@ GET /stats/draftcombinedrillresults
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `temp_player_id` | integer |  |
+| `temp_player_id` | integer | Temporary combine player identifier assigned by the NBA before a permanent player id exists. |
 | `player_id` | integer | Unique player identifier. |
 | `first_name` | character | Player's first name. |
 | `last_name` | character | Player's last name. |
 | `player_name` | character | Player name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
-| `standing_vertical_leap` | numeric |  |
-| `max_vertical_leap` | numeric |  |
-| `lane_agility_time` | numeric |  |
-| `modified_lane_agility_time` | numeric |  |
-| `three_quarter_sprint` | numeric |  |
-| `bench_press` | character |  |
+| `standing_vertical_leap` | numeric | Standing (no-step) vertical leap, in inches. |
+| `max_vertical_leap` | numeric | Maximum (running) vertical leap, in inches. |
+| `lane_agility_time` | numeric | Lane agility drill time, in seconds. |
+| `modified_lane_agility_time` | numeric | Modified (shuttle) lane agility drill time, in seconds. |
+| `three_quarter_sprint` | numeric | Three-quarter-court sprint time, in seconds. |
+| `bench_press` | character | Repetitions of 185 pounds completed on the bench press. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1457,36 +1457,36 @@ GET /stats/draftcombinenonstationaryshooting
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `temp_player_id` | integer |  |
+| `temp_player_id` | integer | Temporary combine player identifier assigned by the NBA before a permanent player id exists. |
 | `player_id` | integer | Unique player identifier. |
 | `first_name` | character | Player's first name. |
 | `last_name` | character | Player's last name. |
 | `player_name` | character | Player name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
-| `off_drib_fifteen_break_left_made` | character |  |
-| `off_drib_fifteen_break_left_attempt` | character |  |
-| `off_drib_fifteen_break_left_pct` | character |  |
-| `off_drib_fifteen_top_key_made` | character |  |
-| `off_drib_fifteen_top_key_attempt` | character |  |
-| `off_drib_fifteen_top_key_pct` | character |  |
-| `off_drib_fifteen_break_right_made` | character |  |
-| `off_drib_fifteen_break_right_attempt` | character |  |
-| `off_drib_fifteen_break_right_pct` | character |  |
-| `off_drib_college_break_left_made` | integer |  |
-| `off_drib_college_break_left_attempt` | integer |  |
-| `off_drib_college_break_left_pct` | numeric |  |
-| `off_drib_college_top_key_made` | character |  |
-| `off_drib_college_top_key_attempt` | character |  |
-| `off_drib_college_top_key_pct` | character |  |
-| `off_drib_college_break_right_made` | character |  |
-| `off_drib_college_break_right_attempt` | character |  |
-| `off_drib_college_break_right_pct` | character |  |
-| `on_move_fifteen_made` | character |  |
-| `on_move_fifteen_attempt` | character |  |
-| `on_move_fifteen_pct` | character |  |
-| `on_move_college_made` | integer |  |
-| `on_move_college_attempt` | integer |  |
-| `on_move_college_pct` | numeric |  |
+| `off_drib_fifteen_break_left_made` | character | Shots made from the 15-foot left wing (break) spot in the off-the-dribble shooting drill at the combine. |
+| `off_drib_fifteen_break_left_attempt` | character | Shots attempted from the 15-foot left wing (break) spot in the off-the-dribble shooting drill at the combine. |
+| `off_drib_fifteen_break_left_pct` | character | Shooting percentage from the 15-foot left wing (break) spot in the off-the-dribble shooting drill, as a decimal. |
+| `off_drib_fifteen_top_key_made` | character | Shots made from the 15-foot top of the key spot in the off-the-dribble shooting drill at the combine. |
+| `off_drib_fifteen_top_key_attempt` | character | Shots attempted from the 15-foot top of the key spot in the off-the-dribble shooting drill at the combine. |
+| `off_drib_fifteen_top_key_pct` | character | Shooting percentage from the 15-foot top of the key spot in the off-the-dribble shooting drill, as a decimal. |
+| `off_drib_fifteen_break_right_made` | character | Shots made from the 15-foot right wing (break) spot in the off-the-dribble shooting drill at the combine. |
+| `off_drib_fifteen_break_right_attempt` | character | Shots attempted from the 15-foot right wing (break) spot in the off-the-dribble shooting drill at the combine. |
+| `off_drib_fifteen_break_right_pct` | character | Shooting percentage from the 15-foot right wing (break) spot in the off-the-dribble shooting drill, as a decimal. |
+| `off_drib_college_break_left_made` | integer | Shots made from the college three-point left wing (break) spot in the off-the-dribble shooting drill at the combine. |
+| `off_drib_college_break_left_attempt` | integer | Shots attempted from the college three-point left wing (break) spot in the off-the-dribble shooting drill at the combine. |
+| `off_drib_college_break_left_pct` | numeric | Shooting percentage from the college three-point left wing (break) spot in the off-the-dribble shooting drill, as a decimal. |
+| `off_drib_college_top_key_made` | character | Shots made from the college three-point top of the key spot in the off-the-dribble shooting drill at the combine. |
+| `off_drib_college_top_key_attempt` | character | Shots attempted from the college three-point top of the key spot in the off-the-dribble shooting drill at the combine. |
+| `off_drib_college_top_key_pct` | character | Shooting percentage from the college three-point top of the key spot in the off-the-dribble shooting drill, as a decimal. |
+| `off_drib_college_break_right_made` | character | Shots made from the college three-point right wing (break) spot in the off-the-dribble shooting drill at the combine. |
+| `off_drib_college_break_right_attempt` | character | Shots attempted from the college three-point right wing (break) spot in the off-the-dribble shooting drill at the combine. |
+| `off_drib_college_break_right_pct` | character | Shooting percentage from the college three-point right wing (break) spot in the off-the-dribble shooting drill, as a decimal. |
+| `on_move_fifteen_made` | character | Shots made from the 15-foot spot in the shooting-on-the-move drill at the combine. |
+| `on_move_fifteen_attempt` | character | Shots attempted from the 15-foot spot in the shooting-on-the-move drill at the combine. |
+| `on_move_fifteen_pct` | character | Shooting percentage from the 15-foot spot in the shooting-on-the-move drill, as a decimal. |
+| `on_move_college_made` | integer | Shots made from the college three-point spot in the shooting-on-the-move drill at the combine. |
+| `on_move_college_attempt` | integer | Shots attempted from the college three-point spot in the shooting-on-the-move drill at the combine. |
+| `on_move_college_pct` | numeric | Shooting percentage from the college three-point spot in the shooting-on-the-move drill, as a decimal. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1516,24 +1516,24 @@ GET /stats/draftcombineplayeranthro
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `temp_player_id` | integer |  |
+| `temp_player_id` | integer | Temporary combine player identifier assigned by the NBA before a permanent player id exists. |
 | `player_id` | integer | Unique player identifier. |
 | `first_name` | character | Player's first name. |
 | `last_name` | character | Player's last name. |
 | `player_name` | character | Player name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
-| `height_wo_shoes` | numeric |  |
-| `height_wo_shoes_ft_in` | character |  |
-| `height_w_shoes` | character |  |
-| `height_w_shoes_ft_in` | character |  |
+| `height_wo_shoes` | numeric | Height measured without shoes, in inches. |
+| `height_wo_shoes_ft_in` | character | Height without shoes formatted as feet and inches. |
+| `height_w_shoes` | character | Height measured with shoes, in inches. |
+| `height_w_shoes_ft_in` | character | Height with shoes formatted as feet and inches. |
 | `weight` | character | Player weight in pounds. |
-| `wingspan` | numeric |  |
-| `wingspan_ft_in` | character |  |
-| `standing_reach` | numeric |  |
-| `standing_reach_ft_in` | character |  |
-| `body_fat_pct` | character |  |
-| `hand_length` | numeric |  |
-| `hand_width` | numeric |  |
+| `wingspan` | numeric | Wingspan measured at the combine, in inches. |
+| `wingspan_ft_in` | character | Wingspan formatted as feet and inches. |
+| `standing_reach` | numeric | Standing reach measured at the combine, in inches. |
+| `standing_reach_ft_in` | character | Standing reach formatted as feet and inches. |
+| `body_fat_pct` | character | Body fat percentage measured at the combine. |
+| `hand_length` | numeric | Hand length measured at the combine, in inches. |
+| `hand_width` | numeric | Hand width measured at the combine, in inches. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1563,57 +1563,57 @@ GET /stats/draftcombinespotshooting
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `temp_player_id` | integer |  |
+| `temp_player_id` | integer | Temporary combine player identifier assigned by the NBA before a permanent player id exists. |
 | `player_id` | integer | Unique player identifier. |
 | `first_name` | character | Player's first name. |
 | `last_name` | character | Player's last name. |
 | `player_name` | character | Player name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
-| `fifteen_corner_left_made` | character |  |
-| `fifteen_corner_left_attempt` | character |  |
-| `fifteen_corner_left_pct` | character |  |
-| `fifteen_break_left_made` | character |  |
-| `fifteen_break_left_attempt` | character |  |
-| `fifteen_break_left_pct` | character |  |
-| `fifteen_top_key_made` | character |  |
-| `fifteen_top_key_attempt` | character |  |
-| `fifteen_top_key_pct` | character |  |
-| `fifteen_break_right_made` | character |  |
-| `fifteen_break_right_attempt` | character |  |
-| `fifteen_break_right_pct` | character |  |
-| `fifteen_corner_right_made` | character |  |
-| `fifteen_corner_right_attempt` | character |  |
-| `fifteen_corner_right_pct` | character |  |
-| `college_corner_left_made` | integer |  |
-| `college_corner_left_attempt` | integer |  |
-| `college_corner_left_pct` | numeric |  |
-| `college_break_left_made` | character |  |
-| `college_break_left_attempt` | character |  |
-| `college_break_left_pct` | character |  |
-| `college_top_key_made` | character |  |
-| `college_top_key_attempt` | character |  |
-| `college_top_key_pct` | character |  |
-| `college_break_right_made` | character |  |
-| `college_break_right_attempt` | character |  |
-| `college_break_right_pct` | character |  |
-| `college_corner_right_made` | character |  |
-| `college_corner_right_attempt` | character |  |
-| `college_corner_right_pct` | character |  |
-| `nba_corner_left_made` | character |  |
-| `nba_corner_left_attempt` | character |  |
-| `nba_corner_left_pct` | character |  |
-| `nba_break_left_made` | character |  |
-| `nba_break_left_attempt` | character |  |
-| `nba_break_left_pct` | character |  |
-| `nba_top_key_made` | character |  |
-| `nba_top_key_attempt` | character |  |
-| `nba_top_key_pct` | character |  |
-| `nba_break_right_made` | character |  |
-| `nba_break_right_attempt` | character |  |
-| `nba_break_right_pct` | character |  |
-| `nba_corner_right_made` | character |  |
-| `nba_corner_right_attempt` | character |  |
-| `nba_corner_right_pct` | character |  |
+| `fifteen_corner_left_made` | character | Shots made from the 15-foot left corner spot in the stationary spot-up shooting drill at the combine. |
+| `fifteen_corner_left_attempt` | character | Shots attempted from the 15-foot left corner spot in the stationary spot-up shooting drill at the combine. |
+| `fifteen_corner_left_pct` | character | Shooting percentage from the 15-foot left corner spot in the stationary spot-up shooting drill, as a decimal. |
+| `fifteen_break_left_made` | character | Shots made from the 15-foot left wing (break) spot in the stationary spot-up shooting drill at the combine. |
+| `fifteen_break_left_attempt` | character | Shots attempted from the 15-foot left wing (break) spot in the stationary spot-up shooting drill at the combine. |
+| `fifteen_break_left_pct` | character | Shooting percentage from the 15-foot left wing (break) spot in the stationary spot-up shooting drill, as a decimal. |
+| `fifteen_top_key_made` | character | Shots made from the 15-foot top of the key spot in the stationary spot-up shooting drill at the combine. |
+| `fifteen_top_key_attempt` | character | Shots attempted from the 15-foot top of the key spot in the stationary spot-up shooting drill at the combine. |
+| `fifteen_top_key_pct` | character | Shooting percentage from the 15-foot top of the key spot in the stationary spot-up shooting drill, as a decimal. |
+| `fifteen_break_right_made` | character | Shots made from the 15-foot right wing (break) spot in the stationary spot-up shooting drill at the combine. |
+| `fifteen_break_right_attempt` | character | Shots attempted from the 15-foot right wing (break) spot in the stationary spot-up shooting drill at the combine. |
+| `fifteen_break_right_pct` | character | Shooting percentage from the 15-foot right wing (break) spot in the stationary spot-up shooting drill, as a decimal. |
+| `fifteen_corner_right_made` | character | Shots made from the 15-foot right corner spot in the stationary spot-up shooting drill at the combine. |
+| `fifteen_corner_right_attempt` | character | Shots attempted from the 15-foot right corner spot in the stationary spot-up shooting drill at the combine. |
+| `fifteen_corner_right_pct` | character | Shooting percentage from the 15-foot right corner spot in the stationary spot-up shooting drill, as a decimal. |
+| `college_corner_left_made` | integer | Shots made from the college three-point left corner spot in the stationary spot-up shooting drill at the combine. |
+| `college_corner_left_attempt` | integer | Shots attempted from the college three-point left corner spot in the stationary spot-up shooting drill at the combine. |
+| `college_corner_left_pct` | numeric | Shooting percentage from the college three-point left corner spot in the stationary spot-up shooting drill, as a decimal. |
+| `college_break_left_made` | character | Shots made from the college three-point left wing (break) spot in the stationary spot-up shooting drill at the combine. |
+| `college_break_left_attempt` | character | Shots attempted from the college three-point left wing (break) spot in the stationary spot-up shooting drill at the combine. |
+| `college_break_left_pct` | character | Shooting percentage from the college three-point left wing (break) spot in the stationary spot-up shooting drill, as a decimal. |
+| `college_top_key_made` | character | Shots made from the college three-point top of the key spot in the stationary spot-up shooting drill at the combine. |
+| `college_top_key_attempt` | character | Shots attempted from the college three-point top of the key spot in the stationary spot-up shooting drill at the combine. |
+| `college_top_key_pct` | character | Shooting percentage from the college three-point top of the key spot in the stationary spot-up shooting drill, as a decimal. |
+| `college_break_right_made` | character | Shots made from the college three-point right wing (break) spot in the stationary spot-up shooting drill at the combine. |
+| `college_break_right_attempt` | character | Shots attempted from the college three-point right wing (break) spot in the stationary spot-up shooting drill at the combine. |
+| `college_break_right_pct` | character | Shooting percentage from the college three-point right wing (break) spot in the stationary spot-up shooting drill, as a decimal. |
+| `college_corner_right_made` | character | Shots made from the college three-point right corner spot in the stationary spot-up shooting drill at the combine. |
+| `college_corner_right_attempt` | character | Shots attempted from the college three-point right corner spot in the stationary spot-up shooting drill at the combine. |
+| `college_corner_right_pct` | character | Shooting percentage from the college three-point right corner spot in the stationary spot-up shooting drill, as a decimal. |
+| `nba_corner_left_made` | character | Shots made from the NBA three-point left corner spot in the stationary spot-up shooting drill at the combine. |
+| `nba_corner_left_attempt` | character | Shots attempted from the NBA three-point left corner spot in the stationary spot-up shooting drill at the combine. |
+| `nba_corner_left_pct` | character | Shooting percentage from the NBA three-point left corner spot in the stationary spot-up shooting drill, as a decimal. |
+| `nba_break_left_made` | character | Shots made from the NBA three-point left wing (break) spot in the stationary spot-up shooting drill at the combine. |
+| `nba_break_left_attempt` | character | Shots attempted from the NBA three-point left wing (break) spot in the stationary spot-up shooting drill at the combine. |
+| `nba_break_left_pct` | character | Shooting percentage from the NBA three-point left wing (break) spot in the stationary spot-up shooting drill, as a decimal. |
+| `nba_top_key_made` | character | Shots made from the NBA three-point top of the key spot in the stationary spot-up shooting drill at the combine. |
+| `nba_top_key_attempt` | character | Shots attempted from the NBA three-point top of the key spot in the stationary spot-up shooting drill at the combine. |
+| `nba_top_key_pct` | character | Shooting percentage from the NBA three-point top of the key spot in the stationary spot-up shooting drill, as a decimal. |
+| `nba_break_right_made` | character | Shots made from the NBA three-point right wing (break) spot in the stationary spot-up shooting drill at the combine. |
+| `nba_break_right_attempt` | character | Shots attempted from the NBA three-point right wing (break) spot in the stationary spot-up shooting drill at the combine. |
+| `nba_break_right_pct` | character | Shooting percentage from the NBA three-point right wing (break) spot in the stationary spot-up shooting drill, as a decimal. |
+| `nba_corner_right_made` | character | Shots made from the NBA three-point right corner spot in the stationary spot-up shooting drill at the combine. |
+| `nba_corner_right_attempt` | character | Shots attempted from the NBA three-point right corner spot in the stationary spot-up shooting drill at the combine. |
+| `nba_corner_right_pct` | character | Shooting percentage from the NBA three-point right corner spot in the stationary spot-up shooting drill, as a decimal. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1649,47 +1649,47 @@ GET /stats/draftcombinestats
 | `last_name` | character | Player's last name. |
 | `player_name` | character | Player name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
-| `height_wo_shoes` | numeric |  |
-| `height_wo_shoes_ft_in` | character |  |
-| `height_w_shoes` | character |  |
-| `height_w_shoes_ft_in` | character |  |
+| `height_wo_shoes` | numeric | Height measured without shoes, in inches. |
+| `height_wo_shoes_ft_in` | character | Height without shoes formatted as feet and inches. |
+| `height_w_shoes` | character | Height measured with shoes, in inches. |
+| `height_w_shoes_ft_in` | character | Height with shoes formatted as feet and inches. |
 | `weight` | character | Player weight in pounds. |
-| `wingspan` | numeric |  |
-| `wingspan_ft_in` | character |  |
-| `standing_reach` | numeric |  |
-| `standing_reach_ft_in` | character |  |
-| `body_fat_pct` | character |  |
-| `hand_length` | numeric |  |
-| `hand_width` | numeric |  |
-| `standing_vertical_leap` | numeric |  |
-| `max_vertical_leap` | numeric |  |
-| `lane_agility_time` | numeric |  |
-| `modified_lane_agility_time` | numeric |  |
-| `three_quarter_sprint` | numeric |  |
-| `bench_press` | character |  |
-| `spot_fifteen_corner_left` | character |  |
-| `spot_fifteen_break_left` | character |  |
-| `spot_fifteen_top_key` | character |  |
-| `spot_fifteen_break_right` | character |  |
-| `spot_fifteen_corner_right` | character |  |
-| `spot_college_corner_left` | character |  |
-| `spot_college_break_left` | character |  |
-| `spot_college_top_key` | character |  |
-| `spot_college_break_right` | character |  |
-| `spot_college_corner_right` | character |  |
-| `spot_nba_corner_left` | character |  |
-| `spot_nba_break_left` | character |  |
-| `spot_nba_top_key` | character |  |
-| `spot_nba_break_right` | character |  |
-| `spot_nba_corner_right` | character |  |
-| `off_drib_fifteen_break_left` | character |  |
-| `off_drib_fifteen_top_key` | character |  |
-| `off_drib_fifteen_break_right` | character |  |
-| `off_drib_college_break_left` | character |  |
-| `off_drib_college_top_key` | character |  |
-| `off_drib_college_break_right` | character |  |
-| `on_move_fifteen` | character |  |
-| `on_move_college` | character |  |
+| `wingspan` | numeric | Wingspan measured at the combine, in inches. |
+| `wingspan_ft_in` | character | Wingspan formatted as feet and inches. |
+| `standing_reach` | numeric | Standing reach measured at the combine, in inches. |
+| `standing_reach_ft_in` | character | Standing reach formatted as feet and inches. |
+| `body_fat_pct` | character | Body fat percentage measured at the combine. |
+| `hand_length` | numeric | Hand length measured at the combine, in inches. |
+| `hand_width` | numeric | Hand width measured at the combine, in inches. |
+| `standing_vertical_leap` | numeric | Standing (no-step) vertical leap, in inches. |
+| `max_vertical_leap` | numeric | Maximum (running) vertical leap, in inches. |
+| `lane_agility_time` | numeric | Lane agility drill time, in seconds. |
+| `modified_lane_agility_time` | numeric | Modified (shuttle) lane agility drill time, in seconds. |
+| `three_quarter_sprint` | numeric | Three-quarter-court sprint time, in seconds. |
+| `bench_press` | character | Repetitions of 185 pounds completed on the bench press. |
+| `spot_fifteen_corner_left` | character | Made-attempted result (e.g. "3-5") from the 15-foot left corner spot-up shooting station at the combine. |
+| `spot_fifteen_break_left` | character | Made-attempted result (e.g. "3-5") from the 15-foot left wing (break) spot-up shooting station at the combine. |
+| `spot_fifteen_top_key` | character | Made-attempted result (e.g. "3-5") from the 15-foot top of the key spot-up shooting station at the combine. |
+| `spot_fifteen_break_right` | character | Made-attempted result (e.g. "3-5") from the 15-foot right wing (break) spot-up shooting station at the combine. |
+| `spot_fifteen_corner_right` | character | Made-attempted result (e.g. "3-5") from the 15-foot right corner spot-up shooting station at the combine. |
+| `spot_college_corner_left` | character | Made-attempted result (e.g. "3-5") from the college three-point left corner spot-up shooting station at the combine. |
+| `spot_college_break_left` | character | Made-attempted result (e.g. "3-5") from the college three-point left wing (break) spot-up shooting station at the combine. |
+| `spot_college_top_key` | character | Made-attempted result (e.g. "3-5") from the college three-point top of the key spot-up shooting station at the combine. |
+| `spot_college_break_right` | character | Made-attempted result (e.g. "3-5") from the college three-point right wing (break) spot-up shooting station at the combine. |
+| `spot_college_corner_right` | character | Made-attempted result (e.g. "3-5") from the college three-point right corner spot-up shooting station at the combine. |
+| `spot_nba_corner_left` | character | Made-attempted result (e.g. "3-5") from the NBA three-point left corner spot-up shooting station at the combine. |
+| `spot_nba_break_left` | character | Made-attempted result (e.g. "3-5") from the NBA three-point left wing (break) spot-up shooting station at the combine. |
+| `spot_nba_top_key` | character | Made-attempted result (e.g. "3-5") from the NBA three-point top of the key spot-up shooting station at the combine. |
+| `spot_nba_break_right` | character | Made-attempted result (e.g. "3-5") from the NBA three-point right wing (break) spot-up shooting station at the combine. |
+| `spot_nba_corner_right` | character | Made-attempted result (e.g. "3-5") from the NBA three-point right corner spot-up shooting station at the combine. |
+| `off_drib_fifteen_break_left` | character | Made-attempted result from the 15-foot left wing (break) off-the-dribble shooting station at the combine. |
+| `off_drib_fifteen_top_key` | character | Made-attempted result from the 15-foot top of the key off-the-dribble shooting station at the combine. |
+| `off_drib_fifteen_break_right` | character | Made-attempted result from the 15-foot right wing (break) off-the-dribble shooting station at the combine. |
+| `off_drib_college_break_left` | character | Made-attempted result from the college three-point left wing (break) off-the-dribble shooting station at the combine. |
+| `off_drib_college_top_key` | character | Made-attempted result from the college three-point top of the key off-the-dribble shooting station at the combine. |
+| `off_drib_college_break_right` | character | Made-attempted result from the college three-point right wing (break) off-the-dribble shooting station at the combine. |
+| `on_move_fifteen` | character | Made-attempted result from the 15-foot shooting-on-the-move station at the combine. |
+| `on_move_college` | character | Made-attempted result from the college three-point shooting-on-the-move station at the combine. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1792,8 +1792,8 @@ GET /stats/fantasywidget
 | `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
 | `gp` | integer | Games played. |
 | `min` | numeric | Minutes played. |
-| `fan_duel_pts` | numeric |  |
-| `nba_fantasy_pts` | numeric |  |
+| `fan_duel_pts` | numeric | Fantasy points under FanDuel's scoring formula. |
+| `nba_fantasy_pts` | numeric | Fantasy points under the NBA's fantasy scoring formula. |
 | `pts` | numeric | Points scored. |
 | `reb` | numeric | Rebounds per game. |
 | `ast` | numeric | Assists. |
@@ -1930,7 +1930,7 @@ GET /stats/franchiseleaderswrank
 | `person_id` | integer | Unique player identifier (V3 endpoints). |
 | `player` | character | Player name. |
 | `season_type` | character | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
-| `active_with_team` | integer |  |
+| `active_with_team` | integer | Flag indicating whether the franchise leader is still active with the team. |
 | `gp` | integer | Games played. |
 | `minutes` | numeric | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
 | `fgm` | numeric | Field goals made. |
@@ -1951,26 +1951,26 @@ GET /stats/franchiseleaderswrank
 | `tov` | numeric | Turnovers. |
 | `blk` | numeric | Blocks. |
 | `pts` | numeric | Points scored. |
-| `f_rank_gp` | integer |  |
-| `f_rank_minutes` | integer |  |
-| `f_rank_fgm` | integer |  |
-| `f_rank_fga` | integer |  |
-| `f_rank_fg_pct` | integer |  |
-| `f_rank_fg3m` | integer |  |
-| `f_rank_fg3a` | integer |  |
-| `f_rank_fg3_pct` | integer |  |
-| `f_rank_ftm` | integer |  |
-| `f_rank_fta` | integer |  |
-| `f_rank_ft_pct` | integer |  |
-| `f_rank_oreb` | integer |  |
-| `f_rank_dreb` | integer |  |
-| `f_rank_reb` | integer |  |
-| `f_rank_ast` | integer |  |
-| `f_rank_pf` | integer |  |
-| `f_rank_stl` | integer |  |
-| `f_rank_tov` | integer |  |
-| `f_rank_blk` | integer |  |
-| `f_rank_pts` | integer |  |
+| `f_rank_gp` | integer | Franchise all-time rank of the player's career games played. |
+| `f_rank_minutes` | integer | Franchise all-time rank of the player's career minutes played. |
+| `f_rank_fgm` | integer | Franchise all-time rank of the player's career field goals made. |
+| `f_rank_fga` | integer | Franchise all-time rank of the player's career field goals attempted. |
+| `f_rank_fg_pct` | integer | Franchise all-time rank of the player's career field goal percentage. |
+| `f_rank_fg3m` | integer | Franchise all-time rank of the player's career three-point field goals made. |
+| `f_rank_fg3a` | integer | Franchise all-time rank of the player's career three-point field goals attempted. |
+| `f_rank_fg3_pct` | integer | Franchise all-time rank of the player's career three-point field goal percentage. |
+| `f_rank_ftm` | integer | Franchise all-time rank of the player's career free throws made. |
+| `f_rank_fta` | integer | Franchise all-time rank of the player's career free throws attempted. |
+| `f_rank_ft_pct` | integer | Franchise all-time rank of the player's career free throw percentage. |
+| `f_rank_oreb` | integer | Franchise all-time rank of the player's career offensive rebounds. |
+| `f_rank_dreb` | integer | Franchise all-time rank of the player's career defensive rebounds. |
+| `f_rank_reb` | integer | Franchise all-time rank of the player's career total rebounds. |
+| `f_rank_ast` | integer | Franchise all-time rank of the player's career assists. |
+| `f_rank_pf` | integer | Franchise all-time rank of the player's career personal fouls committed. |
+| `f_rank_stl` | integer | Franchise all-time rank of the player's career steals. |
+| `f_rank_tov` | integer | Franchise all-time rank of the player's career turnovers. |
+| `f_rank_blk` | integer | Franchise all-time rank of the player's career blocked shots. |
+| `f_rank_pts` | integer | Franchise all-time rank of the player's career points scored. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2008,7 +2008,7 @@ GET /stats/franchiseplayers
 | `person_id` | integer | Unique player identifier (V3 endpoints). |
 | `player` | character | Player name. |
 | `season_type` | character | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
-| `active_with_team` | integer |  |
+| `active_with_team` | integer | Flag indicating whether the player is still active with the franchise. |
 | `gp` | integer | Games played. |
 | `fgm` | numeric | Field goals made. |
 | `fga` | numeric | Field goal attempts. |
@@ -2111,9 +2111,9 @@ GET /stats/homepageleaders
 | `fg_pct` | numeric | Field goal percentage (0-1). |
 | `fg3_pct` | numeric | Three-point field goal percentage (0-1). |
 | `ft_pct` | numeric | Free throw percentage (0-1). |
-| `efg_pct` | numeric |  |
+| `efg_pct` | numeric | Effective field goal percentage, as a decimal. |
 | `ts_pct` | numeric | True shooting percentage (0-1). |
-| `pts_per48` | character |  |
+| `pts_per48` | character | Points scored per 48 minutes played. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2191,24 +2191,24 @@ GET /stats/hustlestatsboxscore
 | `team_city` | character | Team city or region (e.g. 'Las Vegas'). |
 | `player_id` | character | Unique player identifier. |
 | `player_name` | character | Player name. |
-| `start_position` | character |  |
+| `start_position` | character | Position the player started the game at (F, C, or G); empty for reserves. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
 | `pts` | integer | Points scored. |
 | `contested_shots` | numeric | Defensively contested shots. |
-| `contested_shots_2pt` | numeric |  |
-| `contested_shots_3pt` | numeric |  |
+| `contested_shots_2pt` | numeric | Opponent two-point attempts contested. |
+| `contested_shots_3pt` | numeric | Opponent three-point attempts contested. |
 | `deflections` | numeric | Defensive deflections. |
 | `charges_drawn` | numeric | Charges drawn. |
 | `screen_assists` | numeric | Screen assists (resulting in a basket). |
-| `screen_ast_pts` | numeric |  |
-| `off_loose_balls_recovered` | numeric |  |
-| `def_loose_balls_recovered` | numeric |  |
-| `loose_balls_recovered` | numeric |  |
-| `off_boxouts` | numeric |  |
-| `def_boxouts` | numeric |  |
-| `box_out_player_team_rebs` | numeric |  |
-| `box_out_player_rebs` | numeric |  |
+| `screen_ast_pts` | numeric | Points teammates scored directly off the row's screen assists. |
+| `off_loose_balls_recovered` | numeric | Loose balls recovered while on offense. |
+| `def_loose_balls_recovered` | numeric | Loose balls recovered while on defense. |
+| `loose_balls_recovered` | numeric | Total loose balls recovered. |
+| `off_boxouts` | numeric | Box-outs recorded on the offensive glass. |
+| `def_boxouts` | numeric | Box-outs recorded on the defensive glass. |
+| `box_out_player_team_rebs` | numeric | Team rebounds secured following the row's box-outs. |
+| `box_out_player_rebs` | numeric | Rebounds the player secured directly off their own box-outs. |
 | `box_outs` | numeric | Box-outs executed. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -2640,7 +2640,7 @@ GET /stats/leaguedashplayerclutch
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
 | `player_id` | integer | Unique player identifier. |
 | `player_name` | character | Player name. |
 | `nickname` | character | Team or athlete nickname. |
@@ -2668,46 +2668,46 @@ GET /stats/leaguedashplayerclutch
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `nba_fantasy_pts` | numeric |  |
-| `dd2` | integer |  |
-| `td3` | integer |  |
-| `wnba_fantasy_pts` | numeric |  |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
-| `nba_fantasy_pts_rank` | integer |  |
-| `dd2_rank` | integer |  |
-| `td3_rank` | integer |  |
-| `wnba_fantasy_pts_rank` | integer |  |
-| `team_count` | integer |  |
+| `nba_fantasy_pts` | numeric | Fantasy points under the NBA's fantasy scoring formula. |
+| `dd2` | integer | Double-doubles recorded over the split. |
+| `td3` | integer | Triple-doubles recorded over the split. |
+| `wnba_fantasy_pts` | numeric | Fantasy points under the WNBA's fantasy scoring formula. |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
+| `nba_fantasy_pts_rank` | integer | League rank of the row's NBA fantasy points (league scoring formula) for the season and split. |
+| `dd2_rank` | integer | League rank of the row's double-doubles for the season and split. |
+| `td3_rank` | integer | League rank of the row's triple-doubles for the season and split. |
+| `wnba_fantasy_pts_rank` | integer | League rank of the row's WNBA fantasy points (league scoring formula) for the season and split. |
+| `team_count` | integer | Number of distinct teams aggregated into the split row. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2859,33 +2859,33 @@ GET /stats/leaguedashplayershotlocations
 | `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
 | `age` | numeric | Player age (in years). |
 | `nickname` | character | Team or athlete nickname. |
-| `less_than_5_ft_fgm` | numeric |  |
-| `less_than_5_ft_fga` | numeric |  |
-| `less_than_5_ft_fg_pct` | numeric |  |
-| `5-9_ft_fgm` | numeric |  |
-| `5-9_ft_fga` | numeric |  |
-| `5-9_ft_fg_pct` | numeric |  |
-| `10-14_ft_fgm` | numeric |  |
-| `10-14_ft_fga` | numeric |  |
-| `10-14_ft_fg_pct` | numeric |  |
-| `15-19_ft_fgm` | numeric |  |
-| `15-19_ft_fga` | numeric |  |
-| `15-19_ft_fg_pct` | numeric |  |
-| `20-24_ft_fgm` | numeric |  |
-| `20-24_ft_fga` | numeric |  |
-| `20-24_ft_fg_pct` | numeric |  |
-| `25-29_ft_fgm` | numeric |  |
-| `25-29_ft_fga` | numeric |  |
-| `25-29_ft_fg_pct` | numeric |  |
-| `30-34_ft_fgm` | numeric |  |
-| `30-34_ft_fga` | numeric |  |
-| `30-34_ft_fg_pct` | numeric |  |
-| `35-39_ft_fgm` | numeric |  |
-| `35-39_ft_fga` | numeric |  |
-| `35-39_ft_fg_pct` | numeric |  |
-| `40+_ft_fgm` | numeric |  |
-| `40+_ft_fga` | numeric |  |
-| `40+_ft_fg_pct` | numeric |  |
+| `less_than_5_ft_fgm` | numeric | Field goals made from less than 5 feet. |
+| `less_than_5_ft_fga` | numeric | Field goals attempted from less than 5 feet. |
+| `less_than_5_ft_fg_pct` | numeric | Field goal percentage on shots from less than 5 feet, as a decimal. |
+| `5-9_ft_fgm` | numeric | Field goals made from 5-9 feet. |
+| `5-9_ft_fga` | numeric | Field goals attempted from 5-9 feet. |
+| `5-9_ft_fg_pct` | numeric | Field goal percentage on shots from 5-9-f feet, as a decimal. |
+| `10-14_ft_fgm` | numeric | Field goals made from 10-14 feet. |
+| `10-14_ft_fga` | numeric | Field goals attempted from 10-14 feet. |
+| `10-14_ft_fg_pct` | numeric | Field goal percentage on shots from 10-14-f feet, as a decimal. |
+| `15-19_ft_fgm` | numeric | Field goals made from 15-19 feet. |
+| `15-19_ft_fga` | numeric | Field goals attempted from 15-19 feet. |
+| `15-19_ft_fg_pct` | numeric | Field goal percentage on shots from 15-19-f feet, as a decimal. |
+| `20-24_ft_fgm` | numeric | Field goals made from 20-24 feet. |
+| `20-24_ft_fga` | numeric | Field goals attempted from 20-24 feet. |
+| `20-24_ft_fg_pct` | numeric | Field goal percentage on shots from 20-24-f feet, as a decimal. |
+| `25-29_ft_fgm` | numeric | Field goals made from 25-29 feet. |
+| `25-29_ft_fga` | numeric | Field goals attempted from 25-29 feet. |
+| `25-29_ft_fg_pct` | numeric | Field goal percentage on shots from 25-29-f feet, as a decimal. |
+| `30-34_ft_fgm` | numeric | Field goals made from 30-34 feet. |
+| `30-34_ft_fga` | numeric | Field goals attempted from 30-34 feet. |
+| `30-34_ft_fg_pct` | numeric | Field goal percentage on shots from 30-34-f feet, as a decimal. |
+| `35-39_ft_fgm` | numeric | Field goals made from 35-39 feet. |
+| `35-39_ft_fga` | numeric | Field goals attempted from 35-39 feet. |
+| `35-39_ft_fg_pct` | numeric | Field goal percentage on shots from 35-39-f feet, as a decimal. |
+| `40+_ft_fgm` | numeric | Field goals made from 40 feet and beyond, per the stats API's shot-location distance bands. |
+| `40+_ft_fga` | numeric | Field goals attempted from 40 feet and beyond, per the stats API's shot-location distance bands. |
+| `40+_ft_fg_pct` | numeric | Field-goal percentage on attempts from 40 feet and beyond, as a decimal. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3301,37 +3301,37 @@ GET /stats/leaguedashteamclutch
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3462,33 +3462,33 @@ GET /stats/leaguedashteamshotlocations
 |---|---|---|
 | `team_id` | integer | Unique team identifier. |
 | `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
-| `less_than_5_ft_fgm` | numeric |  |
-| `less_than_5_ft_fga` | numeric |  |
-| `less_than_5_ft_fg_pct` | numeric |  |
-| `5-9_ft_fgm` | numeric |  |
-| `5-9_ft_fga` | numeric |  |
-| `5-9_ft_fg_pct` | numeric |  |
-| `10-14_ft_fgm` | numeric |  |
-| `10-14_ft_fga` | numeric |  |
-| `10-14_ft_fg_pct` | numeric |  |
-| `15-19_ft_fgm` | numeric |  |
-| `15-19_ft_fga` | numeric |  |
-| `15-19_ft_fg_pct` | numeric |  |
-| `20-24_ft_fgm` | numeric |  |
-| `20-24_ft_fga` | numeric |  |
-| `20-24_ft_fg_pct` | numeric |  |
-| `25-29_ft_fgm` | numeric |  |
-| `25-29_ft_fga` | numeric |  |
-| `25-29_ft_fg_pct` | numeric |  |
-| `30-34_ft_fgm` | numeric |  |
-| `30-34_ft_fga` | numeric |  |
-| `30-34_ft_fg_pct` | numeric |  |
-| `35-39_ft_fgm` | numeric |  |
-| `35-39_ft_fga` | numeric |  |
-| `35-39_ft_fg_pct` | numeric |  |
-| `40+_ft_fgm` | numeric |  |
-| `40+_ft_fga` | numeric |  |
-| `40+_ft_fg_pct` | numeric |  |
+| `less_than_5_ft_fgm` | numeric | Field goals made from less than 5 feet. |
+| `less_than_5_ft_fga` | numeric | Field goals attempted from less than 5 feet. |
+| `less_than_5_ft_fg_pct` | numeric | Field goal percentage on shots from less than 5 feet, as a decimal. |
+| `5-9_ft_fgm` | numeric | Field goals made from 5-9 feet. |
+| `5-9_ft_fga` | numeric | Field goals attempted from 5-9 feet. |
+| `5-9_ft_fg_pct` | numeric | Field goal percentage on shots from 5-9-f feet, as a decimal. |
+| `10-14_ft_fgm` | numeric | Field goals made from 10-14 feet. |
+| `10-14_ft_fga` | numeric | Field goals attempted from 10-14 feet. |
+| `10-14_ft_fg_pct` | numeric | Field goal percentage on shots from 10-14-f feet, as a decimal. |
+| `15-19_ft_fgm` | numeric | Field goals made from 15-19 feet. |
+| `15-19_ft_fga` | numeric | Field goals attempted from 15-19 feet. |
+| `15-19_ft_fg_pct` | numeric | Field goal percentage on shots from 15-19-f feet, as a decimal. |
+| `20-24_ft_fgm` | numeric | Field goals made from 20-24 feet. |
+| `20-24_ft_fga` | numeric | Field goals attempted from 20-24 feet. |
+| `20-24_ft_fg_pct` | numeric | Field goal percentage on shots from 20-24-f feet, as a decimal. |
+| `25-29_ft_fgm` | numeric | Field goals made from 25-29 feet. |
+| `25-29_ft_fga` | numeric | Field goals attempted from 25-29 feet. |
+| `25-29_ft_fg_pct` | numeric | Field goal percentage on shots from 25-29-f feet, as a decimal. |
+| `30-34_ft_fgm` | numeric | Field goals made from 30-34 feet. |
+| `30-34_ft_fga` | numeric | Field goals attempted from 30-34 feet. |
+| `30-34_ft_fg_pct` | numeric | Field goal percentage on shots from 30-34-f feet, as a decimal. |
+| `35-39_ft_fgm` | numeric | Field goals made from 35-39 feet. |
+| `35-39_ft_fga` | numeric | Field goals attempted from 35-39 feet. |
+| `35-39_ft_fg_pct` | numeric | Field goal percentage on shots from 35-39-f feet, as a decimal. |
+| `40+_ft_fgm` | numeric | Team field goals made from 40 feet and beyond, per the stats API's shot-location distance bands. |
+| `40+_ft_fga` | numeric | Team field goals attempted from 40 feet and beyond, per the stats API's shot-location distance bands. |
+| `40+_ft_fg_pct` | numeric | Team field-goal percentage on attempts from 40 feet and beyond, as a decimal. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3868,26 +3868,26 @@ GET /stats/leaguehustlestatsplayer
 | `g` | integer | Games played. |
 | `min` | numeric | Minutes played. |
 | `contested_shots` | numeric | Defensively contested shots. |
-| `contested_shots_2pt` | numeric |  |
-| `contested_shots_3pt` | numeric |  |
+| `contested_shots_2pt` | numeric | Opponent two-point attempts contested. |
+| `contested_shots_3pt` | numeric | Opponent three-point attempts contested. |
 | `deflections` | numeric | Defensive deflections. |
 | `charges_drawn` | numeric | Charges drawn. |
 | `screen_assists` | numeric | Screen assists (resulting in a basket). |
-| `screen_ast_pts` | numeric |  |
-| `off_loose_balls_recovered` | numeric |  |
-| `def_loose_balls_recovered` | numeric |  |
-| `loose_balls_recovered` | numeric |  |
-| `pct_loose_balls_recovered_off` | numeric |  |
-| `pct_loose_balls_recovered_def` | numeric |  |
-| `off_boxouts` | numeric |  |
-| `def_boxouts` | numeric |  |
+| `screen_ast_pts` | numeric | Points teammates scored directly off the row's screen assists. |
+| `off_loose_balls_recovered` | numeric | Loose balls recovered while on offense. |
+| `def_loose_balls_recovered` | numeric | Loose balls recovered while on defense. |
+| `loose_balls_recovered` | numeric | Total loose balls recovered. |
+| `pct_loose_balls_recovered_off` | numeric | Share of recovered loose balls that came on offense, as a decimal. |
+| `pct_loose_balls_recovered_def` | numeric | Share of recovered loose balls that came on defense, as a decimal. |
+| `off_boxouts` | numeric | Box-outs recorded on the offensive glass. |
+| `def_boxouts` | numeric | Box-outs recorded on the defensive glass. |
 | `box_outs` | numeric | Box-outs executed. |
-| `box_out_player_team_rebs` | numeric |  |
-| `box_out_player_rebs` | numeric |  |
-| `pct_box_outs_off` | numeric |  |
-| `pct_box_outs_def` | numeric |  |
-| `pct_box_outs_team_reb` | numeric |  |
-| `pct_box_outs_reb` | numeric |  |
+| `box_out_player_team_rebs` | numeric | Team rebounds secured following the row's box-outs. |
+| `box_out_player_rebs` | numeric | Rebounds the player secured directly off their own box-outs. |
+| `pct_box_outs_off` | numeric | Share of box-outs recorded on the offensive glass, as a decimal. |
+| `pct_box_outs_def` | numeric | Share of box-outs recorded on the defensive glass, as a decimal. |
+| `pct_box_outs_team_reb` | numeric | Share of box-outs after which the team secured the rebound, as a decimal. |
+| `pct_box_outs_reb` | numeric | Share of box-outs after which the player secured the rebound, as a decimal. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3944,22 +3944,22 @@ GET /stats/leaguehustlestatsteam
 | `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
 | `min` | numeric | Minutes played. |
 | `contested_shots` | numeric | Defensively contested shots. |
-| `contested_shots_2pt` | numeric |  |
-| `contested_shots_3pt` | numeric |  |
+| `contested_shots_2pt` | numeric | Opponent two-point attempts contested. |
+| `contested_shots_3pt` | numeric | Opponent three-point attempts contested. |
 | `deflections` | numeric | Defensive deflections. |
 | `charges_drawn` | numeric | Charges drawn. |
 | `screen_assists` | numeric | Screen assists (resulting in a basket). |
-| `screen_ast_pts` | numeric |  |
-| `off_loose_balls_recovered` | numeric |  |
-| `def_loose_balls_recovered` | numeric |  |
-| `loose_balls_recovered` | numeric |  |
-| `pct_loose_balls_recovered_off` | numeric |  |
-| `pct_loose_balls_recovered_def` | numeric |  |
-| `off_boxouts` | numeric |  |
-| `def_boxouts` | numeric |  |
+| `screen_ast_pts` | numeric | Points teammates scored directly off the row's screen assists. |
+| `off_loose_balls_recovered` | numeric | Loose balls recovered while on offense. |
+| `def_loose_balls_recovered` | numeric | Loose balls recovered while on defense. |
+| `loose_balls_recovered` | numeric | Total loose balls recovered. |
+| `pct_loose_balls_recovered_off` | numeric | Share of recovered loose balls that came on offense, as a decimal. |
+| `pct_loose_balls_recovered_def` | numeric | Share of recovered loose balls that came on defense, as a decimal. |
+| `off_boxouts` | numeric | Box-outs recorded on the offensive glass. |
+| `def_boxouts` | numeric | Box-outs recorded on the defensive glass. |
 | `box_outs` | numeric | Box-outs executed. |
-| `pct_box_outs_off` | numeric |  |
-| `pct_box_outs_def` | numeric |  |
+| `pct_box_outs_off` | numeric | Share of box-outs recorded on the offensive glass, as a decimal. |
+| `pct_box_outs_def` | numeric | Share of box-outs recorded on the defensive glass, as a decimal. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -4079,26 +4079,26 @@ GET /stats/leaguelineupviz
 | `team_id` | integer | Unique team identifier. |
 | `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
 | `min` | numeric | Minutes played. |
-| `off_rating` | numeric |  |
-| `def_rating` | numeric |  |
+| `off_rating` | numeric | Points scored per 100 possessions with the lineup on the floor (offensive rating). |
+| `def_rating` | numeric | Points allowed per 100 possessions with the lineup on the floor (defensive rating). |
 | `net_rating` | numeric | Net rating (off rating - def rating). |
 | `pace` | numeric | Possessions per 48 minutes. |
 | `ts_pct` | numeric | True shooting percentage (0-1). |
-| `fta_rate` | numeric |  |
-| `tm_ast_pct` | numeric |  |
-| `pct_fga_2pt` | numeric |  |
-| `pct_fga_3pt` | numeric |  |
-| `pct_pts_2pt_mr` | numeric |  |
-| `pct_pts_fb` | numeric |  |
-| `pct_pts_ft` | numeric |  |
-| `pct_pts_paint` | numeric |  |
-| `pct_ast_fgm` | numeric |  |
-| `pct_uast_fgm` | numeric |  |
-| `opp_fg3_pct` | numeric |  |
-| `opp_efg_pct` | numeric |  |
-| `opp_fta_rate` | numeric |  |
-| `opp_tov_pct` | numeric |  |
-| `sum_tm_min` | numeric |  |
+| `fta_rate` | numeric | Free throw attempts per field goal attempt for the lineup. |
+| `tm_ast_pct` | numeric | Percentage of the lineup's made field goals that were assisted, as a decimal. |
+| `pct_fga_2pt` | numeric | Share of field goal attempts taken as two-pointers, as a decimal. |
+| `pct_fga_3pt` | numeric | Share of field goal attempts taken as three-pointers, as a decimal. |
+| `pct_pts_2pt_mr` | numeric | Share of points scored on mid-range two-pointers, as a decimal. |
+| `pct_pts_fb` | numeric | Share of points scored on fast breaks, as a decimal. |
+| `pct_pts_ft` | numeric | Share of points scored at the free throw line, as a decimal. |
+| `pct_pts_paint` | numeric | Share of points scored in the paint, as a decimal. |
+| `pct_ast_fgm` | numeric | Percentage of made field goals that were assisted, as a decimal. |
+| `pct_uast_fgm` | numeric | Percentage of made field goals that were unassisted, as a decimal. |
+| `opp_fg3_pct` | numeric | Opponent three-point percentage against the lineup, as a decimal. |
+| `opp_efg_pct` | numeric | Opponent effective field goal percentage against the lineup, as a decimal. |
+| `opp_fta_rate` | numeric | Opponent free throw attempt rate against the lineup. |
+| `opp_tov_pct` | numeric | Opponent turnover percentage forced by the lineup. |
+| `sum_tm_min` | numeric | Total team minutes summed across the lineup's stints on the floor. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -4687,7 +4687,7 @@ GET /stats/playercareerbycollegerollup
 | col_name | type | description |
 |---|---|---|
 | `region` | character | Region label. |
-| `seed` | character |  |
+| `seed` | character | Region seed slot of the college in the stats API's career-by-college rollup grid. |
 | `college` | character | College. |
 | `players` | character | Nested list of per-player box scores. |
 | `gp` | integer | Games played. |
@@ -4819,7 +4819,7 @@ GET /stats/playercompare
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
 | `description` | character | Long-form description text. |
 | `min` | numeric | Minutes played. |
 | `fgm` | numeric | Field goals made. |
@@ -4838,9 +4838,9 @@ GET /stats/playercompare
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
 
@@ -5345,8 +5345,8 @@ GET /stats/playerdashboardbyopponent
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -5368,46 +5368,46 @@ GET /stats/playerdashboardbyopponent
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `nba_fantasy_pts` | numeric |  |
-| `dd2` | integer |  |
-| `td3` | integer |  |
-| `wnba_fantasy_pts` | numeric |  |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
-| `nba_fantasy_pts_rank` | integer |  |
-| `dd2_rank` | integer |  |
-| `td3_rank` | integer |  |
-| `wnba_fantasy_pts_rank` | integer |  |
-| `team_count` | integer |  |
+| `nba_fantasy_pts` | numeric | Fantasy points under the NBA's fantasy scoring formula. |
+| `dd2` | integer | Double-doubles recorded over the split. |
+| `td3` | integer | Triple-doubles recorded over the split. |
+| `wnba_fantasy_pts` | numeric | Fantasy points under the WNBA's fantasy scoring formula. |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
+| `nba_fantasy_pts_rank` | integer | League rank of the row's NBA fantasy points (league scoring formula) for the season and split. |
+| `dd2_rank` | integer | League rank of the row's double-doubles for the season and split. |
+| `td3_rank` | integer | League rank of the row's triple-doubles for the season and split. |
+| `wnba_fantasy_pts_rank` | integer | League rank of the row's WNBA fantasy points (league scoring formula) for the season and split. |
+| `team_count` | integer | Number of distinct teams aggregated into the split row. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -6063,8 +6063,8 @@ GET /stats/playerfantasyprofile
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `season_year` | character | Season year string ('YYYY-YY' format). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
@@ -6087,15 +6087,15 @@ GET /stats/playerfantasyprofile
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `dd2` | integer |  |
-| `td3` | integer |  |
-| `fan_duel_pts` | numeric |  |
-| `nba_fantasy_pts` | numeric |  |
+| `dd2` | integer | Double-doubles recorded over the split. |
+| `td3` | integer | Triple-doubles recorded over the split. |
+| `fan_duel_pts` | numeric | Fantasy points under FanDuel's scoring formula. |
+| `nba_fantasy_pts` | numeric | Fantasy points under the NBA's fantasy scoring formula. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -6617,12 +6617,12 @@ GET /stats/playervsplayer
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
 | `player_id` | integer | Unique player identifier. |
 | `player_name` | character | Player name. |
-| `vs_player_id` | integer |  |
-| `vs_player_name` | character |  |
-| `court_status` | character |  |
+| `vs_player_id` | integer | Stats API player id of the comparison (vs.) player. |
+| `vs_player_name` | character | Name of the comparison (vs.) player. |
+| `court_status` | character | Whether the split covers minutes with the vs. player on or off the court. |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -6644,12 +6644,12 @@ GET /stats/playervsplayer
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `nba_fantasy_pts` | numeric |  |
+| `nba_fantasy_pts` | numeric | Fantasy points under the NBA's fantasy scoring formula. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -6687,23 +6687,23 @@ GET /stats/playoffpicture
 | `wins` | integer | Total wins. |
 | `losses` | integer | Total losses. |
 | `pct` | numeric | Win percentage. |
-| `div` | character |  |
+| `div` | character | Abbreviation of the team's division. |
 | `conf` | character | character. |
 | `home` | character | Home. |
 | `away` | character | Away record. |
 | `gb` | numeric | Games behind the conference leader. |
-| `gr_over_500` | integer |  |
-| `gr_over_500_home` | integer |  |
-| `gr_over_500_away` | integer |  |
-| `gr_under_500` | integer |  |
-| `gr_under_500_home` | integer |  |
-| `gr_under_500_away` | integer |  |
-| `ranking_criteria` | integer |  |
-| `clinched_playoffs` | integer |  |
-| `clinched_conference` | integer |  |
-| `clinched_division` | integer |  |
-| `eliminated_playoffs` | integer |  |
-| `sosa_remaining` | character |  |
+| `gr_over_500` | integer | Remaining games against teams with winning (over .500) records. |
+| `gr_over_500_home` | integer | Remaining home games against teams with winning records. |
+| `gr_over_500_away` | integer | Remaining road games against teams with winning records. |
+| `gr_under_500` | integer | Remaining games against teams with losing (under .500) records. |
+| `gr_under_500_home` | integer | Remaining home games against teams with losing records. |
+| `gr_under_500_away` | integer | Remaining road games against teams with losing records. |
+| `ranking_criteria` | integer | Code for the ranking or tiebreak criteria applied to the team in the playoff picture. |
+| `clinched_playoffs` | integer | Flag (1/0) for whether the team has clinched a playoff berth. |
+| `clinched_conference` | integer | Flag (1/0) for whether the team has clinched the conference title. |
+| `clinched_division` | integer | Flag (1/0) for whether the team has clinched its division. |
+| `eliminated_playoffs` | integer | Flag (1/0) for whether the team has been eliminated from playoff contention. |
+| `sosa_remaining` | character | Strength of schedule of the team's remaining opponents (combined opponent winning percentage). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -6909,15 +6909,15 @@ GET /stats/scoreboardv2
 | `pts_qtr3` | character | Pts qtr3. |
 | `pts_qtr4` | character | Pts qtr4. |
 | `pts_ot1` | character | Pts ot1. |
-| `pts_ot2` | character |  |
-| `pts_ot3` | character |  |
-| `pts_ot4` | character |  |
-| `pts_ot5` | character |  |
-| `pts_ot6` | character |  |
-| `pts_ot7` | character |  |
-| `pts_ot8` | character |  |
-| `pts_ot9` | character |  |
-| `pts_ot10` | character |  |
+| `pts_ot2` | character | Points scored by the team in overtime period 2. |
+| `pts_ot3` | character | Points scored by the team in overtime period 3. |
+| `pts_ot4` | character | Points scored by the team in overtime period 4. |
+| `pts_ot5` | character | Points scored by the team in overtime period 5. |
+| `pts_ot6` | character | Points scored by the team in overtime period 6. |
+| `pts_ot7` | character | Points scored by the team in overtime period 7. |
+| `pts_ot8` | character | Points scored by the team in overtime period 8. |
+| `pts_ot9` | character | Points scored by the team in overtime period 9. |
+| `pts_ot10` | character | Points scored by the team in overtime period 10. |
 | `pts` | character | Points scored. |
 | `fg_pct` | numeric | Field goal percentage (0-1). |
 | `ft_pct` | numeric | Free throw percentage (0-1). |
@@ -6954,86 +6954,86 @@ GET /stats/scoreboardv3
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `awayteam_inbonus` | character |  |
-| `awayteam_losses` | integer |  |
-| `awayteam_score` | integer |  |
-| `awayteam_seed` | integer |  |
-| `awayteam_teamcity` | character |  |
-| `awayteam_teamid` | integer |  |
-| `awayteam_teamname` | character |  |
-| `awayteam_teamslug` | character |  |
-| `awayteam_teamtricode` | character |  |
-| `awayteam_timeoutsremaining` | integer |  |
-| `awayteam_wins` | integer |  |
-| `gameclock` | character |  |
+| `awayteam_inbonus` | character | Whether the away team is currently in the bonus (penalty) foul situation. |
+| `awayteam_losses` | integer | Away team's loss total entering the game. |
+| `awayteam_score` | integer | Current or final points scored by the away team. |
+| `awayteam_seed` | integer | Playoff seed of the away team, populated for postseason games. |
+| `awayteam_teamcity` | character | City name of the away team. |
+| `awayteam_teamid` | integer | Team identifier of the away team from the league's stats API. |
+| `awayteam_teamname` | character | Nickname of the away team. |
+| `awayteam_teamslug` | character | URL-friendly slug for the away team's name. |
+| `awayteam_teamtricode` | character | Three-letter abbreviation of the away team. |
+| `awayteam_timeoutsremaining` | integer | Timeouts the away team has remaining. |
+| `awayteam_wins` | integer | Away team's win total entering the game. |
+| `gameclock` | character | Current game clock display for a live game. |
 | `gamecode` | character | Gamecode. |
 | `gamedate` | character | Game date as parsed from the source feed. |
-| `gameet` | character |  |
-| `gameid` | character |  |
-| `gamelabel` | character |  |
-| `gameleaders_awayleaders_assists` | integer |  |
-| `gameleaders_awayleaders_jerseynum` | character |  |
-| `gameleaders_awayleaders_name` | character |  |
-| `gameleaders_awayleaders_personid` | integer |  |
-| `gameleaders_awayleaders_playerslug` | character |  |
-| `gameleaders_awayleaders_points` | integer |  |
-| `gameleaders_awayleaders_position` | character |  |
-| `gameleaders_awayleaders_rebounds` | integer |  |
-| `gameleaders_awayleaders_teamtricode` | character |  |
-| `gameleaders_homeleaders_assists` | integer |  |
-| `gameleaders_homeleaders_jerseynum` | character |  |
-| `gameleaders_homeleaders_name` | character |  |
-| `gameleaders_homeleaders_personid` | integer |  |
-| `gameleaders_homeleaders_playerslug` | character |  |
-| `gameleaders_homeleaders_points` | integer |  |
-| `gameleaders_homeleaders_position` | character |  |
-| `gameleaders_homeleaders_rebounds` | integer |  |
-| `gameleaders_homeleaders_teamtricode` | character |  |
-| `gamestatus` | integer |  |
-| `gamestatustext` | character |  |
-| `gamesublabel` | character |  |
-| `gamesubtype` | character |  |
-| `gametimeutc` | character |  |
-| `hometeam_inbonus` | character |  |
-| `hometeam_losses` | integer |  |
-| `hometeam_score` | integer |  |
-| `hometeam_seed` | integer |  |
-| `hometeam_teamcity` | character |  |
-| `hometeam_teamid` | integer |  |
-| `hometeam_teamname` | character |  |
-| `hometeam_teamslug` | character |  |
-| `hometeam_teamtricode` | character |  |
-| `hometeam_timeoutsremaining` | integer |  |
-| `hometeam_wins` | integer |  |
-| `ifnecessary` | logical |  |
-| `isneutral` | logical |  |
-| `leagueid` | character |  |
-| `leaguename` | character |  |
+| `gameet` | character | Scheduled game start time in US Eastern time. |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `gamelabel` | character | Display label for the game (e.g. a playoff series or event name). |
+| `gameleaders_awayleaders_assists` | integer | Assist total of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_jerseynum` | character | Jersey number of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_name` | character | Name of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_personid` | integer | Stats API player id of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_playerslug` | character | URL name slug of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_points` | integer | Point total of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_position` | character | Position of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_rebounds` | integer | Rebound total of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_teamtricode` | character | Team tricode of the away team's in-game statistical leader. |
+| `gameleaders_homeleaders_assists` | integer | Assist total of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_jerseynum` | character | Jersey number of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_name` | character | Name of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_personid` | integer | Stats API player id of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_playerslug` | character | URL name slug of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_points` | integer | Point total of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_position` | character | Position of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_rebounds` | integer | Rebound total of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_teamtricode` | character | Team tricode of the home team's in-game statistical leader. |
+| `gamestatus` | integer | Numeric game status code (1 = scheduled, 2 = in progress, 3 = final). |
+| `gamestatustext` | character | Human-readable game status (e.g. "Final", "7:00 pm ET"). |
+| `gamesublabel` | character | Secondary display label for the game (e.g. game number within a series). |
+| `gamesubtype` | character | Subtype code for the game as reported by the stats API (e.g. in-season tournament flags). |
+| `gametimeutc` | character | Scheduled game start time in UTC. |
+| `hometeam_inbonus` | character | Whether the home team is currently in the bonus (penalty) foul situation. |
+| `hometeam_losses` | integer | Home team's loss total entering the game. |
+| `hometeam_score` | integer | Current or final points scored by the home team. |
+| `hometeam_seed` | integer | Playoff seed of the home team, populated for postseason games. |
+| `hometeam_teamcity` | character | City name of the home team. |
+| `hometeam_teamid` | integer | Team identifier of the home team from the league's stats API. |
+| `hometeam_teamname` | character | Nickname of the home team. |
+| `hometeam_teamslug` | character | URL-friendly slug for the home team's name. |
+| `hometeam_teamtricode` | character | Three-letter abbreviation of the home team. |
+| `hometeam_timeoutsremaining` | integer | Timeouts the home team has remaining. |
+| `hometeam_wins` | integer | Home team's win total entering the game. |
+| `ifnecessary` | logical | Whether the game is an if-necessary playoff series game. |
+| `isneutral` | logical | Whether the game is played at a neutral site. |
+| `leagueid` | character | League identifier from the stats API ("00" = NBA, "10" = WNBA). |
+| `leaguename` | character | Display name of the league. |
 | `period` | integer | Period of the game (1-4 quarters; 5+ for OT). |
-| `porounddesc` | character |  |
-| `regulationperiods` | integer |  |
-| `seriesconference` | character |  |
-| `seriesgamenumber` | character |  |
-| `seriestext` | character |  |
-| `teamleaders_awayleaders_assists` | numeric |  |
-| `teamleaders_awayleaders_jerseynum` | character |  |
-| `teamleaders_awayleaders_name` | character |  |
-| `teamleaders_awayleaders_personid` | integer |  |
-| `teamleaders_awayleaders_playerslug` | character |  |
-| `teamleaders_awayleaders_points` | numeric |  |
-| `teamleaders_awayleaders_position` | character |  |
-| `teamleaders_awayleaders_rebounds` | numeric |  |
-| `teamleaders_awayleaders_teamtricode` | character |  |
-| `teamleaders_homeleaders_assists` | numeric |  |
-| `teamleaders_homeleaders_jerseynum` | character |  |
-| `teamleaders_homeleaders_name` | character |  |
-| `teamleaders_homeleaders_personid` | integer |  |
-| `teamleaders_homeleaders_playerslug` | character |  |
-| `teamleaders_homeleaders_points` | numeric |  |
-| `teamleaders_homeleaders_position` | character |  |
-| `teamleaders_homeleaders_rebounds` | numeric |  |
-| `teamleaders_homeleaders_teamtricode` | character |  |
-| `teamleaders_seasonleadersflag` | integer |  |
+| `porounddesc` | character | Playoff round description (e.g. Conference Finals). |
+| `regulationperiods` | integer | Number of regulation periods for the game (4). |
+| `seriesconference` | character | Conference of the playoff series the game belongs to. |
+| `seriesgamenumber` | character | Game number within the playoff series. |
+| `seriestext` | character | Display text summarizing the series state (e.g. "BOS leads 2-1"). |
+| `teamleaders_awayleaders_assists` | numeric | Assist total of the away team's season statistical leader. |
+| `teamleaders_awayleaders_jerseynum` | character | Jersey number of the away team's season statistical leader. |
+| `teamleaders_awayleaders_name` | character | Name of the away team's season statistical leader. |
+| `teamleaders_awayleaders_personid` | integer | Stats API player id of the away team's season statistical leader. |
+| `teamleaders_awayleaders_playerslug` | character | URL name slug of the away team's season statistical leader. |
+| `teamleaders_awayleaders_points` | numeric | Point total of the away team's season statistical leader. |
+| `teamleaders_awayleaders_position` | character | Position of the away team's season statistical leader. |
+| `teamleaders_awayleaders_rebounds` | numeric | Rebound total of the away team's season statistical leader. |
+| `teamleaders_awayleaders_teamtricode` | character | Team tricode of the away team's season statistical leader. |
+| `teamleaders_homeleaders_assists` | numeric | Assist total of the home team's season statistical leader. |
+| `teamleaders_homeleaders_jerseynum` | character | Jersey number of the home team's season statistical leader. |
+| `teamleaders_homeleaders_name` | character | Name of the home team's season statistical leader. |
+| `teamleaders_homeleaders_personid` | integer | Stats API player id of the home team's season statistical leader. |
+| `teamleaders_homeleaders_playerslug` | character | URL name slug of the home team's season statistical leader. |
+| `teamleaders_homeleaders_points` | numeric | Point total of the home team's season statistical leader. |
+| `teamleaders_homeleaders_position` | character | Position of the home team's season statistical leader. |
+| `teamleaders_homeleaders_rebounds` | numeric | Rebound total of the home team's season statistical leader. |
+| `teamleaders_homeleaders_teamtricode` | character | Team tricode of the home team's season statistical leader. |
+| `teamleaders_seasonleadersflag` | integer | Flag indicating the team-leaders block carries season-long leaders rather than in-game leaders. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -7092,7 +7092,7 @@ GET /stats/shotchartdetail
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `grid_type` | character |  |
+| `grid_type` | character | Shot chart grid type label returned by the stats API (e.g. "Shot Chart Detail"). |
 | `game_id` | character | Unique game identifier. |
 | `game_event_id` | character | Unique identifier for game event. |
 | `player_id` | character | Unique player identifier. |
@@ -7114,8 +7114,8 @@ GET /stats/shotchartdetail
 | `shot_attempted_flag` | character | 1 if a shot was attempted on this event. |
 | `shot_made_flag` | character | 1 if the shot was made; 0 if missed. |
 | `game_date` | character | Game date (YYYY-MM-DD). |
-| `htm` | character |  |
-| `vtm` | character |  |
+| `htm` | character | Home team abbreviation for the game. |
+| `vtm` | character | Visiting team abbreviation for the game. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -7199,7 +7199,7 @@ GET /stats/shotchartlineupdetail
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `grid_type` | character |  |
+| `grid_type` | character | Shot chart grid type label returned by the stats API (e.g. "Shot Chart Detail"). |
 | `game_id` | character | Unique game identifier. |
 | `game_event_id` | character | Unique identifier for game event. |
 | `group_id` | character | ESPN group id. |
@@ -7223,8 +7223,8 @@ GET /stats/shotchartlineupdetail
 | `shot_attempted_flag` | character | 1 if a shot was attempted on this event. |
 | `shot_made_flag` | character | 1 if the shot was made; 0 if missed. |
 | `game_date` | character | Game date (YYYY-MM-DD). |
-| `htm` | character |  |
-| `vtm` | character |  |
+| `htm` | character | Home team abbreviation for the game. |
+| `vtm` | character | Visiting team abbreviation for the game. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -7266,23 +7266,23 @@ GET /stats/synergyplaytypes
 | `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
 | `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
 | `play_type` | character | Play type description. |
-| `type_grouping` | character |  |
-| `percentile` | numeric |  |
+| `type_grouping` | character | Whether the play-type row measures the offensive or defensive side. |
+| `percentile` | numeric | League percentile of the row's points per possession for the play type, as a decimal. |
 | `gp` | integer | Games played. |
 | `poss_pct` | numeric | Poss percentage (0-1 decimal). |
-| `ppp` | numeric |  |
+| `ppp` | numeric | Points scored per possession on the play type (Synergy play-type tracking). |
 | `fg_pct` | numeric | Field goal percentage (0-1). |
-| `ft_poss_pct` | numeric |  |
-| `tov_poss_pct` | numeric |  |
-| `sf_poss_pct` | numeric |  |
-| `plusone_poss_pct` | numeric |  |
-| `score_poss_pct` | numeric |  |
-| `efg_pct` | numeric |  |
+| `ft_poss_pct` | numeric | Share of play-type possessions ending in free throws, as a decimal. |
+| `tov_poss_pct` | numeric | Share of play-type possessions ending in a turnover, as a decimal. |
+| `sf_poss_pct` | numeric | Share of play-type possessions on which a shooting foul was drawn, as a decimal. |
+| `plusone_poss_pct` | numeric | Share of play-type possessions producing an and-one, as a decimal. |
+| `score_poss_pct` | numeric | Share of play-type possessions on which points were scored, as a decimal. |
+| `efg_pct` | numeric | Effective field goal percentage on the play type, as a decimal. |
 | `poss` | numeric | Poss. |
 | `pts` | numeric | Points scored. |
 | `fgm` | numeric | Field goals made. |
 | `fga` | numeric | Field goal attempts. |
-| `fgmx` | numeric |  |
+| `fgmx` | numeric | Field goals missed on the play type. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -7333,8 +7333,8 @@ GET /stats/teamdashboardbyclutch
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -7356,37 +7356,37 @@ GET /stats/teamdashboardbyclutch
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -7437,8 +7437,8 @@ GET /stats/teamdashboardbygamesplits
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -7460,37 +7460,37 @@ GET /stats/teamdashboardbygamesplits
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -7646,8 +7646,8 @@ GET /stats/teamdashboardbylastngames
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -7669,37 +7669,37 @@ GET /stats/teamdashboardbylastngames
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -7750,8 +7750,8 @@ GET /stats/teamdashboardbyopponent
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -7773,37 +7773,37 @@ GET /stats/teamdashboardbyopponent
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -7935,10 +7935,10 @@ GET /stats/teamdashboardbyteamperformance
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value_order` | integer |  |
-| `group_value` | character |  |
-| `group_value_2` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value_order` | integer | Sort order of the split value within its group. |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
+| `group_value_2` | character | Secondary split value for the row when the group uses two dimensions. |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -7960,37 +7960,37 @@ GET /stats/teamdashboardbyteamperformance
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -8041,8 +8041,8 @@ GET /stats/teamdashboardbyyearoveryear
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -8064,37 +8064,37 @@ GET /stats/teamdashboardbyyearoveryear
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -8418,14 +8418,14 @@ GET /stats/teamdetails
 | `team_id` | integer | Unique team identifier. |
 | `abbreviation` | character | Short abbreviation. |
 | `nickname` | character | Team or athlete nickname. |
-| `yearfounded` | integer |  |
+| `yearfounded` | integer | Year the franchise was founded. |
 | `city` | character | Venue city. |
 | `arena` | character | Arena. |
-| `arenacapacity` | character |  |
-| `owner` | character |  |
-| `generalmanager` | character |  |
-| `headcoach` | character |  |
-| `dleagueaffiliation` | character |  |
+| `arenacapacity` | character | Seating capacity of the team's home arena. |
+| `owner` | character | Name of the team's owner or ownership group. |
+| `generalmanager` | character | Name of the team's general manager. |
+| `headcoach` | character | Name of the team's head coach. |
+| `dleagueaffiliation` | character | Name of the team's G League (formerly D-League) affiliate. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -8687,15 +8687,15 @@ GET /stats/teaminfocommon
 | `team_city` | character | Team city or region (e.g. 'Las Vegas'). |
 | `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
 | `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
-| `team_conference` | character |  |
-| `team_division` | character |  |
+| `team_conference` | character | Conference the team belongs to. |
+| `team_division` | character | Division the team belongs to. |
 | `team_code` | character | Internal team code. |
 | `team_slug` | character | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
 | `pct` | numeric | Win percentage. |
-| `conf_rank` | integer |  |
-| `div_rank` | integer |  |
+| `conf_rank` | integer | Team's current rank within its conference. |
+| `div_rank` | integer | Team's current rank within its division. |
 | `min_year` | character | Minimum year queried (echoes `min_year`). |
 | `max_year` | character | Maximum year queried (echoes `max_year`). |
 
@@ -9075,8 +9075,8 @@ GET /stats/teamvsplayer
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `player_id` | integer | Unique player identifier. |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
@@ -9099,46 +9099,46 @@ GET /stats/teamvsplayer
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `nba_fantasy_pts` | numeric |  |
-| `dd2` | integer |  |
-| `td3` | integer |  |
-| `wnba_fantasy_pts` | numeric |  |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
-| `nba_fantasy_pts_rank` | integer |  |
-| `dd2_rank` | integer |  |
-| `td3_rank` | integer |  |
-| `wnba_fantasy_pts_rank` | integer |  |
-| `team_count` | integer |  |
+| `nba_fantasy_pts` | numeric | Fantasy points under the NBA's fantasy scoring formula. |
+| `dd2` | integer | Double-doubles recorded over the split. |
+| `td3` | integer | Triple-doubles recorded over the split. |
+| `wnba_fantasy_pts` | numeric | Fantasy points under the WNBA's fantasy scoring formula. |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
+| `nba_fantasy_pts_rank` | integer | League rank of the row's NBA fantasy points (league scoring formula) for the season and split. |
+| `dd2_rank` | integer | League rank of the row's double-doubles for the season and split. |
+| `td3_rank` | integer | League rank of the row's triple-doubles for the season and split. |
+| `wnba_fantasy_pts_rank` | integer | League rank of the row's WNBA fantasy points (league scoring formula) for the season and split. |
+| `team_count` | integer | Number of distinct teams aggregated into the split row. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -9178,13 +9178,13 @@ GET /stats/teamyearbyyearstats
 | `wins` | integer | Total wins. |
 | `losses` | integer | Total losses. |
 | `win_pct` | numeric | Win percentage (0-1 decimal). |
-| `conf_rank` | integer |  |
-| `div_rank` | integer |  |
-| `po_wins` | integer |  |
-| `po_losses` | integer |  |
-| `conf_count` | integer |  |
-| `div_count` | integer |  |
-| `nba_finals_appearance` | character |  |
+| `conf_rank` | integer | Team's final rank within its conference for the season. |
+| `div_rank` | integer | Team's final rank within its division for the season. |
+| `po_wins` | integer | Playoff wins recorded by the team that season. |
+| `po_losses` | integer | Playoff losses recorded by the team that season. |
+| `conf_count` | integer | Number of teams in the team's conference that season. |
+| `div_count` | integer | Number of teams in the team's division that season. |
+| `nba_finals_appearance` | character | Whether the team reached the league finals that season (e.g. "FINALS APPEARANCE" or "N/A"). |
 | `fgm` | numeric | Field goals made. |
 | `fga` | numeric | Field goal attempts. |
 | `fg_pct` | numeric | Field goal percentage (0-1). |
@@ -9203,7 +9203,7 @@ GET /stats/teamyearbyyearstats
 | `tov` | numeric | Turnovers. |
 | `blk` | numeric | Blocks. |
 | `pts` | numeric | Points scored. |
-| `pts_rank` | integer |  |
+| `pts_rank` | integer | League rank of the team's points scored for the season. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -9391,16 +9391,16 @@ GET /stats/videostatus
 | `game_id` | integer | Unique game identifier. |
 | `game_date` | character | Game date (YYYY-MM-DD). |
 | `visitor_team_id` | integer | Unique identifier for visitor team. |
-| `visitor_team_city` | character |  |
-| `visitor_team_name` | character |  |
-| `visitor_team_abbreviation` | character |  |
+| `visitor_team_city` | character | City name of the visiting team. |
+| `visitor_team_name` | character | Nickname of the visiting team. |
+| `visitor_team_abbreviation` | character | Abbreviation of the visiting team. |
 | `home_team_id` | integer | Unique identifier for the home team. |
 | `home_team_city` | character | Home team city / location. |
 | `home_team_name` | character | Home team name. |
 | `home_team_abbreviation` | character | Home team abbreviation; `team_detail = TRUE` only. |
 | `game_status` | character | Game status label. |
 | `game_status_text` | character | Game status display text (e.g. 'Final', '4:32 - 4th'). |
-| `is_available` | character |  |
+| `is_available` | character | Flag indicating whether game video is available in the league's stats video system. |
 | `pt_xyz_available` | character | Pt xyz available. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.

--- a/docs/docs/nfl/reference/pff_core.md
+++ b/docs/docs/nfl/reference/pff_core.md
@@ -31,30 +31,30 @@ Facet report /defense/run (By Position leaderboard; add franchiseId for By Team,
 | col_name | type | description |
 |---|---|---|
 | `assists` | numeric | Total assists. |
-| `avg_depth_of_tackle` | numeric |  |
-| `declined_penalties` | numeric |  |
-| `draft_season` | numeric |  |
-| `eligible_season` | numeric |  |
-| `forced_fumbles` | numeric |  |
+| `avg_depth_of_tackle` | numeric | Average depth downfield, in yards, at which the player made his tackles on run plays. |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `forced_fumbles` | numeric | Fumbles forced by the player. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `grades_coverage_defense` | numeric |  |
-| `grades_defense` | numeric |  |
-| `grades_defense_penalty` | numeric |  |
-| `grades_pass_rush_defense` | numeric |  |
-| `grades_run_defense` | numeric |  |
-| `grades_tackle` | numeric |  |
+| `grades_coverage_defense` | numeric | PFF coverage grade, 0-100. |
+| `grades_defense` | numeric | PFF overall defense grade, 0-100. |
+| `grades_defense_penalty` | numeric | PFF defensive penalty grade, 0-100. |
+| `grades_pass_rush_defense` | numeric | PFF pass-rush grade, 0-100. |
+| `grades_run_defense` | numeric | PFF run-defense grade, 0-100. |
+| `grades_tackle` | numeric | PFF tackling grade, 0-100. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `missed_tackle_rate` | numeric |  |
-| `missed_tackles` | numeric |  |
+| `missed_tackle_rate` | numeric | Share of tackle attempts the player missed. |
+| `missed_tackles` | numeric | Missed tackles. |
 | `penalties` | numeric | Total number of penalties. |
 | `player` | character | Player name |
-| `player_game_count` | numeric |  |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 | `position` | character | Primary position as reported by NFL.com |
-| `run_stop_opp` | numeric |  |
-| `snap_counts_run` | numeric |  |
-| `stop_percent` | numeric |  |
-| `stops` | numeric |  |
+| `run_stop_opp` | numeric | Run-defense snaps PFF counts as run-stop opportunities. |
+| `snap_counts_run` | numeric | Run-defense snaps played. |
+| `stop_percent` | numeric | Percentage of run-stop opportunities converted into stops. |
+| `stops` | numeric | Stops, PFF's tackles that constitute a failed play for the offense. |
 | `tackles` | numeric | Team tackles. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
@@ -91,39 +91,39 @@ Facet report /field_goal/summary (By Position leaderboard; add franchiseId for B
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `twenty_attempts` | numeric |  |
-| `pat_percent` | numeric |  |
-| `draft_season` | numeric |  |
-| `forty_made` | numeric |  |
+| `twenty_attempts` | numeric | Field goals attempted from 20-29 yards. |
+| `pat_percent` | numeric | Extra-point percentage. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `forty_made` | numeric | Field goals made from 40-49 yards. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `fifty_percent` | numeric |  |
-| `total_made` | numeric |  |
+| `fifty_percent` | numeric | Field-goal percentage from 50 or more yards. |
+| `total_made` | numeric | Total field goals made across all distances. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `one_made` | numeric |  |
-| `fifty_attempts` | numeric |  |
-| `forty_attempts` | numeric |  |
-| `player_game_count` | numeric |  |
-| `eligible_season` | numeric |  |
-| `thirty_percent` | numeric |  |
-| `total_attempts` | numeric |  |
-| `pat_attempts` | numeric |  |
-| `twenty_made` | numeric |  |
-| `one_attempts` | numeric |  |
-| `grades_fgep_kicker` | numeric |  |
-| `thirty_attempts` | numeric |  |
+| `one_made` | numeric | Field goals made from 1-19 yards. |
+| `fifty_attempts` | numeric | Field goals attempted from 50 or more yards. |
+| `forty_attempts` | numeric | Field goals attempted from 40-49 yards. |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `thirty_percent` | numeric | Field-goal percentage from 30-39 yards. |
+| `total_attempts` | numeric | Total field goals attempted across all distances. |
+| `pat_attempts` | numeric | Extra points attempted. |
+| `twenty_made` | numeric | Field goals made from 20-29 yards. |
+| `one_attempts` | numeric | Field goals attempted from 1-19 yards. |
+| `grades_fgep_kicker` | numeric | PFF field-goal and extra-point kicking grade, 0-100. |
+| `thirty_attempts` | numeric | Field goals attempted from 30-39 yards. |
 | `penalties` | numeric | Total number of penalties. |
-| `pat_made` | numeric |  |
+| `pat_made` | numeric | Extra points made. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `declined_penalties` | numeric |  |
-| `one_percent` | numeric |  |
-| `total_percent` | numeric |  |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `one_percent` | numeric | Field-goal percentage from 1-19 yards. |
+| `total_percent` | numeric | Overall field-goal percentage. |
 | `position` | character | Primary position as reported by NFL.com |
-| `twenty_percent` | numeric |  |
-| `forty_percent` | numeric |  |
+| `twenty_percent` | numeric | Field-goal percentage from 20-29 yards. |
+| `forty_percent` | numeric | Field-goal percentage from 40-49 yards. |
 | `player` | character | Player name |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `fifty_made` | numeric |  |
-| `thirty_made` | numeric |  |
+| `fifty_made` | numeric | Field goals made from 50 or more yards. |
+| `thirty_made` | numeric | Field goals made from 30-39 yards. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -159,49 +159,49 @@ Facet report /defense/coverage (By Position leaderboard; add franchiseId for By 
 | col_name | type | description |
 |---|---|---|
 | `targets` | numeric | The number of pass plays where the player was the targeted receiver. |
-| `yards_per_coverage_snap` | numeric |  |
-| `draft_season` | numeric |  |
-| `missed_tackles` | numeric |  |
-| `catch_rate` | numeric |  |
+| `yards_per_coverage_snap` | numeric | Receiving yards allowed per coverage snap. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `missed_tackles` | numeric | Missed tackles. |
+| `catch_rate` | numeric | Completion percentage allowed on targets into the player's coverage. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `tackles` | numeric | Team tackles. |
-| `coverage_percent` | numeric |  |
+| `coverage_percent` | numeric | Share of pass-play snaps spent in coverage. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `dropped_ints` | numeric |  |
-| `player_game_count` | numeric |  |
-| `eligible_season` | numeric |  |
-| `grades_tackle` | numeric |  |
+| `dropped_ints` | numeric | Interception chances PFF charted as dropped. |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `grades_tackle` | numeric | PFF tackling grade, 0-100. |
 | `yards` | numeric | The number of receiving yards |
 | `receptions` | numeric | The number of pass receptions. Lateral receptions officially don't count as reception. |
-| `forced_incompletion_rate` | numeric |  |
-| `grades_coverage_defense` | numeric |  |
+| `forced_incompletion_rate` | numeric | Share of targets into the player's coverage with a PFF-charted forced incompletion. |
+| `grades_coverage_defense` | numeric | PFF coverage grade, 0-100. |
 | `interceptions` | numeric | The number of interceptions thrown. |
-| `snap_counts_coverage` | numeric |  |
-| `grades_run_defense` | numeric |  |
-| `snap_counts_pass_play` | numeric |  |
+| `snap_counts_coverage` | numeric | Coverage snaps played. |
+| `grades_run_defense` | numeric | PFF run-defense grade, 0-100. |
+| `snap_counts_pass_play` | numeric | Pass-play snaps. |
 | `penalties` | numeric | Total number of penalties. |
-| `forced_incompletes` | numeric |  |
+| `forced_incompletes` | numeric | Incompletions forced by the player's coverage, per PFF charting. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `coverage_snaps_per_target` | numeric |  |
-| `stops` | numeric |  |
-| `declined_penalties` | numeric |  |
+| `coverage_snaps_per_target` | numeric | Coverage snaps played per target into the player's coverage. |
+| `stops` | numeric | Stops, PFF's tackles that constitute a failed play for the offense. |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
 | `position` | character | Primary position as reported by NFL.com |
-| `longest` | numeric |  |
-| `missed_tackle_rate` | numeric |  |
-| `grades_defense` | numeric |  |
-| `yards_per_reception` | numeric |  |
-| `grades_defense_penalty` | numeric |  |
+| `longest` | numeric | Longest completion allowed, in yards. |
+| `missed_tackle_rate` | numeric | Share of tackle attempts the player missed. |
+| `grades_defense` | numeric | PFF overall defense grade, 0-100. |
+| `yards_per_reception` | numeric | Average yards allowed per reception. |
+| `grades_defense_penalty` | numeric | PFF defensive penalty grade, 0-100. |
 | `player` | character | Player name |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `yards_after_catch` | numeric | Numeric value for distance in yards perpendicular to the yard line where the receiver made the reception to where the play ended. |
-| `avg_depth_of_target` | numeric |  |
-| `pass_break_ups` | numeric |  |
-| `qb_rating_against` | numeric |  |
-| `coverage_snaps_per_reception` | numeric |  |
+| `avg_depth_of_target` | numeric | Average depth of targets into the player's coverage, in yards downfield. |
+| `pass_break_ups` | numeric | Passes broken up. |
+| `qb_rating_against` | numeric | NFL passer rating allowed on targets into the player's coverage. |
+| `coverage_snaps_per_reception` | numeric | Coverage snaps played per reception allowed. |
 | `assists` | numeric | Total assists. |
-| `grades_pass_rush_defense` | numeric |  |
+| `grades_pass_rush_defense` | numeric | PFF pass-rush grade, 0-100. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
-| `touchdowns` | numeric |  |
+| `touchdowns` | numeric | Touchdowns allowed into the player's coverage. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -236,32 +236,32 @@ Facet report /kickoff/summary (By Position leaderboard; add franchiseId for By T
 | col_name | type | description |
 |---|---|---|
 | `attempts` | numeric | The number of pass attempts as defined by the NFL. |
-| `attempts_with_hangtime` | numeric |  |
-| `average_distance` | numeric |  |
-| `average_hangtime` | numeric |  |
-| `average_starting_field_position` | numeric |  |
-| `average_yards_per_return` | numeric |  |
-| `declined_penalties` | numeric |  |
-| `draft_season` | numeric |  |
-| `eligible_season` | numeric |  |
-| `fair_catches` | numeric |  |
+| `attempts_with_hangtime` | numeric | Kickoffs with a PFF-recorded hangtime. |
+| `average_distance` | numeric | Average kickoff distance in yards. |
+| `average_hangtime` | numeric | Average kickoff hangtime in seconds. |
+| `average_starting_field_position` | numeric | Average opponent starting field position following the player's kickoffs. |
+| `average_yards_per_return` | numeric | Average return yards allowed per kickoff returned. |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `fair_catches` | numeric | Kickoffs fair-caught by the return team. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `grades_kickoff_kicker` | numeric |  |
+| `grades_kickoff_kicker` | numeric | PFF kickoff kicking grade, 0-100. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `kicked_yards` | numeric |  |
-| `kicks_returned` | numeric |  |
-| `onside_kicks` | numeric |  |
+| `kicked_yards` | numeric | Total kickoff yards. |
+| `kicks_returned` | numeric | Kickoffs returned by the opponent. |
+| `onside_kicks` | numeric | Onside kicks attempted. |
 | `penalties` | numeric | Total number of penalties. |
-| `percent_returned` | numeric |  |
+| `percent_returned` | numeric | Percentage of the player's kickoffs that were returned. |
 | `player` | character | Player name |
-| `player_game_count` | numeric |  |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 | `position` | character | Primary position as reported by NFL.com |
 | `return_yards` | numeric | Yards gained by the return team. Returns may occur on any of: interception, fumble, kickoff, punt, or blocked kicks. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `total_hangtime` | numeric |  |
-| `touchbacks` | numeric |  |
+| `total_hangtime` | numeric | Total kickoff hangtime in seconds. |
+| `touchbacks` | numeric | Kickoffs resulting in touchbacks. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -295,40 +295,40 @@ Facet report /offense/blocking (By Position leaderboard; add franchiseId for By 
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `grades_pass_block` | numeric |  |
-| `grades_offense` | numeric |  |
-| `pbe` | numeric |  |
-| `non_spike_pass_block_percentage` | numeric |  |
-| `draft_season` | numeric |  |
-| `snap_counts_rg` | numeric |  |
+| `grades_pass_block` | numeric | PFF pass-blocking grade, 0-100. |
+| `grades_offense` | numeric | PFF overall offense grade, 0-100. |
+| `pbe` | numeric | PFF Pass Blocking Efficiency rating, pressures allowed per pass-blocking snap weighted toward sacks. |
+| `non_spike_pass_block_percentage` | numeric | Share of non-spike pass-play snaps spent pass blocking. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `snap_counts_rg` | numeric | Snaps aligned at right guard. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `snap_counts_ce` | numeric |  |
-| `hits_allowed` | numeric |  |
-| `block_percent` | numeric |  |
-| `snap_counts_offense` | numeric |  |
-| `player_game_count` | numeric |  |
-| `eligible_season` | numeric |  |
-| `snap_counts_block` | numeric |  |
-| `hurries_allowed` | numeric |  |
-| `grades_run_block` | numeric |  |
-| `snap_counts_run_block` | numeric |  |
-| `pressures_allowed` | numeric |  |
-| `snap_counts_pass_play` | numeric |  |
+| `snap_counts_ce` | numeric | Snaps aligned at center. |
+| `hits_allowed` | numeric | Quarterback hits allowed. |
+| `block_percent` | numeric | Share of offensive snaps spent blocking. |
+| `snap_counts_offense` | numeric | Offensive snaps played. |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `snap_counts_block` | numeric | Total blocking snaps played. |
+| `hurries_allowed` | numeric | Quarterback hurries allowed. |
+| `grades_run_block` | numeric | PFF run-blocking grade, 0-100. |
+| `snap_counts_run_block` | numeric | Run-blocking snaps played. |
+| `pressures_allowed` | numeric | Total pressures allowed (sacks, hits, and hurries). |
+| `snap_counts_pass_play` | numeric | Pass-play snaps. |
 | `penalties` | numeric | Total number of penalties. |
 | `sacks_allowed` | numeric | Opponent sacks. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `declined_penalties` | numeric |  |
-| `snap_counts_te` | numeric |  |
-| `snap_counts_rt` | numeric |  |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `snap_counts_te` | numeric | Snaps aligned at tight end. |
+| `snap_counts_rt` | numeric | Snaps aligned at right tackle. |
 | `position` | character | Primary position as reported by NFL.com |
-| `non_spike_pass_block` | numeric |  |
-| `snap_counts_lt` | numeric |  |
+| `non_spike_pass_block` | numeric | Pass-blocking snaps excluding spike plays. |
+| `snap_counts_lt` | numeric | Snaps aligned at left tackle. |
 | `player` | character | Player name |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `snap_counts_pass_block` | numeric |  |
-| `pass_block_percent` | numeric |  |
-| `snap_counts_lg` | numeric |  |
+| `snap_counts_pass_block` | numeric | Pass-blocking snaps played. |
+| `pass_block_percent` | numeric | Share of pass-play snaps spent pass blocking. |
+| `snap_counts_lg` | numeric | Snaps aligned at left guard. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -365,63 +365,63 @@ Facet report /defense/summary (By Position leaderboard; add franchiseId for By T
 |---|---|---|
 | `targets` | numeric | The number of pass plays where the player was the targeted receiver. |
 | `interception_touchdowns` | numeric | Touchdowns scored on interception returns. |
-| `draft_season` | numeric |  |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
 | `forced_fumbles` | numeric | Forced fumbles. |
-| `missed_tackles` | numeric |  |
-| `catch_rate` | numeric |  |
+| `missed_tackles` | numeric | Missed tackles. |
+| `catch_rate` | numeric | Completion percentage allowed on targets into the player's coverage. |
 | `team_name` | character | Team abbreviation the player is credited to for the range. |
 | `tackles` | numeric | Total tackles made by the defender. |
 | `jersey_number` | character | Jersey number (string; zero-padded, e.g. "09"). |
-| `snap_counts_offball` | numeric |  |
-| `snap_counts_box` | numeric |  |
+| `snap_counts_offball` | numeric | Snaps aligned as an off-ball linebacker. |
+| `snap_counts_box` | numeric | Snaps aligned in the box. |
 | `sacks` | numeric | Sacks credited. |
-| `snap_counts_pass_rush` | numeric |  |
+| `snap_counts_pass_rush` | numeric | Pass-rush snaps played. |
 | `player_game_count` | numeric | Games with at least one qualifying snap in the requested range. |
-| `eligible_season` | numeric |  |
-| `snap_counts_dl` | numeric |  |
-| `grades_tackle` | numeric |  |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `snap_counts_dl` | numeric | Snaps aligned on the defensive line. |
+| `grades_tackle` | numeric | PFF tackling grade, 0-100. |
 | `yards` | numeric | The number of receiving yards |
 | `receptions` | numeric | The number of pass receptions. Lateral receptions officially don't count as reception. |
 | `grades_coverage_defense` | numeric | PFF coverage grade (0-100). |
-| `hurries` | numeric |  |
+| `hurries` | numeric | Quarterback hurries recorded. |
 | `interceptions` | numeric | Interceptions made in coverage. |
-| `snap_counts_coverage` | numeric |  |
-| `snap_counts_dl_over_t` | numeric |  |
-| `snap_counts_dl_a_gap` | numeric |  |
-| `fumble_recoveries` | numeric |  |
+| `snap_counts_coverage` | numeric | Coverage snaps played. |
+| `snap_counts_dl_over_t` | numeric | Defensive-line snaps aligned head-up over the offensive tackle. |
+| `snap_counts_dl_a_gap` | numeric | Defensive-line snaps aligned in the A gap. |
+| `fumble_recoveries` | numeric | Opponent fumbles recovered by the player. |
 | `grades_run_defense` | numeric | PFF run-defense grade (0-100). |
-| `snap_counts_corner` | numeric |  |
+| `snap_counts_corner` | numeric | Snaps aligned at outside cornerback. |
 | `hits` | numeric | Hits. |
 | `penalties` | numeric | Total number of penalties. |
-| `batted_passes` | numeric |  |
+| `batted_passes` | numeric | Passes batted down at the line of scrimmage. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
 | `stops` | numeric | Tackles that constitute an offensive failure ("stops"). |
-| `declined_penalties` | numeric |  |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
 | `total_pressures` | numeric | Total quarterback pressures (sacks + hits + hurries). |
 | `position` | character | Primary position as reported by NFL.com |
-| `fumble_recovery_touchdowns` | numeric |  |
-| `longest` | numeric |  |
-| `snap_counts_slot` | numeric |  |
-| `missed_tackle_rate` | numeric |  |
+| `fumble_recovery_touchdowns` | numeric | Touchdowns scored on fumble recoveries. |
+| `longest` | numeric | Longest completion allowed, in yards. |
+| `snap_counts_slot` | numeric | Snaps aligned in the slot. |
+| `missed_tackle_rate` | numeric | Share of tackle attempts the player missed. |
 | `grades_defense` | numeric | PFF overall defense grade (0-100). |
-| `yards_per_reception` | numeric |  |
-| `grades_defense_penalty` | numeric |  |
-| `safeties` | numeric |  |
+| `yards_per_reception` | numeric | Average yards allowed per reception. |
+| `grades_defense_penalty` | numeric | PFF defensive penalty grade, 0-100. |
+| `safeties` | numeric | Safeties recorded by the player. |
 | `player` | character | Player name |
 | `franchise_id` | numeric | PFF franchise (team) id (integer join key). |
-| `snap_counts_defense` | numeric |  |
+| `snap_counts_defense` | numeric | Total defensive snaps played. |
 | `yards_after_catch` | numeric | Numeric value for distance in yards perpendicular to the yard line where the receiver made the reception to where the play ended. |
-| `snap_counts_dl_b_gap` | numeric |  |
-| `pass_break_ups` | numeric |  |
-| `qb_rating_against` | numeric |  |
-| `snap_counts_run_defense` | numeric |  |
+| `snap_counts_dl_b_gap` | numeric | Defensive-line snaps aligned in the B gap. |
+| `pass_break_ups` | numeric | Passes broken up. |
+| `qb_rating_against` | numeric | NFL passer rating allowed on targets into the player's coverage. |
+| `snap_counts_run_defense` | numeric | Run-defense snaps played. |
 | `tackles_for_loss` | numeric | Team tackles for a loss. |
 | `assists` | numeric | Assisted tackles. |
-| `grades_pass_rush_defense` | numeric |  |
+| `grades_pass_rush_defense` | numeric | PFF pass-rush grade, 0-100. |
 | `player_id` | numeric | PFF player id (integer; matches the /players id and every player_id join key). |
-| `snap_counts_fs` | numeric |  |
-| `touchdowns` | numeric |  |
-| `snap_counts_dl_outside_t` | numeric |  |
+| `snap_counts_fs` | numeric | Snaps aligned at free safety. |
+| `touchdowns` | numeric | Touchdowns allowed into the player's coverage. |
+| `snap_counts_dl_outside_t` | numeric | Defensive-line snaps aligned outside the offensive tackle. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -455,13 +455,13 @@ Facet report /offense/summary (By Position leaderboard; add franchiseId for By T
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `declined_penalties` | numeric |  |
-| `draft_season` | numeric |  |
-| `eligible_season` | numeric |  |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
 | `franchise_id` | numeric | PFF franchise (team) id (integer join key). |
-| `grades_hands_fumble` | numeric |  |
+| `grades_hands_fumble` | numeric | PFF ball-security (hands/fumble) grade, 0-100. |
 | `grades_offense` | numeric | PFF overall offense grade (0-100). |
-| `grades_offense_penalty` | numeric |  |
+| `grades_offense_penalty` | numeric | PFF offensive penalty grade, 0-100. |
 | `grades_pass` | numeric | PFF passing grade (0-100). |
 | `grades_run` | numeric | PFF rushing grade (0-100). |
 | `grades_run_block` | numeric | PFF run-blocking grade (0-100). |
@@ -471,14 +471,14 @@ Facet report /offense/summary (By Position leaderboard; add franchiseId for By T
 | `player_game_count` | numeric | Games with at least one qualifying snap in the requested range. |
 | `player_id` | numeric | PFF player id (integer; matches the /players id and every player_id join key). |
 | `position` | character | Primary position as reported by NFL.com |
-| `snap_counts_pass` | numeric |  |
-| `snap_counts_pass_block` | numeric |  |
-| `snap_counts_pass_route` | numeric |  |
-| `snap_counts_run` | numeric |  |
-| `snap_counts_run_block` | numeric |  |
-| `snap_counts_total` | numeric |  |
-| `snap_counts_total_pass` | numeric |  |
-| `snap_counts_total_run` | numeric |  |
+| `snap_counts_pass` | numeric | Pass-play snaps spent as the passer, rather than blocking or running a route. |
+| `snap_counts_pass_block` | numeric | Pass-blocking snaps played. |
+| `snap_counts_pass_route` | numeric | Snaps spent running a pass route. |
+| `snap_counts_run` | numeric | Run-play snaps spent as a runner, rather than run blocking. |
+| `snap_counts_run_block` | numeric | Run-blocking snaps played. |
+| `snap_counts_total` | numeric | Total offensive snaps played. |
+| `snap_counts_total_pass` | numeric | Total pass-play snaps across passing, pass blocking, and route running. |
+| `snap_counts_total_run` | numeric | Total run-play snaps across rushing and run blocking. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
 | `team_name` | character | Team abbreviation the player is credited to for the range. |
 | `grades_pass_block` | numeric | PFF pass-blocking grade (0-100). |
@@ -516,41 +516,41 @@ Facet report /passing/allowed_pressure (By Position leaderboard; add franchiseId
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `te_percent` | numeric |  |
-| `draft_season` | numeric |  |
-| `pressures_lt` | numeric |  |
-| `pressures_rg` | numeric |  |
+| `te_percent` | numeric | Share of allowed pressures attributed to tight ends, expressed as a percentage. |
+| `draft_season` | numeric | NFL season (year) in which the player was drafted, per PFF player metadata. |
+| `pressures_lt` | numeric | Number of allowed pressures PFF attributes to left tackle. |
+| `pressures_rg` | numeric | Number of allowed pressures PFF attributes to right guard. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `lt_percent` | numeric |  |
+| `lt_percent` | numeric | Share of allowed pressures attributed to left tackle, expressed as a percentage. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `hits_allowed` | numeric |  |
-| `pressures_lg` | numeric |  |
-| `player_game_count` | numeric |  |
-| `eligible_season` | numeric |  |
-| `hurries_allowed` | numeric |  |
-| `self_percent` | numeric |  |
-| `pressures_rt` | numeric |  |
-| `pressures_allowed` | numeric |  |
-| `pressures_ol_te` | numeric |  |
-| `pressures_ce` | numeric |  |
+| `hits_allowed` | numeric | Number of quarterback hits allowed on the player's dropbacks, as charted by PFF. |
+| `pressures_lg` | numeric | Number of allowed pressures PFF attributes to left guard. |
+| `player_game_count` | numeric | Number of games the player appeared in during the period covered. |
+| `eligible_season` | numeric | Season (year) of the player's NFL draft eligibility, per PFF player metadata. |
+| `hurries_allowed` | numeric | Number of hurries allowed on the player's dropbacks, as charted by PFF. |
+| `self_percent` | numeric | Share of allowed pressures attributed to the quarterback himself, expressed as a percentage. |
+| `pressures_rt` | numeric | Number of allowed pressures PFF attributes to right tackle. |
+| `pressures_allowed` | numeric | Total pressures allowed on the quarterback's dropbacks, as attributed by PFF. |
+| `pressures_ol_te` | numeric | Number of allowed pressures PFF attributes to the offensive line and tight ends combined. |
+| `pressures_ce` | numeric | Number of allowed pressures PFF attributes to center. |
 | `penalties` | numeric | Total number of penalties. |
 | `sacks_allowed` | numeric | Opponent sacks. |
-| `ol_te_percent` | numeric |  |
-| `allowed_pressure_dropbacks` | numeric |  |
-| `pressures_other` | numeric |  |
+| `ol_te_percent` | numeric | Share of allowed pressures attributed to the offensive line and tight ends combined, expressed as a percentage. |
+| `allowed_pressure_dropbacks` | numeric | Number of dropbacks over which allowed pressures are attributed, from the PFF allowed-pressure facet. |
+| `pressures_other` | numeric | Number of allowed pressures PFF attributes to other players outside the listed blocking positions. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `declined_penalties` | numeric |  |
-| `ce_percent` | numeric |  |
+| `declined_penalties` | numeric | Number of declined penalties committed by the player. |
+| `ce_percent` | numeric | Share of allowed pressures attributed to center, expressed as a percentage. |
 | `position` | character | Primary position as reported by NFL.com |
-| `pressures_te` | numeric |  |
-| `pressures_self` | numeric |  |
-| `lg_percent` | numeric |  |
+| `pressures_te` | numeric | Number of allowed pressures PFF attributes to tight ends. |
+| `pressures_self` | numeric | Number of allowed pressures PFF attributes to the quarterback himself. |
+| `lg_percent` | numeric | Share of allowed pressures attributed to left guard, expressed as a percentage. |
 | `player` | character | Player name |
-| `rt_percent` | numeric |  |
+| `rt_percent` | numeric | Share of allowed pressures attributed to right tackle, expressed as a percentage. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `other_percent` | numeric |  |
-| `pressures_off` | numeric |  |
-| `rg_percent` | numeric |  |
+| `other_percent` | numeric | Share of allowed pressures attributed to other players outside the listed blocking positions, expressed as a percentage. |
+| `pressures_off` | numeric | Number of allowed pressures PFF attributes to the offense without a specific blocker charged. |
+| `rg_percent` | numeric | Share of allowed pressures attributed to right guard, expressed as a percentage. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -585,43 +585,43 @@ Facet report /defense/pass_rush (By Position leaderboard; add franchiseId for By
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `true_pass_set_total_pressures` | numeric |  |
-| `draft_season` | numeric |  |
-| `true_pass_set_prp` | numeric |  |
-| `true_pass_set_hurries` | numeric |  |
+| `true_pass_set_total_pressures` | numeric | Total pressures generated (sacks, hits, and hurries) on PFF-designated true pass sets. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `true_pass_set_prp` | numeric | PFF Pass Rush Productivity rating, pressure generated per pass-rush snap weighted toward sacks on PFF-designated true pass sets. |
+| `true_pass_set_hurries` | numeric | Quarterback hurries recorded on PFF-designated true pass sets. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `prp` | numeric |  |
-| `true_pass_set_sacks` | numeric |  |
-| `pass_rush_win_rate` | numeric |  |
+| `prp` | numeric | PFF Pass Rush Productivity rating, pressure generated per pass-rush snap weighted toward sacks. |
+| `true_pass_set_sacks` | numeric | Sacks recorded on PFF-designated true pass sets. |
+| `pass_rush_win_rate` | numeric | Percentage of pass-rush snaps with a PFF-charted pass-rush win. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `sacks` | numeric | The Number of times sacked. |
-| `snap_counts_pass_rush` | numeric |  |
-| `player_game_count` | numeric |  |
-| `eligible_season` | numeric |  |
-| `true_pass_set_snap_counts_pass_play` | numeric |  |
-| `pass_rush_wins` | numeric |  |
-| `hurries` | numeric |  |
-| `pass_rush_opp` | numeric |  |
-| `snap_counts_pass_play` | numeric |  |
+| `snap_counts_pass_rush` | numeric | Pass-rush snaps played. |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `true_pass_set_snap_counts_pass_play` | numeric | Pass-play snaps on PFF-designated true pass sets. |
+| `pass_rush_wins` | numeric | PFF-charted pass-rush wins. |
+| `hurries` | numeric | Quarterback hurries recorded. |
+| `pass_rush_opp` | numeric | Pass-rush snaps PFF counts as pressure opportunities. |
+| `snap_counts_pass_play` | numeric | Pass-play snaps. |
 | `hits` | numeric | Hits. |
-| `true_pass_set_pass_rush_win_rate` | numeric |  |
+| `true_pass_set_pass_rush_win_rate` | numeric | Percentage of pass-rush snaps with a PFF-charted pass-rush win on PFF-designated true pass sets. |
 | `penalties` | numeric | Total number of penalties. |
-| `batted_passes` | numeric |  |
-| `true_pass_set_hits` | numeric |  |
-| `true_pass_set_snap_counts_pass_rush` | numeric |  |
+| `batted_passes` | numeric | Passes batted down at the line of scrimmage. |
+| `true_pass_set_hits` | numeric | Quarterback hits recorded on PFF-designated true pass sets. |
+| `true_pass_set_snap_counts_pass_rush` | numeric | Pass-rush snaps played on PFF-designated true pass sets. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `declined_penalties` | numeric |  |
-| `true_pass_set_pass_rush_wins` | numeric |  |
-| `total_pressures` | numeric |  |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `true_pass_set_pass_rush_wins` | numeric | PFF-charted pass-rush wins on PFF-designated true pass sets. |
+| `total_pressures` | numeric | Total pressures generated (sacks, hits, and hurries). |
 | `position` | character | Primary position as reported by NFL.com |
-| `true_pass_set_grades_pass_rush_defense` | numeric |  |
-| `true_pass_set_batted_passes` | numeric |  |
+| `true_pass_set_grades_pass_rush_defense` | numeric | PFF pass-rush grade on PFF-designated true pass sets, 0-100. |
+| `true_pass_set_batted_passes` | numeric | Passes batted down at the line of scrimmage on PFF-designated true pass sets. |
 | `player` | character | Player name |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `pass_rush_percent` | numeric |  |
-| `true_pass_set_pass_rush_opp` | numeric |  |
-| `true_pass_set_pass_rush_percent` | numeric |  |
-| `grades_pass_rush_defense` | numeric |  |
+| `pass_rush_percent` | numeric | Share of pass-play snaps spent rushing the passer. |
+| `true_pass_set_pass_rush_opp` | numeric | Pass-rush snaps PFF counts as pressure opportunities on PFF-designated true pass sets. |
+| `true_pass_set_pass_rush_percent` | numeric | Share of pass-play snaps spent rushing the passer on PFF-designated true pass sets. |
+| `grades_pass_rush_defense` | numeric | PFF pass-rush grade, 0-100. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -656,221 +656,221 @@ Facet report /passing/concept (By Position leaderboard; add franchiseId for By T
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `comp_pct_diff` | numeric |  |
-| `pa_grades_pass` | numeric |  |
-| `no_screen_grades_offense` | numeric |  |
-| `pa_qb_rating` | numeric |  |
-| `no_screen_qb_rating` | numeric |  |
-| `pa_completions` | numeric |  |
-| `pa_thrown_aways` | numeric |  |
-| `pa_dropbacks_percent` | numeric |  |
-| `ypa_diff` | numeric |  |
-| `no_screen_drops` | numeric |  |
-| `screen_completion_percent` | numeric |  |
-| `npa_bats` | numeric |  |
-| `no_screen_thrown_aways` | numeric |  |
-| `pa_grades_run` | numeric |  |
-| `screen_pressure_to_sack_rate` | numeric |  |
-| `pa_drop_rate` | numeric |  |
-| `screen_grades_offense` | numeric |  |
-| `dropbacks` | numeric |  |
-| `npa_thrown_aways` | numeric |  |
-| `no_screen_def_gen_pressures` | numeric |  |
-| `screen_grades_hands_fumble` | numeric |  |
-| `pa_touchdowns` | numeric |  |
-| `npa_ypa` | numeric |  |
-| `draft_season` | numeric |  |
-| `screen_avg_time_to_throw` | numeric |  |
-| `screen_thrown_aways` | numeric |  |
-| `npa_sacks` | numeric |  |
-| `npa_aimed_passes` | numeric |  |
-| `no_screen_completions` | numeric |  |
-| `no_screen_positive_epa_percent` | numeric |  |
-| `screen_spikes` | numeric |  |
-| `pa_first_downs` | numeric |  |
-| `pa_big_time_throws` | numeric |  |
+| `comp_pct_diff` | numeric | Difference in completion percentage between play-action and non-play-action attempts (PA minus non-PA), from the PFF passing-concept split. |
+| `pa_grades_pass` | numeric | PFF passing grade (0-100) on play-action dropbacks. |
+| `no_screen_grades_offense` | numeric | PFF overall offense grade for the player (0-100) excluding screen passes. |
+| `pa_qb_rating` | numeric | Traditional NFL passer rating on play-action dropbacks. |
+| `no_screen_qb_rating` | numeric | Traditional NFL passer rating excluding screen passes. |
+| `pa_completions` | numeric | Number of completed passes on play-action dropbacks. |
+| `pa_thrown_aways` | numeric | Number of intentional throwaways on play-action dropbacks. |
+| `pa_dropbacks_percent` | numeric | Share of the player's total dropbacks that came on play-action dropbacks, expressed as a percentage. |
+| `ypa_diff` | numeric | Difference in yards per attempt between play-action and non-play-action attempts (PA minus non-PA), from the PFF passing-concept split. |
+| `no_screen_drops` | numeric | Number of catchable passes dropped by receivers excluding screen passes. |
+| `screen_completion_percent` | numeric | Percentage of pass attempts completed on screen passes. |
+| `npa_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on non-play-action dropbacks. |
+| `no_screen_thrown_aways` | numeric | Number of intentional throwaways excluding screen passes. |
+| `pa_grades_run` | numeric | PFF rushing grade for the player (0-100) on play-action dropbacks. |
+| `screen_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on screen passes. |
+| `pa_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on play-action dropbacks. |
+| `screen_grades_offense` | numeric | PFF overall offense grade for the player (0-100) on screen passes. |
+| `dropbacks` | numeric | Number of dropbacks. |
+| `npa_thrown_aways` | numeric | Number of intentional throwaways on non-play-action dropbacks. |
+| `no_screen_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks excluding screen passes, as charted by PFF. |
+| `screen_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) on screen passes. |
+| `pa_touchdowns` | numeric | Number of passing touchdowns thrown on play-action dropbacks. |
+| `npa_ypa` | numeric | Yards gained per pass attempt on non-play-action dropbacks. |
+| `draft_season` | numeric | NFL season (year) in which the player was drafted, per PFF player metadata. |
+| `screen_avg_time_to_throw` | numeric | Average time from snap to release in seconds on screen passes. |
+| `screen_thrown_aways` | numeric | Number of intentional throwaways on screen passes. |
+| `npa_sacks` | numeric | Number of sacks taken on non-play-action dropbacks. |
+| `npa_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on non-play-action dropbacks, as charted by PFF. |
+| `no_screen_completions` | numeric | Number of completed passes excluding screen passes. |
+| `no_screen_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added excluding screen passes. |
+| `screen_spikes` | numeric | Number of clock-stopping spikes on screen passes. |
+| `pa_first_downs` | numeric | Number of passing first downs gained on play-action dropbacks. |
+| `pa_big_time_throws` | numeric | Number of big-time throws on play-action dropbacks, per PFF's highest-value, highest-difficulty throw designation. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `pa_spikes` | numeric |  |
-| `pa_sack_percent` | numeric |  |
-| `screen_dropbacks_percent` | numeric |  |
-| `no_screen_epa` | numeric |  |
-| `npa_avg_time_to_throw` | numeric |  |
-| `screen_bats` | numeric |  |
-| `screen_grades_run_block` | numeric |  |
+| `pa_spikes` | numeric | Number of clock-stopping spikes on play-action dropbacks. |
+| `pa_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on play-action dropbacks. |
+| `screen_dropbacks_percent` | numeric | Share of the player's total dropbacks that came on screen passes, expressed as a percentage. |
+| `no_screen_epa` | numeric | Total expected points added (EPA) on the player's dropbacks excluding screen passes. |
+| `npa_avg_time_to_throw` | numeric | Average time from snap to release in seconds on non-play-action dropbacks. |
+| `screen_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on screen passes. |
+| `screen_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) on screen passes. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `no_screen_bats` | numeric |  |
-| `npa_grades_offense` | numeric |  |
-| `no_screen_grades_pass_route` | numeric |  |
-| `screen_def_gen_pressures` | numeric |  |
-| `pa_pressure_to_sack_rate` | numeric |  |
-| `screen_sack_percent` | numeric |  |
-| `no_screen_btt_rate` | numeric |  |
-| `npa_btt_rate` | numeric |  |
-| `screen_interceptions` | numeric |  |
-| `no_screen_passing_snaps` | numeric |  |
-| `no_screen_grades_hands_fumble` | numeric |  |
-| `screen_scrambles` | numeric |  |
-| `screen_grades_pass` | numeric |  |
-| `npa_qb_rating` | numeric |  |
-| `no_screen_grades_pass` | numeric |  |
-| `pa_avg_time_to_throw` | numeric |  |
-| `screen_twp_rate` | numeric |  |
-| `player_game_count` | numeric |  |
-| `npa_accuracy_percent` | numeric |  |
-| `eligible_season` | numeric |  |
-| `npa_drops` | numeric |  |
-| `screen_yards` | numeric |  |
-| `no_screen_drop_rate` | numeric |  |
-| `no_screen_grades_offense_penalty` | numeric |  |
-| `npa_passing_snaps` | numeric |  |
-| `screen_drop_rate` | numeric |  |
-| `screen_epa` | numeric |  |
-| `screen_grades_pass_route` | numeric |  |
-| `screen_grades_offense_penalty` | numeric |  |
-| `npa_spikes` | numeric |  |
-| `screen_hit_as_threw` | numeric |  |
-| `no_screen_aimed_passes` | numeric |  |
-| `screen_drops` | numeric |  |
-| `screen_ypa` | numeric |  |
-| `npa_twp_rate` | numeric |  |
-| `screen_accuracy_percent` | numeric |  |
-| `npa_hit_as_threw` | numeric |  |
-| `pa_accuracy_percent` | numeric |  |
-| `pa_def_gen_pressures` | numeric |  |
-| `screen_avg_depth_of_target` | numeric |  |
-| `pa_sacks` | numeric |  |
-| `screen_passing_snaps` | numeric |  |
-| `no_screen_grades_run` | numeric |  |
-| `no_screen_first_downs` | numeric |  |
-| `pa_ypa` | numeric |  |
-| `npa_scrambles` | numeric |  |
-| `npa_pressure_to_sack_rate` | numeric |  |
-| `pa_twp_rate` | numeric |  |
-| `no_screen_twp_rate` | numeric |  |
-| `npa_grades_hands_fumble` | numeric |  |
-| `screen_completions` | numeric |  |
-| `screen_btt_rate` | numeric |  |
-| `npa_grades_run` | numeric |  |
-| `no_screen_interceptions` | numeric |  |
-| `npa_grades_run_block` | numeric |  |
-| `no_screen_sacks` | numeric |  |
+| `no_screen_bats` | numeric | Number of pass attempts batted down at the line of scrimmage excluding screen passes. |
+| `npa_grades_offense` | numeric | PFF overall offense grade for the player (0-100) on non-play-action dropbacks. |
+| `no_screen_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) excluding screen passes. |
+| `screen_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on screen passes, as charted by PFF. |
+| `pa_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on play-action dropbacks. |
+| `screen_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on screen passes. |
+| `no_screen_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts excluding screen passes, per PFF charting. |
+| `npa_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on non-play-action dropbacks, per PFF charting. |
+| `screen_interceptions` | numeric | Number of passes intercepted on screen passes. |
+| `no_screen_passing_snaps` | numeric | Number of passing snaps played excluding screen passes. |
+| `no_screen_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) excluding screen passes. |
+| `screen_scrambles` | numeric | Number of scrambles on screen passes. |
+| `screen_grades_pass` | numeric | PFF passing grade (0-100) on screen passes. |
+| `npa_qb_rating` | numeric | Traditional NFL passer rating on non-play-action dropbacks. |
+| `no_screen_grades_pass` | numeric | PFF passing grade (0-100) excluding screen passes. |
+| `pa_avg_time_to_throw` | numeric | Average time from snap to release in seconds on play-action dropbacks. |
+| `screen_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on screen passes, per PFF charting. |
+| `player_game_count` | numeric | Number of games the player appeared in during the period covered. |
+| `npa_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on non-play-action dropbacks. |
+| `eligible_season` | numeric | Season (year) of the player's NFL draft eligibility, per PFF player metadata. |
+| `npa_drops` | numeric | Number of catchable passes dropped by receivers on non-play-action dropbacks. |
+| `screen_yards` | numeric | Passing yards gained on screen passes. |
+| `no_screen_drop_rate` | numeric | Percentage of catchable passes dropped by receivers excluding screen passes. |
+| `no_screen_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) excluding screen passes. |
+| `npa_passing_snaps` | numeric | Number of passing snaps played on non-play-action dropbacks. |
+| `screen_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on screen passes. |
+| `screen_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on screen passes. |
+| `screen_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) on screen passes. |
+| `screen_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) on screen passes. |
+| `npa_spikes` | numeric | Number of clock-stopping spikes on non-play-action dropbacks. |
+| `screen_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on screen passes, as charted by PFF. |
+| `no_screen_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) excluding screen passes, as charted by PFF. |
+| `screen_drops` | numeric | Number of catchable passes dropped by receivers on screen passes. |
+| `screen_ypa` | numeric | Yards gained per pass attempt on screen passes. |
+| `npa_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on non-play-action dropbacks, per PFF charting. |
+| `screen_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on screen passes. |
+| `npa_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on non-play-action dropbacks, as charted by PFF. |
+| `pa_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on play-action dropbacks. |
+| `pa_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on play-action dropbacks, as charted by PFF. |
+| `screen_avg_depth_of_target` | numeric | Average depth of target in air yards on screen passes. |
+| `pa_sacks` | numeric | Number of sacks taken on play-action dropbacks. |
+| `screen_passing_snaps` | numeric | Number of passing snaps played on screen passes. |
+| `no_screen_grades_run` | numeric | PFF rushing grade for the player (0-100) excluding screen passes. |
+| `no_screen_first_downs` | numeric | Number of passing first downs gained excluding screen passes. |
+| `pa_ypa` | numeric | Yards gained per pass attempt on play-action dropbacks. |
+| `npa_scrambles` | numeric | Number of scrambles on non-play-action dropbacks. |
+| `npa_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on non-play-action dropbacks. |
+| `pa_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on play-action dropbacks, per PFF charting. |
+| `no_screen_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts excluding screen passes, per PFF charting. |
+| `npa_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) on non-play-action dropbacks. |
+| `screen_completions` | numeric | Number of completed passes on screen passes. |
+| `screen_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on screen passes, per PFF charting. |
+| `npa_grades_run` | numeric | PFF rushing grade for the player (0-100) on non-play-action dropbacks. |
+| `no_screen_interceptions` | numeric | Number of passes intercepted excluding screen passes. |
+| `npa_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) on non-play-action dropbacks. |
+| `no_screen_sacks` | numeric | Number of sacks taken excluding screen passes. |
 | `penalties` | numeric | Total number of penalties. |
-| `no_screen_big_time_throws` | numeric |  |
-| `npa_drop_rate` | numeric |  |
-| `npa_attempts` | numeric |  |
-| `screen_qb_rating` | numeric |  |
-| `npa_grades_offense_penalty` | numeric |  |
-| `pa_bats` | numeric |  |
-| `pa_attempts` | numeric |  |
-| `npa_def_gen_pressures` | numeric |  |
-| `no_screen_avg_time_to_throw` | numeric |  |
-| `pa_yards` | numeric |  |
-| `npa_positive_epa_percent` | numeric |  |
+| `no_screen_big_time_throws` | numeric | Number of big-time throws excluding screen passes, per PFF's highest-value, highest-difficulty throw designation. |
+| `npa_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on non-play-action dropbacks. |
+| `npa_attempts` | numeric | Number of pass attempts on non-play-action dropbacks. |
+| `screen_qb_rating` | numeric | Traditional NFL passer rating on screen passes. |
+| `npa_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) on non-play-action dropbacks. |
+| `pa_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on play-action dropbacks. |
+| `pa_attempts` | numeric | Number of pass attempts on play-action dropbacks. |
+| `npa_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on non-play-action dropbacks, as charted by PFF. |
+| `no_screen_avg_time_to_throw` | numeric | Average time from snap to release in seconds excluding screen passes. |
+| `pa_yards` | numeric | Passing yards gained on play-action dropbacks. |
+| `npa_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on non-play-action dropbacks. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `no_screen_scrambles` | numeric |  |
-| `pa_turnover_worthy_plays` | numeric |  |
-| `pa_aimed_passes` | numeric |  |
-| `declined_penalties` | numeric |  |
-| `pa_grades_offense` | numeric |  |
-| `screen_positive_epa_percent` | numeric |  |
-| `no_screen_dropbacks` | numeric |  |
-| `no_screen_dropbacks_percent` | numeric |  |
-| `npa_grades_pass_route` | numeric |  |
-| `npa_sack_percent` | numeric |  |
-| `pa_positive_epa_percent` | numeric |  |
-| `pa_grades_run_block` | numeric |  |
-| `no_screen_turnover_worthy_plays` | numeric |  |
+| `no_screen_scrambles` | numeric | Number of scrambles excluding screen passes. |
+| `pa_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on play-action dropbacks, plays PFF charts as deserving of a turnover. |
+| `pa_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on play-action dropbacks, as charted by PFF. |
+| `declined_penalties` | numeric | Number of declined penalties committed by the player. |
+| `pa_grades_offense` | numeric | PFF overall offense grade for the player (0-100) on play-action dropbacks. |
+| `screen_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on screen passes. |
+| `no_screen_dropbacks` | numeric | Number of dropbacks excluding screen passes. |
+| `no_screen_dropbacks_percent` | numeric | Share of the player's total dropbacks that came excluding screen passes, expressed as a percentage. |
+| `npa_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) on non-play-action dropbacks. |
+| `npa_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on non-play-action dropbacks. |
+| `pa_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on play-action dropbacks. |
+| `pa_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) on play-action dropbacks. |
+| `no_screen_turnover_worthy_plays` | numeric | Number of turnover-worthy plays excluding screen passes, plays PFF charts as deserving of a turnover. |
 | `position` | character | Primary position as reported by NFL.com |
-| `pa_grades_pass_route` | numeric |  |
-| `npa_epa` | numeric |  |
-| `no_screen_avg_depth_of_target` | numeric |  |
-| `pa_grades_hands_fumble` | numeric |  |
-| `no_screen_completion_percent` | numeric |  |
-| `pa_hit_as_threw` | numeric |  |
-| `pa_grades_offense_penalty` | numeric |  |
-| `npa_dropbacks_percent` | numeric |  |
-| `npa_grades_pass` | numeric |  |
-| `screen_grades_run` | numeric |  |
-| `screen_first_downs` | numeric |  |
-| `npa_completion_percent` | numeric |  |
-| `no_screen_grades_run_block` | numeric |  |
-| `no_screen_hit_as_threw` | numeric |  |
-| `screen_turnover_worthy_plays` | numeric |  |
-| `npa_avg_depth_of_target` | numeric |  |
-| `npa_dropbacks` | numeric |  |
+| `pa_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) on play-action dropbacks. |
+| `npa_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on non-play-action dropbacks. |
+| `no_screen_avg_depth_of_target` | numeric | Average depth of target in air yards excluding screen passes. |
+| `pa_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) on play-action dropbacks. |
+| `no_screen_completion_percent` | numeric | Percentage of pass attempts completed excluding screen passes. |
+| `pa_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on play-action dropbacks, as charted by PFF. |
+| `pa_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) on play-action dropbacks. |
+| `npa_dropbacks_percent` | numeric | Share of the player's total dropbacks that came on non-play-action dropbacks, expressed as a percentage. |
+| `npa_grades_pass` | numeric | PFF passing grade (0-100) on non-play-action dropbacks. |
+| `screen_grades_run` | numeric | PFF rushing grade for the player (0-100) on screen passes. |
+| `screen_first_downs` | numeric | Number of passing first downs gained on screen passes. |
+| `npa_completion_percent` | numeric | Percentage of pass attempts completed on non-play-action dropbacks. |
+| `no_screen_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) excluding screen passes. |
+| `no_screen_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw excluding screen passes, as charted by PFF. |
+| `screen_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on screen passes, plays PFF charts as deserving of a turnover. |
+| `npa_avg_depth_of_target` | numeric | Average depth of target in air yards on non-play-action dropbacks. |
+| `npa_dropbacks` | numeric | Number of dropbacks on non-play-action dropbacks. |
 | `player` | character | Player name |
-| `pa_drops` | numeric |  |
-| `pa_btt_rate` | numeric |  |
+| `pa_drops` | numeric | Number of catchable passes dropped by receivers on play-action dropbacks. |
+| `pa_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on play-action dropbacks, per PFF charting. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `screen_big_time_throws` | numeric |  |
-| `screen_aimed_passes` | numeric |  |
-| `npa_touchdowns` | numeric |  |
-| `screen_attempts` | numeric |  |
-| `screen_dropbacks` | numeric |  |
-| `no_screen_yards` | numeric |  |
-| `pa_scrambles` | numeric |  |
-| `pa_completion_percent` | numeric |  |
-| `pa_avg_depth_of_target` | numeric |  |
-| `pa_interceptions` | numeric |  |
-| `no_screen_accuracy_percent` | numeric |  |
-| `no_screen_spikes` | numeric |  |
-| `pa_dropbacks` | numeric |  |
-| `npa_big_time_throws` | numeric |  |
-| `no_screen_sack_percent` | numeric |  |
-| `pa_epa` | numeric |  |
-| `no_screen_attempts` | numeric |  |
-| `pa_passing_snaps` | numeric |  |
-| `npa_completions` | numeric |  |
-| `screen_touchdowns` | numeric |  |
-| `npa_first_downs` | numeric |  |
-| `no_screen_touchdowns` | numeric |  |
+| `screen_big_time_throws` | numeric | Number of big-time throws on screen passes, per PFF's highest-value, highest-difficulty throw designation. |
+| `screen_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on screen passes, as charted by PFF. |
+| `npa_touchdowns` | numeric | Number of passing touchdowns thrown on non-play-action dropbacks. |
+| `screen_attempts` | numeric | Number of pass attempts on screen passes. |
+| `screen_dropbacks` | numeric | Number of dropbacks on screen passes. |
+| `no_screen_yards` | numeric | Passing yards gained excluding screen passes. |
+| `pa_scrambles` | numeric | Number of scrambles on play-action dropbacks. |
+| `pa_completion_percent` | numeric | Percentage of pass attempts completed on play-action dropbacks. |
+| `pa_avg_depth_of_target` | numeric | Average depth of target in air yards on play-action dropbacks. |
+| `pa_interceptions` | numeric | Number of passes intercepted on play-action dropbacks. |
+| `no_screen_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF excluding screen passes. |
+| `no_screen_spikes` | numeric | Number of clock-stopping spikes excluding screen passes. |
+| `pa_dropbacks` | numeric | Number of dropbacks on play-action dropbacks. |
+| `npa_big_time_throws` | numeric | Number of big-time throws on non-play-action dropbacks, per PFF's highest-value, highest-difficulty throw designation. |
+| `no_screen_sack_percent` | numeric | Percentage of dropbacks that ended in a sack excluding screen passes. |
+| `pa_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on play-action dropbacks. |
+| `no_screen_attempts` | numeric | Number of pass attempts excluding screen passes. |
+| `pa_passing_snaps` | numeric | Number of passing snaps played on play-action dropbacks. |
+| `npa_completions` | numeric | Number of completed passes on non-play-action dropbacks. |
+| `screen_touchdowns` | numeric | Number of passing touchdowns thrown on screen passes. |
+| `npa_first_downs` | numeric | Number of passing first downs gained on non-play-action dropbacks. |
+| `no_screen_touchdowns` | numeric | Number of passing touchdowns thrown excluding screen passes. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
-| `npa_yards` | numeric |  |
-| `no_screen_ypa` | numeric |  |
-| `npa_turnover_worthy_plays` | numeric |  |
-| `npa_interceptions` | numeric |  |
-| `no_screen_pressure_to_sack_rate` | numeric |  |
-| `screen_sacks` | numeric |  |
-| `screen_grades_hands_drop` | numeric |  |
-| `screen_grades_pass_block` | numeric |  |
-| `no_screen_grades_pass_block` | numeric |  |
-| `pa_grades_hands_drop` | numeric |  |
-| `npa_grades_pass_block` | numeric |  |
-| `pa_grades_pass_block` | numeric |  |
-| `npa_grades_hands_drop` | numeric |  |
-| `no_screen_grades_hands_drop` | numeric |  |
-| `pa_grades_screen_block` | numeric |  |
-| `screen_grades_screen_block` | numeric |  |
-| `no_screen_grades_screen_block` | numeric |  |
-| `npa_grades_screen_block` | numeric |  |
-| `pa_grades_defense_penalty` | numeric |  |
-| `npa_grades_defense_penalty` | numeric |  |
-| `npa_grades_coverage_defense` | numeric |  |
-| `pa_grades_defense` | numeric |  |
-| `screen_grades_coverage_defense` | numeric |  |
-| `npa_grades_defense` | numeric |  |
-| `screen_grades_defense` | numeric |  |
-| `screen_grades_defense_penalty` | numeric |  |
-| `no_screen_grades_defense` | numeric |  |
-| `pa_grades_coverage_defense` | numeric |  |
-| `no_screen_grades_defense_penalty` | numeric |  |
-| `no_screen_grades_coverage_defense` | numeric |  |
-| `no_screen_grades_overall_tackle` | numeric |  |
-| `pa_grades_overall_tackle` | numeric |  |
-| `pa_grades_tackle` | numeric |  |
-| `pa_grades_pass_rush_defense` | character |  |
-| `screen_grades_run_defense` | character |  |
-| `pa_grades_run_defense` | character |  |
-| `npa_grades_overall_tackle` | numeric |  |
-| `no_screen_grades_pass_rush_defense` | numeric |  |
-| `npa_grades_tackle` | numeric |  |
-| `screen_grades_tackle` | character |  |
-| `no_screen_grades_tackle` | numeric |  |
-| `npa_grades_pass_rush_defense` | numeric |  |
-| `no_screen_grades_run_defense` | numeric |  |
-| `screen_grades_overall_tackle` | character |  |
-| `npa_grades_run_defense` | numeric |  |
-| `screen_grades_pass_rush_defense` | numeric |  |
+| `npa_yards` | numeric | Passing yards gained on non-play-action dropbacks. |
+| `no_screen_ypa` | numeric | Yards gained per pass attempt excluding screen passes. |
+| `npa_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on non-play-action dropbacks, plays PFF charts as deserving of a turnover. |
+| `npa_interceptions` | numeric | Number of passes intercepted on non-play-action dropbacks. |
+| `no_screen_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack excluding screen passes. |
+| `screen_sacks` | numeric | Number of sacks taken on screen passes. |
+| `screen_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) on screen passes. |
+| `screen_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) on screen passes. |
+| `no_screen_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) excluding screen passes. |
+| `pa_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) on play-action dropbacks. |
+| `npa_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) on non-play-action dropbacks. |
+| `pa_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) on play-action dropbacks. |
+| `npa_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) on non-play-action dropbacks. |
+| `no_screen_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) excluding screen passes. |
+| `pa_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) on play-action dropbacks. |
+| `screen_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) on screen passes. |
+| `no_screen_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) excluding screen passes. |
+| `npa_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) on non-play-action dropbacks. |
+| `pa_grades_defense_penalty` | numeric | PFF defensive penalty grade for the player (0-100) on play-action dropbacks. |
+| `npa_grades_defense_penalty` | numeric | PFF defensive penalty grade for the player (0-100) on non-play-action dropbacks. |
+| `npa_grades_coverage_defense` | numeric | PFF coverage grade for the player (0-100) on non-play-action dropbacks. |
+| `pa_grades_defense` | numeric | PFF overall defense grade for the player (0-100) on play-action dropbacks. |
+| `screen_grades_coverage_defense` | numeric | PFF coverage grade for the player (0-100) on screen passes. |
+| `npa_grades_defense` | numeric | PFF overall defense grade for the player (0-100) on non-play-action dropbacks. |
+| `screen_grades_defense` | numeric | PFF overall defense grade for the player (0-100) on screen passes. |
+| `screen_grades_defense_penalty` | numeric | PFF defensive penalty grade for the player (0-100) on screen passes. |
+| `no_screen_grades_defense` | numeric | PFF overall defense grade for the player (0-100) excluding screen passes. |
+| `pa_grades_coverage_defense` | numeric | PFF coverage grade for the player (0-100) on play-action dropbacks. |
+| `no_screen_grades_defense_penalty` | numeric | PFF defensive penalty grade for the player (0-100) excluding screen passes. |
+| `no_screen_grades_coverage_defense` | numeric | PFF coverage grade for the player (0-100) excluding screen passes. |
+| `no_screen_grades_overall_tackle` | numeric | PFF overall tackling grade for the player (0-100) excluding screen passes. |
+| `pa_grades_overall_tackle` | numeric | PFF overall tackling grade for the player (0-100) on play-action dropbacks. |
+| `pa_grades_tackle` | numeric | PFF tackling grade for the player (0-100) on play-action dropbacks. |
+| `pa_grades_pass_rush_defense` | character | PFF pass-rush grade for the player (0-100) on play-action dropbacks. |
+| `screen_grades_run_defense` | character | PFF run-defense grade for the player (0-100) on screen passes. |
+| `pa_grades_run_defense` | character | PFF run-defense grade for the player (0-100) on play-action dropbacks. |
+| `npa_grades_overall_tackle` | numeric | PFF overall tackling grade for the player (0-100) on non-play-action dropbacks. |
+| `no_screen_grades_pass_rush_defense` | numeric | PFF pass-rush grade for the player (0-100) excluding screen passes. |
+| `npa_grades_tackle` | numeric | PFF tackling grade for the player (0-100) on non-play-action dropbacks. |
+| `screen_grades_tackle` | character | PFF tackling grade for the player (0-100) on screen passes. |
+| `no_screen_grades_tackle` | numeric | PFF tackling grade for the player (0-100) excluding screen passes. |
+| `npa_grades_pass_rush_defense` | numeric | PFF pass-rush grade for the player (0-100) on non-play-action dropbacks. |
+| `no_screen_grades_run_defense` | numeric | PFF run-defense grade for the player (0-100) excluding screen passes. |
+| `screen_grades_overall_tackle` | character | PFF overall tackling grade for the player (0-100) on screen passes. |
+| `npa_grades_run_defense` | numeric | PFF run-defense grade for the player (0-100) on non-play-action dropbacks. |
+| `screen_grades_pass_rush_defense` | numeric | PFF pass-rush grade for the player (0-100) on screen passes. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -904,75 +904,75 @@ Facet report /defense/coverage_scheme (By Position leaderboard; add franchiseId 
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `man_touchdowns` | numeric |  |
-| `man_interceptions` | numeric |  |
-| `zone_snap_counts_coverage_percent` | numeric |  |
-| `man_avg_depth_of_target` | numeric |  |
-| `man_dropped_ints` | numeric |  |
-| `draft_season` | numeric |  |
-| `zone_coverage_snaps_per_target` | numeric |  |
-| `man_yards_per_reception` | numeric |  |
+| `man_touchdowns` | numeric | Touchdowns allowed into the player's coverage when in man coverage. |
+| `man_interceptions` | numeric | Interceptions made in coverage when in man coverage. |
+| `zone_snap_counts_coverage_percent` | numeric | Share of the player's coverage snaps played when in zone coverage. |
+| `man_avg_depth_of_target` | numeric | Average depth of targets into the player's coverage, in yards downfield when in man coverage. |
+| `man_dropped_ints` | numeric | Interception chances PFF charted as dropped when in man coverage. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `zone_coverage_snaps_per_target` | numeric | Coverage snaps played per target into the player's coverage when in zone coverage. |
+| `man_yards_per_reception` | numeric | Average yards allowed per reception when in man coverage. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `man_snap_counts_coverage` | numeric |  |
-| `man_tackles` | numeric |  |
-| `zone_stops` | numeric |  |
-| `zone_snap_counts_coverage` | numeric |  |
-| `zone_yards` | numeric |  |
-| `man_coverage_snaps_per_target` | numeric |  |
-| `zone_coverage_percent` | numeric |  |
-| `player_game_count` | numeric |  |
-| `eligible_season` | numeric |  |
-| `zone_receptions` | numeric |  |
-| `zone_forced_incompletion_rate` | numeric |  |
-| `man_snap_counts_pass_play` | numeric |  |
-| `zone_yards_per_reception` | numeric |  |
-| `man_longest` | numeric |  |
-| `man_assists` | numeric |  |
-| `zone_yards_after_catch` | numeric |  |
-| `man_stops` | numeric |  |
-| `man_receptions` | numeric |  |
-| `zone_tackles` | numeric |  |
-| `man_coverage_percent` | numeric |  |
+| `man_snap_counts_coverage` | numeric | Coverage snaps played when in man coverage. |
+| `man_tackles` | numeric | Tackles made when in man coverage. |
+| `zone_stops` | numeric | Stops, PFF's tackles that constitute a failed play for the offense when in zone coverage. |
+| `zone_snap_counts_coverage` | numeric | Coverage snaps played when in zone coverage. |
+| `zone_yards` | numeric | Receiving yards allowed when in zone coverage. |
+| `man_coverage_snaps_per_target` | numeric | Coverage snaps played per target into the player's coverage when in man coverage. |
+| `zone_coverage_percent` | numeric | Share of pass-play snaps spent in coverage when in zone coverage. |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `zone_receptions` | numeric | Receptions allowed into the player's coverage when in zone coverage. |
+| `zone_forced_incompletion_rate` | numeric | Share of targets into the player's coverage with a PFF-charted forced incompletion when in zone coverage. |
+| `man_snap_counts_pass_play` | numeric | Pass-play snaps when in man coverage. |
+| `zone_yards_per_reception` | numeric | Average yards allowed per reception when in zone coverage. |
+| `man_longest` | numeric | Longest completion allowed, in yards when in man coverage. |
+| `man_assists` | numeric | Assisted tackles when in man coverage. |
+| `zone_yards_after_catch` | numeric | Yards after the catch allowed when in zone coverage. |
+| `man_stops` | numeric | Stops, PFF's tackles that constitute a failed play for the offense when in man coverage. |
+| `man_receptions` | numeric | Receptions allowed into the player's coverage when in man coverage. |
+| `zone_tackles` | numeric | Tackles made when in zone coverage. |
+| `man_coverage_percent` | numeric | Share of pass-play snaps spent in coverage when in man coverage. |
 | `penalties` | numeric | Total number of penalties. |
-| `zone_yards_per_coverage_snap` | numeric |  |
+| `zone_yards_per_coverage_snap` | numeric | Receiving yards allowed per coverage snap when in zone coverage. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `man_catch_rate` | numeric |  |
-| `man_grades_coverage_defense` | numeric |  |
-| `declined_penalties` | numeric |  |
-| `man_yards_after_catch` | numeric |  |
-| `man_pass_break_ups` | numeric |  |
-| `man_yards` | numeric |  |
+| `man_catch_rate` | numeric | Completion percentage allowed on targets into the player's coverage when in man coverage. |
+| `man_grades_coverage_defense` | numeric | PFF coverage grade when in man coverage, 0-100. |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `man_yards_after_catch` | numeric | Yards after the catch allowed when in man coverage. |
+| `man_pass_break_ups` | numeric | Passes broken up when in man coverage. |
+| `man_yards` | numeric | Receiving yards allowed when in man coverage. |
 | `position` | character | Primary position as reported by NFL.com |
-| `man_targets` | numeric |  |
-| `man_missed_tackle_rate` | numeric |  |
-| `zone_assists` | numeric |  |
-| `zone_snap_counts_pass_play` | numeric |  |
-| `zone_missed_tackle_rate` | numeric |  |
-| `zone_touchdowns` | numeric |  |
-| `zone_coverage_snaps_per_reception` | numeric |  |
-| `man_coverage_snaps_per_reception` | numeric |  |
-| `zone_avg_depth_of_target` | numeric |  |
-| `man_snap_counts_coverage_percent` | numeric |  |
+| `man_targets` | numeric | Targets into the player's coverage when in man coverage. |
+| `man_missed_tackle_rate` | numeric | Share of tackle attempts the player missed when in man coverage. |
+| `zone_assists` | numeric | Assisted tackles when in zone coverage. |
+| `zone_snap_counts_pass_play` | numeric | Pass-play snaps when in zone coverage. |
+| `zone_missed_tackle_rate` | numeric | Share of tackle attempts the player missed when in zone coverage. |
+| `zone_touchdowns` | numeric | Touchdowns allowed into the player's coverage when in zone coverage. |
+| `zone_coverage_snaps_per_reception` | numeric | Coverage snaps played per reception allowed when in zone coverage. |
+| `man_coverage_snaps_per_reception` | numeric | Coverage snaps played per reception allowed when in man coverage. |
+| `zone_avg_depth_of_target` | numeric | Average depth of targets into the player's coverage, in yards downfield when in zone coverage. |
+| `man_snap_counts_coverage_percent` | numeric | Share of the player's coverage snaps played when in man coverage. |
 | `player` | character | Player name |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `zone_forced_incompletes` | numeric |  |
-| `man_forced_incompletion_rate` | numeric |  |
-| `zone_targets` | numeric |  |
-| `zone_longest` | numeric |  |
-| `zone_dropped_ints` | numeric |  |
-| `zone_interceptions` | numeric |  |
-| `man_forced_incompletes` | numeric |  |
+| `zone_forced_incompletes` | numeric | Incompletions forced by the player's coverage, per PFF charting when in zone coverage. |
+| `man_forced_incompletion_rate` | numeric | Share of targets into the player's coverage with a PFF-charted forced incompletion when in man coverage. |
+| `zone_targets` | numeric | Targets into the player's coverage when in zone coverage. |
+| `zone_longest` | numeric | Longest completion allowed, in yards when in zone coverage. |
+| `zone_dropped_ints` | numeric | Interception chances PFF charted as dropped when in zone coverage. |
+| `zone_interceptions` | numeric | Interceptions made in coverage when in zone coverage. |
+| `man_forced_incompletes` | numeric | Incompletions forced by the player's coverage, per PFF charting when in man coverage. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
-| `zone_missed_tackles` | numeric |  |
-| `base_snap_counts_coverage` | numeric |  |
-| `man_missed_tackles` | numeric |  |
-| `zone_grades_coverage_defense` | numeric |  |
-| `man_qb_rating_against` | numeric |  |
-| `zone_pass_break_ups` | numeric |  |
-| `zone_qb_rating_against` | numeric |  |
-| `man_yards_per_coverage_snap` | numeric |  |
-| `zone_catch_rate` | numeric |  |
+| `zone_missed_tackles` | numeric | Missed tackles when in zone coverage. |
+| `base_snap_counts_coverage` | numeric | Coverage snaps from the facet's unsplit base row, covering all coverage schemes. |
+| `man_missed_tackles` | numeric | Missed tackles when in man coverage. |
+| `zone_grades_coverage_defense` | numeric | PFF coverage grade when in zone coverage, 0-100. |
+| `man_qb_rating_against` | numeric | NFL passer rating allowed on targets into the player's coverage when in man coverage. |
+| `zone_pass_break_ups` | numeric | Passes broken up when in zone coverage. |
+| `zone_qb_rating_against` | numeric | NFL passer rating allowed on targets into the player's coverage when in zone coverage. |
+| `man_yards_per_coverage_snap` | numeric | Receiving yards allowed per coverage snap when in man coverage. |
+| `zone_catch_rate` | numeric | Completion percentage allowed on targets into the player's coverage when in zone coverage. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1006,954 +1006,954 @@ Facet report /passing/detail (By Position leaderboard; add franchiseId for By Te
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `left_behind_los_accuracy_percent` | numeric |  |
-| `left_short_scrambles` | numeric |  |
-| `center_short_first_downs` | numeric |  |
-| `no_blitz_completion_percent` | numeric |  |
-| `right_short_bats` | numeric |  |
-| `right_behind_los_positive_epa_percent` | numeric |  |
-| `left_behind_los_completions` | numeric |  |
-| `comp_pct_diff` | numeric |  |
-| `pa_grades_pass` | numeric |  |
-| `left_medium_dropbacks` | numeric |  |
-| `right_medium_grades_pass` | numeric |  |
-| `right_medium_hit_as_threw` | numeric |  |
-| `behind_los_attempts_percent` | numeric |  |
-| `grades_offense` | numeric |  |
-| `no_screen_grades_offense` | numeric |  |
-| `pa_qb_rating` | numeric |  |
-| `right_short_turnover_worthy_plays` | numeric |  |
-| `no_screen_qb_rating` | numeric |  |
-| `pa_completions` | numeric |  |
-| `right_medium_qb_rating` | numeric |  |
-| `deep_twp_rate` | numeric |  |
-| `center_medium_sacks` | numeric |  |
-| `medium_interceptions` | numeric |  |
-| `left_deep_completions` | numeric |  |
-| `no_pressure_scrambles` | numeric |  |
-| `twp_rate` | numeric |  |
-| `behind_los_spikes` | numeric |  |
-| `medium_aimed_passes` | numeric |  |
-| `pa_thrown_aways` | numeric |  |
-| `pa_dropbacks_percent` | numeric |  |
-| `ypa_diff` | numeric |  |
-| `blitz_touchdowns` | numeric |  |
-| `center_behind_los_drops` | numeric |  |
-| `pressure_yards` | numeric |  |
-| `no_pressure_spikes` | numeric |  |
-| `blitz_ypa` | numeric |  |
-| `center_behind_los_interceptions` | numeric |  |
-| `no_screen_drops` | numeric |  |
-| `behind_los_dropbacks` | numeric |  |
-| `no_blitz_grades_run` | numeric |  |
-| `screen_completion_percent` | numeric |  |
-| `npa_bats` | numeric |  |
-| `left_behind_los_interceptions` | numeric |  |
-| `left_deep_first_downs` | numeric |  |
-| `deep_passing_snaps` | numeric |  |
-| `btt_rate` | numeric |  |
-| `center_short_btt_rate` | numeric |  |
-| `center_medium_thrown_aways` | numeric |  |
-| `center_deep_avg_depth_of_target` | numeric |  |
-| `blitz_qb_rating` | numeric |  |
-| `center_short_drops` | numeric |  |
-| `no_pressure_thrown_aways` | numeric |  |
-| `no_screen_thrown_aways` | numeric |  |
-| `no_blitz_bats` | numeric |  |
-| `center_deep_first_downs` | numeric |  |
-| `left_medium_completion_percent` | numeric |  |
-| `center_deep_attempts` | numeric |  |
-| `pa_grades_run` | numeric |  |
-| `center_behind_los_attempts` | numeric |  |
-| `right_short_positive_epa_percent` | numeric |  |
-| `no_blitz_drops` | numeric |  |
-| `center_deep_aimed_passes` | numeric |  |
-| `right_deep_grades_pass` | numeric |  |
-| `right_medium_big_time_throws` | numeric |  |
-| `deep_sack_percent` | numeric |  |
-| `no_pressure_completion_percent` | numeric |  |
-| `blitz_aimed_passes` | numeric |  |
-| `screen_pressure_to_sack_rate` | numeric |  |
-| `pa_drop_rate` | numeric |  |
-| `center_medium_pressure_to_sack_rate` | numeric |  |
-| `deep_sacks` | numeric |  |
-| `right_medium_ypa` | numeric |  |
+| `left_behind_los_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage to the left side of the field. |
+| `left_short_scrambles` | numeric | Number of scrambles on short (0-9 air yards) throws to the left side of the field. |
+| `center_short_first_downs` | numeric | Number of passing first downs gained on short (0-9 air yards) throws to the center of the field. |
+| `no_blitz_completion_percent` | numeric | Percentage of pass attempts completed when not blitzed. |
+| `right_short_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws to the right side of the field. |
+| `right_behind_los_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on throws behind the line of scrimmage to the right side of the field. |
+| `left_behind_los_completions` | numeric | Number of completed passes on throws behind the line of scrimmage to the left side of the field. |
+| `comp_pct_diff` | numeric | Difference in completion percentage between play-action and non-play-action attempts (PA minus non-PA), from the PFF passing-concept split. |
+| `pa_grades_pass` | numeric | PFF passing grade (0-100) on play-action dropbacks. |
+| `left_medium_dropbacks` | numeric | Number of dropbacks on medium (10-19 air yards) throws to the left side of the field. |
+| `right_medium_grades_pass` | numeric | PFF passing grade (0-100) on medium (10-19 air yards) throws to the right side of the field. |
+| `right_medium_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws to the right side of the field, as charted by PFF. |
+| `behind_los_attempts_percent` | numeric | Share of the player's total pass attempts that came on throws behind the line of scrimmage, expressed as a percentage. |
+| `grades_offense` | numeric | PFF overall offense grade for the player (0-100). |
+| `no_screen_grades_offense` | numeric | PFF overall offense grade for the player (0-100) excluding screen passes. |
+| `pa_qb_rating` | numeric | Traditional NFL passer rating on play-action dropbacks. |
+| `right_short_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on short (0-9 air yards) throws to the right side of the field, plays PFF charts as deserving of a turnover. |
+| `no_screen_qb_rating` | numeric | Traditional NFL passer rating excluding screen passes. |
+| `pa_completions` | numeric | Number of completed passes on play-action dropbacks. |
+| `right_medium_qb_rating` | numeric | Traditional NFL passer rating on medium (10-19 air yards) throws to the right side of the field. |
+| `deep_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws, per PFF charting. |
+| `center_medium_sacks` | numeric | Number of sacks taken on medium (10-19 air yards) throws to the center of the field. |
+| `medium_interceptions` | numeric | Number of passes intercepted on medium (10-19 air yards) throws. |
+| `left_deep_completions` | numeric | Number of completed passes on deep (20+ air yards) throws to the left side of the field. |
+| `no_pressure_scrambles` | numeric | Number of scrambles from a clean pocket (no pressure). |
+| `twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts, per PFF charting. |
+| `behind_los_spikes` | numeric | Number of clock-stopping spikes on throws behind the line of scrimmage. |
+| `medium_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards) throws, as charted by PFF. |
+| `pa_thrown_aways` | numeric | Number of intentional throwaways on play-action dropbacks. |
+| `pa_dropbacks_percent` | numeric | Share of the player's total dropbacks that came on play-action dropbacks, expressed as a percentage. |
+| `ypa_diff` | numeric | Difference in yards per attempt between play-action and non-play-action attempts (PA minus non-PA), from the PFF passing-concept split. |
+| `blitz_touchdowns` | numeric | Number of passing touchdowns thrown when blitzed. |
+| `center_behind_los_drops` | numeric | Number of catchable passes dropped by receivers on throws behind the line of scrimmage to the center of the field. |
+| `pressure_yards` | numeric | Passing yards gained when under pressure. |
+| `no_pressure_spikes` | numeric | Number of clock-stopping spikes from a clean pocket (no pressure). |
+| `blitz_ypa` | numeric | Yards gained per pass attempt when blitzed. |
+| `center_behind_los_interceptions` | numeric | Number of passes intercepted on throws behind the line of scrimmage to the center of the field. |
+| `no_screen_drops` | numeric | Number of catchable passes dropped by receivers excluding screen passes. |
+| `behind_los_dropbacks` | numeric | Number of dropbacks on throws behind the line of scrimmage. |
+| `no_blitz_grades_run` | numeric | PFF rushing grade for the player (0-100) when not blitzed. |
+| `screen_completion_percent` | numeric | Percentage of pass attempts completed on screen passes. |
+| `npa_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on non-play-action dropbacks. |
+| `left_behind_los_interceptions` | numeric | Number of passes intercepted on throws behind the line of scrimmage to the left side of the field. |
+| `left_deep_first_downs` | numeric | Number of passing first downs gained on deep (20+ air yards) throws to the left side of the field. |
+| `deep_passing_snaps` | numeric | Number of passing snaps played on deep (20+ air yards) throws. |
+| `btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts, per PFF charting. |
+| `center_short_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws to the center of the field, per PFF charting. |
+| `center_medium_thrown_aways` | numeric | Number of intentional throwaways on medium (10-19 air yards) throws to the center of the field. |
+| `center_deep_avg_depth_of_target` | numeric | Average depth of target in air yards on deep (20+ air yards) throws to the center of the field. |
+| `blitz_qb_rating` | numeric | Traditional NFL passer rating when blitzed. |
+| `center_short_drops` | numeric | Number of catchable passes dropped by receivers on short (0-9 air yards) throws to the center of the field. |
+| `no_pressure_thrown_aways` | numeric | Number of intentional throwaways from a clean pocket (no pressure). |
+| `no_screen_thrown_aways` | numeric | Number of intentional throwaways excluding screen passes. |
+| `no_blitz_bats` | numeric | Number of pass attempts batted down at the line of scrimmage when not blitzed. |
+| `center_deep_first_downs` | numeric | Number of passing first downs gained on deep (20+ air yards) throws to the center of the field. |
+| `left_medium_completion_percent` | numeric | Percentage of pass attempts completed on medium (10-19 air yards) throws to the left side of the field. |
+| `center_deep_attempts` | numeric | Number of pass attempts on deep (20+ air yards) throws to the center of the field. |
+| `pa_grades_run` | numeric | PFF rushing grade for the player (0-100) on play-action dropbacks. |
+| `center_behind_los_attempts` | numeric | Number of pass attempts on throws behind the line of scrimmage to the center of the field. |
+| `right_short_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws to the right side of the field. |
+| `no_blitz_drops` | numeric | Number of catchable passes dropped by receivers when not blitzed. |
+| `center_deep_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws to the center of the field, as charted by PFF. |
+| `right_deep_grades_pass` | numeric | PFF passing grade (0-100) on deep (20+ air yards) throws to the right side of the field. |
+| `right_medium_big_time_throws` | numeric | Number of big-time throws on medium (10-19 air yards) throws to the right side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `deep_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws. |
+| `no_pressure_completion_percent` | numeric | Percentage of pass attempts completed from a clean pocket (no pressure). |
+| `blitz_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) when blitzed, as charted by PFF. |
+| `screen_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on screen passes. |
+| `pa_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on play-action dropbacks. |
+| `center_medium_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws to the center of the field. |
+| `deep_sacks` | numeric | Number of sacks taken on deep (20+ air yards) throws. |
+| `right_medium_ypa` | numeric | Yards gained per pass attempt on medium (10-19 air yards) throws to the right side of the field. |
 | `spikes` | numeric | Spikes |
-| `left_deep_drop_rate` | numeric |  |
-| `screen_grades_offense` | numeric |  |
-| `right_medium_attempts_percent` | numeric |  |
-| `right_deep_btt_rate` | numeric |  |
-| `center_short_attempts_percent` | numeric |  |
-| `deep_drops` | numeric |  |
-| `center_behind_los_big_time_throws` | numeric |  |
-| `center_behind_los_touchdowns` | numeric |  |
-| `dropbacks` | numeric |  |
-| `right_behind_los_twp_rate` | numeric |  |
-| `center_deep_completions` | numeric |  |
-| `npa_thrown_aways` | numeric |  |
-| `center_short_attempts` | numeric |  |
-| `pressure_grades_run` | numeric |  |
-| `left_behind_los_sack_percent` | numeric |  |
-| `center_short_pressure_to_sack_rate` | numeric |  |
-| `deep_touchdowns` | numeric |  |
-| `no_blitz_sack_percent` | numeric |  |
-| `no_pressure_bats` | numeric |  |
-| `center_behind_los_accuracy_percent` | numeric |  |
-| `pressure_completions` | numeric |  |
-| `blitz_big_time_throws` | numeric |  |
-| `center_deep_drop_rate` | numeric |  |
-| `right_short_first_downs` | numeric |  |
-| `no_screen_def_gen_pressures` | numeric |  |
-| `right_behind_los_first_downs` | numeric |  |
-| `screen_grades_hands_fumble` | numeric |  |
-| `pa_touchdowns` | numeric |  |
-| `short_interceptions` | numeric |  |
-| `center_medium_scrambles` | numeric |  |
-| `left_behind_los_sacks` | numeric |  |
-| `npa_ypa` | numeric |  |
-| `no_blitz_drop_rate` | numeric |  |
-| `blitz_spikes` | numeric |  |
-| `left_short_ypa` | numeric |  |
-| `no_pressure_completions` | numeric |  |
-| `left_short_qb_rating` | numeric |  |
-| `thrown_aways` | numeric |  |
-| `right_behind_los_qb_rating` | numeric |  |
-| `draft_season` | numeric |  |
-| `screen_avg_time_to_throw` | numeric |  |
-| `right_behind_los_dropbacks` | numeric |  |
-| `screen_thrown_aways` | numeric |  |
-| `behind_los_def_gen_pressures` | numeric |  |
-| `npa_sacks` | numeric |  |
-| `no_pressure_passing_snaps` | numeric |  |
-| `npa_aimed_passes` | numeric |  |
-| `no_blitz_first_downs` | numeric |  |
-| `right_short_thrown_aways` | numeric |  |
-| `deep_def_gen_pressures` | numeric |  |
-| `right_short_btt_rate` | numeric |  |
-| `center_behind_los_positive_epa_percent` | numeric |  |
-| `blitz_avg_time_to_throw` | numeric |  |
-| `left_behind_los_grades_pass` | numeric |  |
-| `deep_grades_pass` | numeric |  |
-| `no_pressure_grades_hands_fumble` | numeric |  |
-| `center_short_turnover_worthy_plays` | numeric |  |
-| `center_behind_los_scrambles` | numeric |  |
-| `pressure_aimed_passes` | numeric |  |
-| `no_screen_completions` | numeric |  |
-| `right_short_aimed_passes` | numeric |  |
-| `no_screen_positive_epa_percent` | numeric |  |
-| `center_short_dropbacks` | numeric |  |
-| `medium_epa` | numeric |  |
-| `right_short_ypa` | numeric |  |
-| `blitz_sacks` | numeric |  |
-| `center_medium_ypa` | numeric |  |
-| `screen_spikes` | numeric |  |
-| `pa_first_downs` | numeric |  |
-| `medium_attempts` | numeric |  |
-| `no_pressure_interceptions` | numeric |  |
-| `right_deep_accuracy_percent` | numeric |  |
-| `behind_los_scrambles` | numeric |  |
-| `center_behind_los_completion_percent` | numeric |  |
-| `left_behind_los_btt_rate` | numeric |  |
-| `right_behind_los_btt_rate` | numeric |  |
-| `pa_big_time_throws` | numeric |  |
+| `left_deep_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws to the left side of the field. |
+| `screen_grades_offense` | numeric | PFF overall offense grade for the player (0-100) on screen passes. |
+| `right_medium_attempts_percent` | numeric | Share of the player's total pass attempts that came on medium (10-19 air yards) throws to the right side of the field, expressed as a percentage. |
+| `right_deep_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws to the right side of the field, per PFF charting. |
+| `center_short_attempts_percent` | numeric | Share of the player's total pass attempts that came on short (0-9 air yards) throws to the center of the field, expressed as a percentage. |
+| `deep_drops` | numeric | Number of catchable passes dropped by receivers on deep (20+ air yards) throws. |
+| `center_behind_los_big_time_throws` | numeric | Number of big-time throws on throws behind the line of scrimmage to the center of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `center_behind_los_touchdowns` | numeric | Number of passing touchdowns thrown on throws behind the line of scrimmage to the center of the field. |
+| `dropbacks` | numeric | Number of dropbacks. |
+| `right_behind_los_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage to the right side of the field, per PFF charting. |
+| `center_deep_completions` | numeric | Number of completed passes on deep (20+ air yards) throws to the center of the field. |
+| `npa_thrown_aways` | numeric | Number of intentional throwaways on non-play-action dropbacks. |
+| `center_short_attempts` | numeric | Number of pass attempts on short (0-9 air yards) throws to the center of the field. |
+| `pressure_grades_run` | numeric | PFF rushing grade for the player (0-100) when under pressure. |
+| `left_behind_los_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage to the left side of the field. |
+| `center_short_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws to the center of the field. |
+| `deep_touchdowns` | numeric | Number of passing touchdowns thrown on deep (20+ air yards) throws. |
+| `no_blitz_sack_percent` | numeric | Percentage of dropbacks that ended in a sack when not blitzed. |
+| `no_pressure_bats` | numeric | Number of pass attempts batted down at the line of scrimmage from a clean pocket (no pressure). |
+| `center_behind_los_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage to the center of the field. |
+| `pressure_completions` | numeric | Number of completed passes when under pressure. |
+| `blitz_big_time_throws` | numeric | Number of big-time throws when blitzed, per PFF's highest-value, highest-difficulty throw designation. |
+| `center_deep_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws to the center of the field. |
+| `right_short_first_downs` | numeric | Number of passing first downs gained on short (0-9 air yards) throws to the right side of the field. |
+| `no_screen_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks excluding screen passes, as charted by PFF. |
+| `right_behind_los_first_downs` | numeric | Number of passing first downs gained on throws behind the line of scrimmage to the right side of the field. |
+| `screen_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) on screen passes. |
+| `pa_touchdowns` | numeric | Number of passing touchdowns thrown on play-action dropbacks. |
+| `short_interceptions` | numeric | Number of passes intercepted on short (0-9 air yards) throws. |
+| `center_medium_scrambles` | numeric | Number of scrambles on medium (10-19 air yards) throws to the center of the field. |
+| `left_behind_los_sacks` | numeric | Number of sacks taken on throws behind the line of scrimmage to the left side of the field. |
+| `npa_ypa` | numeric | Yards gained per pass attempt on non-play-action dropbacks. |
+| `no_blitz_drop_rate` | numeric | Percentage of catchable passes dropped by receivers when not blitzed. |
+| `blitz_spikes` | numeric | Number of clock-stopping spikes when blitzed. |
+| `left_short_ypa` | numeric | Yards gained per pass attempt on short (0-9 air yards) throws to the left side of the field. |
+| `no_pressure_completions` | numeric | Number of completed passes from a clean pocket (no pressure). |
+| `left_short_qb_rating` | numeric | Traditional NFL passer rating on short (0-9 air yards) throws to the left side of the field. |
+| `thrown_aways` | numeric | Number of intentional throwaways. |
+| `right_behind_los_qb_rating` | numeric | Traditional NFL passer rating on throws behind the line of scrimmage to the right side of the field. |
+| `draft_season` | numeric | NFL season (year) in which the player was drafted, per PFF player metadata. |
+| `screen_avg_time_to_throw` | numeric | Average time from snap to release in seconds on screen passes. |
+| `right_behind_los_dropbacks` | numeric | Number of dropbacks on throws behind the line of scrimmage to the right side of the field. |
+| `screen_thrown_aways` | numeric | Number of intentional throwaways on screen passes. |
+| `behind_los_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on throws behind the line of scrimmage, as charted by PFF. |
+| `npa_sacks` | numeric | Number of sacks taken on non-play-action dropbacks. |
+| `no_pressure_passing_snaps` | numeric | Number of passing snaps played from a clean pocket (no pressure). |
+| `npa_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on non-play-action dropbacks, as charted by PFF. |
+| `no_blitz_first_downs` | numeric | Number of passing first downs gained when not blitzed. |
+| `right_short_thrown_aways` | numeric | Number of intentional throwaways on short (0-9 air yards) throws to the right side of the field. |
+| `deep_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws, as charted by PFF. |
+| `right_short_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws to the right side of the field, per PFF charting. |
+| `center_behind_los_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on throws behind the line of scrimmage to the center of the field. |
+| `blitz_avg_time_to_throw` | numeric | Average time from snap to release in seconds when blitzed. |
+| `left_behind_los_grades_pass` | numeric | PFF passing grade (0-100) on throws behind the line of scrimmage to the left side of the field. |
+| `deep_grades_pass` | numeric | PFF passing grade (0-100) on deep (20+ air yards) throws. |
+| `no_pressure_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) from a clean pocket (no pressure). |
+| `center_short_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on short (0-9 air yards) throws to the center of the field, plays PFF charts as deserving of a turnover. |
+| `center_behind_los_scrambles` | numeric | Number of scrambles on throws behind the line of scrimmage to the center of the field. |
+| `pressure_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) when under pressure, as charted by PFF. |
+| `no_screen_completions` | numeric | Number of completed passes excluding screen passes. |
+| `right_short_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws to the right side of the field, as charted by PFF. |
+| `no_screen_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added excluding screen passes. |
+| `center_short_dropbacks` | numeric | Number of dropbacks on short (0-9 air yards) throws to the center of the field. |
+| `medium_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws. |
+| `right_short_ypa` | numeric | Yards gained per pass attempt on short (0-9 air yards) throws to the right side of the field. |
+| `blitz_sacks` | numeric | Number of sacks taken when blitzed. |
+| `center_medium_ypa` | numeric | Yards gained per pass attempt on medium (10-19 air yards) throws to the center of the field. |
+| `screen_spikes` | numeric | Number of clock-stopping spikes on screen passes. |
+| `pa_first_downs` | numeric | Number of passing first downs gained on play-action dropbacks. |
+| `medium_attempts` | numeric | Number of pass attempts on medium (10-19 air yards) throws. |
+| `no_pressure_interceptions` | numeric | Number of passes intercepted from a clean pocket (no pressure). |
+| `right_deep_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws to the right side of the field. |
+| `behind_los_scrambles` | numeric | Number of scrambles on throws behind the line of scrimmage. |
+| `center_behind_los_completion_percent` | numeric | Percentage of pass attempts completed on throws behind the line of scrimmage to the center of the field. |
+| `left_behind_los_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage to the left side of the field, per PFF charting. |
+| `right_behind_los_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage to the right side of the field, per PFF charting. |
+| `pa_big_time_throws` | numeric | Number of big-time throws on play-action dropbacks, per PFF's highest-value, highest-difficulty throw designation. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `short_touchdowns` | numeric |  |
-| `pa_spikes` | numeric |  |
-| `center_medium_drops` | numeric |  |
-| `left_behind_los_aimed_passes` | numeric |  |
-| `pa_sack_percent` | numeric |  |
-| `deep_attempts` | numeric |  |
-| `right_behind_los_sack_percent` | numeric |  |
-| `pressure_epa` | numeric |  |
-| `center_short_positive_epa_percent` | numeric |  |
-| `deep_avg_depth_of_target` | numeric |  |
-| `left_deep_btt_rate` | numeric |  |
-| `medium_scrambles` | numeric |  |
-| `blitz_completions` | numeric |  |
-| `center_behind_los_avg_depth_of_target` | numeric |  |
-| `blitz_attempts` | numeric |  |
-| `short_attempts_percent` | numeric |  |
-| `right_behind_los_sacks` | numeric |  |
-| `screen_dropbacks_percent` | numeric |  |
-| `center_medium_avg_time_to_throw` | numeric |  |
-| `pressure_twp_rate` | numeric |  |
-| `pressure_sacks` | numeric |  |
-| `left_short_pressure_to_sack_rate` | numeric |  |
-| `no_blitz_pressure_to_sack_rate` | numeric |  |
-| `no_pressure_ypa` | numeric |  |
-| `no_screen_epa` | numeric |  |
-| `center_deep_sack_percent` | numeric |  |
-| `center_deep_ypa` | numeric |  |
-| `left_behind_los_hit_as_threw` | numeric |  |
-| `pressure_passing_snaps` | numeric |  |
-| `medium_big_time_throws` | numeric |  |
-| `grades_pass` | numeric |  |
-| `npa_avg_time_to_throw` | numeric |  |
-| `deep_thrown_aways` | numeric |  |
-| `right_short_accuracy_percent` | numeric |  |
-| `left_deep_turnover_worthy_plays` | numeric |  |
-| `center_medium_bats` | numeric |  |
-| `right_short_grades_pass` | numeric |  |
-| `hit_as_threw` | numeric |  |
-| `right_deep_spikes` | numeric |  |
-| `left_deep_passing_snaps` | numeric |  |
-| `center_medium_twp_rate` | numeric |  |
-| `right_behind_los_passing_snaps` | numeric |  |
-| `left_deep_qb_rating` | numeric |  |
-| `screen_bats` | numeric |  |
-| `right_deep_drop_rate` | numeric |  |
+| `short_touchdowns` | numeric | Number of passing touchdowns thrown on short (0-9 air yards) throws. |
+| `pa_spikes` | numeric | Number of clock-stopping spikes on play-action dropbacks. |
+| `center_medium_drops` | numeric | Number of catchable passes dropped by receivers on medium (10-19 air yards) throws to the center of the field. |
+| `left_behind_los_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line of scrimmage to the left side of the field, as charted by PFF. |
+| `pa_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on play-action dropbacks. |
+| `deep_attempts` | numeric | Number of pass attempts on deep (20+ air yards) throws. |
+| `right_behind_los_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage to the right side of the field. |
+| `pressure_epa` | numeric | Total expected points added (EPA) on the player's dropbacks when under pressure. |
+| `center_short_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws to the center of the field. |
+| `deep_avg_depth_of_target` | numeric | Average depth of target in air yards on deep (20+ air yards) throws. |
+| `left_deep_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws to the left side of the field, per PFF charting. |
+| `medium_scrambles` | numeric | Number of scrambles on medium (10-19 air yards) throws. |
+| `blitz_completions` | numeric | Number of completed passes when blitzed. |
+| `center_behind_los_avg_depth_of_target` | numeric | Average depth of target in air yards on throws behind the line of scrimmage to the center of the field. |
+| `blitz_attempts` | numeric | Number of pass attempts when blitzed. |
+| `short_attempts_percent` | numeric | Share of the player's total pass attempts that came on short (0-9 air yards) throws, expressed as a percentage. |
+| `right_behind_los_sacks` | numeric | Number of sacks taken on throws behind the line of scrimmage to the right side of the field. |
+| `screen_dropbacks_percent` | numeric | Share of the player's total dropbacks that came on screen passes, expressed as a percentage. |
+| `center_medium_avg_time_to_throw` | numeric | Average time from snap to release in seconds on medium (10-19 air yards) throws to the center of the field. |
+| `pressure_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts when under pressure, per PFF charting. |
+| `pressure_sacks` | numeric | Number of sacks taken when under pressure. |
+| `left_short_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws to the left side of the field. |
+| `no_blitz_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack when not blitzed. |
+| `no_pressure_ypa` | numeric | Yards gained per pass attempt from a clean pocket (no pressure). |
+| `no_screen_epa` | numeric | Total expected points added (EPA) on the player's dropbacks excluding screen passes. |
+| `center_deep_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws to the center of the field. |
+| `center_deep_ypa` | numeric | Yards gained per pass attempt on deep (20+ air yards) throws to the center of the field. |
+| `left_behind_los_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage to the left side of the field, as charted by PFF. |
+| `pressure_passing_snaps` | numeric | Number of passing snaps played when under pressure. |
+| `medium_big_time_throws` | numeric | Number of big-time throws on medium (10-19 air yards) throws, per PFF's highest-value, highest-difficulty throw designation. |
+| `grades_pass` | numeric | PFF passing grade (0-100). |
+| `npa_avg_time_to_throw` | numeric | Average time from snap to release in seconds on non-play-action dropbacks. |
+| `deep_thrown_aways` | numeric | Number of intentional throwaways on deep (20+ air yards) throws. |
+| `right_short_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws to the right side of the field. |
+| `left_deep_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on deep (20+ air yards) throws to the left side of the field, plays PFF charts as deserving of a turnover. |
+| `center_medium_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws to the center of the field. |
+| `right_short_grades_pass` | numeric | PFF passing grade (0-100) on short (0-9 air yards) throws to the right side of the field. |
+| `hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw, as charted by PFF. |
+| `right_deep_spikes` | numeric | Number of clock-stopping spikes on deep (20+ air yards) throws to the right side of the field. |
+| `left_deep_passing_snaps` | numeric | Number of passing snaps played on deep (20+ air yards) throws to the left side of the field. |
+| `center_medium_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws to the center of the field, per PFF charting. |
+| `right_behind_los_passing_snaps` | numeric | Number of passing snaps played on throws behind the line of scrimmage to the right side of the field. |
+| `left_deep_qb_rating` | numeric | Traditional NFL passer rating on deep (20+ air yards) throws to the left side of the field. |
+| `screen_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on screen passes. |
+| `right_deep_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws to the right side of the field. |
 | `first_downs` | numeric | First downs earned by the team. |
-| `screen_grades_run_block` | numeric |  |
-| `left_behind_los_drop_rate` | numeric |  |
-| `pressure_bats` | numeric |  |
-| `left_medium_drop_rate` | numeric |  |
-| `right_deep_attempts` | numeric |  |
-| `left_deep_spikes` | numeric |  |
-| `center_behind_los_dropbacks` | numeric |  |
-| `blitz_thrown_aways` | numeric |  |
-| `right_deep_big_time_throws` | numeric |  |
-| `medium_hit_as_threw` | numeric |  |
-| `right_short_dropbacks` | numeric |  |
-| `no_pressure_drops` | numeric |  |
-| `medium_def_gen_pressures` | numeric |  |
+| `screen_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) on screen passes. |
+| `left_behind_los_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage to the left side of the field. |
+| `pressure_bats` | numeric | Number of pass attempts batted down at the line of scrimmage when under pressure. |
+| `left_medium_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws to the left side of the field. |
+| `right_deep_attempts` | numeric | Number of pass attempts on deep (20+ air yards) throws to the right side of the field. |
+| `left_deep_spikes` | numeric | Number of clock-stopping spikes on deep (20+ air yards) throws to the left side of the field. |
+| `center_behind_los_dropbacks` | numeric | Number of dropbacks on throws behind the line of scrimmage to the center of the field. |
+| `blitz_thrown_aways` | numeric | Number of intentional throwaways when blitzed. |
+| `right_deep_big_time_throws` | numeric | Number of big-time throws on deep (20+ air yards) throws to the right side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `medium_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws, as charted by PFF. |
+| `right_short_dropbacks` | numeric | Number of dropbacks on short (0-9 air yards) throws to the right side of the field. |
+| `no_pressure_drops` | numeric | Number of catchable passes dropped by receivers from a clean pocket (no pressure). |
+| `medium_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards) throws, as charted by PFF. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `left_short_positive_epa_percent` | numeric |  |
-| `left_short_attempts` | numeric |  |
-| `pressure_grades_offense_penalty` | numeric |  |
-| `center_deep_twp_rate` | numeric |  |
-| `right_medium_avg_time_to_throw` | numeric |  |
-| `left_behind_los_qb_rating` | numeric |  |
-| `no_screen_bats` | numeric |  |
-| `left_behind_los_dropbacks` | numeric |  |
-| `pressure_scrambles` | numeric |  |
-| `blitz_drop_rate` | numeric |  |
-| `deep_dropbacks` | numeric |  |
-| `right_behind_los_scrambles` | numeric |  |
-| `sack_percent` | numeric |  |
-| `behind_los_interceptions` | numeric |  |
-| `right_deep_drops` | numeric |  |
-| `right_deep_yards` | numeric |  |
-| `right_short_hit_as_threw` | numeric |  |
-| `npa_grades_offense` | numeric |  |
-| `right_short_avg_depth_of_target` | numeric |  |
-| `short_bats` | numeric |  |
-| `right_deep_twp_rate` | numeric |  |
-| `right_behind_los_pressure_to_sack_rate` | numeric |  |
-| `screen_def_gen_pressures` | numeric |  |
-| `deep_spikes` | numeric |  |
-| `pa_pressure_to_sack_rate` | numeric |  |
-| `center_medium_spikes` | numeric |  |
-| `screen_sack_percent` | numeric |  |
-| `blitz_completion_percent` | numeric |  |
-| `behind_los_aimed_passes` | numeric |  |
-| `right_behind_los_touchdowns` | numeric |  |
-| `bats` | numeric |  |
-| `right_medium_pressure_to_sack_rate` | numeric |  |
-| `no_screen_btt_rate` | numeric |  |
-| `medium_thrown_aways` | numeric |  |
-| `short_sacks` | numeric |  |
-| `center_behind_los_twp_rate` | numeric |  |
-| `left_behind_los_attempts` | numeric |  |
-| `short_aimed_passes` | numeric |  |
-| `short_completions` | numeric |  |
-| `right_short_pressure_to_sack_rate` | numeric |  |
-| `npa_btt_rate` | numeric |  |
-| `medium_avg_depth_of_target` | numeric |  |
-| `left_behind_los_positive_epa_percent` | numeric |  |
-| `screen_interceptions` | numeric |  |
-| `center_medium_attempts_percent` | numeric |  |
-| `left_medium_touchdowns` | numeric |  |
-| `center_short_bats` | numeric |  |
-| `left_deep_avg_time_to_throw` | numeric |  |
-| `no_screen_passing_snaps` | numeric |  |
-| `no_pressure_first_downs` | numeric |  |
-| `center_behind_los_passing_snaps` | numeric |  |
-| `center_short_yards` | numeric |  |
-| `blitz_grades_offense_penalty` | numeric |  |
-| `right_medium_btt_rate` | numeric |  |
-| `right_medium_scrambles` | numeric |  |
-| `no_screen_grades_hands_fumble` | numeric |  |
-| `medium_btt_rate` | numeric |  |
-| `no_blitz_epa` | numeric |  |
-| `center_behind_los_btt_rate` | numeric |  |
-| `blitz_interceptions` | numeric |  |
-| `no_blitz_dropbacks` | numeric |  |
-| `center_short_avg_depth_of_target` | numeric |  |
-| `left_medium_sacks` | numeric |  |
-| `right_short_yards` | numeric |  |
-| `left_medium_first_downs` | numeric |  |
-| `no_blitz_grades_pass` | numeric |  |
-| `right_medium_positive_epa_percent` | numeric |  |
-| `screen_scrambles` | numeric |  |
-| `left_short_big_time_throws` | numeric |  |
-| `deep_turnover_worthy_plays` | numeric |  |
-| `no_blitz_scrambles` | numeric |  |
-| `pressure_drop_rate` | numeric |  |
-| `left_deep_bats` | numeric |  |
-| `no_blitz_yards` | numeric |  |
-| `left_medium_turnover_worthy_plays` | numeric |  |
-| `screen_grades_pass` | numeric |  |
-| `center_deep_drops` | numeric |  |
-| `center_medium_avg_depth_of_target` | numeric |  |
+| `left_short_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws to the left side of the field. |
+| `left_short_attempts` | numeric | Number of pass attempts on short (0-9 air yards) throws to the left side of the field. |
+| `pressure_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) when under pressure. |
+| `center_deep_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws to the center of the field, per PFF charting. |
+| `right_medium_avg_time_to_throw` | numeric | Average time from snap to release in seconds on medium (10-19 air yards) throws to the right side of the field. |
+| `left_behind_los_qb_rating` | numeric | Traditional NFL passer rating on throws behind the line of scrimmage to the left side of the field. |
+| `no_screen_bats` | numeric | Number of pass attempts batted down at the line of scrimmage excluding screen passes. |
+| `left_behind_los_dropbacks` | numeric | Number of dropbacks on throws behind the line of scrimmage to the left side of the field. |
+| `pressure_scrambles` | numeric | Number of scrambles when under pressure. |
+| `blitz_drop_rate` | numeric | Percentage of catchable passes dropped by receivers when blitzed. |
+| `deep_dropbacks` | numeric | Number of dropbacks on deep (20+ air yards) throws. |
+| `right_behind_los_scrambles` | numeric | Number of scrambles on throws behind the line of scrimmage to the right side of the field. |
+| `sack_percent` | numeric | Percentage of dropbacks that ended in a sack. |
+| `behind_los_interceptions` | numeric | Number of passes intercepted on throws behind the line of scrimmage. |
+| `right_deep_drops` | numeric | Number of catchable passes dropped by receivers on deep (20+ air yards) throws to the right side of the field. |
+| `right_deep_yards` | numeric | Passing yards gained on deep (20+ air yards) throws to the right side of the field. |
+| `right_short_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws to the right side of the field, as charted by PFF. |
+| `npa_grades_offense` | numeric | PFF overall offense grade for the player (0-100) on non-play-action dropbacks. |
+| `right_short_avg_depth_of_target` | numeric | Average depth of target in air yards on short (0-9 air yards) throws to the right side of the field. |
+| `short_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws. |
+| `right_deep_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws to the right side of the field, per PFF charting. |
+| `right_behind_los_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on throws behind the line of scrimmage to the right side of the field. |
+| `screen_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on screen passes, as charted by PFF. |
+| `deep_spikes` | numeric | Number of clock-stopping spikes on deep (20+ air yards) throws. |
+| `pa_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on play-action dropbacks. |
+| `center_medium_spikes` | numeric | Number of clock-stopping spikes on medium (10-19 air yards) throws to the center of the field. |
+| `screen_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on screen passes. |
+| `blitz_completion_percent` | numeric | Percentage of pass attempts completed when blitzed. |
+| `behind_los_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line of scrimmage, as charted by PFF. |
+| `right_behind_los_touchdowns` | numeric | Number of passing touchdowns thrown on throws behind the line of scrimmage to the right side of the field. |
+| `bats` | numeric | Number of pass attempts batted down at the line of scrimmage. |
+| `right_medium_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws to the right side of the field. |
+| `no_screen_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts excluding screen passes, per PFF charting. |
+| `medium_thrown_aways` | numeric | Number of intentional throwaways on medium (10-19 air yards) throws. |
+| `short_sacks` | numeric | Number of sacks taken on short (0-9 air yards) throws. |
+| `center_behind_los_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage to the center of the field, per PFF charting. |
+| `left_behind_los_attempts` | numeric | Number of pass attempts on throws behind the line of scrimmage to the left side of the field. |
+| `short_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws, as charted by PFF. |
+| `short_completions` | numeric | Number of completed passes on short (0-9 air yards) throws. |
+| `right_short_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws to the right side of the field. |
+| `npa_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on non-play-action dropbacks, per PFF charting. |
+| `medium_avg_depth_of_target` | numeric | Average depth of target in air yards on medium (10-19 air yards) throws. |
+| `left_behind_los_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on throws behind the line of scrimmage to the left side of the field. |
+| `screen_interceptions` | numeric | Number of passes intercepted on screen passes. |
+| `center_medium_attempts_percent` | numeric | Share of the player's total pass attempts that came on medium (10-19 air yards) throws to the center of the field, expressed as a percentage. |
+| `left_medium_touchdowns` | numeric | Number of passing touchdowns thrown on medium (10-19 air yards) throws to the left side of the field. |
+| `center_short_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws to the center of the field. |
+| `left_deep_avg_time_to_throw` | numeric | Average time from snap to release in seconds on deep (20+ air yards) throws to the left side of the field. |
+| `no_screen_passing_snaps` | numeric | Number of passing snaps played excluding screen passes. |
+| `no_pressure_first_downs` | numeric | Number of passing first downs gained from a clean pocket (no pressure). |
+| `center_behind_los_passing_snaps` | numeric | Number of passing snaps played on throws behind the line of scrimmage to the center of the field. |
+| `center_short_yards` | numeric | Passing yards gained on short (0-9 air yards) throws to the center of the field. |
+| `blitz_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) when blitzed. |
+| `right_medium_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws to the right side of the field, per PFF charting. |
+| `right_medium_scrambles` | numeric | Number of scrambles on medium (10-19 air yards) throws to the right side of the field. |
+| `no_screen_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) excluding screen passes. |
+| `medium_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws, per PFF charting. |
+| `no_blitz_epa` | numeric | Total expected points added (EPA) on the player's dropbacks when not blitzed. |
+| `center_behind_los_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage to the center of the field, per PFF charting. |
+| `blitz_interceptions` | numeric | Number of passes intercepted when blitzed. |
+| `no_blitz_dropbacks` | numeric | Number of dropbacks when not blitzed. |
+| `center_short_avg_depth_of_target` | numeric | Average depth of target in air yards on short (0-9 air yards) throws to the center of the field. |
+| `left_medium_sacks` | numeric | Number of sacks taken on medium (10-19 air yards) throws to the left side of the field. |
+| `right_short_yards` | numeric | Passing yards gained on short (0-9 air yards) throws to the right side of the field. |
+| `left_medium_first_downs` | numeric | Number of passing first downs gained on medium (10-19 air yards) throws to the left side of the field. |
+| `no_blitz_grades_pass` | numeric | PFF passing grade (0-100) when not blitzed. |
+| `right_medium_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on medium (10-19 air yards) throws to the right side of the field. |
+| `screen_scrambles` | numeric | Number of scrambles on screen passes. |
+| `left_short_big_time_throws` | numeric | Number of big-time throws on short (0-9 air yards) throws to the left side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `deep_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on deep (20+ air yards) throws, plays PFF charts as deserving of a turnover. |
+| `no_blitz_scrambles` | numeric | Number of scrambles when not blitzed. |
+| `pressure_drop_rate` | numeric | Percentage of catchable passes dropped by receivers when under pressure. |
+| `left_deep_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws to the left side of the field. |
+| `no_blitz_yards` | numeric | Passing yards gained when not blitzed. |
+| `left_medium_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on medium (10-19 air yards) throws to the left side of the field, plays PFF charts as deserving of a turnover. |
+| `screen_grades_pass` | numeric | PFF passing grade (0-100) on screen passes. |
+| `center_deep_drops` | numeric | Number of catchable passes dropped by receivers on deep (20+ air yards) throws to the center of the field. |
+| `center_medium_avg_depth_of_target` | numeric | Average depth of target in air yards on medium (10-19 air yards) throws to the center of the field. |
 | `sacks` | numeric | The Number of times sacked. |
-| `pressure_pressure_to_sack_rate` | numeric |  |
-| `center_behind_los_ypa` | numeric |  |
-| `right_short_attempts` | numeric |  |
-| `center_medium_completion_percent` | numeric |  |
-| `no_blitz_grades_hands_fumble` | numeric |  |
-| `right_short_sack_percent` | numeric |  |
-| `left_behind_los_avg_depth_of_target` | numeric |  |
-| `center_medium_epa` | numeric |  |
-| `center_behind_los_sack_percent` | numeric |  |
-| `npa_qb_rating` | numeric |  |
-| `no_pressure_grades_offense` | numeric |  |
-| `medium_completions` | numeric |  |
-| `no_screen_grades_pass` | numeric |  |
-| `medium_sack_percent` | numeric |  |
-| `left_short_grades_pass` | numeric |  |
-| `deep_btt_rate` | numeric |  |
-| `pa_avg_time_to_throw` | numeric |  |
-| `left_short_accuracy_percent` | numeric |  |
-| `no_pressure_avg_time_to_throw` | numeric |  |
-| `screen_twp_rate` | numeric |  |
-| `pressure_dropbacks` | numeric |  |
-| `short_twp_rate` | numeric |  |
-| `short_passing_snaps` | numeric |  |
-| `left_deep_sacks` | numeric |  |
-| `short_scrambles` | numeric |  |
-| `center_medium_turnover_worthy_plays` | numeric |  |
-| `no_blitz_grades_offense_penalty` | numeric |  |
-| `behind_los_drop_rate` | numeric |  |
-| `right_behind_los_epa` | numeric |  |
-| `right_medium_aimed_passes` | numeric |  |
-| `no_pressure_grades_run` | numeric |  |
-| `short_accuracy_percent` | numeric |  |
-| `player_game_count` | numeric |  |
-| `short_btt_rate` | numeric |  |
-| `right_short_touchdowns` | numeric |  |
-| `center_short_completions` | numeric |  |
-| `right_short_spikes` | numeric |  |
-| `behind_los_first_downs` | numeric |  |
-| `right_medium_def_gen_pressures` | numeric |  |
-| `blitz_turnover_worthy_plays` | numeric |  |
-| `deep_pressure_to_sack_rate` | numeric |  |
-| `npa_accuracy_percent` | numeric |  |
-| `no_blitz_touchdowns` | numeric |  |
-| `no_blitz_avg_depth_of_target` | numeric |  |
-| `medium_qb_rating` | numeric |  |
-| `short_completion_percent` | numeric |  |
-| `right_deep_attempts_percent` | numeric |  |
-| `no_pressure_dropbacks_percent` | numeric |  |
-| `blitz_grades_pass` | numeric |  |
-| `eligible_season` | numeric |  |
-| `short_big_time_throws` | numeric |  |
-| `behind_los_attempts` | numeric |  |
-| `blitz_avg_depth_of_target` | numeric |  |
-| `no_blitz_spikes` | numeric |  |
-| `center_behind_los_yards` | numeric |  |
-| `npa_drops` | numeric |  |
-| `center_behind_los_bats` | numeric |  |
-| `center_behind_los_qb_rating` | numeric |  |
-| `right_deep_pressure_to_sack_rate` | numeric |  |
-| `center_short_accuracy_percent` | numeric |  |
-| `left_behind_los_bats` | numeric |  |
-| `no_pressure_dropbacks` | numeric |  |
-| `center_deep_passing_snaps` | numeric |  |
-| `right_behind_los_hit_as_threw` | numeric |  |
-| `medium_bats` | numeric |  |
-| `right_medium_first_downs` | numeric |  |
+| `pressure_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack, reported within the pressure split. |
+| `center_behind_los_ypa` | numeric | Yards gained per pass attempt on throws behind the line of scrimmage to the center of the field. |
+| `right_short_attempts` | numeric | Number of pass attempts on short (0-9 air yards) throws to the right side of the field. |
+| `center_medium_completion_percent` | numeric | Percentage of pass attempts completed on medium (10-19 air yards) throws to the center of the field. |
+| `no_blitz_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) when not blitzed. |
+| `right_short_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws to the right side of the field. |
+| `left_behind_los_avg_depth_of_target` | numeric | Average depth of target in air yards on throws behind the line of scrimmage to the left side of the field. |
+| `center_medium_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws to the center of the field. |
+| `center_behind_los_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage to the center of the field. |
+| `npa_qb_rating` | numeric | Traditional NFL passer rating on non-play-action dropbacks. |
+| `no_pressure_grades_offense` | numeric | PFF overall offense grade for the player (0-100) from a clean pocket (no pressure). |
+| `medium_completions` | numeric | Number of completed passes on medium (10-19 air yards) throws. |
+| `no_screen_grades_pass` | numeric | PFF passing grade (0-100) excluding screen passes. |
+| `medium_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws. |
+| `left_short_grades_pass` | numeric | PFF passing grade (0-100) on short (0-9 air yards) throws to the left side of the field. |
+| `deep_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws, per PFF charting. |
+| `pa_avg_time_to_throw` | numeric | Average time from snap to release in seconds on play-action dropbacks. |
+| `left_short_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws to the left side of the field. |
+| `no_pressure_avg_time_to_throw` | numeric | Average time from snap to release in seconds from a clean pocket (no pressure). |
+| `screen_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on screen passes, per PFF charting. |
+| `pressure_dropbacks` | numeric | Number of dropbacks when under pressure. |
+| `short_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws, per PFF charting. |
+| `short_passing_snaps` | numeric | Number of passing snaps played on short (0-9 air yards) throws. |
+| `left_deep_sacks` | numeric | Number of sacks taken on deep (20+ air yards) throws to the left side of the field. |
+| `short_scrambles` | numeric | Number of scrambles on short (0-9 air yards) throws. |
+| `center_medium_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on medium (10-19 air yards) throws to the center of the field, plays PFF charts as deserving of a turnover. |
+| `no_blitz_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) when not blitzed. |
+| `behind_los_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage. |
+| `right_behind_los_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage to the right side of the field. |
+| `right_medium_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards) throws to the right side of the field, as charted by PFF. |
+| `no_pressure_grades_run` | numeric | PFF rushing grade for the player (0-100) from a clean pocket (no pressure). |
+| `short_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws. |
+| `player_game_count` | numeric | Number of games the player appeared in during the period covered. |
+| `short_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws, per PFF charting. |
+| `right_short_touchdowns` | numeric | Number of passing touchdowns thrown on short (0-9 air yards) throws to the right side of the field. |
+| `center_short_completions` | numeric | Number of completed passes on short (0-9 air yards) throws to the center of the field. |
+| `right_short_spikes` | numeric | Number of clock-stopping spikes on short (0-9 air yards) throws to the right side of the field. |
+| `behind_los_first_downs` | numeric | Number of passing first downs gained on throws behind the line of scrimmage. |
+| `right_medium_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards) throws to the right side of the field, as charted by PFF. |
+| `blitz_turnover_worthy_plays` | numeric | Number of turnover-worthy plays when blitzed, plays PFF charts as deserving of a turnover. |
+| `deep_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws. |
+| `npa_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on non-play-action dropbacks. |
+| `no_blitz_touchdowns` | numeric | Number of passing touchdowns thrown when not blitzed. |
+| `no_blitz_avg_depth_of_target` | numeric | Average depth of target in air yards when not blitzed. |
+| `medium_qb_rating` | numeric | Traditional NFL passer rating on medium (10-19 air yards) throws. |
+| `short_completion_percent` | numeric | Percentage of pass attempts completed on short (0-9 air yards) throws. |
+| `right_deep_attempts_percent` | numeric | Share of the player's total pass attempts that came on deep (20+ air yards) throws to the right side of the field, expressed as a percentage. |
+| `no_pressure_dropbacks_percent` | numeric | Share of the player's total dropbacks that came from a clean pocket (no pressure), expressed as a percentage. |
+| `blitz_grades_pass` | numeric | PFF passing grade (0-100) when blitzed. |
+| `eligible_season` | numeric | Season (year) of the player's NFL draft eligibility, per PFF player metadata. |
+| `short_big_time_throws` | numeric | Number of big-time throws on short (0-9 air yards) throws, per PFF's highest-value, highest-difficulty throw designation. |
+| `behind_los_attempts` | numeric | Number of pass attempts on throws behind the line of scrimmage. |
+| `blitz_avg_depth_of_target` | numeric | Average depth of target in air yards when blitzed. |
+| `no_blitz_spikes` | numeric | Number of clock-stopping spikes when not blitzed. |
+| `center_behind_los_yards` | numeric | Passing yards gained on throws behind the line of scrimmage to the center of the field. |
+| `npa_drops` | numeric | Number of catchable passes dropped by receivers on non-play-action dropbacks. |
+| `center_behind_los_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage to the center of the field. |
+| `center_behind_los_qb_rating` | numeric | Traditional NFL passer rating on throws behind the line of scrimmage to the center of the field. |
+| `right_deep_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws to the right side of the field. |
+| `center_short_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws to the center of the field. |
+| `left_behind_los_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage to the left side of the field. |
+| `no_pressure_dropbacks` | numeric | Number of dropbacks from a clean pocket (no pressure). |
+| `center_deep_passing_snaps` | numeric | Number of passing snaps played on deep (20+ air yards) throws to the center of the field. |
+| `right_behind_los_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage to the right side of the field, as charted by PFF. |
+| `medium_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws. |
+| `right_medium_first_downs` | numeric | Number of passing first downs gained on medium (10-19 air yards) throws to the right side of the field. |
 | `completions` | numeric | The number of completed passes. |
-| `medium_spikes` | numeric |  |
-| `left_deep_thrown_aways` | numeric |  |
-| `screen_yards` | numeric |  |
-| `right_deep_epa` | numeric |  |
-| `center_medium_hit_as_threw` | numeric |  |
-| `left_behind_los_completion_percent` | numeric |  |
-| `blitz_btt_rate` | numeric |  |
-| `no_screen_drop_rate` | numeric |  |
-| `center_short_ypa` | numeric |  |
-| `right_short_drop_rate` | numeric |  |
-| `right_behind_los_accuracy_percent` | numeric |  |
-| `blitz_positive_epa_percent` | numeric |  |
-| `no_pressure_btt_rate` | numeric |  |
-| `left_short_yards` | numeric |  |
-| `deep_accuracy_percent` | numeric |  |
-| `right_behind_los_avg_depth_of_target` | numeric |  |
-| `center_behind_los_thrown_aways` | numeric |  |
-| `center_behind_los_attempts_percent` | numeric |  |
-| `no_screen_grades_offense_penalty` | numeric |  |
-| `right_deep_first_downs` | numeric |  |
-| `left_short_completions` | numeric |  |
-| `deep_completion_percent` | numeric |  |
-| `left_deep_positive_epa_percent` | numeric |  |
-| `npa_passing_snaps` | numeric |  |
-| `screen_drop_rate` | numeric |  |
-| `screen_epa` | numeric |  |
-| `no_pressure_drop_rate` | numeric |  |
-| `no_blitz_turnover_worthy_plays` | numeric |  |
+| `medium_spikes` | numeric | Number of clock-stopping spikes on medium (10-19 air yards) throws. |
+| `left_deep_thrown_aways` | numeric | Number of intentional throwaways on deep (20+ air yards) throws to the left side of the field. |
+| `screen_yards` | numeric | Passing yards gained on screen passes. |
+| `right_deep_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws to the right side of the field. |
+| `center_medium_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws to the center of the field, as charted by PFF. |
+| `left_behind_los_completion_percent` | numeric | Percentage of pass attempts completed on throws behind the line of scrimmage to the left side of the field. |
+| `blitz_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts when blitzed, per PFF charting. |
+| `no_screen_drop_rate` | numeric | Percentage of catchable passes dropped by receivers excluding screen passes. |
+| `center_short_ypa` | numeric | Yards gained per pass attempt on short (0-9 air yards) throws to the center of the field. |
+| `right_short_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws to the right side of the field. |
+| `right_behind_los_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage to the right side of the field. |
+| `blitz_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added when blitzed. |
+| `no_pressure_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts from a clean pocket (no pressure), per PFF charting. |
+| `left_short_yards` | numeric | Passing yards gained on short (0-9 air yards) throws to the left side of the field. |
+| `deep_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws. |
+| `right_behind_los_avg_depth_of_target` | numeric | Average depth of target in air yards on throws behind the line of scrimmage to the right side of the field. |
+| `center_behind_los_thrown_aways` | numeric | Number of intentional throwaways on throws behind the line of scrimmage to the center of the field. |
+| `center_behind_los_attempts_percent` | numeric | Share of the player's total pass attempts that came on throws behind the line of scrimmage to the center of the field, expressed as a percentage. |
+| `no_screen_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) excluding screen passes. |
+| `right_deep_first_downs` | numeric | Number of passing first downs gained on deep (20+ air yards) throws to the right side of the field. |
+| `left_short_completions` | numeric | Number of completed passes on short (0-9 air yards) throws to the left side of the field. |
+| `deep_completion_percent` | numeric | Percentage of pass attempts completed on deep (20+ air yards) throws. |
+| `left_deep_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws to the left side of the field. |
+| `npa_passing_snaps` | numeric | Number of passing snaps played on non-play-action dropbacks. |
+| `screen_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on screen passes. |
+| `screen_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on screen passes. |
+| `no_pressure_drop_rate` | numeric | Percentage of catchable passes dropped by receivers from a clean pocket (no pressure). |
+| `no_blitz_turnover_worthy_plays` | numeric | Number of turnover-worthy plays when not blitzed, plays PFF charts as deserving of a turnover. |
 | `yards` | numeric | The number of receiving yards |
-| `right_deep_sack_percent` | numeric |  |
-| `behind_los_pressure_to_sack_rate` | numeric |  |
-| `screen_grades_offense_penalty` | numeric |  |
-| `right_deep_touchdowns` | numeric |  |
-| `npa_spikes` | numeric |  |
-| `pressure_positive_epa_percent` | numeric |  |
-| `screen_hit_as_threw` | numeric |  |
-| `left_behind_los_def_gen_pressures` | numeric |  |
-| `left_behind_los_drops` | numeric |  |
-| `deep_epa` | numeric |  |
-| `left_deep_ypa` | numeric |  |
-| `medium_touchdowns` | numeric |  |
-| `no_screen_aimed_passes` | numeric |  |
-| `screen_drops` | numeric |  |
-| `left_medium_grades_pass` | numeric |  |
-| `accuracy_percent` | numeric |  |
-| `right_behind_los_spikes` | numeric |  |
-| `screen_ypa` | numeric |  |
-| `medium_grades_pass` | numeric |  |
-| `blitz_first_downs` | numeric |  |
-| `npa_twp_rate` | numeric |  |
-| `behind_los_passing_snaps` | numeric |  |
-| `left_short_first_downs` | numeric |  |
-| `center_short_passing_snaps` | numeric |  |
-| `center_deep_accuracy_percent` | numeric |  |
-| `right_deep_positive_epa_percent` | numeric |  |
-| `right_medium_sack_percent` | numeric |  |
-| `right_deep_qb_rating` | numeric |  |
-| `no_blitz_dropbacks_percent` | numeric |  |
-| `right_short_completion_percent` | numeric |  |
-| `screen_accuracy_percent` | numeric |  |
-| `right_behind_los_interceptions` | numeric |  |
-| `behind_los_yards` | numeric |  |
-| `center_behind_los_grades_pass` | numeric |  |
-| `left_deep_dropbacks` | numeric |  |
-| `npa_hit_as_threw` | numeric |  |
-| `center_behind_los_spikes` | numeric |  |
-| `scrambles` | numeric |  |
-| `right_behind_los_aimed_passes` | numeric |  |
-| `left_short_interceptions` | numeric |  |
-| `right_medium_interceptions` | numeric |  |
-| `left_behind_los_yards` | numeric |  |
-| `pa_accuracy_percent` | numeric |  |
-| `center_deep_btt_rate` | numeric |  |
-| `pressure_turnover_worthy_plays` | numeric |  |
-| `medium_first_downs` | numeric |  |
-| `no_pressure_epa` | numeric |  |
-| `left_short_avg_depth_of_target` | numeric |  |
-| `left_behind_los_ypa` | numeric |  |
-| `short_attempts` | numeric |  |
-| `right_medium_bats` | numeric |  |
-| `no_blitz_avg_time_to_throw` | numeric |  |
-| `left_behind_los_touchdowns` | numeric |  |
-| `pa_def_gen_pressures` | numeric |  |
-| `right_medium_dropbacks` | numeric |  |
+| `right_deep_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws to the right side of the field. |
+| `behind_los_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on throws behind the line of scrimmage. |
+| `screen_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) on screen passes. |
+| `right_deep_touchdowns` | numeric | Number of passing touchdowns thrown on deep (20+ air yards) throws to the right side of the field. |
+| `npa_spikes` | numeric | Number of clock-stopping spikes on non-play-action dropbacks. |
+| `pressure_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added when under pressure. |
+| `screen_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on screen passes, as charted by PFF. |
+| `left_behind_los_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on throws behind the line of scrimmage to the left side of the field, as charted by PFF. |
+| `left_behind_los_drops` | numeric | Number of catchable passes dropped by receivers on throws behind the line of scrimmage to the left side of the field. |
+| `deep_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws. |
+| `left_deep_ypa` | numeric | Yards gained per pass attempt on deep (20+ air yards) throws to the left side of the field. |
+| `medium_touchdowns` | numeric | Number of passing touchdowns thrown on medium (10-19 air yards) throws. |
+| `no_screen_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) excluding screen passes, as charted by PFF. |
+| `screen_drops` | numeric | Number of catchable passes dropped by receivers on screen passes. |
+| `left_medium_grades_pass` | numeric | PFF passing grade (0-100) on medium (10-19 air yards) throws to the left side of the field. |
+| `accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF. |
+| `right_behind_los_spikes` | numeric | Number of clock-stopping spikes on throws behind the line of scrimmage to the right side of the field. |
+| `screen_ypa` | numeric | Yards gained per pass attempt on screen passes. |
+| `medium_grades_pass` | numeric | PFF passing grade (0-100) on medium (10-19 air yards) throws. |
+| `blitz_first_downs` | numeric | Number of passing first downs gained when blitzed. |
+| `npa_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on non-play-action dropbacks, per PFF charting. |
+| `behind_los_passing_snaps` | numeric | Number of passing snaps played on throws behind the line of scrimmage. |
+| `left_short_first_downs` | numeric | Number of passing first downs gained on short (0-9 air yards) throws to the left side of the field. |
+| `center_short_passing_snaps` | numeric | Number of passing snaps played on short (0-9 air yards) throws to the center of the field. |
+| `center_deep_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws to the center of the field. |
+| `right_deep_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws to the right side of the field. |
+| `right_medium_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws to the right side of the field. |
+| `right_deep_qb_rating` | numeric | Traditional NFL passer rating on deep (20+ air yards) throws to the right side of the field. |
+| `no_blitz_dropbacks_percent` | numeric | Share of the player's total dropbacks that came when not blitzed, expressed as a percentage. |
+| `right_short_completion_percent` | numeric | Percentage of pass attempts completed on short (0-9 air yards) throws to the right side of the field. |
+| `screen_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on screen passes. |
+| `right_behind_los_interceptions` | numeric | Number of passes intercepted on throws behind the line of scrimmage to the right side of the field. |
+| `behind_los_yards` | numeric | Passing yards gained on throws behind the line of scrimmage. |
+| `center_behind_los_grades_pass` | numeric | PFF passing grade (0-100) on throws behind the line of scrimmage to the center of the field. |
+| `left_deep_dropbacks` | numeric | Number of dropbacks on deep (20+ air yards) throws to the left side of the field. |
+| `npa_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on non-play-action dropbacks, as charted by PFF. |
+| `center_behind_los_spikes` | numeric | Number of clock-stopping spikes on throws behind the line of scrimmage to the center of the field. |
+| `scrambles` | numeric | Number of scrambles. |
+| `right_behind_los_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line of scrimmage to the right side of the field, as charted by PFF. |
+| `left_short_interceptions` | numeric | Number of passes intercepted on short (0-9 air yards) throws to the left side of the field. |
+| `right_medium_interceptions` | numeric | Number of passes intercepted on medium (10-19 air yards) throws to the right side of the field. |
+| `left_behind_los_yards` | numeric | Passing yards gained on throws behind the line of scrimmage to the left side of the field. |
+| `pa_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on play-action dropbacks. |
+| `center_deep_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws to the center of the field, per PFF charting. |
+| `pressure_turnover_worthy_plays` | numeric | Number of turnover-worthy plays when under pressure, plays PFF charts as deserving of a turnover. |
+| `medium_first_downs` | numeric | Number of passing first downs gained on medium (10-19 air yards) throws. |
+| `no_pressure_epa` | numeric | Total expected points added (EPA) on the player's dropbacks from a clean pocket (no pressure). |
+| `left_short_avg_depth_of_target` | numeric | Average depth of target in air yards on short (0-9 air yards) throws to the left side of the field. |
+| `left_behind_los_ypa` | numeric | Yards gained per pass attempt on throws behind the line of scrimmage to the left side of the field. |
+| `short_attempts` | numeric | Number of pass attempts on short (0-9 air yards) throws. |
+| `right_medium_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws to the right side of the field. |
+| `no_blitz_avg_time_to_throw` | numeric | Average time from snap to release in seconds when not blitzed. |
+| `left_behind_los_touchdowns` | numeric | Number of passing touchdowns thrown on throws behind the line of scrimmage to the left side of the field. |
+| `pa_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on play-action dropbacks, as charted by PFF. |
+| `right_medium_dropbacks` | numeric | Number of dropbacks on medium (10-19 air yards) throws to the right side of the field. |
 | `interceptions` | numeric | The number of interceptions thrown. |
-| `screen_avg_depth_of_target` | numeric |  |
-| `pa_sacks` | numeric |  |
-| `short_turnover_worthy_plays` | numeric |  |
-| `screen_passing_snaps` | numeric |  |
-| `right_deep_thrown_aways` | numeric |  |
-| `drop_rate` | numeric |  |
-| `right_behind_los_drop_rate` | numeric |  |
-| `no_screen_grades_run` | numeric |  |
-| `right_short_qb_rating` | numeric |  |
-| `medium_sacks` | numeric |  |
-| `center_deep_attempts_percent` | numeric |  |
-| `left_short_dropbacks` | numeric |  |
-| `behind_los_drops` | numeric |  |
-| `short_sack_percent` | numeric |  |
-| `no_screen_first_downs` | numeric |  |
-| `no_blitz_positive_epa_percent` | numeric |  |
-| `left_medium_spikes` | numeric |  |
-| `left_medium_accuracy_percent` | numeric |  |
-| `pressure_btt_rate` | numeric |  |
-| `pa_ypa` | numeric |  |
-| `behind_los_completions` | numeric |  |
-| `npa_scrambles` | numeric |  |
-| `no_pressure_aimed_passes` | numeric |  |
-| `pressure_dropbacks_percent` | numeric |  |
-| `grades_run` | numeric |  |
-| `behind_los_sack_percent` | numeric |  |
-| `left_deep_yards` | numeric |  |
-| `left_short_aimed_passes` | numeric |  |
-| `npa_pressure_to_sack_rate` | numeric |  |
-| `center_behind_los_completions` | numeric |  |
-| `pa_twp_rate` | numeric |  |
-| `no_pressure_def_gen_pressures` | numeric |  |
-| `left_short_thrown_aways` | numeric |  |
-| `pressure_grades_offense` | numeric |  |
-| `left_short_sack_percent` | numeric |  |
-| `center_short_thrown_aways` | numeric |  |
-| `center_short_interceptions` | numeric |  |
-| `short_avg_depth_of_target` | numeric |  |
-| `pressure_completion_percent` | numeric |  |
-| `left_deep_touchdowns` | numeric |  |
-| `deep_yards` | numeric |  |
-| `center_behind_los_turnover_worthy_plays` | numeric |  |
-| `medium_ypa` | numeric |  |
-| `left_medium_epa` | numeric |  |
-| `left_deep_avg_depth_of_target` | numeric |  |
-| `deep_first_downs` | numeric |  |
-| `pressure_avg_depth_of_target` | numeric |  |
-| `short_drop_rate` | numeric |  |
-| `left_medium_bats` | numeric |  |
-| `blitz_epa` | numeric |  |
-| `center_deep_spikes` | numeric |  |
-| `center_short_hit_as_threw` | numeric |  |
-| `left_medium_positive_epa_percent` | numeric |  |
-| `center_deep_touchdowns` | numeric |  |
-| `right_deep_ypa` | numeric |  |
-| `right_short_big_time_throws` | numeric |  |
-| `center_short_big_time_throws` | numeric |  |
-| `short_positive_epa_percent` | numeric |  |
-| `no_screen_twp_rate` | numeric |  |
-| `left_behind_los_avg_time_to_throw` | numeric |  |
-| `right_deep_passing_snaps` | numeric |  |
-| `pressure_drops` | numeric |  |
-| `right_short_twp_rate` | numeric |  |
-| `center_medium_attempts` | numeric |  |
-| `right_deep_avg_time_to_throw` | numeric |  |
-| `no_blitz_def_gen_pressures` | numeric |  |
-| `center_deep_def_gen_pressures` | numeric |  |
-| `pressure_attempts` | numeric |  |
-| `npa_grades_hands_fumble` | numeric |  |
-| `behind_los_epa` | numeric |  |
-| `right_medium_twp_rate` | numeric |  |
-| `right_deep_aimed_passes` | numeric |  |
-| `right_deep_scrambles` | numeric |  |
-| `deep_big_time_throws` | numeric |  |
-| `left_short_turnover_worthy_plays` | numeric |  |
-| `qb_rating` | numeric |  |
-| `center_short_touchdowns` | numeric |  |
-| `right_medium_drops` | numeric |  |
-| `left_deep_epa` | numeric |  |
-| `pressure_big_time_throws` | numeric |  |
-| `no_blitz_thrown_aways` | numeric |  |
-| `short_ypa` | numeric |  |
-| `medium_pressure_to_sack_rate` | numeric |  |
-| `left_medium_thrown_aways` | numeric |  |
-| `right_behind_los_avg_time_to_throw` | numeric |  |
-| `completion_percent` | numeric |  |
-| `blitz_drops` | numeric |  |
-| `behind_los_btt_rate` | numeric |  |
-| `screen_completions` | numeric |  |
-| `screen_btt_rate` | numeric |  |
-| `npa_grades_run` | numeric |  |
-| `no_pressure_touchdowns` | numeric |  |
-| `no_screen_interceptions` | numeric |  |
-| `medium_avg_time_to_throw` | numeric |  |
-| `center_deep_completion_percent` | numeric |  |
-| `behind_los_avg_time_to_throw` | numeric |  |
-| `right_medium_touchdowns` | numeric |  |
-| `no_pressure_sacks` | numeric |  |
-| `center_short_avg_time_to_throw` | numeric |  |
-| `npa_grades_run_block` | numeric |  |
-| `left_deep_aimed_passes` | numeric |  |
-| `left_medium_yards` | numeric |  |
-| `center_medium_touchdowns` | numeric |  |
-| `blitz_sack_percent` | numeric |  |
-| `no_screen_sacks` | numeric |  |
-| `center_short_drop_rate` | numeric |  |
-| `left_short_twp_rate` | numeric |  |
-| `pressure_sack_percent` | numeric |  |
-| `no_pressure_attempts` | numeric |  |
-| `right_behind_los_attempts_percent` | numeric |  |
-| `no_blitz_grades_offense` | numeric |  |
+| `screen_avg_depth_of_target` | numeric | Average depth of target in air yards on screen passes. |
+| `pa_sacks` | numeric | Number of sacks taken on play-action dropbacks. |
+| `short_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on short (0-9 air yards) throws, plays PFF charts as deserving of a turnover. |
+| `screen_passing_snaps` | numeric | Number of passing snaps played on screen passes. |
+| `right_deep_thrown_aways` | numeric | Number of intentional throwaways on deep (20+ air yards) throws to the right side of the field. |
+| `drop_rate` | numeric | Percentage of catchable passes dropped by receivers. |
+| `right_behind_los_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage to the right side of the field. |
+| `no_screen_grades_run` | numeric | PFF rushing grade for the player (0-100) excluding screen passes. |
+| `right_short_qb_rating` | numeric | Traditional NFL passer rating on short (0-9 air yards) throws to the right side of the field. |
+| `medium_sacks` | numeric | Number of sacks taken on medium (10-19 air yards) throws. |
+| `center_deep_attempts_percent` | numeric | Share of the player's total pass attempts that came on deep (20+ air yards) throws to the center of the field, expressed as a percentage. |
+| `left_short_dropbacks` | numeric | Number of dropbacks on short (0-9 air yards) throws to the left side of the field. |
+| `behind_los_drops` | numeric | Number of catchable passes dropped by receivers on throws behind the line of scrimmage. |
+| `short_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws. |
+| `no_screen_first_downs` | numeric | Number of passing first downs gained excluding screen passes. |
+| `no_blitz_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added when not blitzed. |
+| `left_medium_spikes` | numeric | Number of clock-stopping spikes on medium (10-19 air yards) throws to the left side of the field. |
+| `left_medium_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws to the left side of the field. |
+| `pressure_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts when under pressure, per PFF charting. |
+| `pa_ypa` | numeric | Yards gained per pass attempt on play-action dropbacks. |
+| `behind_los_completions` | numeric | Number of completed passes on throws behind the line of scrimmage. |
+| `npa_scrambles` | numeric | Number of scrambles on non-play-action dropbacks. |
+| `no_pressure_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) from a clean pocket (no pressure), as charted by PFF. |
+| `pressure_dropbacks_percent` | numeric | Share of the player's total dropbacks that came when under pressure, expressed as a percentage. |
+| `grades_run` | numeric | PFF rushing grade for the player (0-100). |
+| `behind_los_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage. |
+| `left_deep_yards` | numeric | Passing yards gained on deep (20+ air yards) throws to the left side of the field. |
+| `left_short_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws to the left side of the field, as charted by PFF. |
+| `npa_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on non-play-action dropbacks. |
+| `center_behind_los_completions` | numeric | Number of completed passes on throws behind the line of scrimmage to the center of the field. |
+| `pa_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on play-action dropbacks, per PFF charting. |
+| `no_pressure_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks from a clean pocket (no pressure), as charted by PFF. |
+| `left_short_thrown_aways` | numeric | Number of intentional throwaways on short (0-9 air yards) throws to the left side of the field. |
+| `pressure_grades_offense` | numeric | PFF overall offense grade for the player (0-100) when under pressure. |
+| `left_short_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws to the left side of the field. |
+| `center_short_thrown_aways` | numeric | Number of intentional throwaways on short (0-9 air yards) throws to the center of the field. |
+| `center_short_interceptions` | numeric | Number of passes intercepted on short (0-9 air yards) throws to the center of the field. |
+| `short_avg_depth_of_target` | numeric | Average depth of target in air yards on short (0-9 air yards) throws. |
+| `pressure_completion_percent` | numeric | Percentage of pass attempts completed when under pressure. |
+| `left_deep_touchdowns` | numeric | Number of passing touchdowns thrown on deep (20+ air yards) throws to the left side of the field. |
+| `deep_yards` | numeric | Passing yards gained on deep (20+ air yards) throws. |
+| `center_behind_los_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on throws behind the line of scrimmage to the center of the field, plays PFF charts as deserving of a turnover. |
+| `medium_ypa` | numeric | Yards gained per pass attempt on medium (10-19 air yards) throws. |
+| `left_medium_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws to the left side of the field. |
+| `left_deep_avg_depth_of_target` | numeric | Average depth of target in air yards on deep (20+ air yards) throws to the left side of the field. |
+| `deep_first_downs` | numeric | Number of passing first downs gained on deep (20+ air yards) throws. |
+| `pressure_avg_depth_of_target` | numeric | Average depth of target in air yards when under pressure. |
+| `short_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws. |
+| `left_medium_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws to the left side of the field. |
+| `blitz_epa` | numeric | Total expected points added (EPA) on the player's dropbacks when blitzed. |
+| `center_deep_spikes` | numeric | Number of clock-stopping spikes on deep (20+ air yards) throws to the center of the field. |
+| `center_short_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws to the center of the field, as charted by PFF. |
+| `left_medium_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on medium (10-19 air yards) throws to the left side of the field. |
+| `center_deep_touchdowns` | numeric | Number of passing touchdowns thrown on deep (20+ air yards) throws to the center of the field. |
+| `right_deep_ypa` | numeric | Yards gained per pass attempt on deep (20+ air yards) throws to the right side of the field. |
+| `right_short_big_time_throws` | numeric | Number of big-time throws on short (0-9 air yards) throws to the right side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `center_short_big_time_throws` | numeric | Number of big-time throws on short (0-9 air yards) throws to the center of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `short_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws. |
+| `no_screen_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts excluding screen passes, per PFF charting. |
+| `left_behind_los_avg_time_to_throw` | numeric | Average time from snap to release in seconds on throws behind the line of scrimmage to the left side of the field. |
+| `right_deep_passing_snaps` | numeric | Number of passing snaps played on deep (20+ air yards) throws to the right side of the field. |
+| `pressure_drops` | numeric | Number of catchable passes dropped by receivers when under pressure. |
+| `right_short_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws to the right side of the field, per PFF charting. |
+| `center_medium_attempts` | numeric | Number of pass attempts on medium (10-19 air yards) throws to the center of the field. |
+| `right_deep_avg_time_to_throw` | numeric | Average time from snap to release in seconds on deep (20+ air yards) throws to the right side of the field. |
+| `no_blitz_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks when not blitzed, as charted by PFF. |
+| `center_deep_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws to the center of the field, as charted by PFF. |
+| `pressure_attempts` | numeric | Number of pass attempts when under pressure. |
+| `npa_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) on non-play-action dropbacks. |
+| `behind_los_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage. |
+| `right_medium_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws to the right side of the field, per PFF charting. |
+| `right_deep_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws to the right side of the field, as charted by PFF. |
+| `right_deep_scrambles` | numeric | Number of scrambles on deep (20+ air yards) throws to the right side of the field. |
+| `deep_big_time_throws` | numeric | Number of big-time throws on deep (20+ air yards) throws, per PFF's highest-value, highest-difficulty throw designation. |
+| `left_short_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on short (0-9 air yards) throws to the left side of the field, plays PFF charts as deserving of a turnover. |
+| `qb_rating` | numeric | Traditional NFL passer rating. |
+| `center_short_touchdowns` | numeric | Number of passing touchdowns thrown on short (0-9 air yards) throws to the center of the field. |
+| `right_medium_drops` | numeric | Number of catchable passes dropped by receivers on medium (10-19 air yards) throws to the right side of the field. |
+| `left_deep_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws to the left side of the field. |
+| `pressure_big_time_throws` | numeric | Number of big-time throws when under pressure, per PFF's highest-value, highest-difficulty throw designation. |
+| `no_blitz_thrown_aways` | numeric | Number of intentional throwaways when not blitzed. |
+| `short_ypa` | numeric | Yards gained per pass attempt on short (0-9 air yards) throws. |
+| `medium_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws. |
+| `left_medium_thrown_aways` | numeric | Number of intentional throwaways on medium (10-19 air yards) throws to the left side of the field. |
+| `right_behind_los_avg_time_to_throw` | numeric | Average time from snap to release in seconds on throws behind the line of scrimmage to the right side of the field. |
+| `completion_percent` | numeric | Percentage of pass attempts completed. |
+| `blitz_drops` | numeric | Number of catchable passes dropped by receivers when blitzed. |
+| `behind_los_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage, per PFF charting. |
+| `screen_completions` | numeric | Number of completed passes on screen passes. |
+| `screen_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on screen passes, per PFF charting. |
+| `npa_grades_run` | numeric | PFF rushing grade for the player (0-100) on non-play-action dropbacks. |
+| `no_pressure_touchdowns` | numeric | Number of passing touchdowns thrown from a clean pocket (no pressure). |
+| `no_screen_interceptions` | numeric | Number of passes intercepted excluding screen passes. |
+| `medium_avg_time_to_throw` | numeric | Average time from snap to release in seconds on medium (10-19 air yards) throws. |
+| `center_deep_completion_percent` | numeric | Percentage of pass attempts completed on deep (20+ air yards) throws to the center of the field. |
+| `behind_los_avg_time_to_throw` | numeric | Average time from snap to release in seconds on throws behind the line of scrimmage. |
+| `right_medium_touchdowns` | numeric | Number of passing touchdowns thrown on medium (10-19 air yards) throws to the right side of the field. |
+| `no_pressure_sacks` | numeric | Number of sacks taken from a clean pocket (no pressure). |
+| `center_short_avg_time_to_throw` | numeric | Average time from snap to release in seconds on short (0-9 air yards) throws to the center of the field. |
+| `npa_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) on non-play-action dropbacks. |
+| `left_deep_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws to the left side of the field, as charted by PFF. |
+| `left_medium_yards` | numeric | Passing yards gained on medium (10-19 air yards) throws to the left side of the field. |
+| `center_medium_touchdowns` | numeric | Number of passing touchdowns thrown on medium (10-19 air yards) throws to the center of the field. |
+| `blitz_sack_percent` | numeric | Percentage of dropbacks that ended in a sack when blitzed. |
+| `no_screen_sacks` | numeric | Number of sacks taken excluding screen passes. |
+| `center_short_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws to the center of the field. |
+| `left_short_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws to the left side of the field, per PFF charting. |
+| `pressure_sack_percent` | numeric | Percentage of dropbacks that ended in a sack when under pressure. |
+| `no_pressure_attempts` | numeric | Number of pass attempts from a clean pocket (no pressure). |
+| `right_behind_los_attempts_percent` | numeric | Share of the player's total pass attempts that came on throws behind the line of scrimmage to the right side of the field, expressed as a percentage. |
+| `no_blitz_grades_offense` | numeric | PFF overall offense grade for the player (0-100) when not blitzed. |
 | `attempts` | numeric | The number of pass attempts as defined by the NFL. |
-| `blitz_scrambles` | numeric |  |
-| `right_deep_avg_depth_of_target` | numeric |  |
-| `behind_los_sacks` | numeric |  |
-| `center_deep_yards` | numeric |  |
-| `short_dropbacks` | numeric |  |
-| `no_screen_big_time_throws` | numeric |  |
-| `left_deep_sack_percent` | numeric |  |
-| `center_behind_los_avg_time_to_throw` | numeric |  |
-| `blitz_dropbacks_percent` | numeric |  |
-| `behind_los_avg_depth_of_target` | numeric |  |
-| `left_behind_los_epa` | numeric |  |
-| `medium_twp_rate` | numeric |  |
-| `left_short_def_gen_pressures` | numeric |  |
-| `npa_drop_rate` | numeric |  |
-| `medium_turnover_worthy_plays` | numeric |  |
-| `behind_los_twp_rate` | numeric |  |
-| `left_behind_los_thrown_aways` | numeric |  |
-| `left_short_bats` | numeric |  |
-| `center_medium_drop_rate` | numeric |  |
-| `npa_attempts` | numeric |  |
-| `right_deep_bats` | numeric |  |
-| `screen_qb_rating` | numeric |  |
-| `medium_yards` | numeric |  |
-| `center_deep_grades_pass` | numeric |  |
-| `center_medium_passing_snaps` | numeric |  |
-| `center_behind_los_first_downs` | numeric |  |
-| `npa_grades_offense_penalty` | numeric |  |
-| `no_pressure_qb_rating` | numeric |  |
-| `center_medium_interceptions` | numeric |  |
-| `pa_bats` | numeric |  |
-| `pa_attempts` | numeric |  |
-| `behind_los_grades_pass` | numeric |  |
-| `no_blitz_passing_snaps` | numeric |  |
-| `npa_def_gen_pressures` | numeric |  |
-| `left_short_hit_as_threw` | numeric |  |
-| `deep_qb_rating` | numeric |  |
-| `no_blitz_aimed_passes` | numeric |  |
-| `blitz_yards` | numeric |  |
-| `no_screen_avg_time_to_throw` | numeric |  |
-| `center_deep_bats` | numeric |  |
-| `behind_los_ypa` | numeric |  |
-| `pa_yards` | numeric |  |
-| `right_short_interceptions` | numeric |  |
-| `left_deep_interceptions` | numeric |  |
-| `right_medium_sacks` | numeric |  |
-| `npa_positive_epa_percent` | numeric |  |
-| `right_behind_los_turnover_worthy_plays` | numeric |  |
+| `blitz_scrambles` | numeric | Number of scrambles when blitzed. |
+| `right_deep_avg_depth_of_target` | numeric | Average depth of target in air yards on deep (20+ air yards) throws to the right side of the field. |
+| `behind_los_sacks` | numeric | Number of sacks taken on throws behind the line of scrimmage. |
+| `center_deep_yards` | numeric | Passing yards gained on deep (20+ air yards) throws to the center of the field. |
+| `short_dropbacks` | numeric | Number of dropbacks on short (0-9 air yards) throws. |
+| `no_screen_big_time_throws` | numeric | Number of big-time throws excluding screen passes, per PFF's highest-value, highest-difficulty throw designation. |
+| `left_deep_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws to the left side of the field. |
+| `center_behind_los_avg_time_to_throw` | numeric | Average time from snap to release in seconds on throws behind the line of scrimmage to the center of the field. |
+| `blitz_dropbacks_percent` | numeric | Share of the player's total dropbacks that came when blitzed, expressed as a percentage. |
+| `behind_los_avg_depth_of_target` | numeric | Average depth of target in air yards on throws behind the line of scrimmage. |
+| `left_behind_los_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage to the left side of the field. |
+| `medium_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws, per PFF charting. |
+| `left_short_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards) throws to the left side of the field, as charted by PFF. |
+| `npa_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on non-play-action dropbacks. |
+| `medium_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on medium (10-19 air yards) throws, plays PFF charts as deserving of a turnover. |
+| `behind_los_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage, per PFF charting. |
+| `left_behind_los_thrown_aways` | numeric | Number of intentional throwaways on throws behind the line of scrimmage to the left side of the field. |
+| `left_short_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws to the left side of the field. |
+| `center_medium_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws to the center of the field. |
+| `npa_attempts` | numeric | Number of pass attempts on non-play-action dropbacks. |
+| `right_deep_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws to the right side of the field. |
+| `screen_qb_rating` | numeric | Traditional NFL passer rating on screen passes. |
+| `medium_yards` | numeric | Passing yards gained on medium (10-19 air yards) throws. |
+| `center_deep_grades_pass` | numeric | PFF passing grade (0-100) on deep (20+ air yards) throws to the center of the field. |
+| `center_medium_passing_snaps` | numeric | Number of passing snaps played on medium (10-19 air yards) throws to the center of the field. |
+| `center_behind_los_first_downs` | numeric | Number of passing first downs gained on throws behind the line of scrimmage to the center of the field. |
+| `npa_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) on non-play-action dropbacks. |
+| `no_pressure_qb_rating` | numeric | Traditional NFL passer rating from a clean pocket (no pressure). |
+| `center_medium_interceptions` | numeric | Number of passes intercepted on medium (10-19 air yards) throws to the center of the field. |
+| `pa_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on play-action dropbacks. |
+| `pa_attempts` | numeric | Number of pass attempts on play-action dropbacks. |
+| `behind_los_grades_pass` | numeric | PFF passing grade (0-100) on throws behind the line of scrimmage. |
+| `no_blitz_passing_snaps` | numeric | Number of passing snaps played when not blitzed. |
+| `npa_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on non-play-action dropbacks, as charted by PFF. |
+| `left_short_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws to the left side of the field, as charted by PFF. |
+| `deep_qb_rating` | numeric | Traditional NFL passer rating on deep (20+ air yards) throws. |
+| `no_blitz_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) when not blitzed, as charted by PFF. |
+| `blitz_yards` | numeric | Passing yards gained when blitzed. |
+| `no_screen_avg_time_to_throw` | numeric | Average time from snap to release in seconds excluding screen passes. |
+| `center_deep_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws to the center of the field. |
+| `behind_los_ypa` | numeric | Yards gained per pass attempt on throws behind the line of scrimmage. |
+| `pa_yards` | numeric | Passing yards gained on play-action dropbacks. |
+| `right_short_interceptions` | numeric | Number of passes intercepted on short (0-9 air yards) throws to the right side of the field. |
+| `left_deep_interceptions` | numeric | Number of passes intercepted on deep (20+ air yards) throws to the left side of the field. |
+| `right_medium_sacks` | numeric | Number of sacks taken on medium (10-19 air yards) throws to the right side of the field. |
+| `npa_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on non-play-action dropbacks. |
+| `right_behind_los_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on throws behind the line of scrimmage to the right side of the field, plays PFF charts as deserving of a turnover. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `no_screen_scrambles` | numeric |  |
-| `pa_turnover_worthy_plays` | numeric |  |
-| `right_medium_spikes` | numeric |  |
-| `behind_los_hit_as_threw` | numeric |  |
-| `no_blitz_attempts` | numeric |  |
-| `pressure_accuracy_percent` | numeric |  |
-| `left_medium_pressure_to_sack_rate` | numeric |  |
-| `medium_dropbacks` | numeric |  |
-| `deep_hit_as_threw` | numeric |  |
-| `no_blitz_hit_as_threw` | numeric |  |
-| `right_medium_completion_percent` | numeric |  |
-| `pressure_hit_as_threw` | numeric |  |
-| `short_epa` | numeric |  |
-| `deep_drop_rate` | numeric |  |
-| `blitz_pressure_to_sack_rate` | numeric |  |
-| `pa_aimed_passes` | numeric |  |
-| `deep_scrambles` | numeric |  |
-| `pa_grades_offense` | numeric |  |
-| `screen_positive_epa_percent` | numeric |  |
-| `left_deep_completion_percent` | numeric |  |
-| `no_screen_dropbacks` | numeric |  |
-| `right_short_epa` | numeric |  |
-| `no_screen_dropbacks_percent` | numeric |  |
-| `no_blitz_btt_rate` | numeric |  |
-| `medium_attempts_percent` | numeric |  |
-| `right_behind_los_completion_percent` | numeric |  |
-| `left_medium_hit_as_threw` | numeric |  |
-| `left_behind_los_pressure_to_sack_rate` | numeric |  |
-| `right_short_def_gen_pressures` | numeric |  |
-| `no_blitz_ypa` | numeric |  |
-| `right_short_attempts_percent` | numeric |  |
-| `center_short_aimed_passes` | numeric |  |
-| `npa_sack_percent` | numeric |  |
-| `short_hit_as_threw` | numeric |  |
-| `blitz_grades_run` | numeric |  |
-| `right_medium_turnover_worthy_plays` | numeric |  |
-| `left_short_epa` | numeric |  |
-| `center_behind_los_pressure_to_sack_rate` | numeric |  |
-| `pa_positive_epa_percent` | numeric |  |
-| `pressure_interceptions` | numeric |  |
-| `right_behind_los_ypa` | numeric |  |
-| `deep_interceptions` | numeric |  |
-| `left_medium_twp_rate` | numeric |  |
-| `blitz_grades_hands_fumble` | numeric |  |
-| `passing_snaps` | numeric |  |
-| `pa_grades_run_block` | numeric |  |
-| `pressure_to_sack_rate` | numeric |  |
-| `ypa` | numeric |  |
-| `right_behind_los_big_time_throws` | numeric |  |
-| `center_medium_sack_percent` | numeric |  |
+| `no_screen_scrambles` | numeric | Number of scrambles excluding screen passes. |
+| `pa_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on play-action dropbacks, plays PFF charts as deserving of a turnover. |
+| `right_medium_spikes` | numeric | Number of clock-stopping spikes on medium (10-19 air yards) throws to the right side of the field. |
+| `behind_los_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage, as charted by PFF. |
+| `no_blitz_attempts` | numeric | Number of pass attempts when not blitzed. |
+| `pressure_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF when under pressure. |
+| `left_medium_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws to the left side of the field. |
+| `medium_dropbacks` | numeric | Number of dropbacks on medium (10-19 air yards) throws. |
+| `deep_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws, as charted by PFF. |
+| `no_blitz_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw when not blitzed, as charted by PFF. |
+| `right_medium_completion_percent` | numeric | Percentage of pass attempts completed on medium (10-19 air yards) throws to the right side of the field. |
+| `pressure_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw when under pressure, as charted by PFF. |
+| `short_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws. |
+| `deep_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws. |
+| `blitz_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack when blitzed. |
+| `pa_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on play-action dropbacks, as charted by PFF. |
+| `deep_scrambles` | numeric | Number of scrambles on deep (20+ air yards) throws. |
+| `pa_grades_offense` | numeric | PFF overall offense grade for the player (0-100) on play-action dropbacks. |
+| `screen_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on screen passes. |
+| `left_deep_completion_percent` | numeric | Percentage of pass attempts completed on deep (20+ air yards) throws to the left side of the field. |
+| `no_screen_dropbacks` | numeric | Number of dropbacks excluding screen passes. |
+| `right_short_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws to the right side of the field. |
+| `no_screen_dropbacks_percent` | numeric | Share of the player's total dropbacks that came excluding screen passes, expressed as a percentage. |
+| `no_blitz_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts when not blitzed, per PFF charting. |
+| `medium_attempts_percent` | numeric | Share of the player's total pass attempts that came on medium (10-19 air yards) throws, expressed as a percentage. |
+| `right_behind_los_completion_percent` | numeric | Percentage of pass attempts completed on throws behind the line of scrimmage to the right side of the field. |
+| `left_medium_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws to the left side of the field, as charted by PFF. |
+| `left_behind_los_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on throws behind the line of scrimmage to the left side of the field. |
+| `right_short_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards) throws to the right side of the field, as charted by PFF. |
+| `no_blitz_ypa` | numeric | Yards gained per pass attempt when not blitzed. |
+| `right_short_attempts_percent` | numeric | Share of the player's total pass attempts that came on short (0-9 air yards) throws to the right side of the field, expressed as a percentage. |
+| `center_short_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws to the center of the field, as charted by PFF. |
+| `npa_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on non-play-action dropbacks. |
+| `short_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws, as charted by PFF. |
+| `blitz_grades_run` | numeric | PFF rushing grade for the player (0-100) when blitzed. |
+| `right_medium_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on medium (10-19 air yards) throws to the right side of the field, plays PFF charts as deserving of a turnover. |
+| `left_short_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws to the left side of the field. |
+| `center_behind_los_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on throws behind the line of scrimmage to the center of the field. |
+| `pa_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on play-action dropbacks. |
+| `pressure_interceptions` | numeric | Number of passes intercepted when under pressure. |
+| `right_behind_los_ypa` | numeric | Yards gained per pass attempt on throws behind the line of scrimmage to the right side of the field. |
+| `deep_interceptions` | numeric | Number of passes intercepted on deep (20+ air yards) throws. |
+| `left_medium_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws to the left side of the field, per PFF charting. |
+| `blitz_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) when blitzed. |
+| `passing_snaps` | numeric | Number of passing snaps played. |
+| `pa_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) on play-action dropbacks. |
+| `pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack. |
+| `ypa` | numeric | Yards gained per pass attempt. |
+| `right_behind_los_big_time_throws` | numeric | Number of big-time throws on throws behind the line of scrimmage to the right side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `center_medium_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws to the center of the field. |
 | `drops` | numeric | Throws dropped |
-| `center_deep_thrown_aways` | numeric |  |
-| `short_thrown_aways` | numeric |  |
-| `left_short_btt_rate` | numeric |  |
-| `no_screen_turnover_worthy_plays` | numeric |  |
-| `no_pressure_grades_offense_penalty` | numeric |  |
-| `right_medium_accuracy_percent` | numeric |  |
+| `center_deep_thrown_aways` | numeric | Number of intentional throwaways on deep (20+ air yards) throws to the center of the field. |
+| `short_thrown_aways` | numeric | Number of intentional throwaways on short (0-9 air yards) throws. |
+| `left_short_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws to the left side of the field, per PFF charting. |
+| `no_screen_turnover_worthy_plays` | numeric | Number of turnover-worthy plays excluding screen passes, plays PFF charts as deserving of a turnover. |
+| `no_pressure_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) from a clean pocket (no pressure). |
+| `right_medium_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws to the right side of the field. |
 | `position` | character | Primary position as reported by NFL.com |
-| `short_def_gen_pressures` | numeric |  |
-| `center_deep_dropbacks` | numeric |  |
-| `center_medium_accuracy_percent` | numeric |  |
-| `blitz_grades_offense` | numeric |  |
-| `right_behind_los_yards` | numeric |  |
-| `right_medium_attempts` | numeric |  |
-| `grades_hands_fumble` | numeric |  |
-| `left_medium_attempts` | numeric |  |
-| `npa_epa` | numeric |  |
-| `no_screen_avg_depth_of_target` | numeric |  |
-| `medium_accuracy_percent` | numeric |  |
-| `left_medium_drops` | numeric |  |
-| `pa_grades_hands_fumble` | numeric |  |
-| `no_screen_completion_percent` | numeric |  |
-| `left_short_avg_time_to_throw` | numeric |  |
-| `pa_hit_as_threw` | numeric |  |
-| `medium_passing_snaps` | numeric |  |
-| `center_short_epa` | numeric |  |
-| `left_behind_los_passing_snaps` | numeric |  |
-| `left_deep_pressure_to_sack_rate` | numeric |  |
+| `short_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards) throws, as charted by PFF. |
+| `center_deep_dropbacks` | numeric | Number of dropbacks on deep (20+ air yards) throws to the center of the field. |
+| `center_medium_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws to the center of the field. |
+| `blitz_grades_offense` | numeric | PFF overall offense grade for the player (0-100) when blitzed. |
+| `right_behind_los_yards` | numeric | Passing yards gained on throws behind the line of scrimmage to the right side of the field. |
+| `right_medium_attempts` | numeric | Number of pass attempts on medium (10-19 air yards) throws to the right side of the field. |
+| `grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100). |
+| `left_medium_attempts` | numeric | Number of pass attempts on medium (10-19 air yards) throws to the left side of the field. |
+| `npa_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on non-play-action dropbacks. |
+| `no_screen_avg_depth_of_target` | numeric | Average depth of target in air yards excluding screen passes. |
+| `medium_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws. |
+| `left_medium_drops` | numeric | Number of catchable passes dropped by receivers on medium (10-19 air yards) throws to the left side of the field. |
+| `pa_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) on play-action dropbacks. |
+| `no_screen_completion_percent` | numeric | Percentage of pass attempts completed excluding screen passes. |
+| `left_short_avg_time_to_throw` | numeric | Average time from snap to release in seconds on short (0-9 air yards) throws to the left side of the field. |
+| `pa_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on play-action dropbacks, as charted by PFF. |
+| `medium_passing_snaps` | numeric | Number of passing snaps played on medium (10-19 air yards) throws. |
+| `center_short_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws to the center of the field. |
+| `left_behind_los_passing_snaps` | numeric | Number of passing snaps played on throws behind the line of scrimmage to the left side of the field. |
+| `left_deep_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws to the left side of the field. |
 | `avg_time_to_throw` | numeric | Average time elapsed from the time of snap to throw on every pass attempt for a passer (sacks excluded). |
-| `pa_grades_offense_penalty` | numeric |  |
-| `deep_bats` | numeric |  |
-| `npa_dropbacks_percent` | numeric |  |
-| `left_medium_passing_snaps` | numeric |  |
-| `pressure_def_gen_pressures` | numeric |  |
-| `left_medium_scrambles` | numeric |  |
-| `npa_grades_pass` | numeric |  |
-| `pressure_grades_pass` | numeric |  |
-| `right_deep_completion_percent` | numeric |  |
-| `big_time_throws` | numeric |  |
-| `screen_grades_run` | numeric |  |
-| `left_short_drops` | numeric |  |
-| `screen_first_downs` | numeric |  |
-| `npa_completion_percent` | numeric |  |
-| `left_deep_accuracy_percent` | numeric |  |
-| `medium_positive_epa_percent` | numeric |  |
-| `no_blitz_qb_rating` | numeric |  |
-| `blitz_hit_as_threw` | numeric |  |
-| `behind_los_turnover_worthy_plays` | numeric |  |
-| `right_medium_epa` | numeric |  |
-| `right_deep_dropbacks` | numeric |  |
-| `deep_ypa` | numeric |  |
-| `center_medium_completions` | numeric |  |
-| `left_medium_avg_time_to_throw` | numeric |  |
-| `left_short_sacks` | numeric |  |
-| `left_behind_los_spikes` | numeric |  |
-| `no_screen_grades_run_block` | numeric |  |
-| `pressure_ypa` | numeric |  |
-| `left_deep_def_gen_pressures` | numeric |  |
-| `no_screen_hit_as_threw` | numeric |  |
-| `center_short_qb_rating` | numeric |  |
-| `center_deep_interceptions` | numeric |  |
-| `right_deep_completions` | numeric |  |
-| `center_behind_los_sacks` | numeric |  |
-| `screen_turnover_worthy_plays` | numeric |  |
-| `deep_completions` | numeric |  |
-| `left_medium_attempts_percent` | numeric |  |
-| `pressure_avg_time_to_throw` | numeric |  |
-| `short_yards` | numeric |  |
-| `behind_los_qb_rating` | numeric |  |
-| `right_short_sacks` | numeric |  |
-| `right_behind_los_thrown_aways` | numeric |  |
-| `center_short_spikes` | numeric |  |
-| `center_behind_los_hit_as_threw` | numeric |  |
-| `no_blitz_completions` | numeric |  |
-| `center_deep_turnover_worthy_plays` | numeric |  |
-| `left_medium_sack_percent` | numeric |  |
-| `behind_los_completion_percent` | numeric |  |
-| `left_deep_attempts_percent` | numeric |  |
-| `no_pressure_sack_percent` | numeric |  |
-| `center_deep_big_time_throws` | numeric |  |
-| `npa_avg_depth_of_target` | numeric |  |
-| `npa_dropbacks` | numeric |  |
+| `pa_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) on play-action dropbacks. |
+| `deep_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws. |
+| `npa_dropbacks_percent` | numeric | Share of the player's total dropbacks that came on non-play-action dropbacks, expressed as a percentage. |
+| `left_medium_passing_snaps` | numeric | Number of passing snaps played on medium (10-19 air yards) throws to the left side of the field. |
+| `pressure_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks when under pressure, as charted by PFF. |
+| `left_medium_scrambles` | numeric | Number of scrambles on medium (10-19 air yards) throws to the left side of the field. |
+| `npa_grades_pass` | numeric | PFF passing grade (0-100) on non-play-action dropbacks. |
+| `pressure_grades_pass` | numeric | PFF passing grade (0-100) when under pressure. |
+| `right_deep_completion_percent` | numeric | Percentage of pass attempts completed on deep (20+ air yards) throws to the right side of the field. |
+| `big_time_throws` | numeric | Number of big-time throws, per PFF's highest-value, highest-difficulty throw designation. |
+| `screen_grades_run` | numeric | PFF rushing grade for the player (0-100) on screen passes. |
+| `left_short_drops` | numeric | Number of catchable passes dropped by receivers on short (0-9 air yards) throws to the left side of the field. |
+| `screen_first_downs` | numeric | Number of passing first downs gained on screen passes. |
+| `npa_completion_percent` | numeric | Percentage of pass attempts completed on non-play-action dropbacks. |
+| `left_deep_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws to the left side of the field. |
+| `medium_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on medium (10-19 air yards) throws. |
+| `no_blitz_qb_rating` | numeric | Traditional NFL passer rating when not blitzed. |
+| `blitz_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw when blitzed, as charted by PFF. |
+| `behind_los_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on throws behind the line of scrimmage, plays PFF charts as deserving of a turnover. |
+| `right_medium_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws to the right side of the field. |
+| `right_deep_dropbacks` | numeric | Number of dropbacks on deep (20+ air yards) throws to the right side of the field. |
+| `deep_ypa` | numeric | Yards gained per pass attempt on deep (20+ air yards) throws. |
+| `center_medium_completions` | numeric | Number of completed passes on medium (10-19 air yards) throws to the center of the field. |
+| `left_medium_avg_time_to_throw` | numeric | Average time from snap to release in seconds on medium (10-19 air yards) throws to the left side of the field. |
+| `left_short_sacks` | numeric | Number of sacks taken on short (0-9 air yards) throws to the left side of the field. |
+| `left_behind_los_spikes` | numeric | Number of clock-stopping spikes on throws behind the line of scrimmage to the left side of the field. |
+| `no_screen_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) excluding screen passes. |
+| `pressure_ypa` | numeric | Yards gained per pass attempt when under pressure. |
+| `left_deep_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws to the left side of the field, as charted by PFF. |
+| `no_screen_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw excluding screen passes, as charted by PFF. |
+| `center_short_qb_rating` | numeric | Traditional NFL passer rating on short (0-9 air yards) throws to the center of the field. |
+| `center_deep_interceptions` | numeric | Number of passes intercepted on deep (20+ air yards) throws to the center of the field. |
+| `right_deep_completions` | numeric | Number of completed passes on deep (20+ air yards) throws to the right side of the field. |
+| `center_behind_los_sacks` | numeric | Number of sacks taken on throws behind the line of scrimmage to the center of the field. |
+| `screen_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on screen passes, plays PFF charts as deserving of a turnover. |
+| `deep_completions` | numeric | Number of completed passes on deep (20+ air yards) throws. |
+| `left_medium_attempts_percent` | numeric | Share of the player's total pass attempts that came on medium (10-19 air yards) throws to the left side of the field, expressed as a percentage. |
+| `pressure_avg_time_to_throw` | numeric | Average time from snap to release in seconds when under pressure. |
+| `short_yards` | numeric | Passing yards gained on short (0-9 air yards) throws. |
+| `behind_los_qb_rating` | numeric | Traditional NFL passer rating on throws behind the line of scrimmage. |
+| `right_short_sacks` | numeric | Number of sacks taken on short (0-9 air yards) throws to the right side of the field. |
+| `right_behind_los_thrown_aways` | numeric | Number of intentional throwaways on throws behind the line of scrimmage to the right side of the field. |
+| `center_short_spikes` | numeric | Number of clock-stopping spikes on short (0-9 air yards) throws to the center of the field. |
+| `center_behind_los_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage to the center of the field, as charted by PFF. |
+| `no_blitz_completions` | numeric | Number of completed passes when not blitzed. |
+| `center_deep_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on deep (20+ air yards) throws to the center of the field, plays PFF charts as deserving of a turnover. |
+| `left_medium_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws to the left side of the field. |
+| `behind_los_completion_percent` | numeric | Percentage of pass attempts completed on throws behind the line of scrimmage. |
+| `left_deep_attempts_percent` | numeric | Share of the player's total pass attempts that came on deep (20+ air yards) throws to the left side of the field, expressed as a percentage. |
+| `no_pressure_sack_percent` | numeric | Percentage of dropbacks that ended in a sack from a clean pocket (no pressure). |
+| `center_deep_big_time_throws` | numeric | Number of big-time throws on deep (20+ air yards) throws to the center of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `npa_avg_depth_of_target` | numeric | Average depth of target in air yards on non-play-action dropbacks. |
+| `npa_dropbacks` | numeric | Number of dropbacks on non-play-action dropbacks. |
 | `player` | character | Player name |
-| `left_medium_avg_depth_of_target` | numeric |  |
-| `no_blitz_accuracy_percent` | numeric |  |
-| `behind_los_thrown_aways` | numeric |  |
-| `center_medium_def_gen_pressures` | numeric |  |
-| `short_avg_time_to_throw` | numeric |  |
-| `left_deep_twp_rate` | numeric |  |
-| `center_behind_los_epa` | numeric |  |
-| `left_behind_los_big_time_throws` | numeric |  |
-| `pa_drops` | numeric |  |
-| `no_pressure_pressure_to_sack_rate` | character |  |
-| `right_medium_yards` | numeric |  |
-| `pa_btt_rate` | numeric |  |
-| `no_pressure_turnover_worthy_plays` | numeric |  |
-| `pressure_first_downs` | numeric |  |
-| `positive_epa_percent` | numeric |  |
-| `right_medium_drop_rate` | numeric |  |
-| `blitz_passing_snaps` | numeric |  |
-| `center_medium_big_time_throws` | numeric |  |
+| `left_medium_avg_depth_of_target` | numeric | Average depth of target in air yards on medium (10-19 air yards) throws to the left side of the field. |
+| `no_blitz_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF when not blitzed. |
+| `behind_los_thrown_aways` | numeric | Number of intentional throwaways on throws behind the line of scrimmage. |
+| `center_medium_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards) throws to the center of the field, as charted by PFF. |
+| `short_avg_time_to_throw` | numeric | Average time from snap to release in seconds on short (0-9 air yards) throws. |
+| `left_deep_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws to the left side of the field, per PFF charting. |
+| `center_behind_los_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage to the center of the field. |
+| `left_behind_los_big_time_throws` | numeric | Number of big-time throws on throws behind the line of scrimmage to the left side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `pa_drops` | numeric | Number of catchable passes dropped by receivers on play-action dropbacks. |
+| `no_pressure_pressure_to_sack_rate` | character | Pressure-to-sack rate as reported within the no-pressure split of the PFF passing-pressure facet. |
+| `right_medium_yards` | numeric | Passing yards gained on medium (10-19 air yards) throws to the right side of the field. |
+| `pa_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on play-action dropbacks, per PFF charting. |
+| `no_pressure_turnover_worthy_plays` | numeric | Number of turnover-worthy plays from a clean pocket (no pressure), plays PFF charts as deserving of a turnover. |
+| `pressure_first_downs` | numeric | Number of passing first downs gained when under pressure. |
+| `positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added. |
+| `right_medium_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws to the right side of the field. |
+| `blitz_passing_snaps` | numeric | Number of passing snaps played when blitzed. |
+| `center_medium_big_time_throws` | numeric | Number of big-time throws on medium (10-19 air yards) throws to the center of the field, per PFF's highest-value, highest-difficulty throw designation. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `left_short_completion_percent` | numeric |  |
-| `screen_big_time_throws` | numeric |  |
-| `left_short_drop_rate` | numeric |  |
-| `left_behind_los_scrambles` | numeric |  |
-| `left_medium_btt_rate` | numeric |  |
-| `screen_aimed_passes` | numeric |  |
-| `right_deep_hit_as_threw` | numeric |  |
-| `behind_los_bats` | numeric |  |
-| `no_pressure_twp_rate` | numeric |  |
-| `npa_touchdowns` | numeric |  |
-| `no_blitz_sacks` | numeric |  |
-| `short_first_downs` | numeric |  |
-| `left_deep_attempts` | numeric |  |
-| `right_behind_los_attempts` | numeric |  |
-| `screen_attempts` | numeric |  |
-| `screen_dropbacks` | numeric |  |
-| `right_deep_sacks` | numeric |  |
-| `left_behind_los_attempts_percent` | numeric |  |
-| `behind_los_big_time_throws` | numeric |  |
-| `center_deep_pressure_to_sack_rate` | numeric |  |
-| `left_medium_big_time_throws` | numeric |  |
-| `right_behind_los_bats` | numeric |  |
-| `left_medium_def_gen_pressures` | numeric |  |
-| `no_screen_yards` | numeric |  |
-| `right_deep_turnover_worthy_plays` | numeric |  |
-| `left_short_spikes` | numeric |  |
-| `left_medium_aimed_passes` | numeric |  |
-| `left_behind_los_twp_rate` | numeric |  |
-| `short_grades_pass` | numeric |  |
-| `right_short_drops` | numeric |  |
-| `right_short_avg_time_to_throw` | numeric |  |
-| `pa_scrambles` | numeric |  |
-| `right_medium_thrown_aways` | numeric |  |
-| `no_pressure_accuracy_percent` | numeric |  |
-| `center_short_sack_percent` | numeric |  |
-| `right_short_passing_snaps` | numeric |  |
-| `center_short_def_gen_pressures` | numeric |  |
-| `center_medium_positive_epa_percent` | numeric |  |
-| `medium_drops` | numeric |  |
-| `center_medium_aimed_passes` | numeric |  |
-| `center_short_sacks` | numeric |  |
-| `pa_completion_percent` | numeric |  |
-| `deep_attempts_percent` | numeric |  |
-| `center_behind_los_def_gen_pressures` | numeric |  |
-| `left_short_passing_snaps` | numeric |  |
-| `center_medium_grades_pass` | numeric |  |
-| `center_deep_avg_time_to_throw` | numeric |  |
-| `pa_avg_depth_of_target` | numeric |  |
-| `pa_interceptions` | numeric |  |
-| `no_screen_accuracy_percent` | numeric |  |
-| `behind_los_positive_epa_percent` | numeric |  |
-| `no_screen_spikes` | numeric |  |
-| `center_short_completion_percent` | numeric |  |
-| `pa_dropbacks` | numeric |  |
-| `left_deep_hit_as_threw` | numeric |  |
-| `center_short_grades_pass` | numeric |  |
-| `left_short_attempts_percent` | numeric |  |
-| `left_deep_scrambles` | numeric |  |
-| `no_blitz_twp_rate` | numeric |  |
-| `no_pressure_hit_as_threw` | numeric |  |
-| `right_short_completions` | numeric |  |
-| `center_behind_los_aimed_passes` | numeric |  |
-| `right_short_scrambles` | numeric |  |
-| `center_medium_qb_rating` | numeric |  |
-| `no_pressure_grades_pass` | numeric |  |
-| `npa_big_time_throws` | numeric |  |
-| `deep_avg_time_to_throw` | numeric |  |
-| `no_screen_sack_percent` | numeric |  |
-| `avg_depth_of_target` | numeric |  |
-| `no_pressure_positive_epa_percent` | numeric |  |
-| `turnover_worthy_plays` | numeric |  |
+| `left_short_completion_percent` | numeric | Percentage of pass attempts completed on short (0-9 air yards) throws to the left side of the field. |
+| `screen_big_time_throws` | numeric | Number of big-time throws on screen passes, per PFF's highest-value, highest-difficulty throw designation. |
+| `left_short_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws to the left side of the field. |
+| `left_behind_los_scrambles` | numeric | Number of scrambles on throws behind the line of scrimmage to the left side of the field. |
+| `left_medium_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws to the left side of the field, per PFF charting. |
+| `screen_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on screen passes, as charted by PFF. |
+| `right_deep_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws to the right side of the field, as charted by PFF. |
+| `behind_los_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage. |
+| `no_pressure_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts from a clean pocket (no pressure), per PFF charting. |
+| `npa_touchdowns` | numeric | Number of passing touchdowns thrown on non-play-action dropbacks. |
+| `no_blitz_sacks` | numeric | Number of sacks taken when not blitzed. |
+| `short_first_downs` | numeric | Number of passing first downs gained on short (0-9 air yards) throws. |
+| `left_deep_attempts` | numeric | Number of pass attempts on deep (20+ air yards) throws to the left side of the field. |
+| `right_behind_los_attempts` | numeric | Number of pass attempts on throws behind the line of scrimmage to the right side of the field. |
+| `screen_attempts` | numeric | Number of pass attempts on screen passes. |
+| `screen_dropbacks` | numeric | Number of dropbacks on screen passes. |
+| `right_deep_sacks` | numeric | Number of sacks taken on deep (20+ air yards) throws to the right side of the field. |
+| `left_behind_los_attempts_percent` | numeric | Share of the player's total pass attempts that came on throws behind the line of scrimmage to the left side of the field, expressed as a percentage. |
+| `behind_los_big_time_throws` | numeric | Number of big-time throws on throws behind the line of scrimmage, per PFF's highest-value, highest-difficulty throw designation. |
+| `center_deep_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws to the center of the field. |
+| `left_medium_big_time_throws` | numeric | Number of big-time throws on medium (10-19 air yards) throws to the left side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `right_behind_los_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage to the right side of the field. |
+| `left_medium_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards) throws to the left side of the field, as charted by PFF. |
+| `no_screen_yards` | numeric | Passing yards gained excluding screen passes. |
+| `right_deep_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on deep (20+ air yards) throws to the right side of the field, plays PFF charts as deserving of a turnover. |
+| `left_short_spikes` | numeric | Number of clock-stopping spikes on short (0-9 air yards) throws to the left side of the field. |
+| `left_medium_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards) throws to the left side of the field, as charted by PFF. |
+| `left_behind_los_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage to the left side of the field, per PFF charting. |
+| `short_grades_pass` | numeric | PFF passing grade (0-100) on short (0-9 air yards) throws. |
+| `right_short_drops` | numeric | Number of catchable passes dropped by receivers on short (0-9 air yards) throws to the right side of the field. |
+| `right_short_avg_time_to_throw` | numeric | Average time from snap to release in seconds on short (0-9 air yards) throws to the right side of the field. |
+| `pa_scrambles` | numeric | Number of scrambles on play-action dropbacks. |
+| `right_medium_thrown_aways` | numeric | Number of intentional throwaways on medium (10-19 air yards) throws to the right side of the field. |
+| `no_pressure_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF from a clean pocket (no pressure). |
+| `center_short_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws to the center of the field. |
+| `right_short_passing_snaps` | numeric | Number of passing snaps played on short (0-9 air yards) throws to the right side of the field. |
+| `center_short_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards) throws to the center of the field, as charted by PFF. |
+| `center_medium_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on medium (10-19 air yards) throws to the center of the field. |
+| `medium_drops` | numeric | Number of catchable passes dropped by receivers on medium (10-19 air yards) throws. |
+| `center_medium_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards) throws to the center of the field, as charted by PFF. |
+| `center_short_sacks` | numeric | Number of sacks taken on short (0-9 air yards) throws to the center of the field. |
+| `pa_completion_percent` | numeric | Percentage of pass attempts completed on play-action dropbacks. |
+| `deep_attempts_percent` | numeric | Share of the player's total pass attempts that came on deep (20+ air yards) throws, expressed as a percentage. |
+| `center_behind_los_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on throws behind the line of scrimmage to the center of the field, as charted by PFF. |
+| `left_short_passing_snaps` | numeric | Number of passing snaps played on short (0-9 air yards) throws to the left side of the field. |
+| `center_medium_grades_pass` | numeric | PFF passing grade (0-100) on medium (10-19 air yards) throws to the center of the field. |
+| `center_deep_avg_time_to_throw` | numeric | Average time from snap to release in seconds on deep (20+ air yards) throws to the center of the field. |
+| `pa_avg_depth_of_target` | numeric | Average depth of target in air yards on play-action dropbacks. |
+| `pa_interceptions` | numeric | Number of passes intercepted on play-action dropbacks. |
+| `no_screen_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF excluding screen passes. |
+| `behind_los_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on throws behind the line of scrimmage. |
+| `no_screen_spikes` | numeric | Number of clock-stopping spikes excluding screen passes. |
+| `center_short_completion_percent` | numeric | Percentage of pass attempts completed on short (0-9 air yards) throws to the center of the field. |
+| `pa_dropbacks` | numeric | Number of dropbacks on play-action dropbacks. |
+| `left_deep_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws to the left side of the field, as charted by PFF. |
+| `center_short_grades_pass` | numeric | PFF passing grade (0-100) on short (0-9 air yards) throws to the center of the field. |
+| `left_short_attempts_percent` | numeric | Share of the player's total pass attempts that came on short (0-9 air yards) throws to the left side of the field, expressed as a percentage. |
+| `left_deep_scrambles` | numeric | Number of scrambles on deep (20+ air yards) throws to the left side of the field. |
+| `no_blitz_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts when not blitzed, per PFF charting. |
+| `no_pressure_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw from a clean pocket (no pressure), as charted by PFF. |
+| `right_short_completions` | numeric | Number of completed passes on short (0-9 air yards) throws to the right side of the field. |
+| `center_behind_los_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line of scrimmage to the center of the field, as charted by PFF. |
+| `right_short_scrambles` | numeric | Number of scrambles on short (0-9 air yards) throws to the right side of the field. |
+| `center_medium_qb_rating` | numeric | Traditional NFL passer rating on medium (10-19 air yards) throws to the center of the field. |
+| `no_pressure_grades_pass` | numeric | PFF passing grade (0-100) from a clean pocket (no pressure). |
+| `npa_big_time_throws` | numeric | Number of big-time throws on non-play-action dropbacks, per PFF's highest-value, highest-difficulty throw designation. |
+| `deep_avg_time_to_throw` | numeric | Average time from snap to release in seconds on deep (20+ air yards) throws. |
+| `no_screen_sack_percent` | numeric | Percentage of dropbacks that ended in a sack excluding screen passes. |
+| `avg_depth_of_target` | numeric | Average depth of target in air yards. |
+| `no_pressure_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added from a clean pocket (no pressure). |
+| `turnover_worthy_plays` | numeric | Number of turnover-worthy plays, plays PFF charts as deserving of a turnover. |
 | `epa` | numeric | Expected points added (EPA) by the posteam for the given play. |
-| `pressure_spikes` | numeric |  |
-| `pressure_grades_hands_fumble` | numeric |  |
-| `left_deep_drops` | numeric |  |
-| `right_behind_los_def_gen_pressures` | numeric |  |
-| `pa_epa` | numeric |  |
-| `pressure_qb_rating` | numeric |  |
-| `center_deep_positive_epa_percent` | numeric |  |
-| `center_deep_hit_as_threw` | numeric |  |
-| `no_screen_attempts` | numeric |  |
-| `pa_passing_snaps` | numeric |  |
-| `aimed_passes` | numeric |  |
-| `blitz_bats` | numeric |  |
-| `pressure_touchdowns` | numeric |  |
-| `npa_completions` | numeric |  |
-| `short_spikes` | numeric |  |
-| `pressure_thrown_aways` | numeric |  |
-| `right_behind_los_completions` | numeric |  |
-| `no_blitz_interceptions` | numeric |  |
-| `center_behind_los_drop_rate` | numeric |  |
-| `short_drops` | numeric |  |
-| `deep_aimed_passes` | numeric |  |
-| `right_medium_avg_depth_of_target` | numeric |  |
-| `short_pressure_to_sack_rate` | numeric |  |
-| `screen_touchdowns` | numeric |  |
-| `center_deep_qb_rating` | numeric |  |
-| `left_medium_completions` | numeric |  |
-| `center_deep_sacks` | numeric |  |
-| `left_deep_big_time_throws` | numeric |  |
-| `blitz_dropbacks` | numeric |  |
-| `center_medium_first_downs` | numeric |  |
-| `center_medium_dropbacks` | numeric |  |
-| `blitz_def_gen_pressures` | numeric |  |
-| `npa_first_downs` | numeric |  |
-| `no_screen_touchdowns` | numeric |  |
-| `right_deep_def_gen_pressures` | numeric |  |
-| `left_short_touchdowns` | numeric |  |
-| `medium_drop_rate` | numeric |  |
+| `pressure_spikes` | numeric | Number of clock-stopping spikes when under pressure. |
+| `pressure_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) when under pressure. |
+| `left_deep_drops` | numeric | Number of catchable passes dropped by receivers on deep (20+ air yards) throws to the left side of the field. |
+| `right_behind_los_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on throws behind the line of scrimmage to the right side of the field, as charted by PFF. |
+| `pa_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on play-action dropbacks. |
+| `pressure_qb_rating` | numeric | Traditional NFL passer rating when under pressure. |
+| `center_deep_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws to the center of the field. |
+| `center_deep_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws to the center of the field, as charted by PFF. |
+| `no_screen_attempts` | numeric | Number of pass attempts excluding screen passes. |
+| `pa_passing_snaps` | numeric | Number of passing snaps played on play-action dropbacks. |
+| `aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways), as charted by PFF. |
+| `blitz_bats` | numeric | Number of pass attempts batted down at the line of scrimmage when blitzed. |
+| `pressure_touchdowns` | numeric | Number of passing touchdowns thrown when under pressure. |
+| `npa_completions` | numeric | Number of completed passes on non-play-action dropbacks. |
+| `short_spikes` | numeric | Number of clock-stopping spikes on short (0-9 air yards) throws. |
+| `pressure_thrown_aways` | numeric | Number of intentional throwaways when under pressure. |
+| `right_behind_los_completions` | numeric | Number of completed passes on throws behind the line of scrimmage to the right side of the field. |
+| `no_blitz_interceptions` | numeric | Number of passes intercepted when not blitzed. |
+| `center_behind_los_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage to the center of the field. |
+| `short_drops` | numeric | Number of catchable passes dropped by receivers on short (0-9 air yards) throws. |
+| `deep_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws, as charted by PFF. |
+| `right_medium_avg_depth_of_target` | numeric | Average depth of target in air yards on medium (10-19 air yards) throws to the right side of the field. |
+| `short_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws. |
+| `screen_touchdowns` | numeric | Number of passing touchdowns thrown on screen passes. |
+| `center_deep_qb_rating` | numeric | Traditional NFL passer rating on deep (20+ air yards) throws to the center of the field. |
+| `left_medium_completions` | numeric | Number of completed passes on medium (10-19 air yards) throws to the left side of the field. |
+| `center_deep_sacks` | numeric | Number of sacks taken on deep (20+ air yards) throws to the center of the field. |
+| `left_deep_big_time_throws` | numeric | Number of big-time throws on deep (20+ air yards) throws to the left side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `blitz_dropbacks` | numeric | Number of dropbacks when blitzed. |
+| `center_medium_first_downs` | numeric | Number of passing first downs gained on medium (10-19 air yards) throws to the center of the field. |
+| `center_medium_dropbacks` | numeric | Number of dropbacks on medium (10-19 air yards) throws to the center of the field. |
+| `blitz_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks when blitzed, as charted by PFF. |
+| `npa_first_downs` | numeric | Number of passing first downs gained on non-play-action dropbacks. |
+| `no_screen_touchdowns` | numeric | Number of passing touchdowns thrown excluding screen passes. |
+| `right_deep_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws to the right side of the field, as charted by PFF. |
+| `left_short_touchdowns` | numeric | Number of passing touchdowns thrown on short (0-9 air yards) throws to the left side of the field. |
+| `medium_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
-| `npa_yards` | numeric |  |
-| `left_medium_ypa` | numeric |  |
-| `right_medium_passing_snaps` | numeric |  |
-| `no_screen_ypa` | numeric |  |
-| `no_blitz_big_time_throws` | numeric |  |
-| `center_short_scrambles` | numeric |  |
-| `npa_turnover_worthy_plays` | numeric |  |
-| `left_behind_los_turnover_worthy_plays` | numeric |  |
-| `center_medium_yards` | numeric |  |
-| `center_deep_epa` | numeric |  |
-| `npa_interceptions` | numeric |  |
-| `left_medium_interceptions` | numeric |  |
-| `right_deep_interceptions` | numeric |  |
-| `no_pressure_avg_depth_of_target` | numeric |  |
-| `touchdowns` | numeric |  |
-| `medium_completion_percent` | numeric |  |
-| `right_behind_los_grades_pass` | numeric |  |
-| `deep_positive_epa_percent` | numeric |  |
-| `no_screen_pressure_to_sack_rate` | numeric |  |
-| `behind_los_accuracy_percent` | numeric |  |
-| `center_deep_scrambles` | numeric |  |
-| `center_short_twp_rate` | numeric |  |
-| `behind_los_touchdowns` | numeric |  |
-| `left_medium_qb_rating` | numeric |  |
-| `no_pressure_yards` | numeric |  |
-| `screen_sacks` | numeric |  |
-| `def_gen_pressures` | numeric |  |
-| `right_medium_completions` | numeric |  |
-| `right_behind_los_drops` | numeric |  |
-| `left_behind_los_first_downs` | numeric |  |
-| `blitz_twp_rate` | numeric |  |
-| `short_qb_rating` | numeric |  |
-| `blitz_accuracy_percent` | numeric |  |
-| `center_medium_btt_rate` | numeric |  |
-| `no_pressure_big_time_throws` | numeric |  |
-| `left_deep_grades_pass` | numeric |  |
-| `no_blitz_grades_pass_block` | numeric |  |
-| `screen_grades_hands_drop` | numeric |  |
-| `screen_grades_pass_block` | numeric |  |
-| `no_screen_grades_pass_block` | numeric |  |
-| `pressure_grades_pass_route` | numeric |  |
-| `no_screen_grades_pass_route` | numeric |  |
-| `pa_grades_hands_drop` | numeric |  |
-| `blitz_grades_pass_block` | numeric |  |
-| `screen_grades_pass_route` | numeric |  |
-| `no_pressure_grades_pass_block` | numeric |  |
-| `npa_grades_pass_block` | numeric |  |
-| `pressure_grades_pass_block` | numeric |  |
-| `pa_grades_pass_block` | numeric |  |
-| `no_pressure_grades_hands_drop` | numeric |  |
-| `npa_grades_pass_route` | numeric |  |
-| `npa_grades_hands_drop` | numeric |  |
-| `pa_grades_pass_route` | numeric |  |
-| `blitz_grades_hands_drop` | numeric |  |
-| `blitz_grades_pass_route` | numeric |  |
-| `no_screen_grades_hands_drop` | numeric |  |
-| `no_pressure_grades_pass_route` | numeric |  |
-| `no_blitz_grades_pass_route` | numeric |  |
-| `pressure_grades_hands_drop` | numeric |  |
-| `no_blitz_grades_hands_drop` | numeric |  |
-| `pa_grades_screen_block` | numeric |  |
-| `blitz_grades_run_block` | numeric |  |
-| `screen_grades_screen_block` | numeric |  |
-| `no_pressure_grades_run_block` | numeric |  |
-| `no_screen_grades_screen_block` | numeric |  |
-| `no_blitz_grades_run_block` | numeric |  |
-| `blitz_grades_screen_block` | numeric |  |
-| `pressure_grades_screen_block` | numeric |  |
-| `no_blitz_grades_screen_block` | numeric |  |
-| `npa_grades_screen_block` | numeric |  |
-| `pressure_grades_run_block` | numeric |  |
-| `no_pressure_grades_screen_block` | numeric |  |
-| `pa_grades_defense_penalty` | character |  |
-| `screen_grades_run_defense` | character |  |
-| `npa_grades_defense_penalty` | numeric |  |
-| `pa_grades_run_defense` | character |  |
-| `pa_grades_defense` | character |  |
-| `npa_grades_defense` | numeric |  |
-| `screen_grades_defense` | character |  |
-| `screen_grades_defense_penalty` | character |  |
-| `no_screen_grades_run_defense` | numeric |  |
-| `no_screen_grades_defense` | numeric |  |
-| `no_screen_grades_defense_penalty` | numeric |  |
-| `npa_grades_run_defense` | numeric |  |
+| `npa_yards` | numeric | Passing yards gained on non-play-action dropbacks. |
+| `left_medium_ypa` | numeric | Yards gained per pass attempt on medium (10-19 air yards) throws to the left side of the field. |
+| `right_medium_passing_snaps` | numeric | Number of passing snaps played on medium (10-19 air yards) throws to the right side of the field. |
+| `no_screen_ypa` | numeric | Yards gained per pass attempt excluding screen passes. |
+| `no_blitz_big_time_throws` | numeric | Number of big-time throws when not blitzed, per PFF's highest-value, highest-difficulty throw designation. |
+| `center_short_scrambles` | numeric | Number of scrambles on short (0-9 air yards) throws to the center of the field. |
+| `npa_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on non-play-action dropbacks, plays PFF charts as deserving of a turnover. |
+| `left_behind_los_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on throws behind the line of scrimmage to the left side of the field, plays PFF charts as deserving of a turnover. |
+| `center_medium_yards` | numeric | Passing yards gained on medium (10-19 air yards) throws to the center of the field. |
+| `center_deep_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws to the center of the field. |
+| `npa_interceptions` | numeric | Number of passes intercepted on non-play-action dropbacks. |
+| `left_medium_interceptions` | numeric | Number of passes intercepted on medium (10-19 air yards) throws to the left side of the field. |
+| `right_deep_interceptions` | numeric | Number of passes intercepted on deep (20+ air yards) throws to the right side of the field. |
+| `no_pressure_avg_depth_of_target` | numeric | Average depth of target in air yards from a clean pocket (no pressure). |
+| `touchdowns` | numeric | Number of passing touchdowns thrown. |
+| `medium_completion_percent` | numeric | Percentage of pass attempts completed on medium (10-19 air yards) throws. |
+| `right_behind_los_grades_pass` | numeric | PFF passing grade (0-100) on throws behind the line of scrimmage to the right side of the field. |
+| `deep_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws. |
+| `no_screen_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack excluding screen passes. |
+| `behind_los_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage. |
+| `center_deep_scrambles` | numeric | Number of scrambles on deep (20+ air yards) throws to the center of the field. |
+| `center_short_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws to the center of the field, per PFF charting. |
+| `behind_los_touchdowns` | numeric | Number of passing touchdowns thrown on throws behind the line of scrimmage. |
+| `left_medium_qb_rating` | numeric | Traditional NFL passer rating on medium (10-19 air yards) throws to the left side of the field. |
+| `no_pressure_yards` | numeric | Passing yards gained from a clean pocket (no pressure). |
+| `screen_sacks` | numeric | Number of sacks taken on screen passes. |
+| `def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks, as charted by PFF. |
+| `right_medium_completions` | numeric | Number of completed passes on medium (10-19 air yards) throws to the right side of the field. |
+| `right_behind_los_drops` | numeric | Number of catchable passes dropped by receivers on throws behind the line of scrimmage to the right side of the field. |
+| `left_behind_los_first_downs` | numeric | Number of passing first downs gained on throws behind the line of scrimmage to the left side of the field. |
+| `blitz_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts when blitzed, per PFF charting. |
+| `short_qb_rating` | numeric | Traditional NFL passer rating on short (0-9 air yards) throws. |
+| `blitz_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF when blitzed. |
+| `center_medium_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws to the center of the field, per PFF charting. |
+| `no_pressure_big_time_throws` | numeric | Number of big-time throws from a clean pocket (no pressure), per PFF's highest-value, highest-difficulty throw designation. |
+| `left_deep_grades_pass` | numeric | PFF passing grade (0-100) on deep (20+ air yards) throws to the left side of the field. |
+| `no_blitz_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) when not blitzed. |
+| `screen_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) on screen passes. |
+| `screen_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) on screen passes. |
+| `no_screen_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) excluding screen passes. |
+| `pressure_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) when under pressure. |
+| `no_screen_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) excluding screen passes. |
+| `pa_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) on play-action dropbacks. |
+| `blitz_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) when blitzed. |
+| `screen_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) on screen passes. |
+| `no_pressure_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) from a clean pocket (no pressure). |
+| `npa_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) on non-play-action dropbacks. |
+| `pressure_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) when under pressure. |
+| `pa_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) on play-action dropbacks. |
+| `no_pressure_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) from a clean pocket (no pressure). |
+| `npa_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) on non-play-action dropbacks. |
+| `npa_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) on non-play-action dropbacks. |
+| `pa_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) on play-action dropbacks. |
+| `blitz_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) when blitzed. |
+| `blitz_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) when blitzed. |
+| `no_screen_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) excluding screen passes. |
+| `no_pressure_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) from a clean pocket (no pressure). |
+| `no_blitz_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) when not blitzed. |
+| `pressure_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) when under pressure. |
+| `no_blitz_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) when not blitzed. |
+| `pa_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) on play-action dropbacks. |
+| `blitz_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) when blitzed. |
+| `screen_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) on screen passes. |
+| `no_pressure_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) from a clean pocket (no pressure). |
+| `no_screen_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) excluding screen passes. |
+| `no_blitz_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) when not blitzed. |
+| `blitz_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) when blitzed. |
+| `pressure_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) when under pressure. |
+| `no_blitz_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) when not blitzed. |
+| `npa_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) on non-play-action dropbacks. |
+| `pressure_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) when under pressure. |
+| `no_pressure_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) from a clean pocket (no pressure). |
+| `pa_grades_defense_penalty` | character | PFF defensive penalty grade for the player (0-100) on play-action dropbacks. |
+| `screen_grades_run_defense` | character | PFF run-defense grade for the player (0-100) on screen passes. |
+| `npa_grades_defense_penalty` | numeric | PFF defensive penalty grade for the player (0-100) on non-play-action dropbacks. |
+| `pa_grades_run_defense` | character | PFF run-defense grade for the player (0-100) on play-action dropbacks. |
+| `pa_grades_defense` | character | PFF overall defense grade for the player (0-100) on play-action dropbacks. |
+| `npa_grades_defense` | numeric | PFF overall defense grade for the player (0-100) on non-play-action dropbacks. |
+| `screen_grades_defense` | character | PFF overall defense grade for the player (0-100) on screen passes. |
+| `screen_grades_defense_penalty` | character | PFF defensive penalty grade for the player (0-100) on screen passes. |
+| `no_screen_grades_run_defense` | numeric | PFF run-defense grade for the player (0-100) excluding screen passes. |
+| `no_screen_grades_defense` | numeric | PFF overall defense grade for the player (0-100) excluding screen passes. |
+| `no_screen_grades_defense_penalty` | numeric | PFF defensive penalty grade for the player (0-100) excluding screen passes. |
+| `npa_grades_run_defense` | numeric | PFF run-defense grade for the player (0-100) on non-play-action dropbacks. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1987,32 +1987,32 @@ Facet report /offense/run_blocking (By Position leaderboard; add franchiseId for
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `declined_penalties` | numeric |  |
-| `draft_season` | numeric |  |
-| `eligible_season` | numeric |  |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `gap_grades_run_block` | numeric |  |
-| `gap_run_block_percent` | numeric |  |
-| `gap_snap_counts_run_block` | numeric |  |
-| `gap_snap_counts_run_block_percent` | numeric |  |
-| `gap_snap_counts_run_play` | numeric |  |
-| `grades_run_block` | numeric |  |
+| `gap_grades_run_block` | numeric | PFF run-blocking grade on gap-scheme runs, 0-100. |
+| `gap_run_block_percent` | numeric | Share of run-play snaps spent run blocking on gap-scheme runs. |
+| `gap_snap_counts_run_block` | numeric | Run-blocking snaps played on gap-scheme runs. |
+| `gap_snap_counts_run_block_percent` | numeric | Share of the player's run-blocking snaps on gap-scheme runs. |
+| `gap_snap_counts_run_play` | numeric | Run-play snaps on gap-scheme runs. |
+| `grades_run_block` | numeric | PFF run-blocking grade, 0-100. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `penalties` | numeric | Total number of penalties. |
 | `player` | character | Player name |
-| `player_game_count` | numeric |  |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 | `position` | character | Primary position as reported by NFL.com |
-| `run_block_percent` | numeric |  |
-| `snap_counts_run_block` | numeric |  |
-| `snap_counts_run_play` | numeric |  |
+| `run_block_percent` | numeric | Share of run-play snaps spent run blocking. |
+| `snap_counts_run_block` | numeric | Run-blocking snaps played. |
+| `snap_counts_run_play` | numeric | Run-play snaps. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `zone_grades_run_block` | numeric |  |
-| `zone_run_block_percent` | numeric |  |
-| `zone_snap_counts_run_block` | numeric |  |
-| `zone_snap_counts_run_block_percent` | numeric |  |
-| `zone_snap_counts_run_play` | numeric |  |
+| `zone_grades_run_block` | numeric | PFF run-blocking grade on zone-scheme runs, 0-100. |
+| `zone_run_block_percent` | numeric | Share of run-play snaps spent run blocking on zone-scheme runs. |
+| `zone_snap_counts_run_block` | numeric | Run-blocking snaps played on zone-scheme runs. |
+| `zone_snap_counts_run_block_percent` | numeric | Share of the player's run-blocking snaps on zone-scheme runs. |
+| `zone_snap_counts_run_play` | numeric | Run-play snaps on zone-scheme runs. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2046,39 +2046,39 @@ Facet report /offense/pass_blocking (By Position leaderboard; add franchiseId fo
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `true_pass_set_non_spike_pass_block_percentage` | numeric |  |
-| `true_pass_set_pressures_allowed` | numeric |  |
-| `grades_pass_block` | numeric |  |
-| `true_pass_set_pass_block_percent` | numeric |  |
-| `pbe` | numeric |  |
-| `non_spike_pass_block_percentage` | numeric |  |
-| `draft_season` | numeric |  |
+| `true_pass_set_non_spike_pass_block_percentage` | numeric | Share of non-spike pass-play snaps spent pass blocking on PFF-designated true pass sets. |
+| `true_pass_set_pressures_allowed` | numeric | Total pressures allowed (sacks, hits, and hurries) on PFF-designated true pass sets. |
+| `grades_pass_block` | numeric | PFF pass-blocking grade, 0-100. |
+| `true_pass_set_pass_block_percent` | numeric | Share of pass-play snaps spent pass blocking on PFF-designated true pass sets. |
+| `pbe` | numeric | PFF Pass Blocking Efficiency rating, pressures allowed per pass-blocking snap weighted toward sacks. |
+| `non_spike_pass_block_percentage` | numeric | Share of non-spike pass-play snaps spent pass blocking. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `hits_allowed` | numeric |  |
-| `true_pass_set_non_spike_pass_block` | numeric |  |
-| `player_game_count` | numeric |  |
-| `eligible_season` | numeric |  |
-| `hurries_allowed` | numeric |  |
-| `true_pass_set_hurries_allowed` | numeric |  |
-| `true_pass_set_snap_counts_pass_play` | numeric |  |
-| `true_pass_set_hits_allowed` | numeric |  |
-| `pressures_allowed` | numeric |  |
-| `true_pass_set_pbe` | numeric |  |
-| `snap_counts_pass_play` | numeric |  |
+| `hits_allowed` | numeric | Quarterback hits allowed. |
+| `true_pass_set_non_spike_pass_block` | numeric | Pass-blocking snaps excluding spike plays on PFF-designated true pass sets. |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `hurries_allowed` | numeric | Quarterback hurries allowed. |
+| `true_pass_set_hurries_allowed` | numeric | Quarterback hurries allowed on PFF-designated true pass sets. |
+| `true_pass_set_snap_counts_pass_play` | numeric | Pass-play snaps on PFF-designated true pass sets. |
+| `true_pass_set_hits_allowed` | numeric | Quarterback hits allowed on PFF-designated true pass sets. |
+| `pressures_allowed` | numeric | Total pressures allowed (sacks, hits, and hurries). |
+| `true_pass_set_pbe` | numeric | PFF Pass Blocking Efficiency rating, pressures allowed per pass-blocking snap weighted toward sacks on PFF-designated true pass sets. |
+| `snap_counts_pass_play` | numeric | Pass-play snaps. |
 | `penalties` | numeric | Total number of penalties. |
 | `sacks_allowed` | numeric | Opponent sacks. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `declined_penalties` | numeric |  |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
 | `position` | character | Primary position as reported by NFL.com |
-| `true_pass_set_grades_pass_block` | numeric |  |
-| `non_spike_pass_block` | numeric |  |
-| `true_pass_set_snap_counts_pass_block` | numeric |  |
+| `true_pass_set_grades_pass_block` | numeric | PFF pass-blocking grade on PFF-designated true pass sets, 0-100. |
+| `non_spike_pass_block` | numeric | Pass-blocking snaps excluding spike plays. |
+| `true_pass_set_snap_counts_pass_block` | numeric | Pass-blocking snaps played on PFF-designated true pass sets. |
 | `player` | character | Player name |
-| `true_pass_set_sacks_allowed` | numeric |  |
+| `true_pass_set_sacks_allowed` | numeric | Sacks allowed on PFF-designated true pass sets. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `snap_counts_pass_block` | numeric |  |
-| `pass_block_percent` | numeric |  |
+| `snap_counts_pass_block` | numeric | Pass-blocking snaps played. |
+| `pass_block_percent` | numeric | Share of pass-play snaps spent pass blocking. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -2143,24 +2143,24 @@ Facet report /passing/summary (By Position leaderboard; add franchiseId for By T
 | `attempts` | numeric | Pass attempts thrown by the passer. |
 | `team` | character | Team abbreviation the player is credited to for the range. |
 | `declined_penalties` | numeric | Declined penalties. |
-| `passing_snaps` | numeric |  |
-| `pressure_to_sack_rate` | numeric |  |
-| `ypa` | numeric |  |
+| `passing_snaps` | numeric | Number of passing snaps played. |
+| `pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack. |
+| `ypa` | numeric | Yards gained per pass attempt. |
 | `drops` | numeric | Throws dropped |
 | `position` | character | Primary position as reported by NFL.com |
-| `grades_hands_fumble` | numeric |  |
+| `grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100). |
 | `avg_time_to_throw` | numeric | Average time elapsed from the time of snap to throw on every pass attempt for a passer (sacks excluded). |
-| `big_time_throws` | numeric |  |
+| `big_time_throws` | numeric | Number of big-time throws, per PFF's highest-value, highest-difficulty throw designation. |
 | `player` | character | Player name |
-| `positive_epa_percent` | numeric |  |
+| `positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added. |
 | `franchise_id` | numeric | PFF franchise (team) id (integer join key). |
-| `avg_depth_of_target` | numeric |  |
-| `turnover_worthy_plays` | numeric |  |
+| `avg_depth_of_target` | numeric | Average depth of target in air yards. |
+| `turnover_worthy_plays` | numeric | Number of turnover-worthy plays, plays PFF charts as deserving of a turnover. |
 | `epa` | numeric | Expected points added (EPA) by the posteam for the given play. |
-| `aimed_passes` | numeric |  |
+| `aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways), as charted by PFF. |
 | `player_id` | numeric | PFF player id (integer; matches the /players id and every player_id join key). |
-| `touchdowns` | numeric |  |
-| `def_gen_pressures` | numeric |  |
+| `touchdowns` | numeric | Number of passing touchdowns thrown. |
+| `def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks, as charted by PFF. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2194,39 +2194,39 @@ Facet report /punting/summary (By Position leaderboard; add franchiseId for By T
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `touchbacks` | numeric |  |
-| `attempts_with_hangtime` | numeric |  |
-| `draft_season` | numeric |  |
-| `percent_returned` | numeric |  |
-| `fair_catches` | numeric |  |
+| `touchbacks` | numeric | Punts resulting in touchbacks. |
+| `attempts_with_hangtime` | numeric | Punts with a PFF-recorded hangtime. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `percent_returned` | numeric | Percentage of the player's punts that were returned. |
+| `fair_catches` | numeric | Punts fair-caught by the return team. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `player_game_count` | numeric |  |
-| `eligible_season` | numeric |  |
-| `average_net_yards` | numeric |  |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `average_net_yards` | numeric | Average net punting yards per attempt. |
 | `yards` | numeric | The number of receiving yards |
-| `average_hangtime` | numeric |  |
-| `total_net_yards` | numeric |  |
+| `average_hangtime` | numeric | Average punt hangtime in seconds. |
+| `total_net_yards` | numeric | Total net punting yards. |
 | `penalties` | numeric | Total number of penalties. |
 | `attempts` | numeric | The number of pass attempts as defined by the NFL. |
-| `inside_twenties` | numeric |  |
+| `inside_twenties` | numeric | Punts downed inside the opponent 20-yard line. |
 | `out_of_bounds` | numeric | 1 if play description contains ran ob, pushed ob, or sacked ob; 0 otherwise. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `average_yards_per_return` | numeric |  |
-| `total_hangtime` | numeric |  |
-| `declined_penalties` | numeric |  |
-| `returns` | numeric |  |
+| `average_yards_per_return` | numeric | Average return yards allowed per punt returned. |
+| `total_hangtime` | numeric | Total punt hangtime in seconds. |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `returns` | numeric | Punts returned by the opponent. |
 | `position` | character | Primary position as reported by NFL.com |
-| `long` | numeric |  |
+| `long` | numeric | Longest punt in yards. |
 | `blocks` | numeric | Total blocks. |
-| `average_yards_per_attempt` | numeric |  |
+| `average_yards_per_attempt` | numeric | Average gross punting yards per attempt. |
 | `player` | character | Player name |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `grades_punter` | numeric |  |
+| `grades_punter` | numeric | PFF punting grade, 0-100. |
 | `return_yards` | numeric | Yards gained by the return team. Returns may occur on any of: interception, fumble, kickoff, punt, or blocked kicks. |
-| `downeds` | numeric |  |
+| `downeds` | numeric | Punts downed by the coverage unit. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
-| `snaps` | numeric |  |
+| `snaps` | numeric | Punting snaps played. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2260,564 +2260,564 @@ Facet report /passing/depth (By Position leaderboard; add franchiseId for By Tea
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `left_behind_los_accuracy_percent` | numeric |  |
-| `left_short_scrambles` | numeric |  |
-| `center_short_first_downs` | numeric |  |
-| `right_short_bats` | numeric |  |
-| `right_behind_los_positive_epa_percent` | numeric |  |
-| `left_behind_los_completions` | numeric |  |
-| `left_medium_dropbacks` | numeric |  |
-| `right_medium_grades_pass` | numeric |  |
-| `right_medium_hit_as_threw` | numeric |  |
-| `behind_los_attempts_percent` | numeric |  |
-| `right_short_turnover_worthy_plays` | numeric |  |
-| `right_medium_qb_rating` | numeric |  |
-| `deep_twp_rate` | numeric |  |
-| `center_medium_sacks` | numeric |  |
-| `medium_interceptions` | numeric |  |
-| `left_deep_completions` | numeric |  |
-| `behind_los_spikes` | numeric |  |
-| `medium_aimed_passes` | numeric |  |
-| `center_behind_los_drops` | numeric |  |
-| `center_behind_los_interceptions` | numeric |  |
-| `behind_los_dropbacks` | numeric |  |
-| `left_behind_los_interceptions` | numeric |  |
-| `left_deep_first_downs` | numeric |  |
-| `deep_passing_snaps` | numeric |  |
-| `center_short_btt_rate` | numeric |  |
-| `center_medium_thrown_aways` | numeric |  |
-| `center_deep_avg_depth_of_target` | numeric |  |
-| `center_short_drops` | numeric |  |
-| `center_deep_first_downs` | numeric |  |
-| `left_medium_completion_percent` | numeric |  |
-| `center_deep_attempts` | numeric |  |
-| `center_behind_los_attempts` | numeric |  |
-| `right_short_positive_epa_percent` | numeric |  |
-| `center_deep_aimed_passes` | numeric |  |
-| `right_deep_grades_pass` | numeric |  |
-| `right_medium_big_time_throws` | numeric |  |
-| `deep_sack_percent` | numeric |  |
-| `center_medium_pressure_to_sack_rate` | numeric |  |
-| `deep_sacks` | numeric |  |
-| `right_medium_ypa` | numeric |  |
-| `left_deep_drop_rate` | numeric |  |
-| `right_medium_attempts_percent` | numeric |  |
-| `right_deep_btt_rate` | numeric |  |
-| `center_short_attempts_percent` | numeric |  |
-| `deep_drops` | numeric |  |
-| `center_behind_los_big_time_throws` | numeric |  |
-| `center_behind_los_touchdowns` | numeric |  |
-| `right_behind_los_twp_rate` | numeric |  |
-| `center_deep_completions` | numeric |  |
-| `center_short_attempts` | numeric |  |
-| `left_behind_los_sack_percent` | numeric |  |
-| `center_short_pressure_to_sack_rate` | numeric |  |
-| `deep_touchdowns` | numeric |  |
-| `center_behind_los_accuracy_percent` | numeric |  |
-| `center_deep_drop_rate` | numeric |  |
-| `right_short_first_downs` | numeric |  |
-| `right_behind_los_first_downs` | numeric |  |
-| `short_interceptions` | numeric |  |
-| `center_medium_scrambles` | numeric |  |
-| `left_behind_los_sacks` | numeric |  |
-| `left_short_ypa` | numeric |  |
-| `left_short_qb_rating` | numeric |  |
-| `right_behind_los_qb_rating` | numeric |  |
-| `draft_season` | numeric |  |
-| `right_behind_los_dropbacks` | numeric |  |
-| `behind_los_def_gen_pressures` | numeric |  |
-| `right_short_thrown_aways` | numeric |  |
-| `deep_def_gen_pressures` | numeric |  |
-| `right_short_btt_rate` | numeric |  |
-| `center_behind_los_positive_epa_percent` | numeric |  |
-| `left_behind_los_grades_pass` | numeric |  |
-| `deep_grades_pass` | numeric |  |
-| `center_short_turnover_worthy_plays` | numeric |  |
-| `center_behind_los_scrambles` | numeric |  |
-| `right_short_aimed_passes` | numeric |  |
-| `center_short_dropbacks` | numeric |  |
-| `medium_epa` | numeric |  |
-| `right_short_ypa` | numeric |  |
-| `center_medium_ypa` | numeric |  |
-| `medium_attempts` | numeric |  |
-| `right_deep_accuracy_percent` | numeric |  |
-| `behind_los_scrambles` | numeric |  |
-| `center_behind_los_completion_percent` | numeric |  |
-| `left_behind_los_btt_rate` | numeric |  |
-| `right_behind_los_btt_rate` | numeric |  |
+| `left_behind_los_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage to the left side of the field. |
+| `left_short_scrambles` | numeric | Number of scrambles on short (0-9 air yards) throws to the left side of the field. |
+| `center_short_first_downs` | numeric | Number of passing first downs gained on short (0-9 air yards) throws to the center of the field. |
+| `right_short_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws to the right side of the field. |
+| `right_behind_los_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on throws behind the line of scrimmage to the right side of the field. |
+| `left_behind_los_completions` | numeric | Number of completed passes on throws behind the line of scrimmage to the left side of the field. |
+| `left_medium_dropbacks` | numeric | Number of dropbacks on medium (10-19 air yards) throws to the left side of the field. |
+| `right_medium_grades_pass` | numeric | PFF passing grade (0-100) on medium (10-19 air yards) throws to the right side of the field. |
+| `right_medium_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws to the right side of the field, as charted by PFF. |
+| `behind_los_attempts_percent` | numeric | Share of the player's total pass attempts that came on throws behind the line of scrimmage, expressed as a percentage. |
+| `right_short_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on short (0-9 air yards) throws to the right side of the field, plays PFF charts as deserving of a turnover. |
+| `right_medium_qb_rating` | numeric | Traditional NFL passer rating on medium (10-19 air yards) throws to the right side of the field. |
+| `deep_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws, per PFF charting. |
+| `center_medium_sacks` | numeric | Number of sacks taken on medium (10-19 air yards) throws to the center of the field. |
+| `medium_interceptions` | numeric | Number of passes intercepted on medium (10-19 air yards) throws. |
+| `left_deep_completions` | numeric | Number of completed passes on deep (20+ air yards) throws to the left side of the field. |
+| `behind_los_spikes` | numeric | Number of clock-stopping spikes on throws behind the line of scrimmage. |
+| `medium_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards) throws, as charted by PFF. |
+| `center_behind_los_drops` | numeric | Number of catchable passes dropped by receivers on throws behind the line of scrimmage to the center of the field. |
+| `center_behind_los_interceptions` | numeric | Number of passes intercepted on throws behind the line of scrimmage to the center of the field. |
+| `behind_los_dropbacks` | numeric | Number of dropbacks on throws behind the line of scrimmage. |
+| `left_behind_los_interceptions` | numeric | Number of passes intercepted on throws behind the line of scrimmage to the left side of the field. |
+| `left_deep_first_downs` | numeric | Number of passing first downs gained on deep (20+ air yards) throws to the left side of the field. |
+| `deep_passing_snaps` | numeric | Number of passing snaps played on deep (20+ air yards) throws. |
+| `center_short_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws to the center of the field, per PFF charting. |
+| `center_medium_thrown_aways` | numeric | Number of intentional throwaways on medium (10-19 air yards) throws to the center of the field. |
+| `center_deep_avg_depth_of_target` | numeric | Average depth of target in air yards on deep (20+ air yards) throws to the center of the field. |
+| `center_short_drops` | numeric | Number of catchable passes dropped by receivers on short (0-9 air yards) throws to the center of the field. |
+| `center_deep_first_downs` | numeric | Number of passing first downs gained on deep (20+ air yards) throws to the center of the field. |
+| `left_medium_completion_percent` | numeric | Percentage of pass attempts completed on medium (10-19 air yards) throws to the left side of the field. |
+| `center_deep_attempts` | numeric | Number of pass attempts on deep (20+ air yards) throws to the center of the field. |
+| `center_behind_los_attempts` | numeric | Number of pass attempts on throws behind the line of scrimmage to the center of the field. |
+| `right_short_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws to the right side of the field. |
+| `center_deep_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws to the center of the field, as charted by PFF. |
+| `right_deep_grades_pass` | numeric | PFF passing grade (0-100) on deep (20+ air yards) throws to the right side of the field. |
+| `right_medium_big_time_throws` | numeric | Number of big-time throws on medium (10-19 air yards) throws to the right side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `deep_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws. |
+| `center_medium_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws to the center of the field. |
+| `deep_sacks` | numeric | Number of sacks taken on deep (20+ air yards) throws. |
+| `right_medium_ypa` | numeric | Yards gained per pass attempt on medium (10-19 air yards) throws to the right side of the field. |
+| `left_deep_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws to the left side of the field. |
+| `right_medium_attempts_percent` | numeric | Share of the player's total pass attempts that came on medium (10-19 air yards) throws to the right side of the field, expressed as a percentage. |
+| `right_deep_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws to the right side of the field, per PFF charting. |
+| `center_short_attempts_percent` | numeric | Share of the player's total pass attempts that came on short (0-9 air yards) throws to the center of the field, expressed as a percentage. |
+| `deep_drops` | numeric | Number of catchable passes dropped by receivers on deep (20+ air yards) throws. |
+| `center_behind_los_big_time_throws` | numeric | Number of big-time throws on throws behind the line of scrimmage to the center of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `center_behind_los_touchdowns` | numeric | Number of passing touchdowns thrown on throws behind the line of scrimmage to the center of the field. |
+| `right_behind_los_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage to the right side of the field, per PFF charting. |
+| `center_deep_completions` | numeric | Number of completed passes on deep (20+ air yards) throws to the center of the field. |
+| `center_short_attempts` | numeric | Number of pass attempts on short (0-9 air yards) throws to the center of the field. |
+| `left_behind_los_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage to the left side of the field. |
+| `center_short_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws to the center of the field. |
+| `deep_touchdowns` | numeric | Number of passing touchdowns thrown on deep (20+ air yards) throws. |
+| `center_behind_los_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage to the center of the field. |
+| `center_deep_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws to the center of the field. |
+| `right_short_first_downs` | numeric | Number of passing first downs gained on short (0-9 air yards) throws to the right side of the field. |
+| `right_behind_los_first_downs` | numeric | Number of passing first downs gained on throws behind the line of scrimmage to the right side of the field. |
+| `short_interceptions` | numeric | Number of passes intercepted on short (0-9 air yards) throws. |
+| `center_medium_scrambles` | numeric | Number of scrambles on medium (10-19 air yards) throws to the center of the field. |
+| `left_behind_los_sacks` | numeric | Number of sacks taken on throws behind the line of scrimmage to the left side of the field. |
+| `left_short_ypa` | numeric | Yards gained per pass attempt on short (0-9 air yards) throws to the left side of the field. |
+| `left_short_qb_rating` | numeric | Traditional NFL passer rating on short (0-9 air yards) throws to the left side of the field. |
+| `right_behind_los_qb_rating` | numeric | Traditional NFL passer rating on throws behind the line of scrimmage to the right side of the field. |
+| `draft_season` | numeric | NFL season (year) in which the player was drafted, per PFF player metadata. |
+| `right_behind_los_dropbacks` | numeric | Number of dropbacks on throws behind the line of scrimmage to the right side of the field. |
+| `behind_los_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on throws behind the line of scrimmage, as charted by PFF. |
+| `right_short_thrown_aways` | numeric | Number of intentional throwaways on short (0-9 air yards) throws to the right side of the field. |
+| `deep_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws, as charted by PFF. |
+| `right_short_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws to the right side of the field, per PFF charting. |
+| `center_behind_los_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on throws behind the line of scrimmage to the center of the field. |
+| `left_behind_los_grades_pass` | numeric | PFF passing grade (0-100) on throws behind the line of scrimmage to the left side of the field. |
+| `deep_grades_pass` | numeric | PFF passing grade (0-100) on deep (20+ air yards) throws. |
+| `center_short_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on short (0-9 air yards) throws to the center of the field, plays PFF charts as deserving of a turnover. |
+| `center_behind_los_scrambles` | numeric | Number of scrambles on throws behind the line of scrimmage to the center of the field. |
+| `right_short_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws to the right side of the field, as charted by PFF. |
+| `center_short_dropbacks` | numeric | Number of dropbacks on short (0-9 air yards) throws to the center of the field. |
+| `medium_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws. |
+| `right_short_ypa` | numeric | Yards gained per pass attempt on short (0-9 air yards) throws to the right side of the field. |
+| `center_medium_ypa` | numeric | Yards gained per pass attempt on medium (10-19 air yards) throws to the center of the field. |
+| `medium_attempts` | numeric | Number of pass attempts on medium (10-19 air yards) throws. |
+| `right_deep_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws to the right side of the field. |
+| `behind_los_scrambles` | numeric | Number of scrambles on throws behind the line of scrimmage. |
+| `center_behind_los_completion_percent` | numeric | Percentage of pass attempts completed on throws behind the line of scrimmage to the center of the field. |
+| `left_behind_los_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage to the left side of the field, per PFF charting. |
+| `right_behind_los_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage to the right side of the field, per PFF charting. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `short_touchdowns` | numeric |  |
-| `center_medium_drops` | numeric |  |
-| `left_behind_los_aimed_passes` | numeric |  |
-| `deep_attempts` | numeric |  |
-| `right_behind_los_sack_percent` | numeric |  |
-| `center_short_positive_epa_percent` | numeric |  |
-| `deep_avg_depth_of_target` | numeric |  |
-| `left_deep_btt_rate` | numeric |  |
-| `medium_scrambles` | numeric |  |
-| `center_behind_los_avg_depth_of_target` | numeric |  |
-| `short_attempts_percent` | numeric |  |
-| `right_behind_los_sacks` | numeric |  |
-| `center_medium_avg_time_to_throw` | numeric |  |
-| `left_short_pressure_to_sack_rate` | numeric |  |
-| `center_deep_sack_percent` | numeric |  |
-| `center_deep_ypa` | numeric |  |
-| `left_behind_los_hit_as_threw` | numeric |  |
-| `medium_big_time_throws` | numeric |  |
-| `deep_thrown_aways` | numeric |  |
-| `right_short_accuracy_percent` | numeric |  |
-| `left_deep_turnover_worthy_plays` | numeric |  |
-| `center_medium_bats` | numeric |  |
-| `right_short_grades_pass` | numeric |  |
-| `right_deep_spikes` | numeric |  |
-| `left_deep_passing_snaps` | numeric |  |
-| `center_medium_twp_rate` | numeric |  |
-| `right_behind_los_passing_snaps` | numeric |  |
-| `left_deep_qb_rating` | numeric |  |
-| `right_deep_drop_rate` | numeric |  |
-| `left_behind_los_drop_rate` | numeric |  |
-| `left_medium_drop_rate` | numeric |  |
-| `right_deep_attempts` | numeric |  |
-| `left_deep_spikes` | numeric |  |
-| `center_behind_los_dropbacks` | numeric |  |
-| `right_deep_big_time_throws` | numeric |  |
-| `medium_hit_as_threw` | numeric |  |
-| `right_short_dropbacks` | numeric |  |
-| `medium_def_gen_pressures` | numeric |  |
+| `short_touchdowns` | numeric | Number of passing touchdowns thrown on short (0-9 air yards) throws. |
+| `center_medium_drops` | numeric | Number of catchable passes dropped by receivers on medium (10-19 air yards) throws to the center of the field. |
+| `left_behind_los_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line of scrimmage to the left side of the field, as charted by PFF. |
+| `deep_attempts` | numeric | Number of pass attempts on deep (20+ air yards) throws. |
+| `right_behind_los_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage to the right side of the field. |
+| `center_short_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws to the center of the field. |
+| `deep_avg_depth_of_target` | numeric | Average depth of target in air yards on deep (20+ air yards) throws. |
+| `left_deep_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws to the left side of the field, per PFF charting. |
+| `medium_scrambles` | numeric | Number of scrambles on medium (10-19 air yards) throws. |
+| `center_behind_los_avg_depth_of_target` | numeric | Average depth of target in air yards on throws behind the line of scrimmage to the center of the field. |
+| `short_attempts_percent` | numeric | Share of the player's total pass attempts that came on short (0-9 air yards) throws, expressed as a percentage. |
+| `right_behind_los_sacks` | numeric | Number of sacks taken on throws behind the line of scrimmage to the right side of the field. |
+| `center_medium_avg_time_to_throw` | numeric | Average time from snap to release in seconds on medium (10-19 air yards) throws to the center of the field. |
+| `left_short_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws to the left side of the field. |
+| `center_deep_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws to the center of the field. |
+| `center_deep_ypa` | numeric | Yards gained per pass attempt on deep (20+ air yards) throws to the center of the field. |
+| `left_behind_los_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage to the left side of the field, as charted by PFF. |
+| `medium_big_time_throws` | numeric | Number of big-time throws on medium (10-19 air yards) throws, per PFF's highest-value, highest-difficulty throw designation. |
+| `deep_thrown_aways` | numeric | Number of intentional throwaways on deep (20+ air yards) throws. |
+| `right_short_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws to the right side of the field. |
+| `left_deep_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on deep (20+ air yards) throws to the left side of the field, plays PFF charts as deserving of a turnover. |
+| `center_medium_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws to the center of the field. |
+| `right_short_grades_pass` | numeric | PFF passing grade (0-100) on short (0-9 air yards) throws to the right side of the field. |
+| `right_deep_spikes` | numeric | Number of clock-stopping spikes on deep (20+ air yards) throws to the right side of the field. |
+| `left_deep_passing_snaps` | numeric | Number of passing snaps played on deep (20+ air yards) throws to the left side of the field. |
+| `center_medium_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws to the center of the field, per PFF charting. |
+| `right_behind_los_passing_snaps` | numeric | Number of passing snaps played on throws behind the line of scrimmage to the right side of the field. |
+| `left_deep_qb_rating` | numeric | Traditional NFL passer rating on deep (20+ air yards) throws to the left side of the field. |
+| `right_deep_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws to the right side of the field. |
+| `left_behind_los_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage to the left side of the field. |
+| `left_medium_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws to the left side of the field. |
+| `right_deep_attempts` | numeric | Number of pass attempts on deep (20+ air yards) throws to the right side of the field. |
+| `left_deep_spikes` | numeric | Number of clock-stopping spikes on deep (20+ air yards) throws to the left side of the field. |
+| `center_behind_los_dropbacks` | numeric | Number of dropbacks on throws behind the line of scrimmage to the center of the field. |
+| `right_deep_big_time_throws` | numeric | Number of big-time throws on deep (20+ air yards) throws to the right side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `medium_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws, as charted by PFF. |
+| `right_short_dropbacks` | numeric | Number of dropbacks on short (0-9 air yards) throws to the right side of the field. |
+| `medium_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards) throws, as charted by PFF. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `left_short_positive_epa_percent` | numeric |  |
-| `left_short_attempts` | numeric |  |
-| `center_deep_twp_rate` | numeric |  |
-| `right_medium_avg_time_to_throw` | numeric |  |
-| `left_behind_los_qb_rating` | numeric |  |
-| `left_behind_los_dropbacks` | numeric |  |
-| `deep_dropbacks` | numeric |  |
-| `right_behind_los_scrambles` | numeric |  |
-| `behind_los_interceptions` | numeric |  |
-| `right_deep_drops` | numeric |  |
-| `right_deep_yards` | numeric |  |
-| `right_short_hit_as_threw` | numeric |  |
-| `right_short_avg_depth_of_target` | numeric |  |
-| `short_bats` | numeric |  |
-| `right_deep_twp_rate` | numeric |  |
-| `right_behind_los_pressure_to_sack_rate` | numeric |  |
-| `deep_spikes` | numeric |  |
-| `center_medium_spikes` | numeric |  |
-| `behind_los_aimed_passes` | numeric |  |
-| `right_behind_los_touchdowns` | numeric |  |
-| `right_medium_pressure_to_sack_rate` | numeric |  |
-| `medium_thrown_aways` | numeric |  |
-| `short_sacks` | numeric |  |
-| `center_behind_los_twp_rate` | numeric |  |
-| `left_behind_los_attempts` | numeric |  |
-| `short_aimed_passes` | numeric |  |
-| `short_completions` | numeric |  |
-| `right_short_pressure_to_sack_rate` | numeric |  |
-| `medium_avg_depth_of_target` | numeric |  |
-| `left_behind_los_positive_epa_percent` | numeric |  |
-| `center_medium_attempts_percent` | numeric |  |
-| `left_medium_touchdowns` | numeric |  |
-| `center_short_bats` | numeric |  |
-| `left_deep_avg_time_to_throw` | numeric |  |
-| `center_behind_los_passing_snaps` | numeric |  |
-| `center_short_yards` | numeric |  |
-| `right_medium_btt_rate` | numeric |  |
-| `right_medium_scrambles` | numeric |  |
-| `medium_btt_rate` | numeric |  |
-| `center_behind_los_btt_rate` | numeric |  |
-| `center_short_avg_depth_of_target` | numeric |  |
-| `left_medium_sacks` | numeric |  |
-| `right_short_yards` | numeric |  |
-| `left_medium_first_downs` | numeric |  |
-| `right_medium_positive_epa_percent` | numeric |  |
-| `left_short_big_time_throws` | numeric |  |
-| `deep_turnover_worthy_plays` | numeric |  |
-| `left_deep_bats` | numeric |  |
-| `left_medium_turnover_worthy_plays` | numeric |  |
-| `base_dropbacks` | numeric |  |
-| `center_deep_drops` | numeric |  |
-| `center_medium_avg_depth_of_target` | numeric |  |
-| `center_behind_los_ypa` | numeric |  |
-| `right_short_attempts` | numeric |  |
-| `center_medium_completion_percent` | numeric |  |
-| `right_short_sack_percent` | numeric |  |
-| `left_behind_los_avg_depth_of_target` | numeric |  |
-| `center_medium_epa` | numeric |  |
-| `center_behind_los_sack_percent` | numeric |  |
-| `medium_completions` | numeric |  |
-| `medium_sack_percent` | numeric |  |
-| `left_short_grades_pass` | numeric |  |
-| `deep_btt_rate` | numeric |  |
-| `left_short_accuracy_percent` | numeric |  |
-| `short_twp_rate` | numeric |  |
-| `short_passing_snaps` | numeric |  |
-| `left_deep_sacks` | numeric |  |
-| `short_scrambles` | numeric |  |
-| `center_medium_turnover_worthy_plays` | numeric |  |
-| `behind_los_drop_rate` | numeric |  |
-| `right_behind_los_epa` | numeric |  |
-| `right_medium_aimed_passes` | numeric |  |
-| `short_accuracy_percent` | numeric |  |
-| `player_game_count` | numeric |  |
-| `short_btt_rate` | numeric |  |
-| `right_short_touchdowns` | numeric |  |
-| `center_short_completions` | numeric |  |
-| `right_short_spikes` | numeric |  |
-| `behind_los_first_downs` | numeric |  |
-| `right_medium_def_gen_pressures` | numeric |  |
-| `deep_pressure_to_sack_rate` | numeric |  |
-| `medium_qb_rating` | numeric |  |
-| `short_completion_percent` | numeric |  |
-| `right_deep_attempts_percent` | numeric |  |
-| `eligible_season` | numeric |  |
-| `short_big_time_throws` | numeric |  |
-| `behind_los_attempts` | numeric |  |
-| `center_behind_los_yards` | numeric |  |
-| `center_behind_los_bats` | numeric |  |
-| `center_behind_los_qb_rating` | numeric |  |
-| `right_deep_pressure_to_sack_rate` | numeric |  |
-| `center_short_accuracy_percent` | numeric |  |
-| `left_behind_los_bats` | numeric |  |
-| `center_deep_passing_snaps` | numeric |  |
-| `right_behind_los_hit_as_threw` | numeric |  |
-| `medium_bats` | numeric |  |
-| `right_medium_first_downs` | numeric |  |
-| `medium_spikes` | numeric |  |
-| `left_deep_thrown_aways` | numeric |  |
-| `right_deep_epa` | numeric |  |
-| `center_medium_hit_as_threw` | numeric |  |
-| `left_behind_los_completion_percent` | numeric |  |
-| `center_short_ypa` | numeric |  |
-| `right_short_drop_rate` | numeric |  |
-| `right_behind_los_accuracy_percent` | numeric |  |
-| `left_short_yards` | numeric |  |
-| `deep_accuracy_percent` | numeric |  |
-| `right_behind_los_avg_depth_of_target` | numeric |  |
-| `center_behind_los_thrown_aways` | numeric |  |
-| `center_behind_los_attempts_percent` | numeric |  |
-| `right_deep_first_downs` | numeric |  |
-| `left_short_completions` | numeric |  |
-| `deep_completion_percent` | numeric |  |
-| `left_deep_positive_epa_percent` | numeric |  |
-| `right_deep_sack_percent` | numeric |  |
-| `behind_los_pressure_to_sack_rate` | numeric |  |
-| `right_deep_touchdowns` | numeric |  |
-| `left_behind_los_def_gen_pressures` | numeric |  |
-| `left_behind_los_drops` | numeric |  |
-| `deep_epa` | numeric |  |
-| `left_deep_ypa` | numeric |  |
-| `medium_touchdowns` | numeric |  |
-| `left_medium_grades_pass` | numeric |  |
-| `right_behind_los_spikes` | numeric |  |
-| `medium_grades_pass` | numeric |  |
-| `behind_los_passing_snaps` | numeric |  |
-| `left_short_first_downs` | numeric |  |
-| `center_short_passing_snaps` | numeric |  |
-| `center_deep_accuracy_percent` | numeric |  |
-| `right_deep_positive_epa_percent` | numeric |  |
-| `right_medium_sack_percent` | numeric |  |
-| `right_deep_qb_rating` | numeric |  |
-| `right_short_completion_percent` | numeric |  |
-| `right_behind_los_interceptions` | numeric |  |
-| `behind_los_yards` | numeric |  |
-| `center_behind_los_grades_pass` | numeric |  |
-| `left_deep_dropbacks` | numeric |  |
-| `center_behind_los_spikes` | numeric |  |
-| `right_behind_los_aimed_passes` | numeric |  |
-| `left_short_interceptions` | numeric |  |
-| `right_medium_interceptions` | numeric |  |
-| `left_behind_los_yards` | numeric |  |
-| `center_deep_btt_rate` | numeric |  |
-| `medium_first_downs` | numeric |  |
-| `left_short_avg_depth_of_target` | numeric |  |
-| `left_behind_los_ypa` | numeric |  |
-| `short_attempts` | numeric |  |
-| `right_medium_bats` | numeric |  |
-| `left_behind_los_touchdowns` | numeric |  |
-| `right_medium_dropbacks` | numeric |  |
-| `short_turnover_worthy_plays` | numeric |  |
-| `right_deep_thrown_aways` | numeric |  |
-| `right_behind_los_drop_rate` | numeric |  |
-| `right_short_qb_rating` | numeric |  |
-| `medium_sacks` | numeric |  |
-| `center_deep_attempts_percent` | numeric |  |
-| `left_short_dropbacks` | numeric |  |
-| `behind_los_drops` | numeric |  |
-| `short_sack_percent` | numeric |  |
-| `left_medium_spikes` | numeric |  |
-| `left_medium_accuracy_percent` | numeric |  |
-| `behind_los_completions` | numeric |  |
-| `behind_los_sack_percent` | numeric |  |
-| `left_deep_yards` | numeric |  |
-| `left_short_aimed_passes` | numeric |  |
-| `center_behind_los_completions` | numeric |  |
-| `left_short_thrown_aways` | numeric |  |
-| `left_short_sack_percent` | numeric |  |
-| `center_short_thrown_aways` | numeric |  |
-| `center_short_interceptions` | numeric |  |
-| `short_avg_depth_of_target` | numeric |  |
-| `left_deep_touchdowns` | numeric |  |
-| `deep_yards` | numeric |  |
-| `center_behind_los_turnover_worthy_plays` | numeric |  |
-| `medium_ypa` | numeric |  |
-| `left_medium_epa` | numeric |  |
-| `left_deep_avg_depth_of_target` | numeric |  |
-| `deep_first_downs` | numeric |  |
-| `short_drop_rate` | numeric |  |
-| `left_medium_bats` | numeric |  |
-| `center_deep_spikes` | numeric |  |
-| `center_short_hit_as_threw` | numeric |  |
-| `left_medium_positive_epa_percent` | numeric |  |
-| `center_deep_touchdowns` | numeric |  |
-| `right_deep_ypa` | numeric |  |
-| `right_short_big_time_throws` | numeric |  |
-| `center_short_big_time_throws` | numeric |  |
-| `short_positive_epa_percent` | numeric |  |
-| `left_behind_los_avg_time_to_throw` | numeric |  |
-| `right_deep_passing_snaps` | numeric |  |
-| `right_short_twp_rate` | numeric |  |
-| `center_medium_attempts` | numeric |  |
-| `right_deep_avg_time_to_throw` | numeric |  |
-| `center_deep_def_gen_pressures` | numeric |  |
-| `behind_los_epa` | numeric |  |
-| `right_medium_twp_rate` | numeric |  |
-| `right_deep_aimed_passes` | numeric |  |
-| `right_deep_scrambles` | numeric |  |
-| `deep_big_time_throws` | numeric |  |
-| `left_short_turnover_worthy_plays` | numeric |  |
-| `center_short_touchdowns` | numeric |  |
-| `right_medium_drops` | numeric |  |
-| `left_deep_epa` | numeric |  |
-| `short_ypa` | numeric |  |
-| `medium_pressure_to_sack_rate` | numeric |  |
-| `left_medium_thrown_aways` | numeric |  |
-| `right_behind_los_avg_time_to_throw` | numeric |  |
-| `behind_los_btt_rate` | numeric |  |
-| `medium_avg_time_to_throw` | numeric |  |
-| `center_deep_completion_percent` | numeric |  |
-| `behind_los_avg_time_to_throw` | numeric |  |
-| `right_medium_touchdowns` | numeric |  |
-| `center_short_avg_time_to_throw` | numeric |  |
-| `left_deep_aimed_passes` | numeric |  |
-| `left_medium_yards` | numeric |  |
-| `center_medium_touchdowns` | numeric |  |
-| `center_short_drop_rate` | numeric |  |
-| `left_short_twp_rate` | numeric |  |
+| `left_short_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws to the left side of the field. |
+| `left_short_attempts` | numeric | Number of pass attempts on short (0-9 air yards) throws to the left side of the field. |
+| `center_deep_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws to the center of the field, per PFF charting. |
+| `right_medium_avg_time_to_throw` | numeric | Average time from snap to release in seconds on medium (10-19 air yards) throws to the right side of the field. |
+| `left_behind_los_qb_rating` | numeric | Traditional NFL passer rating on throws behind the line of scrimmage to the left side of the field. |
+| `left_behind_los_dropbacks` | numeric | Number of dropbacks on throws behind the line of scrimmage to the left side of the field. |
+| `deep_dropbacks` | numeric | Number of dropbacks on deep (20+ air yards) throws. |
+| `right_behind_los_scrambles` | numeric | Number of scrambles on throws behind the line of scrimmage to the right side of the field. |
+| `behind_los_interceptions` | numeric | Number of passes intercepted on throws behind the line of scrimmage. |
+| `right_deep_drops` | numeric | Number of catchable passes dropped by receivers on deep (20+ air yards) throws to the right side of the field. |
+| `right_deep_yards` | numeric | Passing yards gained on deep (20+ air yards) throws to the right side of the field. |
+| `right_short_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws to the right side of the field, as charted by PFF. |
+| `right_short_avg_depth_of_target` | numeric | Average depth of target in air yards on short (0-9 air yards) throws to the right side of the field. |
+| `short_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws. |
+| `right_deep_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws to the right side of the field, per PFF charting. |
+| `right_behind_los_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on throws behind the line of scrimmage to the right side of the field. |
+| `deep_spikes` | numeric | Number of clock-stopping spikes on deep (20+ air yards) throws. |
+| `center_medium_spikes` | numeric | Number of clock-stopping spikes on medium (10-19 air yards) throws to the center of the field. |
+| `behind_los_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line of scrimmage, as charted by PFF. |
+| `right_behind_los_touchdowns` | numeric | Number of passing touchdowns thrown on throws behind the line of scrimmage to the right side of the field. |
+| `right_medium_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws to the right side of the field. |
+| `medium_thrown_aways` | numeric | Number of intentional throwaways on medium (10-19 air yards) throws. |
+| `short_sacks` | numeric | Number of sacks taken on short (0-9 air yards) throws. |
+| `center_behind_los_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage to the center of the field, per PFF charting. |
+| `left_behind_los_attempts` | numeric | Number of pass attempts on throws behind the line of scrimmage to the left side of the field. |
+| `short_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws, as charted by PFF. |
+| `short_completions` | numeric | Number of completed passes on short (0-9 air yards) throws. |
+| `right_short_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws to the right side of the field. |
+| `medium_avg_depth_of_target` | numeric | Average depth of target in air yards on medium (10-19 air yards) throws. |
+| `left_behind_los_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on throws behind the line of scrimmage to the left side of the field. |
+| `center_medium_attempts_percent` | numeric | Share of the player's total pass attempts that came on medium (10-19 air yards) throws to the center of the field, expressed as a percentage. |
+| `left_medium_touchdowns` | numeric | Number of passing touchdowns thrown on medium (10-19 air yards) throws to the left side of the field. |
+| `center_short_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws to the center of the field. |
+| `left_deep_avg_time_to_throw` | numeric | Average time from snap to release in seconds on deep (20+ air yards) throws to the left side of the field. |
+| `center_behind_los_passing_snaps` | numeric | Number of passing snaps played on throws behind the line of scrimmage to the center of the field. |
+| `center_short_yards` | numeric | Passing yards gained on short (0-9 air yards) throws to the center of the field. |
+| `right_medium_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws to the right side of the field, per PFF charting. |
+| `right_medium_scrambles` | numeric | Number of scrambles on medium (10-19 air yards) throws to the right side of the field. |
+| `medium_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws, per PFF charting. |
+| `center_behind_los_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage to the center of the field, per PFF charting. |
+| `center_short_avg_depth_of_target` | numeric | Average depth of target in air yards on short (0-9 air yards) throws to the center of the field. |
+| `left_medium_sacks` | numeric | Number of sacks taken on medium (10-19 air yards) throws to the left side of the field. |
+| `right_short_yards` | numeric | Passing yards gained on short (0-9 air yards) throws to the right side of the field. |
+| `left_medium_first_downs` | numeric | Number of passing first downs gained on medium (10-19 air yards) throws to the left side of the field. |
+| `right_medium_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on medium (10-19 air yards) throws to the right side of the field. |
+| `left_short_big_time_throws` | numeric | Number of big-time throws on short (0-9 air yards) throws to the left side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `deep_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on deep (20+ air yards) throws, plays PFF charts as deserving of a turnover. |
+| `left_deep_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws to the left side of the field. |
+| `left_medium_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on medium (10-19 air yards) throws to the left side of the field, plays PFF charts as deserving of a turnover. |
+| `base_dropbacks` | numeric | Number of dropbacks across all splits, the baseline total for this facet. |
+| `center_deep_drops` | numeric | Number of catchable passes dropped by receivers on deep (20+ air yards) throws to the center of the field. |
+| `center_medium_avg_depth_of_target` | numeric | Average depth of target in air yards on medium (10-19 air yards) throws to the center of the field. |
+| `center_behind_los_ypa` | numeric | Yards gained per pass attempt on throws behind the line of scrimmage to the center of the field. |
+| `right_short_attempts` | numeric | Number of pass attempts on short (0-9 air yards) throws to the right side of the field. |
+| `center_medium_completion_percent` | numeric | Percentage of pass attempts completed on medium (10-19 air yards) throws to the center of the field. |
+| `right_short_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws to the right side of the field. |
+| `left_behind_los_avg_depth_of_target` | numeric | Average depth of target in air yards on throws behind the line of scrimmage to the left side of the field. |
+| `center_medium_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws to the center of the field. |
+| `center_behind_los_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage to the center of the field. |
+| `medium_completions` | numeric | Number of completed passes on medium (10-19 air yards) throws. |
+| `medium_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws. |
+| `left_short_grades_pass` | numeric | PFF passing grade (0-100) on short (0-9 air yards) throws to the left side of the field. |
+| `deep_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws, per PFF charting. |
+| `left_short_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws to the left side of the field. |
+| `short_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws, per PFF charting. |
+| `short_passing_snaps` | numeric | Number of passing snaps played on short (0-9 air yards) throws. |
+| `left_deep_sacks` | numeric | Number of sacks taken on deep (20+ air yards) throws to the left side of the field. |
+| `short_scrambles` | numeric | Number of scrambles on short (0-9 air yards) throws. |
+| `center_medium_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on medium (10-19 air yards) throws to the center of the field, plays PFF charts as deserving of a turnover. |
+| `behind_los_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage. |
+| `right_behind_los_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage to the right side of the field. |
+| `right_medium_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards) throws to the right side of the field, as charted by PFF. |
+| `short_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws. |
+| `player_game_count` | numeric | Number of games the player appeared in during the period covered. |
+| `short_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws, per PFF charting. |
+| `right_short_touchdowns` | numeric | Number of passing touchdowns thrown on short (0-9 air yards) throws to the right side of the field. |
+| `center_short_completions` | numeric | Number of completed passes on short (0-9 air yards) throws to the center of the field. |
+| `right_short_spikes` | numeric | Number of clock-stopping spikes on short (0-9 air yards) throws to the right side of the field. |
+| `behind_los_first_downs` | numeric | Number of passing first downs gained on throws behind the line of scrimmage. |
+| `right_medium_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards) throws to the right side of the field, as charted by PFF. |
+| `deep_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws. |
+| `medium_qb_rating` | numeric | Traditional NFL passer rating on medium (10-19 air yards) throws. |
+| `short_completion_percent` | numeric | Percentage of pass attempts completed on short (0-9 air yards) throws. |
+| `right_deep_attempts_percent` | numeric | Share of the player's total pass attempts that came on deep (20+ air yards) throws to the right side of the field, expressed as a percentage. |
+| `eligible_season` | numeric | Season (year) of the player's NFL draft eligibility, per PFF player metadata. |
+| `short_big_time_throws` | numeric | Number of big-time throws on short (0-9 air yards) throws, per PFF's highest-value, highest-difficulty throw designation. |
+| `behind_los_attempts` | numeric | Number of pass attempts on throws behind the line of scrimmage. |
+| `center_behind_los_yards` | numeric | Passing yards gained on throws behind the line of scrimmage to the center of the field. |
+| `center_behind_los_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage to the center of the field. |
+| `center_behind_los_qb_rating` | numeric | Traditional NFL passer rating on throws behind the line of scrimmage to the center of the field. |
+| `right_deep_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws to the right side of the field. |
+| `center_short_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws to the center of the field. |
+| `left_behind_los_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage to the left side of the field. |
+| `center_deep_passing_snaps` | numeric | Number of passing snaps played on deep (20+ air yards) throws to the center of the field. |
+| `right_behind_los_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage to the right side of the field, as charted by PFF. |
+| `medium_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws. |
+| `right_medium_first_downs` | numeric | Number of passing first downs gained on medium (10-19 air yards) throws to the right side of the field. |
+| `medium_spikes` | numeric | Number of clock-stopping spikes on medium (10-19 air yards) throws. |
+| `left_deep_thrown_aways` | numeric | Number of intentional throwaways on deep (20+ air yards) throws to the left side of the field. |
+| `right_deep_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws to the right side of the field. |
+| `center_medium_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws to the center of the field, as charted by PFF. |
+| `left_behind_los_completion_percent` | numeric | Percentage of pass attempts completed on throws behind the line of scrimmage to the left side of the field. |
+| `center_short_ypa` | numeric | Yards gained per pass attempt on short (0-9 air yards) throws to the center of the field. |
+| `right_short_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws to the right side of the field. |
+| `right_behind_los_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage to the right side of the field. |
+| `left_short_yards` | numeric | Passing yards gained on short (0-9 air yards) throws to the left side of the field. |
+| `deep_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws. |
+| `right_behind_los_avg_depth_of_target` | numeric | Average depth of target in air yards on throws behind the line of scrimmage to the right side of the field. |
+| `center_behind_los_thrown_aways` | numeric | Number of intentional throwaways on throws behind the line of scrimmage to the center of the field. |
+| `center_behind_los_attempts_percent` | numeric | Share of the player's total pass attempts that came on throws behind the line of scrimmage to the center of the field, expressed as a percentage. |
+| `right_deep_first_downs` | numeric | Number of passing first downs gained on deep (20+ air yards) throws to the right side of the field. |
+| `left_short_completions` | numeric | Number of completed passes on short (0-9 air yards) throws to the left side of the field. |
+| `deep_completion_percent` | numeric | Percentage of pass attempts completed on deep (20+ air yards) throws. |
+| `left_deep_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws to the left side of the field. |
+| `right_deep_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws to the right side of the field. |
+| `behind_los_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on throws behind the line of scrimmage. |
+| `right_deep_touchdowns` | numeric | Number of passing touchdowns thrown on deep (20+ air yards) throws to the right side of the field. |
+| `left_behind_los_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on throws behind the line of scrimmage to the left side of the field, as charted by PFF. |
+| `left_behind_los_drops` | numeric | Number of catchable passes dropped by receivers on throws behind the line of scrimmage to the left side of the field. |
+| `deep_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws. |
+| `left_deep_ypa` | numeric | Yards gained per pass attempt on deep (20+ air yards) throws to the left side of the field. |
+| `medium_touchdowns` | numeric | Number of passing touchdowns thrown on medium (10-19 air yards) throws. |
+| `left_medium_grades_pass` | numeric | PFF passing grade (0-100) on medium (10-19 air yards) throws to the left side of the field. |
+| `right_behind_los_spikes` | numeric | Number of clock-stopping spikes on throws behind the line of scrimmage to the right side of the field. |
+| `medium_grades_pass` | numeric | PFF passing grade (0-100) on medium (10-19 air yards) throws. |
+| `behind_los_passing_snaps` | numeric | Number of passing snaps played on throws behind the line of scrimmage. |
+| `left_short_first_downs` | numeric | Number of passing first downs gained on short (0-9 air yards) throws to the left side of the field. |
+| `center_short_passing_snaps` | numeric | Number of passing snaps played on short (0-9 air yards) throws to the center of the field. |
+| `center_deep_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws to the center of the field. |
+| `right_deep_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws to the right side of the field. |
+| `right_medium_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws to the right side of the field. |
+| `right_deep_qb_rating` | numeric | Traditional NFL passer rating on deep (20+ air yards) throws to the right side of the field. |
+| `right_short_completion_percent` | numeric | Percentage of pass attempts completed on short (0-9 air yards) throws to the right side of the field. |
+| `right_behind_los_interceptions` | numeric | Number of passes intercepted on throws behind the line of scrimmage to the right side of the field. |
+| `behind_los_yards` | numeric | Passing yards gained on throws behind the line of scrimmage. |
+| `center_behind_los_grades_pass` | numeric | PFF passing grade (0-100) on throws behind the line of scrimmage to the center of the field. |
+| `left_deep_dropbacks` | numeric | Number of dropbacks on deep (20+ air yards) throws to the left side of the field. |
+| `center_behind_los_spikes` | numeric | Number of clock-stopping spikes on throws behind the line of scrimmage to the center of the field. |
+| `right_behind_los_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line of scrimmage to the right side of the field, as charted by PFF. |
+| `left_short_interceptions` | numeric | Number of passes intercepted on short (0-9 air yards) throws to the left side of the field. |
+| `right_medium_interceptions` | numeric | Number of passes intercepted on medium (10-19 air yards) throws to the right side of the field. |
+| `left_behind_los_yards` | numeric | Passing yards gained on throws behind the line of scrimmage to the left side of the field. |
+| `center_deep_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws to the center of the field, per PFF charting. |
+| `medium_first_downs` | numeric | Number of passing first downs gained on medium (10-19 air yards) throws. |
+| `left_short_avg_depth_of_target` | numeric | Average depth of target in air yards on short (0-9 air yards) throws to the left side of the field. |
+| `left_behind_los_ypa` | numeric | Yards gained per pass attempt on throws behind the line of scrimmage to the left side of the field. |
+| `short_attempts` | numeric | Number of pass attempts on short (0-9 air yards) throws. |
+| `right_medium_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws to the right side of the field. |
+| `left_behind_los_touchdowns` | numeric | Number of passing touchdowns thrown on throws behind the line of scrimmage to the left side of the field. |
+| `right_medium_dropbacks` | numeric | Number of dropbacks on medium (10-19 air yards) throws to the right side of the field. |
+| `short_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on short (0-9 air yards) throws, plays PFF charts as deserving of a turnover. |
+| `right_deep_thrown_aways` | numeric | Number of intentional throwaways on deep (20+ air yards) throws to the right side of the field. |
+| `right_behind_los_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage to the right side of the field. |
+| `right_short_qb_rating` | numeric | Traditional NFL passer rating on short (0-9 air yards) throws to the right side of the field. |
+| `medium_sacks` | numeric | Number of sacks taken on medium (10-19 air yards) throws. |
+| `center_deep_attempts_percent` | numeric | Share of the player's total pass attempts that came on deep (20+ air yards) throws to the center of the field, expressed as a percentage. |
+| `left_short_dropbacks` | numeric | Number of dropbacks on short (0-9 air yards) throws to the left side of the field. |
+| `behind_los_drops` | numeric | Number of catchable passes dropped by receivers on throws behind the line of scrimmage. |
+| `short_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws. |
+| `left_medium_spikes` | numeric | Number of clock-stopping spikes on medium (10-19 air yards) throws to the left side of the field. |
+| `left_medium_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws to the left side of the field. |
+| `behind_los_completions` | numeric | Number of completed passes on throws behind the line of scrimmage. |
+| `behind_los_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage. |
+| `left_deep_yards` | numeric | Passing yards gained on deep (20+ air yards) throws to the left side of the field. |
+| `left_short_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws to the left side of the field, as charted by PFF. |
+| `center_behind_los_completions` | numeric | Number of completed passes on throws behind the line of scrimmage to the center of the field. |
+| `left_short_thrown_aways` | numeric | Number of intentional throwaways on short (0-9 air yards) throws to the left side of the field. |
+| `left_short_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws to the left side of the field. |
+| `center_short_thrown_aways` | numeric | Number of intentional throwaways on short (0-9 air yards) throws to the center of the field. |
+| `center_short_interceptions` | numeric | Number of passes intercepted on short (0-9 air yards) throws to the center of the field. |
+| `short_avg_depth_of_target` | numeric | Average depth of target in air yards on short (0-9 air yards) throws. |
+| `left_deep_touchdowns` | numeric | Number of passing touchdowns thrown on deep (20+ air yards) throws to the left side of the field. |
+| `deep_yards` | numeric | Passing yards gained on deep (20+ air yards) throws. |
+| `center_behind_los_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on throws behind the line of scrimmage to the center of the field, plays PFF charts as deserving of a turnover. |
+| `medium_ypa` | numeric | Yards gained per pass attempt on medium (10-19 air yards) throws. |
+| `left_medium_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws to the left side of the field. |
+| `left_deep_avg_depth_of_target` | numeric | Average depth of target in air yards on deep (20+ air yards) throws to the left side of the field. |
+| `deep_first_downs` | numeric | Number of passing first downs gained on deep (20+ air yards) throws. |
+| `short_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws. |
+| `left_medium_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws to the left side of the field. |
+| `center_deep_spikes` | numeric | Number of clock-stopping spikes on deep (20+ air yards) throws to the center of the field. |
+| `center_short_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws to the center of the field, as charted by PFF. |
+| `left_medium_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on medium (10-19 air yards) throws to the left side of the field. |
+| `center_deep_touchdowns` | numeric | Number of passing touchdowns thrown on deep (20+ air yards) throws to the center of the field. |
+| `right_deep_ypa` | numeric | Yards gained per pass attempt on deep (20+ air yards) throws to the right side of the field. |
+| `right_short_big_time_throws` | numeric | Number of big-time throws on short (0-9 air yards) throws to the right side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `center_short_big_time_throws` | numeric | Number of big-time throws on short (0-9 air yards) throws to the center of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `short_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws. |
+| `left_behind_los_avg_time_to_throw` | numeric | Average time from snap to release in seconds on throws behind the line of scrimmage to the left side of the field. |
+| `right_deep_passing_snaps` | numeric | Number of passing snaps played on deep (20+ air yards) throws to the right side of the field. |
+| `right_short_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws to the right side of the field, per PFF charting. |
+| `center_medium_attempts` | numeric | Number of pass attempts on medium (10-19 air yards) throws to the center of the field. |
+| `right_deep_avg_time_to_throw` | numeric | Average time from snap to release in seconds on deep (20+ air yards) throws to the right side of the field. |
+| `center_deep_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws to the center of the field, as charted by PFF. |
+| `behind_los_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage. |
+| `right_medium_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws to the right side of the field, per PFF charting. |
+| `right_deep_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws to the right side of the field, as charted by PFF. |
+| `right_deep_scrambles` | numeric | Number of scrambles on deep (20+ air yards) throws to the right side of the field. |
+| `deep_big_time_throws` | numeric | Number of big-time throws on deep (20+ air yards) throws, per PFF's highest-value, highest-difficulty throw designation. |
+| `left_short_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on short (0-9 air yards) throws to the left side of the field, plays PFF charts as deserving of a turnover. |
+| `center_short_touchdowns` | numeric | Number of passing touchdowns thrown on short (0-9 air yards) throws to the center of the field. |
+| `right_medium_drops` | numeric | Number of catchable passes dropped by receivers on medium (10-19 air yards) throws to the right side of the field. |
+| `left_deep_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws to the left side of the field. |
+| `short_ypa` | numeric | Yards gained per pass attempt on short (0-9 air yards) throws. |
+| `medium_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws. |
+| `left_medium_thrown_aways` | numeric | Number of intentional throwaways on medium (10-19 air yards) throws to the left side of the field. |
+| `right_behind_los_avg_time_to_throw` | numeric | Average time from snap to release in seconds on throws behind the line of scrimmage to the right side of the field. |
+| `behind_los_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage, per PFF charting. |
+| `medium_avg_time_to_throw` | numeric | Average time from snap to release in seconds on medium (10-19 air yards) throws. |
+| `center_deep_completion_percent` | numeric | Percentage of pass attempts completed on deep (20+ air yards) throws to the center of the field. |
+| `behind_los_avg_time_to_throw` | numeric | Average time from snap to release in seconds on throws behind the line of scrimmage. |
+| `right_medium_touchdowns` | numeric | Number of passing touchdowns thrown on medium (10-19 air yards) throws to the right side of the field. |
+| `center_short_avg_time_to_throw` | numeric | Average time from snap to release in seconds on short (0-9 air yards) throws to the center of the field. |
+| `left_deep_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws to the left side of the field, as charted by PFF. |
+| `left_medium_yards` | numeric | Passing yards gained on medium (10-19 air yards) throws to the left side of the field. |
+| `center_medium_touchdowns` | numeric | Number of passing touchdowns thrown on medium (10-19 air yards) throws to the center of the field. |
+| `center_short_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws to the center of the field. |
+| `left_short_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws to the left side of the field, per PFF charting. |
 | `penalties` | numeric | Total number of penalties. |
-| `right_behind_los_attempts_percent` | numeric |  |
-| `right_deep_avg_depth_of_target` | numeric |  |
-| `behind_los_sacks` | numeric |  |
-| `center_deep_yards` | numeric |  |
-| `short_dropbacks` | numeric |  |
-| `left_deep_sack_percent` | numeric |  |
-| `center_behind_los_avg_time_to_throw` | numeric |  |
-| `behind_los_avg_depth_of_target` | numeric |  |
-| `left_behind_los_epa` | numeric |  |
-| `medium_twp_rate` | numeric |  |
-| `left_short_def_gen_pressures` | numeric |  |
-| `medium_turnover_worthy_plays` | numeric |  |
-| `behind_los_twp_rate` | numeric |  |
-| `left_behind_los_thrown_aways` | numeric |  |
-| `left_short_bats` | numeric |  |
-| `center_medium_drop_rate` | numeric |  |
-| `right_deep_bats` | numeric |  |
-| `medium_yards` | numeric |  |
-| `center_deep_grades_pass` | numeric |  |
-| `center_medium_passing_snaps` | numeric |  |
-| `center_behind_los_first_downs` | numeric |  |
-| `center_medium_interceptions` | numeric |  |
-| `behind_los_grades_pass` | numeric |  |
-| `left_short_hit_as_threw` | numeric |  |
-| `deep_qb_rating` | numeric |  |
-| `center_deep_bats` | numeric |  |
-| `behind_los_ypa` | numeric |  |
-| `right_short_interceptions` | numeric |  |
-| `left_deep_interceptions` | numeric |  |
-| `right_medium_sacks` | numeric |  |
-| `right_behind_los_turnover_worthy_plays` | numeric |  |
+| `right_behind_los_attempts_percent` | numeric | Share of the player's total pass attempts that came on throws behind the line of scrimmage to the right side of the field, expressed as a percentage. |
+| `right_deep_avg_depth_of_target` | numeric | Average depth of target in air yards on deep (20+ air yards) throws to the right side of the field. |
+| `behind_los_sacks` | numeric | Number of sacks taken on throws behind the line of scrimmage. |
+| `center_deep_yards` | numeric | Passing yards gained on deep (20+ air yards) throws to the center of the field. |
+| `short_dropbacks` | numeric | Number of dropbacks on short (0-9 air yards) throws. |
+| `left_deep_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws to the left side of the field. |
+| `center_behind_los_avg_time_to_throw` | numeric | Average time from snap to release in seconds on throws behind the line of scrimmage to the center of the field. |
+| `behind_los_avg_depth_of_target` | numeric | Average depth of target in air yards on throws behind the line of scrimmage. |
+| `left_behind_los_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage to the left side of the field. |
+| `medium_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws, per PFF charting. |
+| `left_short_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards) throws to the left side of the field, as charted by PFF. |
+| `medium_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on medium (10-19 air yards) throws, plays PFF charts as deserving of a turnover. |
+| `behind_los_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage, per PFF charting. |
+| `left_behind_los_thrown_aways` | numeric | Number of intentional throwaways on throws behind the line of scrimmage to the left side of the field. |
+| `left_short_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws to the left side of the field. |
+| `center_medium_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws to the center of the field. |
+| `right_deep_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws to the right side of the field. |
+| `medium_yards` | numeric | Passing yards gained on medium (10-19 air yards) throws. |
+| `center_deep_grades_pass` | numeric | PFF passing grade (0-100) on deep (20+ air yards) throws to the center of the field. |
+| `center_medium_passing_snaps` | numeric | Number of passing snaps played on medium (10-19 air yards) throws to the center of the field. |
+| `center_behind_los_first_downs` | numeric | Number of passing first downs gained on throws behind the line of scrimmage to the center of the field. |
+| `center_medium_interceptions` | numeric | Number of passes intercepted on medium (10-19 air yards) throws to the center of the field. |
+| `behind_los_grades_pass` | numeric | PFF passing grade (0-100) on throws behind the line of scrimmage. |
+| `left_short_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws to the left side of the field, as charted by PFF. |
+| `deep_qb_rating` | numeric | Traditional NFL passer rating on deep (20+ air yards) throws. |
+| `center_deep_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws to the center of the field. |
+| `behind_los_ypa` | numeric | Yards gained per pass attempt on throws behind the line of scrimmage. |
+| `right_short_interceptions` | numeric | Number of passes intercepted on short (0-9 air yards) throws to the right side of the field. |
+| `left_deep_interceptions` | numeric | Number of passes intercepted on deep (20+ air yards) throws to the left side of the field. |
+| `right_medium_sacks` | numeric | Number of sacks taken on medium (10-19 air yards) throws to the right side of the field. |
+| `right_behind_los_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on throws behind the line of scrimmage to the right side of the field, plays PFF charts as deserving of a turnover. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `right_medium_spikes` | numeric |  |
-| `behind_los_hit_as_threw` | numeric |  |
-| `left_medium_pressure_to_sack_rate` | numeric |  |
-| `medium_dropbacks` | numeric |  |
-| `deep_hit_as_threw` | numeric |  |
-| `right_medium_completion_percent` | numeric |  |
-| `short_epa` | numeric |  |
-| `deep_drop_rate` | numeric |  |
-| `declined_penalties` | numeric |  |
-| `deep_scrambles` | numeric |  |
-| `left_deep_completion_percent` | numeric |  |
-| `right_short_epa` | numeric |  |
-| `medium_attempts_percent` | numeric |  |
-| `right_behind_los_completion_percent` | numeric |  |
-| `left_medium_hit_as_threw` | numeric |  |
-| `left_behind_los_pressure_to_sack_rate` | numeric |  |
-| `right_short_def_gen_pressures` | numeric |  |
-| `right_short_attempts_percent` | numeric |  |
-| `center_short_aimed_passes` | numeric |  |
-| `short_hit_as_threw` | numeric |  |
-| `right_medium_turnover_worthy_plays` | numeric |  |
-| `left_short_epa` | numeric |  |
-| `center_behind_los_pressure_to_sack_rate` | numeric |  |
-| `right_behind_los_ypa` | numeric |  |
-| `deep_interceptions` | numeric |  |
-| `left_medium_twp_rate` | numeric |  |
-| `right_behind_los_big_time_throws` | numeric |  |
-| `center_medium_sack_percent` | numeric |  |
-| `center_deep_thrown_aways` | numeric |  |
-| `short_thrown_aways` | numeric |  |
-| `left_short_btt_rate` | numeric |  |
-| `right_medium_accuracy_percent` | numeric |  |
+| `right_medium_spikes` | numeric | Number of clock-stopping spikes on medium (10-19 air yards) throws to the right side of the field. |
+| `behind_los_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage, as charted by PFF. |
+| `left_medium_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws to the left side of the field. |
+| `medium_dropbacks` | numeric | Number of dropbacks on medium (10-19 air yards) throws. |
+| `deep_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws, as charted by PFF. |
+| `right_medium_completion_percent` | numeric | Percentage of pass attempts completed on medium (10-19 air yards) throws to the right side of the field. |
+| `short_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws. |
+| `deep_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws. |
+| `declined_penalties` | numeric | Number of declined penalties committed by the player. |
+| `deep_scrambles` | numeric | Number of scrambles on deep (20+ air yards) throws. |
+| `left_deep_completion_percent` | numeric | Percentage of pass attempts completed on deep (20+ air yards) throws to the left side of the field. |
+| `right_short_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws to the right side of the field. |
+| `medium_attempts_percent` | numeric | Share of the player's total pass attempts that came on medium (10-19 air yards) throws, expressed as a percentage. |
+| `right_behind_los_completion_percent` | numeric | Percentage of pass attempts completed on throws behind the line of scrimmage to the right side of the field. |
+| `left_medium_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws to the left side of the field, as charted by PFF. |
+| `left_behind_los_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on throws behind the line of scrimmage to the left side of the field. |
+| `right_short_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards) throws to the right side of the field, as charted by PFF. |
+| `right_short_attempts_percent` | numeric | Share of the player's total pass attempts that came on short (0-9 air yards) throws to the right side of the field, expressed as a percentage. |
+| `center_short_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws to the center of the field, as charted by PFF. |
+| `short_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws, as charted by PFF. |
+| `right_medium_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on medium (10-19 air yards) throws to the right side of the field, plays PFF charts as deserving of a turnover. |
+| `left_short_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws to the left side of the field. |
+| `center_behind_los_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on throws behind the line of scrimmage to the center of the field. |
+| `right_behind_los_ypa` | numeric | Yards gained per pass attempt on throws behind the line of scrimmage to the right side of the field. |
+| `deep_interceptions` | numeric | Number of passes intercepted on deep (20+ air yards) throws. |
+| `left_medium_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws to the left side of the field, per PFF charting. |
+| `right_behind_los_big_time_throws` | numeric | Number of big-time throws on throws behind the line of scrimmage to the right side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `center_medium_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws to the center of the field. |
+| `center_deep_thrown_aways` | numeric | Number of intentional throwaways on deep (20+ air yards) throws to the center of the field. |
+| `short_thrown_aways` | numeric | Number of intentional throwaways on short (0-9 air yards) throws. |
+| `left_short_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws to the left side of the field, per PFF charting. |
+| `right_medium_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws to the right side of the field. |
 | `position` | character | Primary position as reported by NFL.com |
-| `short_def_gen_pressures` | numeric |  |
-| `center_deep_dropbacks` | numeric |  |
-| `center_medium_accuracy_percent` | numeric |  |
-| `right_behind_los_yards` | numeric |  |
-| `right_medium_attempts` | numeric |  |
-| `left_medium_attempts` | numeric |  |
-| `medium_accuracy_percent` | numeric |  |
-| `left_medium_drops` | numeric |  |
-| `left_short_avg_time_to_throw` | numeric |  |
-| `medium_passing_snaps` | numeric |  |
-| `center_short_epa` | numeric |  |
-| `left_behind_los_passing_snaps` | numeric |  |
-| `left_deep_pressure_to_sack_rate` | numeric |  |
-| `deep_bats` | numeric |  |
-| `left_medium_passing_snaps` | numeric |  |
-| `left_medium_scrambles` | numeric |  |
-| `right_deep_completion_percent` | numeric |  |
-| `left_short_drops` | numeric |  |
-| `left_deep_accuracy_percent` | numeric |  |
-| `medium_positive_epa_percent` | numeric |  |
-| `behind_los_turnover_worthy_plays` | numeric |  |
-| `right_medium_epa` | numeric |  |
-| `right_deep_dropbacks` | numeric |  |
-| `deep_ypa` | numeric |  |
-| `center_medium_completions` | numeric |  |
-| `left_medium_avg_time_to_throw` | numeric |  |
-| `left_short_sacks` | numeric |  |
-| `left_behind_los_spikes` | numeric |  |
-| `left_deep_def_gen_pressures` | numeric |  |
-| `center_short_qb_rating` | numeric |  |
-| `center_deep_interceptions` | numeric |  |
-| `right_deep_completions` | numeric |  |
-| `center_behind_los_sacks` | numeric |  |
-| `deep_completions` | numeric |  |
-| `left_medium_attempts_percent` | numeric |  |
-| `short_yards` | numeric |  |
-| `behind_los_qb_rating` | numeric |  |
-| `right_short_sacks` | numeric |  |
-| `right_behind_los_thrown_aways` | numeric |  |
-| `base_attempts` | numeric |  |
-| `center_short_spikes` | numeric |  |
-| `center_behind_los_hit_as_threw` | numeric |  |
-| `center_deep_turnover_worthy_plays` | numeric |  |
-| `left_medium_sack_percent` | numeric |  |
-| `behind_los_completion_percent` | numeric |  |
-| `left_deep_attempts_percent` | numeric |  |
-| `center_deep_big_time_throws` | numeric |  |
+| `short_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards) throws, as charted by PFF. |
+| `center_deep_dropbacks` | numeric | Number of dropbacks on deep (20+ air yards) throws to the center of the field. |
+| `center_medium_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws to the center of the field. |
+| `right_behind_los_yards` | numeric | Passing yards gained on throws behind the line of scrimmage to the right side of the field. |
+| `right_medium_attempts` | numeric | Number of pass attempts on medium (10-19 air yards) throws to the right side of the field. |
+| `left_medium_attempts` | numeric | Number of pass attempts on medium (10-19 air yards) throws to the left side of the field. |
+| `medium_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws. |
+| `left_medium_drops` | numeric | Number of catchable passes dropped by receivers on medium (10-19 air yards) throws to the left side of the field. |
+| `left_short_avg_time_to_throw` | numeric | Average time from snap to release in seconds on short (0-9 air yards) throws to the left side of the field. |
+| `medium_passing_snaps` | numeric | Number of passing snaps played on medium (10-19 air yards) throws. |
+| `center_short_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws to the center of the field. |
+| `left_behind_los_passing_snaps` | numeric | Number of passing snaps played on throws behind the line of scrimmage to the left side of the field. |
+| `left_deep_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws to the left side of the field. |
+| `deep_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws. |
+| `left_medium_passing_snaps` | numeric | Number of passing snaps played on medium (10-19 air yards) throws to the left side of the field. |
+| `left_medium_scrambles` | numeric | Number of scrambles on medium (10-19 air yards) throws to the left side of the field. |
+| `right_deep_completion_percent` | numeric | Percentage of pass attempts completed on deep (20+ air yards) throws to the right side of the field. |
+| `left_short_drops` | numeric | Number of catchable passes dropped by receivers on short (0-9 air yards) throws to the left side of the field. |
+| `left_deep_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws to the left side of the field. |
+| `medium_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on medium (10-19 air yards) throws. |
+| `behind_los_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on throws behind the line of scrimmage, plays PFF charts as deserving of a turnover. |
+| `right_medium_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws to the right side of the field. |
+| `right_deep_dropbacks` | numeric | Number of dropbacks on deep (20+ air yards) throws to the right side of the field. |
+| `deep_ypa` | numeric | Yards gained per pass attempt on deep (20+ air yards) throws. |
+| `center_medium_completions` | numeric | Number of completed passes on medium (10-19 air yards) throws to the center of the field. |
+| `left_medium_avg_time_to_throw` | numeric | Average time from snap to release in seconds on medium (10-19 air yards) throws to the left side of the field. |
+| `left_short_sacks` | numeric | Number of sacks taken on short (0-9 air yards) throws to the left side of the field. |
+| `left_behind_los_spikes` | numeric | Number of clock-stopping spikes on throws behind the line of scrimmage to the left side of the field. |
+| `left_deep_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws to the left side of the field, as charted by PFF. |
+| `center_short_qb_rating` | numeric | Traditional NFL passer rating on short (0-9 air yards) throws to the center of the field. |
+| `center_deep_interceptions` | numeric | Number of passes intercepted on deep (20+ air yards) throws to the center of the field. |
+| `right_deep_completions` | numeric | Number of completed passes on deep (20+ air yards) throws to the right side of the field. |
+| `center_behind_los_sacks` | numeric | Number of sacks taken on throws behind the line of scrimmage to the center of the field. |
+| `deep_completions` | numeric | Number of completed passes on deep (20+ air yards) throws. |
+| `left_medium_attempts_percent` | numeric | Share of the player's total pass attempts that came on medium (10-19 air yards) throws to the left side of the field, expressed as a percentage. |
+| `short_yards` | numeric | Passing yards gained on short (0-9 air yards) throws. |
+| `behind_los_qb_rating` | numeric | Traditional NFL passer rating on throws behind the line of scrimmage. |
+| `right_short_sacks` | numeric | Number of sacks taken on short (0-9 air yards) throws to the right side of the field. |
+| `right_behind_los_thrown_aways` | numeric | Number of intentional throwaways on throws behind the line of scrimmage to the right side of the field. |
+| `base_attempts` | numeric | Number of pass attempts across all splits, the baseline total for this facet. |
+| `center_short_spikes` | numeric | Number of clock-stopping spikes on short (0-9 air yards) throws to the center of the field. |
+| `center_behind_los_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage to the center of the field, as charted by PFF. |
+| `center_deep_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on deep (20+ air yards) throws to the center of the field, plays PFF charts as deserving of a turnover. |
+| `left_medium_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws to the left side of the field. |
+| `behind_los_completion_percent` | numeric | Percentage of pass attempts completed on throws behind the line of scrimmage. |
+| `left_deep_attempts_percent` | numeric | Share of the player's total pass attempts that came on deep (20+ air yards) throws to the left side of the field, expressed as a percentage. |
+| `center_deep_big_time_throws` | numeric | Number of big-time throws on deep (20+ air yards) throws to the center of the field, per PFF's highest-value, highest-difficulty throw designation. |
 | `player` | character | Player name |
-| `left_medium_avg_depth_of_target` | numeric |  |
-| `behind_los_thrown_aways` | numeric |  |
-| `center_medium_def_gen_pressures` | numeric |  |
-| `short_avg_time_to_throw` | numeric |  |
-| `left_deep_twp_rate` | numeric |  |
-| `center_behind_los_epa` | numeric |  |
-| `left_behind_los_big_time_throws` | numeric |  |
-| `right_medium_yards` | numeric |  |
-| `right_medium_drop_rate` | numeric |  |
-| `center_medium_big_time_throws` | numeric |  |
+| `left_medium_avg_depth_of_target` | numeric | Average depth of target in air yards on medium (10-19 air yards) throws to the left side of the field. |
+| `behind_los_thrown_aways` | numeric | Number of intentional throwaways on throws behind the line of scrimmage. |
+| `center_medium_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards) throws to the center of the field, as charted by PFF. |
+| `short_avg_time_to_throw` | numeric | Average time from snap to release in seconds on short (0-9 air yards) throws. |
+| `left_deep_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws to the left side of the field, per PFF charting. |
+| `center_behind_los_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage to the center of the field. |
+| `left_behind_los_big_time_throws` | numeric | Number of big-time throws on throws behind the line of scrimmage to the left side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `right_medium_yards` | numeric | Passing yards gained on medium (10-19 air yards) throws to the right side of the field. |
+| `right_medium_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws to the right side of the field. |
+| `center_medium_big_time_throws` | numeric | Number of big-time throws on medium (10-19 air yards) throws to the center of the field, per PFF's highest-value, highest-difficulty throw designation. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `left_short_completion_percent` | numeric |  |
-| `left_short_drop_rate` | numeric |  |
-| `left_behind_los_scrambles` | numeric |  |
-| `left_medium_btt_rate` | numeric |  |
-| `right_deep_hit_as_threw` | numeric |  |
-| `behind_los_bats` | numeric |  |
-| `short_first_downs` | numeric |  |
-| `left_deep_attempts` | numeric |  |
-| `right_behind_los_attempts` | numeric |  |
-| `right_deep_sacks` | numeric |  |
-| `left_behind_los_attempts_percent` | numeric |  |
-| `behind_los_big_time_throws` | numeric |  |
-| `center_deep_pressure_to_sack_rate` | numeric |  |
-| `left_medium_big_time_throws` | numeric |  |
-| `right_behind_los_bats` | numeric |  |
-| `left_medium_def_gen_pressures` | numeric |  |
-| `right_deep_turnover_worthy_plays` | numeric |  |
-| `left_short_spikes` | numeric |  |
-| `left_medium_aimed_passes` | numeric |  |
-| `left_behind_los_twp_rate` | numeric |  |
-| `short_grades_pass` | numeric |  |
-| `right_short_drops` | numeric |  |
-| `right_short_avg_time_to_throw` | numeric |  |
-| `right_medium_thrown_aways` | numeric |  |
-| `center_short_sack_percent` | numeric |  |
-| `right_short_passing_snaps` | numeric |  |
-| `center_short_def_gen_pressures` | numeric |  |
-| `center_medium_positive_epa_percent` | numeric |  |
-| `medium_drops` | numeric |  |
-| `center_medium_aimed_passes` | numeric |  |
-| `center_short_sacks` | numeric |  |
-| `deep_attempts_percent` | numeric |  |
-| `center_behind_los_def_gen_pressures` | numeric |  |
-| `left_short_passing_snaps` | numeric |  |
-| `center_medium_grades_pass` | numeric |  |
-| `center_deep_avg_time_to_throw` | numeric |  |
-| `behind_los_positive_epa_percent` | numeric |  |
-| `center_short_completion_percent` | numeric |  |
-| `left_deep_hit_as_threw` | numeric |  |
-| `center_short_grades_pass` | numeric |  |
-| `left_short_attempts_percent` | numeric |  |
-| `left_deep_scrambles` | numeric |  |
-| `right_short_completions` | numeric |  |
-| `center_behind_los_aimed_passes` | numeric |  |
-| `right_short_scrambles` | numeric |  |
-| `center_medium_qb_rating` | numeric |  |
-| `deep_avg_time_to_throw` | numeric |  |
-| `left_deep_drops` | numeric |  |
-| `right_behind_los_def_gen_pressures` | numeric |  |
-| `center_deep_positive_epa_percent` | numeric |  |
-| `center_deep_hit_as_threw` | numeric |  |
-| `short_spikes` | numeric |  |
-| `right_behind_los_completions` | numeric |  |
-| `center_behind_los_drop_rate` | numeric |  |
-| `short_drops` | numeric |  |
-| `deep_aimed_passes` | numeric |  |
-| `right_medium_avg_depth_of_target` | numeric |  |
-| `short_pressure_to_sack_rate` | numeric |  |
-| `center_deep_qb_rating` | numeric |  |
-| `left_medium_completions` | numeric |  |
-| `center_deep_sacks` | numeric |  |
-| `left_deep_big_time_throws` | numeric |  |
-| `center_medium_first_downs` | numeric |  |
-| `center_medium_dropbacks` | numeric |  |
-| `right_deep_def_gen_pressures` | numeric |  |
-| `left_short_touchdowns` | numeric |  |
-| `medium_drop_rate` | numeric |  |
+| `left_short_completion_percent` | numeric | Percentage of pass attempts completed on short (0-9 air yards) throws to the left side of the field. |
+| `left_short_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws to the left side of the field. |
+| `left_behind_los_scrambles` | numeric | Number of scrambles on throws behind the line of scrimmage to the left side of the field. |
+| `left_medium_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws to the left side of the field, per PFF charting. |
+| `right_deep_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws to the right side of the field, as charted by PFF. |
+| `behind_los_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage. |
+| `short_first_downs` | numeric | Number of passing first downs gained on short (0-9 air yards) throws. |
+| `left_deep_attempts` | numeric | Number of pass attempts on deep (20+ air yards) throws to the left side of the field. |
+| `right_behind_los_attempts` | numeric | Number of pass attempts on throws behind the line of scrimmage to the right side of the field. |
+| `right_deep_sacks` | numeric | Number of sacks taken on deep (20+ air yards) throws to the right side of the field. |
+| `left_behind_los_attempts_percent` | numeric | Share of the player's total pass attempts that came on throws behind the line of scrimmage to the left side of the field, expressed as a percentage. |
+| `behind_los_big_time_throws` | numeric | Number of big-time throws on throws behind the line of scrimmage, per PFF's highest-value, highest-difficulty throw designation. |
+| `center_deep_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws to the center of the field. |
+| `left_medium_big_time_throws` | numeric | Number of big-time throws on medium (10-19 air yards) throws to the left side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `right_behind_los_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage to the right side of the field. |
+| `left_medium_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards) throws to the left side of the field, as charted by PFF. |
+| `right_deep_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on deep (20+ air yards) throws to the right side of the field, plays PFF charts as deserving of a turnover. |
+| `left_short_spikes` | numeric | Number of clock-stopping spikes on short (0-9 air yards) throws to the left side of the field. |
+| `left_medium_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards) throws to the left side of the field, as charted by PFF. |
+| `left_behind_los_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage to the left side of the field, per PFF charting. |
+| `short_grades_pass` | numeric | PFF passing grade (0-100) on short (0-9 air yards) throws. |
+| `right_short_drops` | numeric | Number of catchable passes dropped by receivers on short (0-9 air yards) throws to the right side of the field. |
+| `right_short_avg_time_to_throw` | numeric | Average time from snap to release in seconds on short (0-9 air yards) throws to the right side of the field. |
+| `right_medium_thrown_aways` | numeric | Number of intentional throwaways on medium (10-19 air yards) throws to the right side of the field. |
+| `center_short_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws to the center of the field. |
+| `right_short_passing_snaps` | numeric | Number of passing snaps played on short (0-9 air yards) throws to the right side of the field. |
+| `center_short_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards) throws to the center of the field, as charted by PFF. |
+| `center_medium_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on medium (10-19 air yards) throws to the center of the field. |
+| `medium_drops` | numeric | Number of catchable passes dropped by receivers on medium (10-19 air yards) throws. |
+| `center_medium_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards) throws to the center of the field, as charted by PFF. |
+| `center_short_sacks` | numeric | Number of sacks taken on short (0-9 air yards) throws to the center of the field. |
+| `deep_attempts_percent` | numeric | Share of the player's total pass attempts that came on deep (20+ air yards) throws, expressed as a percentage. |
+| `center_behind_los_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on throws behind the line of scrimmage to the center of the field, as charted by PFF. |
+| `left_short_passing_snaps` | numeric | Number of passing snaps played on short (0-9 air yards) throws to the left side of the field. |
+| `center_medium_grades_pass` | numeric | PFF passing grade (0-100) on medium (10-19 air yards) throws to the center of the field. |
+| `center_deep_avg_time_to_throw` | numeric | Average time from snap to release in seconds on deep (20+ air yards) throws to the center of the field. |
+| `behind_los_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on throws behind the line of scrimmage. |
+| `center_short_completion_percent` | numeric | Percentage of pass attempts completed on short (0-9 air yards) throws to the center of the field. |
+| `left_deep_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws to the left side of the field, as charted by PFF. |
+| `center_short_grades_pass` | numeric | PFF passing grade (0-100) on short (0-9 air yards) throws to the center of the field. |
+| `left_short_attempts_percent` | numeric | Share of the player's total pass attempts that came on short (0-9 air yards) throws to the left side of the field, expressed as a percentage. |
+| `left_deep_scrambles` | numeric | Number of scrambles on deep (20+ air yards) throws to the left side of the field. |
+| `right_short_completions` | numeric | Number of completed passes on short (0-9 air yards) throws to the right side of the field. |
+| `center_behind_los_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line of scrimmage to the center of the field, as charted by PFF. |
+| `right_short_scrambles` | numeric | Number of scrambles on short (0-9 air yards) throws to the right side of the field. |
+| `center_medium_qb_rating` | numeric | Traditional NFL passer rating on medium (10-19 air yards) throws to the center of the field. |
+| `deep_avg_time_to_throw` | numeric | Average time from snap to release in seconds on deep (20+ air yards) throws. |
+| `left_deep_drops` | numeric | Number of catchable passes dropped by receivers on deep (20+ air yards) throws to the left side of the field. |
+| `right_behind_los_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on throws behind the line of scrimmage to the right side of the field, as charted by PFF. |
+| `center_deep_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws to the center of the field. |
+| `center_deep_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws to the center of the field, as charted by PFF. |
+| `short_spikes` | numeric | Number of clock-stopping spikes on short (0-9 air yards) throws. |
+| `right_behind_los_completions` | numeric | Number of completed passes on throws behind the line of scrimmage to the right side of the field. |
+| `center_behind_los_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage to the center of the field. |
+| `short_drops` | numeric | Number of catchable passes dropped by receivers on short (0-9 air yards) throws. |
+| `deep_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws, as charted by PFF. |
+| `right_medium_avg_depth_of_target` | numeric | Average depth of target in air yards on medium (10-19 air yards) throws to the right side of the field. |
+| `short_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws. |
+| `center_deep_qb_rating` | numeric | Traditional NFL passer rating on deep (20+ air yards) throws to the center of the field. |
+| `left_medium_completions` | numeric | Number of completed passes on medium (10-19 air yards) throws to the left side of the field. |
+| `center_deep_sacks` | numeric | Number of sacks taken on deep (20+ air yards) throws to the center of the field. |
+| `left_deep_big_time_throws` | numeric | Number of big-time throws on deep (20+ air yards) throws to the left side of the field, per PFF's highest-value, highest-difficulty throw designation. |
+| `center_medium_first_downs` | numeric | Number of passing first downs gained on medium (10-19 air yards) throws to the center of the field. |
+| `center_medium_dropbacks` | numeric | Number of dropbacks on medium (10-19 air yards) throws to the center of the field. |
+| `right_deep_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws to the right side of the field, as charted by PFF. |
+| `left_short_touchdowns` | numeric | Number of passing touchdowns thrown on short (0-9 air yards) throws to the left side of the field. |
+| `medium_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
-| `left_medium_ypa` | numeric |  |
-| `right_medium_passing_snaps` | numeric |  |
-| `center_short_scrambles` | numeric |  |
-| `left_behind_los_turnover_worthy_plays` | numeric |  |
-| `center_medium_yards` | numeric |  |
-| `center_deep_epa` | numeric |  |
-| `left_medium_interceptions` | numeric |  |
-| `right_deep_interceptions` | numeric |  |
-| `medium_completion_percent` | numeric |  |
-| `right_behind_los_grades_pass` | numeric |  |
-| `deep_positive_epa_percent` | numeric |  |
-| `behind_los_accuracy_percent` | numeric |  |
-| `center_deep_scrambles` | numeric |  |
-| `center_short_twp_rate` | numeric |  |
-| `behind_los_touchdowns` | numeric |  |
-| `left_medium_qb_rating` | numeric |  |
-| `right_medium_completions` | numeric |  |
-| `right_behind_los_drops` | numeric |  |
-| `left_behind_los_first_downs` | numeric |  |
-| `short_qb_rating` | numeric |  |
-| `center_medium_btt_rate` | numeric |  |
-| `left_deep_grades_pass` | numeric |  |
+| `left_medium_ypa` | numeric | Yards gained per pass attempt on medium (10-19 air yards) throws to the left side of the field. |
+| `right_medium_passing_snaps` | numeric | Number of passing snaps played on medium (10-19 air yards) throws to the right side of the field. |
+| `center_short_scrambles` | numeric | Number of scrambles on short (0-9 air yards) throws to the center of the field. |
+| `left_behind_los_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on throws behind the line of scrimmage to the left side of the field, plays PFF charts as deserving of a turnover. |
+| `center_medium_yards` | numeric | Passing yards gained on medium (10-19 air yards) throws to the center of the field. |
+| `center_deep_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws to the center of the field. |
+| `left_medium_interceptions` | numeric | Number of passes intercepted on medium (10-19 air yards) throws to the left side of the field. |
+| `right_deep_interceptions` | numeric | Number of passes intercepted on deep (20+ air yards) throws to the right side of the field. |
+| `medium_completion_percent` | numeric | Percentage of pass attempts completed on medium (10-19 air yards) throws. |
+| `right_behind_los_grades_pass` | numeric | PFF passing grade (0-100) on throws behind the line of scrimmage to the right side of the field. |
+| `deep_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws. |
+| `behind_los_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage. |
+| `center_deep_scrambles` | numeric | Number of scrambles on deep (20+ air yards) throws to the center of the field. |
+| `center_short_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws to the center of the field, per PFF charting. |
+| `behind_los_touchdowns` | numeric | Number of passing touchdowns thrown on throws behind the line of scrimmage. |
+| `left_medium_qb_rating` | numeric | Traditional NFL passer rating on medium (10-19 air yards) throws to the left side of the field. |
+| `right_medium_completions` | numeric | Number of completed passes on medium (10-19 air yards) throws to the right side of the field. |
+| `right_behind_los_drops` | numeric | Number of catchable passes dropped by receivers on throws behind the line of scrimmage to the right side of the field. |
+| `left_behind_los_first_downs` | numeric | Number of passing first downs gained on throws behind the line of scrimmage to the left side of the field. |
+| `short_qb_rating` | numeric | Traditional NFL passer rating on short (0-9 air yards) throws. |
+| `center_medium_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws to the center of the field, per PFF charting. |
+| `left_deep_grades_pass` | numeric | PFF passing grade (0-100) on deep (20+ air yards) throws to the left side of the field. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2851,219 +2851,219 @@ Facet report /passing/pressure (By Position leaderboard; add franchiseId for By 
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `no_blitz_completion_percent` | numeric |  |
-| `grades_offense` | numeric |  |
-| `no_pressure_scrambles` | numeric |  |
-| `blitz_touchdowns` | numeric |  |
-| `pressure_yards` | numeric |  |
-| `no_pressure_spikes` | numeric |  |
-| `blitz_ypa` | numeric |  |
-| `no_blitz_grades_run` | numeric |  |
-| `blitz_qb_rating` | numeric |  |
-| `no_pressure_thrown_aways` | numeric |  |
-| `no_blitz_bats` | numeric |  |
-| `no_blitz_drops` | numeric |  |
-| `no_pressure_completion_percent` | numeric |  |
-| `blitz_aimed_passes` | numeric |  |
-| `pressure_grades_run` | numeric |  |
-| `no_blitz_sack_percent` | numeric |  |
-| `no_pressure_bats` | numeric |  |
-| `pressure_completions` | numeric |  |
-| `blitz_big_time_throws` | numeric |  |
-| `no_blitz_drop_rate` | numeric |  |
-| `blitz_spikes` | numeric |  |
-| `no_pressure_completions` | numeric |  |
-| `draft_season` | numeric |  |
-| `no_pressure_passing_snaps` | numeric |  |
-| `no_blitz_first_downs` | numeric |  |
-| `blitz_avg_time_to_throw` | numeric |  |
-| `no_pressure_grades_hands_fumble` | numeric |  |
-| `pressure_aimed_passes` | numeric |  |
-| `blitz_sacks` | numeric |  |
-| `no_pressure_interceptions` | numeric |  |
+| `no_blitz_completion_percent` | numeric | Percentage of pass attempts completed when not blitzed. |
+| `grades_offense` | numeric | PFF overall offense grade for the player (0-100). |
+| `no_pressure_scrambles` | numeric | Number of scrambles from a clean pocket (no pressure). |
+| `blitz_touchdowns` | numeric | Number of passing touchdowns thrown when blitzed. |
+| `pressure_yards` | numeric | Passing yards gained when under pressure. |
+| `no_pressure_spikes` | numeric | Number of clock-stopping spikes from a clean pocket (no pressure). |
+| `blitz_ypa` | numeric | Yards gained per pass attempt when blitzed. |
+| `no_blitz_grades_run` | numeric | PFF rushing grade for the player (0-100) when not blitzed. |
+| `blitz_qb_rating` | numeric | Traditional NFL passer rating when blitzed. |
+| `no_pressure_thrown_aways` | numeric | Number of intentional throwaways from a clean pocket (no pressure). |
+| `no_blitz_bats` | numeric | Number of pass attempts batted down at the line of scrimmage when not blitzed. |
+| `no_blitz_drops` | numeric | Number of catchable passes dropped by receivers when not blitzed. |
+| `no_pressure_completion_percent` | numeric | Percentage of pass attempts completed from a clean pocket (no pressure). |
+| `blitz_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) when blitzed, as charted by PFF. |
+| `pressure_grades_run` | numeric | PFF rushing grade for the player (0-100) when under pressure. |
+| `no_blitz_sack_percent` | numeric | Percentage of dropbacks that ended in a sack when not blitzed. |
+| `no_pressure_bats` | numeric | Number of pass attempts batted down at the line of scrimmage from a clean pocket (no pressure). |
+| `pressure_completions` | numeric | Number of completed passes when under pressure. |
+| `blitz_big_time_throws` | numeric | Number of big-time throws when blitzed, per PFF's highest-value, highest-difficulty throw designation. |
+| `no_blitz_drop_rate` | numeric | Percentage of catchable passes dropped by receivers when not blitzed. |
+| `blitz_spikes` | numeric | Number of clock-stopping spikes when blitzed. |
+| `no_pressure_completions` | numeric | Number of completed passes from a clean pocket (no pressure). |
+| `draft_season` | numeric | NFL season (year) in which the player was drafted, per PFF player metadata. |
+| `no_pressure_passing_snaps` | numeric | Number of passing snaps played from a clean pocket (no pressure). |
+| `no_blitz_first_downs` | numeric | Number of passing first downs gained when not blitzed. |
+| `blitz_avg_time_to_throw` | numeric | Average time from snap to release in seconds when blitzed. |
+| `no_pressure_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) from a clean pocket (no pressure). |
+| `pressure_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) when under pressure, as charted by PFF. |
+| `blitz_sacks` | numeric | Number of sacks taken when blitzed. |
+| `no_pressure_interceptions` | numeric | Number of passes intercepted from a clean pocket (no pressure). |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `pressure_epa` | numeric |  |
-| `blitz_completions` | numeric |  |
-| `blitz_attempts` | numeric |  |
-| `pressure_twp_rate` | numeric |  |
-| `pressure_sacks` | numeric |  |
-| `no_blitz_pressure_to_sack_rate` | numeric |  |
-| `no_pressure_ypa` | numeric |  |
-| `pressure_passing_snaps` | numeric |  |
-| `grades_pass` | numeric |  |
-| `pressure_bats` | numeric |  |
-| `blitz_thrown_aways` | numeric |  |
-| `no_pressure_drops` | numeric |  |
+| `pressure_epa` | numeric | Total expected points added (EPA) on the player's dropbacks when under pressure. |
+| `blitz_completions` | numeric | Number of completed passes when blitzed. |
+| `blitz_attempts` | numeric | Number of pass attempts when blitzed. |
+| `pressure_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts when under pressure, per PFF charting. |
+| `pressure_sacks` | numeric | Number of sacks taken when under pressure. |
+| `no_blitz_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack when not blitzed. |
+| `no_pressure_ypa` | numeric | Yards gained per pass attempt from a clean pocket (no pressure). |
+| `pressure_passing_snaps` | numeric | Number of passing snaps played when under pressure. |
+| `grades_pass` | numeric | PFF passing grade (0-100). |
+| `pressure_bats` | numeric | Number of pass attempts batted down at the line of scrimmage when under pressure. |
+| `blitz_thrown_aways` | numeric | Number of intentional throwaways when blitzed. |
+| `no_pressure_drops` | numeric | Number of catchable passes dropped by receivers from a clean pocket (no pressure). |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `pressure_grades_offense_penalty` | numeric |  |
-| `pressure_scrambles` | numeric |  |
-| `blitz_drop_rate` | numeric |  |
-| `pressure_grades_pass_route` | numeric |  |
-| `blitz_completion_percent` | numeric |  |
-| `no_pressure_first_downs` | numeric |  |
-| `blitz_grades_offense_penalty` | numeric |  |
-| `no_blitz_epa` | numeric |  |
-| `blitz_interceptions` | numeric |  |
-| `no_blitz_dropbacks` | numeric |  |
-| `no_blitz_grades_pass` | numeric |  |
-| `no_blitz_scrambles` | numeric |  |
-| `pressure_drop_rate` | numeric |  |
-| `no_blitz_yards` | numeric |  |
-| `base_dropbacks` | numeric |  |
-| `pressure_pressure_to_sack_rate` | numeric |  |
-| `no_blitz_grades_hands_fumble` | numeric |  |
-| `no_pressure_grades_offense` | numeric |  |
-| `no_pressure_avg_time_to_throw` | numeric |  |
-| `pressure_dropbacks` | numeric |  |
-| `no_blitz_grades_offense_penalty` | numeric |  |
-| `no_pressure_grades_run` | numeric |  |
-| `player_game_count` | numeric |  |
-| `blitz_turnover_worthy_plays` | numeric |  |
-| `no_blitz_touchdowns` | numeric |  |
-| `no_blitz_avg_depth_of_target` | numeric |  |
-| `no_pressure_dropbacks_percent` | numeric |  |
-| `blitz_grades_pass` | numeric |  |
-| `eligible_season` | numeric |  |
-| `blitz_avg_depth_of_target` | numeric |  |
-| `no_blitz_spikes` | numeric |  |
-| `no_pressure_dropbacks` | numeric |  |
-| `blitz_btt_rate` | numeric |  |
-| `blitz_positive_epa_percent` | numeric |  |
-| `no_pressure_btt_rate` | numeric |  |
-| `no_pressure_drop_rate` | numeric |  |
-| `no_blitz_turnover_worthy_plays` | numeric |  |
-| `pressure_positive_epa_percent` | numeric |  |
-| `blitz_first_downs` | numeric |  |
-| `no_blitz_dropbacks_percent` | numeric |  |
-| `pressure_turnover_worthy_plays` | numeric |  |
-| `no_pressure_epa` | numeric |  |
-| `no_blitz_avg_time_to_throw` | numeric |  |
-| `no_blitz_positive_epa_percent` | numeric |  |
-| `pressure_btt_rate` | numeric |  |
-| `no_pressure_aimed_passes` | numeric |  |
-| `pressure_dropbacks_percent` | numeric |  |
-| `grades_run` | numeric |  |
-| `no_pressure_def_gen_pressures` | numeric |  |
-| `pressure_grades_offense` | numeric |  |
-| `pressure_completion_percent` | numeric |  |
-| `pressure_avg_depth_of_target` | numeric |  |
-| `blitz_epa` | numeric |  |
-| `pressure_drops` | numeric |  |
-| `no_blitz_def_gen_pressures` | numeric |  |
-| `pressure_attempts` | numeric |  |
-| `pressure_big_time_throws` | numeric |  |
-| `no_blitz_thrown_aways` | numeric |  |
-| `blitz_drops` | numeric |  |
-| `no_pressure_touchdowns` | numeric |  |
-| `no_pressure_sacks` | numeric |  |
-| `blitz_sack_percent` | numeric |  |
-| `pressure_sack_percent` | numeric |  |
+| `pressure_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) when under pressure. |
+| `pressure_scrambles` | numeric | Number of scrambles when under pressure. |
+| `blitz_drop_rate` | numeric | Percentage of catchable passes dropped by receivers when blitzed. |
+| `pressure_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) when under pressure. |
+| `blitz_completion_percent` | numeric | Percentage of pass attempts completed when blitzed. |
+| `no_pressure_first_downs` | numeric | Number of passing first downs gained from a clean pocket (no pressure). |
+| `blitz_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) when blitzed. |
+| `no_blitz_epa` | numeric | Total expected points added (EPA) on the player's dropbacks when not blitzed. |
+| `blitz_interceptions` | numeric | Number of passes intercepted when blitzed. |
+| `no_blitz_dropbacks` | numeric | Number of dropbacks when not blitzed. |
+| `no_blitz_grades_pass` | numeric | PFF passing grade (0-100) when not blitzed. |
+| `no_blitz_scrambles` | numeric | Number of scrambles when not blitzed. |
+| `pressure_drop_rate` | numeric | Percentage of catchable passes dropped by receivers when under pressure. |
+| `no_blitz_yards` | numeric | Passing yards gained when not blitzed. |
+| `base_dropbacks` | numeric | Number of dropbacks across all splits, the baseline total for this facet. |
+| `pressure_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack, reported within the pressure split. |
+| `no_blitz_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) when not blitzed. |
+| `no_pressure_grades_offense` | numeric | PFF overall offense grade for the player (0-100) from a clean pocket (no pressure). |
+| `no_pressure_avg_time_to_throw` | numeric | Average time from snap to release in seconds from a clean pocket (no pressure). |
+| `pressure_dropbacks` | numeric | Number of dropbacks when under pressure. |
+| `no_blitz_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) when not blitzed. |
+| `no_pressure_grades_run` | numeric | PFF rushing grade for the player (0-100) from a clean pocket (no pressure). |
+| `player_game_count` | numeric | Number of games the player appeared in during the period covered. |
+| `blitz_turnover_worthy_plays` | numeric | Number of turnover-worthy plays when blitzed, plays PFF charts as deserving of a turnover. |
+| `no_blitz_touchdowns` | numeric | Number of passing touchdowns thrown when not blitzed. |
+| `no_blitz_avg_depth_of_target` | numeric | Average depth of target in air yards when not blitzed. |
+| `no_pressure_dropbacks_percent` | numeric | Share of the player's total dropbacks that came from a clean pocket (no pressure), expressed as a percentage. |
+| `blitz_grades_pass` | numeric | PFF passing grade (0-100) when blitzed. |
+| `eligible_season` | numeric | Season (year) of the player's NFL draft eligibility, per PFF player metadata. |
+| `blitz_avg_depth_of_target` | numeric | Average depth of target in air yards when blitzed. |
+| `no_blitz_spikes` | numeric | Number of clock-stopping spikes when not blitzed. |
+| `no_pressure_dropbacks` | numeric | Number of dropbacks from a clean pocket (no pressure). |
+| `blitz_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts when blitzed, per PFF charting. |
+| `blitz_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added when blitzed. |
+| `no_pressure_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts from a clean pocket (no pressure), per PFF charting. |
+| `no_pressure_drop_rate` | numeric | Percentage of catchable passes dropped by receivers from a clean pocket (no pressure). |
+| `no_blitz_turnover_worthy_plays` | numeric | Number of turnover-worthy plays when not blitzed, plays PFF charts as deserving of a turnover. |
+| `pressure_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added when under pressure. |
+| `blitz_first_downs` | numeric | Number of passing first downs gained when blitzed. |
+| `no_blitz_dropbacks_percent` | numeric | Share of the player's total dropbacks that came when not blitzed, expressed as a percentage. |
+| `pressure_turnover_worthy_plays` | numeric | Number of turnover-worthy plays when under pressure, plays PFF charts as deserving of a turnover. |
+| `no_pressure_epa` | numeric | Total expected points added (EPA) on the player's dropbacks from a clean pocket (no pressure). |
+| `no_blitz_avg_time_to_throw` | numeric | Average time from snap to release in seconds when not blitzed. |
+| `no_blitz_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added when not blitzed. |
+| `pressure_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts when under pressure, per PFF charting. |
+| `no_pressure_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) from a clean pocket (no pressure), as charted by PFF. |
+| `pressure_dropbacks_percent` | numeric | Share of the player's total dropbacks that came when under pressure, expressed as a percentage. |
+| `grades_run` | numeric | PFF rushing grade for the player (0-100). |
+| `no_pressure_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks from a clean pocket (no pressure), as charted by PFF. |
+| `pressure_grades_offense` | numeric | PFF overall offense grade for the player (0-100) when under pressure. |
+| `pressure_completion_percent` | numeric | Percentage of pass attempts completed when under pressure. |
+| `pressure_avg_depth_of_target` | numeric | Average depth of target in air yards when under pressure. |
+| `blitz_epa` | numeric | Total expected points added (EPA) on the player's dropbacks when blitzed. |
+| `pressure_drops` | numeric | Number of catchable passes dropped by receivers when under pressure. |
+| `no_blitz_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks when not blitzed, as charted by PFF. |
+| `pressure_attempts` | numeric | Number of pass attempts when under pressure. |
+| `pressure_big_time_throws` | numeric | Number of big-time throws when under pressure, per PFF's highest-value, highest-difficulty throw designation. |
+| `no_blitz_thrown_aways` | numeric | Number of intentional throwaways when not blitzed. |
+| `blitz_drops` | numeric | Number of catchable passes dropped by receivers when blitzed. |
+| `no_pressure_touchdowns` | numeric | Number of passing touchdowns thrown from a clean pocket (no pressure). |
+| `no_pressure_sacks` | numeric | Number of sacks taken from a clean pocket (no pressure). |
+| `blitz_sack_percent` | numeric | Percentage of dropbacks that ended in a sack when blitzed. |
+| `pressure_sack_percent` | numeric | Percentage of dropbacks that ended in a sack when under pressure. |
 | `penalties` | numeric | Total number of penalties. |
-| `no_pressure_attempts` | numeric |  |
-| `no_blitz_grades_offense` | numeric |  |
-| `blitz_scrambles` | numeric |  |
-| `blitz_dropbacks_percent` | numeric |  |
-| `no_pressure_qb_rating` | numeric |  |
-| `no_blitz_passing_snaps` | numeric |  |
-| `no_blitz_aimed_passes` | numeric |  |
-| `blitz_yards` | numeric |  |
+| `no_pressure_attempts` | numeric | Number of pass attempts from a clean pocket (no pressure). |
+| `no_blitz_grades_offense` | numeric | PFF overall offense grade for the player (0-100) when not blitzed. |
+| `blitz_scrambles` | numeric | Number of scrambles when blitzed. |
+| `blitz_dropbacks_percent` | numeric | Share of the player's total dropbacks that came when blitzed, expressed as a percentage. |
+| `no_pressure_qb_rating` | numeric | Traditional NFL passer rating from a clean pocket (no pressure). |
+| `no_blitz_passing_snaps` | numeric | Number of passing snaps played when not blitzed. |
+| `no_blitz_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) when not blitzed, as charted by PFF. |
+| `blitz_yards` | numeric | Passing yards gained when blitzed. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `no_blitz_attempts` | numeric |  |
-| `pressure_accuracy_percent` | numeric |  |
-| `no_blitz_hit_as_threw` | numeric |  |
-| `pressure_hit_as_threw` | numeric |  |
-| `blitz_pressure_to_sack_rate` | numeric |  |
-| `declined_penalties` | numeric |  |
-| `no_blitz_btt_rate` | numeric |  |
-| `no_blitz_ypa` | numeric |  |
-| `blitz_grades_run` | numeric |  |
-| `pressure_interceptions` | numeric |  |
-| `blitz_grades_hands_fumble` | numeric |  |
-| `no_pressure_grades_offense_penalty` | numeric |  |
+| `no_blitz_attempts` | numeric | Number of pass attempts when not blitzed. |
+| `pressure_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF when under pressure. |
+| `no_blitz_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw when not blitzed, as charted by PFF. |
+| `pressure_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw when under pressure, as charted by PFF. |
+| `blitz_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack when blitzed. |
+| `declined_penalties` | numeric | Number of declined penalties committed by the player. |
+| `no_blitz_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts when not blitzed, per PFF charting. |
+| `no_blitz_ypa` | numeric | Yards gained per pass attempt when not blitzed. |
+| `blitz_grades_run` | numeric | PFF rushing grade for the player (0-100) when blitzed. |
+| `pressure_interceptions` | numeric | Number of passes intercepted when under pressure. |
+| `blitz_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) when blitzed. |
+| `no_pressure_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) from a clean pocket (no pressure). |
 | `position` | character | Primary position as reported by NFL.com |
-| `blitz_grades_offense` | numeric |  |
-| `grades_hands_fumble` | numeric |  |
-| `pressure_def_gen_pressures` | numeric |  |
-| `pressure_grades_pass` | numeric |  |
-| `no_blitz_qb_rating` | numeric |  |
-| `blitz_hit_as_threw` | numeric |  |
-| `pressure_ypa` | numeric |  |
-| `blitz_grades_pass_route` | numeric |  |
-| `pressure_avg_time_to_throw` | numeric |  |
-| `no_blitz_completions` | numeric |  |
-| `no_pressure_grades_pass_route` | numeric |  |
-| `no_pressure_sack_percent` | numeric |  |
+| `blitz_grades_offense` | numeric | PFF overall offense grade for the player (0-100) when blitzed. |
+| `grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100). |
+| `pressure_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks when under pressure, as charted by PFF. |
+| `pressure_grades_pass` | numeric | PFF passing grade (0-100) when under pressure. |
+| `no_blitz_qb_rating` | numeric | Traditional NFL passer rating when not blitzed. |
+| `blitz_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw when blitzed, as charted by PFF. |
+| `pressure_ypa` | numeric | Yards gained per pass attempt when under pressure. |
+| `blitz_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) when blitzed. |
+| `pressure_avg_time_to_throw` | numeric | Average time from snap to release in seconds when under pressure. |
+| `no_blitz_completions` | numeric | Number of completed passes when not blitzed. |
+| `no_pressure_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) from a clean pocket (no pressure). |
+| `no_pressure_sack_percent` | numeric | Percentage of dropbacks that ended in a sack from a clean pocket (no pressure). |
 | `player` | character | Player name |
-| `no_blitz_accuracy_percent` | numeric |  |
-| `no_pressure_pressure_to_sack_rate` | character |  |
-| `no_pressure_turnover_worthy_plays` | numeric |  |
-| `pressure_first_downs` | numeric |  |
-| `blitz_passing_snaps` | numeric |  |
+| `no_blitz_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF when not blitzed. |
+| `no_pressure_pressure_to_sack_rate` | character | Pressure-to-sack rate as reported within the no-pressure split of the PFF passing-pressure facet. |
+| `no_pressure_turnover_worthy_plays` | numeric | Number of turnover-worthy plays from a clean pocket (no pressure), plays PFF charts as deserving of a turnover. |
+| `pressure_first_downs` | numeric | Number of passing first downs gained when under pressure. |
+| `blitz_passing_snaps` | numeric | Number of passing snaps played when blitzed. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `no_pressure_twp_rate` | numeric |  |
-| `no_blitz_sacks` | numeric |  |
-| `no_blitz_grades_pass_route` | numeric |  |
-| `no_pressure_accuracy_percent` | numeric |  |
-| `no_blitz_twp_rate` | numeric |  |
-| `no_pressure_hit_as_threw` | numeric |  |
-| `no_pressure_grades_pass` | numeric |  |
-| `no_pressure_positive_epa_percent` | numeric |  |
-| `pressure_spikes` | numeric |  |
-| `pressure_grades_hands_fumble` | numeric |  |
-| `pressure_qb_rating` | numeric |  |
-| `blitz_bats` | numeric |  |
-| `pressure_touchdowns` | numeric |  |
-| `pressure_thrown_aways` | numeric |  |
-| `no_blitz_interceptions` | numeric |  |
-| `blitz_dropbacks` | numeric |  |
-| `blitz_def_gen_pressures` | numeric |  |
+| `no_pressure_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts from a clean pocket (no pressure), per PFF charting. |
+| `no_blitz_sacks` | numeric | Number of sacks taken when not blitzed. |
+| `no_blitz_grades_pass_route` | numeric | PFF receiving (route) grade for the player (0-100) when not blitzed. |
+| `no_pressure_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF from a clean pocket (no pressure). |
+| `no_blitz_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts when not blitzed, per PFF charting. |
+| `no_pressure_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw from a clean pocket (no pressure), as charted by PFF. |
+| `no_pressure_grades_pass` | numeric | PFF passing grade (0-100) from a clean pocket (no pressure). |
+| `no_pressure_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added from a clean pocket (no pressure). |
+| `pressure_spikes` | numeric | Number of clock-stopping spikes when under pressure. |
+| `pressure_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) when under pressure. |
+| `pressure_qb_rating` | numeric | Traditional NFL passer rating when under pressure. |
+| `blitz_bats` | numeric | Number of pass attempts batted down at the line of scrimmage when blitzed. |
+| `pressure_touchdowns` | numeric | Number of passing touchdowns thrown when under pressure. |
+| `pressure_thrown_aways` | numeric | Number of intentional throwaways when under pressure. |
+| `no_blitz_interceptions` | numeric | Number of passes intercepted when not blitzed. |
+| `blitz_dropbacks` | numeric | Number of dropbacks when blitzed. |
+| `blitz_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks when blitzed, as charted by PFF. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
-| `no_blitz_big_time_throws` | numeric |  |
-| `no_pressure_avg_depth_of_target` | numeric |  |
-| `no_pressure_yards` | numeric |  |
-| `blitz_twp_rate` | numeric |  |
-| `blitz_accuracy_percent` | numeric |  |
-| `no_pressure_big_time_throws` | numeric |  |
-| `no_blitz_grades_pass_block` | numeric |  |
-| `blitz_grades_pass_block` | numeric |  |
-| `no_pressure_grades_pass_block` | numeric |  |
-| `pressure_grades_pass_block` | numeric |  |
-| `no_pressure_grades_hands_drop` | numeric |  |
-| `blitz_grades_hands_drop` | numeric |  |
-| `pressure_grades_hands_drop` | numeric |  |
-| `no_blitz_grades_hands_drop` | numeric |  |
-| `blitz_grades_run_block` | numeric |  |
-| `no_pressure_grades_run_block` | numeric |  |
-| `no_blitz_grades_run_block` | numeric |  |
-| `blitz_grades_screen_block` | numeric |  |
-| `pressure_grades_screen_block` | numeric |  |
-| `no_blitz_grades_screen_block` | numeric |  |
-| `pressure_grades_run_block` | numeric |  |
-| `no_pressure_grades_screen_block` | numeric |  |
-| `pressure_grades_coverage_defense` | numeric |  |
-| `pressure_grades_defense` | numeric |  |
-| `no_blitz_grades_defense` | numeric |  |
-| `no_blitz_grades_defense_penalty` | numeric |  |
-| `blitz_grades_coverage_defense` | numeric |  |
-| `no_pressure_grades_defense` | numeric |  |
-| `no_pressure_grades_defense_penalty` | numeric |  |
-| `no_blitz_grades_coverage_defense` | numeric |  |
-| `blitz_grades_defense` | numeric |  |
-| `blitz_grades_defense_penalty` | numeric |  |
-| `no_pressure_grades_coverage_defense` | numeric |  |
-| `pressure_grades_defense_penalty` | numeric |  |
-| `pressure_grades_pass_rush_defense` | numeric |  |
-| `blitz_grades_pass_rush_defense` | numeric |  |
-| `no_pressure_grades_tackle` | numeric |  |
-| `blitz_grades_tackle` | numeric |  |
-| `blitz_grades_overall_tackle` | numeric |  |
-| `no_pressure_grades_pass_rush_defense` | numeric |  |
-| `pressure_grades_overall_tackle` | numeric |  |
-| `no_blitz_grades_overall_tackle` | numeric |  |
-| `pressure_grades_tackle` | numeric |  |
-| `no_blitz_grades_pass_rush_defense` | character |  |
-| `no_pressure_grades_overall_tackle` | numeric |  |
-| `no_blitz_grades_tackle` | numeric |  |
+| `no_blitz_big_time_throws` | numeric | Number of big-time throws when not blitzed, per PFF's highest-value, highest-difficulty throw designation. |
+| `no_pressure_avg_depth_of_target` | numeric | Average depth of target in air yards from a clean pocket (no pressure). |
+| `no_pressure_yards` | numeric | Passing yards gained from a clean pocket (no pressure). |
+| `blitz_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts when blitzed, per PFF charting. |
+| `blitz_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF when blitzed. |
+| `no_pressure_big_time_throws` | numeric | Number of big-time throws from a clean pocket (no pressure), per PFF's highest-value, highest-difficulty throw designation. |
+| `no_blitz_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) when not blitzed. |
+| `blitz_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) when blitzed. |
+| `no_pressure_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) from a clean pocket (no pressure). |
+| `pressure_grades_pass_block` | numeric | PFF pass-blocking grade for the player (0-100) when under pressure. |
+| `no_pressure_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) from a clean pocket (no pressure). |
+| `blitz_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) when blitzed. |
+| `pressure_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) when under pressure. |
+| `no_blitz_grades_hands_drop` | numeric | PFF hands (drop) grade for the player (0-100) when not blitzed. |
+| `blitz_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) when blitzed. |
+| `no_pressure_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) from a clean pocket (no pressure). |
+| `no_blitz_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) when not blitzed. |
+| `blitz_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) when blitzed. |
+| `pressure_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) when under pressure. |
+| `no_blitz_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) when not blitzed. |
+| `pressure_grades_run_block` | numeric | PFF run-blocking grade for the player (0-100) when under pressure. |
+| `no_pressure_grades_screen_block` | numeric | PFF screen-blocking grade for the player (0-100) from a clean pocket (no pressure). |
+| `pressure_grades_coverage_defense` | numeric | PFF coverage grade for the player (0-100) when under pressure. |
+| `pressure_grades_defense` | numeric | PFF overall defense grade for the player (0-100) when under pressure. |
+| `no_blitz_grades_defense` | numeric | PFF overall defense grade for the player (0-100) when not blitzed. |
+| `no_blitz_grades_defense_penalty` | numeric | PFF defensive penalty grade for the player (0-100) when not blitzed. |
+| `blitz_grades_coverage_defense` | numeric | PFF coverage grade for the player (0-100) when blitzed. |
+| `no_pressure_grades_defense` | numeric | PFF overall defense grade for the player (0-100) from a clean pocket (no pressure). |
+| `no_pressure_grades_defense_penalty` | numeric | PFF defensive penalty grade for the player (0-100) from a clean pocket (no pressure). |
+| `no_blitz_grades_coverage_defense` | numeric | PFF coverage grade for the player (0-100) when not blitzed. |
+| `blitz_grades_defense` | numeric | PFF overall defense grade for the player (0-100) when blitzed. |
+| `blitz_grades_defense_penalty` | numeric | PFF defensive penalty grade for the player (0-100) when blitzed. |
+| `no_pressure_grades_coverage_defense` | numeric | PFF coverage grade for the player (0-100) from a clean pocket (no pressure). |
+| `pressure_grades_defense_penalty` | numeric | PFF defensive penalty grade for the player (0-100) when under pressure. |
+| `pressure_grades_pass_rush_defense` | numeric | PFF pass-rush grade for the player (0-100) when under pressure. |
+| `blitz_grades_pass_rush_defense` | numeric | PFF pass-rush grade for the player (0-100) when blitzed. |
+| `no_pressure_grades_tackle` | numeric | PFF tackling grade for the player (0-100) from a clean pocket (no pressure). |
+| `blitz_grades_tackle` | numeric | PFF tackling grade for the player (0-100) when blitzed. |
+| `blitz_grades_overall_tackle` | numeric | PFF overall tackling grade for the player (0-100) when blitzed. |
+| `no_pressure_grades_pass_rush_defense` | numeric | PFF pass-rush grade for the player (0-100) from a clean pocket (no pressure). |
+| `pressure_grades_overall_tackle` | numeric | PFF overall tackling grade for the player (0-100) when under pressure. |
+| `no_blitz_grades_overall_tackle` | numeric | PFF overall tackling grade for the player (0-100) when not blitzed. |
+| `pressure_grades_tackle` | numeric | PFF tackling grade for the player (0-100) when under pressure. |
+| `no_blitz_grades_pass_rush_defense` | character | PFF pass-rush grade for the player (0-100) when not blitzed. |
+| `no_pressure_grades_overall_tackle` | numeric | PFF overall tackling grade for the player (0-100) from a clean pocket (no pressure). |
+| `no_blitz_grades_tackle` | numeric | PFF tackling grade for the player (0-100) when not blitzed. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3098,54 +3098,54 @@ Facet report /receiving/summary (By Position leaderboard; add franchiseId for By
 | col_name | type | description |
 |---|---|---|
 | `targets` | numeric | Times targeted. |
-| `grades_pass_block` | numeric |  |
+| `grades_pass_block` | numeric | PFF pass-blocking grade, 0-100. |
 | `grades_offense` | numeric | PFF overall offense grade (0-100). |
-| `yards_after_catch_per_reception` | numeric |  |
+| `yards_after_catch_per_reception` | numeric | Average yards after the catch per reception. |
 | `grades_pass_route` | numeric | PFF receiving/route grade (0-100). |
-| `draft_season` | numeric |  |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
 | `team_name` | character | Team abbreviation the player is credited to for the range. |
 | `yprr` | numeric | Yards per route run. |
-| `wide_snaps` | numeric |  |
-| `fumbles` | numeric |  |
+| `wide_snaps` | numeric | Receiving snaps aligned out wide. |
+| `fumbles` | numeric | Fumbles by the player after the catch. |
 | `first_downs` | numeric | First downs earned by the team. |
 | `jersey_number` | character | Jersey number (string; zero-padded, e.g. "09"). |
-| `inline_snaps` | numeric |  |
+| `inline_snaps` | numeric | Receiving snaps aligned inline, tight to the formation. |
 | `contested_targets` | numeric | Contested targets. |
 | `player_game_count` | numeric | Games with at least one qualifying snap in the requested range. |
-| `eligible_season` | numeric |  |
-| `inline_rate` | numeric |  |
-| `contested_catch_rate` | numeric |  |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `inline_rate` | numeric | Share of receiving snaps aligned inline, tight to the formation. |
+| `contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught. |
 | `yards` | numeric | Receiving yards. |
 | `receptions` | numeric | Passes caught by the receiver. |
-| `targeted_qb_rating` | numeric |  |
+| `targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player. |
 | `interceptions` | numeric | The number of interceptions thrown. |
-| `caught_percent` | numeric |  |
-| `drop_rate` | numeric |  |
+| `caught_percent` | numeric | Percentage of targets caught. |
+| `drop_rate` | numeric | Share of catchable targets the player dropped. |
 | `grades_hands_drop` | numeric | PFF hands/drop grade (0-100). |
-| `slot_rate` | numeric |  |
-| `slot_snaps` | numeric |  |
+| `slot_rate` | numeric | Share of receiving snaps aligned in the slot. |
+| `slot_snaps` | numeric | Receiving snaps aligned in the slot. |
 | `penalties` | numeric | Total number of penalties. |
-| `wide_rate` | numeric |  |
-| `pass_block_rate` | numeric |  |
+| `wide_rate` | numeric | Share of receiving snaps aligned out wide. |
+| `pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `declined_penalties` | numeric |  |
-| `route_rate` | numeric |  |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `route_rate` | numeric | Share of pass-play snaps on which the player ran a route. |
 | `drops` | numeric | Dropped passes. |
 | `position` | character | Primary position as reported by NFL.com |
-| `grades_hands_fumble` | numeric |  |
-| `longest` | numeric |  |
-| `pass_blocks` | numeric |  |
+| `grades_hands_fumble` | numeric | PFF ball-security (hands/fumble) grade, 0-100. |
+| `longest` | numeric | Longest reception in yards. |
+| `pass_blocks` | numeric | Pass-play snaps spent pass blocking. |
 | `routes` | numeric | Pass routes run by the receiver. |
-| `pass_plays` | numeric |  |
-| `yards_per_reception` | numeric |  |
+| `pass_plays` | numeric | Pass-play snaps. |
+| `yards_per_reception` | numeric | Average yards per reception. |
 | `player` | character | Player name |
-| `positive_epa_percent` | numeric |  |
+| `positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added. |
 | `franchise_id` | numeric | PFF franchise (team) id (integer join key). |
 | `contested_receptions` | numeric | Contested catches made. |
 | `yards_after_catch` | numeric | Yards after the catch. |
-| `avg_depth_of_target` | numeric |  |
+| `avg_depth_of_target` | numeric | Average depth of target in yards downfield. |
 | `epa` | numeric | Expected points added (EPA) by the posteam for the given play. |
-| `avoided_tackles` | numeric |  |
+| `avoided_tackles` | numeric | Tackles avoided after the catch. |
 | `player_id` | numeric | PFF player id (integer; matches the /players id and every player_id join key). |
 | `touchdowns` | numeric | Receiving touchdowns. |
 
@@ -3181,36 +3181,36 @@ Facet report /return/summary (By Position leaderboard; add franchiseId for By Te
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `declined_penalties` | numeric |  |
-| `draft_season` | numeric |  |
-| `eligible_season` | numeric |  |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `grades_kick_return` | numeric |  |
-| `grades_return` | numeric |  |
+| `grades_kick_return` | numeric | PFF kickoff-return grade, 0-100. |
+| `grades_return` | numeric | PFF overall return grade, 0-100. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `kickoff_attempts` | numeric |  |
-| `kickoff_fair_catches` | numeric |  |
-| `kickoff_long` | numeric |  |
-| `kickoff_muffed_returns` | numeric |  |
-| `kickoff_touchdowns` | numeric |  |
-| `kickoff_yards` | numeric |  |
-| `kickoff_ypa` | numeric |  |
+| `kickoff_attempts` | numeric | Kickoff returns attempted. |
+| `kickoff_fair_catches` | numeric | Kickoffs fair-caught by the player. |
+| `kickoff_long` | numeric | Longest kickoff return in yards. |
+| `kickoff_muffed_returns` | numeric | Kickoff returns the player muffed. |
+| `kickoff_touchdowns` | numeric | Kickoff returns scoring a touchdown. |
+| `kickoff_yards` | numeric | Total kickoff-return yards. |
+| `kickoff_ypa` | numeric | Average yards per kickoff return. |
 | `penalties` | numeric | Total number of penalties. |
 | `player` | character | Player name |
-| `player_game_count` | numeric |  |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 | `position` | character | Primary position as reported by NFL.com |
-| `punt_attempts` | numeric |  |
-| `punt_fair_catches` | numeric |  |
-| `punt_long` | numeric |  |
-| `punt_muffed_returns` | numeric |  |
-| `punt_touchdowns` | numeric |  |
-| `punt_yards` | numeric |  |
-| `punt_ypa` | numeric |  |
+| `punt_attempts` | numeric | Punt returns attempted. |
+| `punt_fair_catches` | numeric | Punts fair-caught by the player. |
+| `punt_long` | numeric | Longest punt return in yards. |
+| `punt_muffed_returns` | numeric | Punt returns the player muffed. |
+| `punt_touchdowns` | numeric | Punt returns scoring a touchdown. |
+| `punt_yards` | numeric | Total punt-return yards. |
+| `punt_ypa` | numeric | Average yards per punt return. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `total_attempts` | numeric |  |
-| `grades_punt_return` | numeric |  |
+| `total_attempts` | numeric | Total return attempts, kickoffs and punts combined. |
+| `grades_punt_return` | numeric | PFF punt-return grade, 0-100. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3244,9 +3244,9 @@ Facet report /rushing/direction (By Position leaderboard; add franchiseId for By
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `directions` | list |  |
-| `draft_season` | numeric |  |
-| `eligible_season` | numeric |  |
+| `directions` | list | Nested per-direction rushing splits (attempts and results by run direction) as returned by the PFF API. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `player` | character | Player name |
@@ -3254,7 +3254,7 @@ Facet report /rushing/direction (By Position leaderboard; add franchiseId for By
 | `position` | character | Primary position as reported by NFL.com |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `total_attempts` | numeric |  |
+| `total_attempts` | numeric | Total rushing attempts across all run directions. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3319,56 +3319,56 @@ Facet report /rushing/summary (By Position leaderboard; add franchiseId for By T
 | col_name | type | description |
 |---|---|---|
 | `targets` | numeric | The number of pass plays where the player was the targeted receiver. |
-| `grades_pass_block` | numeric |  |
+| `grades_pass_block` | numeric | PFF pass-blocking grade, 0-100. |
 | `grades_offense` | numeric | PFF overall offense grade (0-100). |
 | `yards_after_contact` | numeric | Yards after contact. |
-| `explosive` | numeric |  |
-| `grades_pass_route` | numeric |  |
-| `draft_season` | numeric |  |
-| `elu_rush_mtf` | numeric |  |
-| `breakaway_attempts` | numeric |  |
-| `designed_yards` | numeric |  |
+| `explosive` | numeric | Runs PFF designates as explosive. |
+| `grades_pass_route` | numeric | PFF route-running (receiving) grade, 0-100. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `elu_rush_mtf` | numeric | Missed tackles forced as a rusher, an input to PFF's elusive rating. |
+| `breakaway_attempts` | numeric | Runs of 15 or more yards, PFF's breakaway designation. |
+| `designed_yards` | numeric | Rushing yards gained on designed runs, excluding scrambles. |
 | `team_name` | character | Team abbreviation the player is credited to for the range. |
-| `yprr` | numeric |  |
-| `breakaway_percent` | numeric |  |
+| `yprr` | numeric | Yards per route run. |
+| `breakaway_percent` | numeric | Share of rushing yards gained on breakaway runs of 15 or more yards. |
 | `fumbles` | numeric | Fumbles by the ball carrier. |
 | `first_downs` | numeric | Rushing first downs. |
 | `elusive_rating` | numeric | PFF elusive rating. |
 | `jersey_number` | character | Jersey number (string; zero-padded, e.g. "09"). |
 | `breakaway_yards` | numeric | Breakaway (long-run) yards. |
 | `player_game_count` | numeric | Games with at least one qualifying snap in the requested range. |
-| `eligible_season` | numeric |  |
-| `total_touches` | numeric |  |
-| `scramble_yards` | numeric |  |
-| `yco_attempt` | numeric |  |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `total_touches` | numeric | Combined carries and receptions. |
+| `scramble_yards` | numeric | Rushing yards gained on scrambles. |
+| `yco_attempt` | numeric | Average yards after contact per rushing attempt. |
 | `yards` | numeric | Total rushing yards gained. |
-| `grades_run_block` | numeric |  |
+| `grades_run_block` | numeric | PFF run-blocking grade, 0-100. |
 | `receptions` | numeric | The number of pass receptions. Lateral receptions officially don't count as reception. |
-| `zone_attempts` | numeric |  |
-| `scrambles` | numeric |  |
+| `zone_attempts` | numeric | Rushing attempts on zone-scheme runs. |
+| `scrambles` | numeric | Quarterback scrambles. |
 | `grades_run` | numeric | PFF rushing grade (0-100). |
 | `penalties` | numeric | Total number of penalties. |
 | `attempts` | numeric | Rushing attempts (carries) by the runner. |
-| `elu_yco` | numeric |  |
-| `elu_recv_mtf` | numeric |  |
+| `elu_yco` | numeric | Yards-after-contact component used in PFF's elusive rating. |
+| `elu_recv_mtf` | numeric | Missed tackles forced as a receiver, an input to PFF's elusive rating. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `declined_penalties` | numeric |  |
-| `ypa` | numeric |  |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `ypa` | numeric | Average yards per rushing attempt. |
 | `drops` | numeric | Throws dropped |
 | `position` | character | Primary position as reported by NFL.com |
-| `grades_hands_fumble` | numeric |  |
-| `longest` | numeric |  |
-| `routes` | numeric |  |
+| `grades_hands_fumble` | numeric | PFF ball-security (hands/fumble) grade, 0-100. |
+| `longest` | numeric | Longest run in yards. |
+| `routes` | numeric | Pass routes run by the player. |
 | `player` | character | Player name |
 | `franchise_id` | numeric | PFF franchise (team) id (integer join key). |
 | `rec_yards` | numeric | Career receiving yards |
-| `gap_attempts` | numeric |  |
-| `run_plays` | numeric |  |
+| `gap_attempts` | numeric | Rushing attempts on gap-scheme runs. |
+| `run_plays` | numeric | Run-play snaps. |
 | `avoided_tackles` | numeric | Missed tackles forced. |
-| `grades_offense_penalty` | numeric |  |
+| `grades_offense_penalty` | numeric | PFF offensive penalty grade, 0-100. |
 | `player_id` | numeric | PFF player id (integer; matches the /players id and every player_id join key). |
 | `touchdowns` | numeric | Rushing touchdowns. |
-| `grades_pass` | numeric |  |
+| `grades_pass` | numeric | PFF passing grade, 0-100. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3402,27 +3402,27 @@ Facet report /signature/defense/slot_coverage (By Position leaderboard; add fran
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `coverage_snaps` | numeric |  |
-| `coverage_snaps_per_reception` | numeric |  |
-| `coverage_snaps_per_target` | numeric |  |
-| `draft_season` | numeric |  |
-| `eligible_season` | numeric |  |
+| `coverage_snaps` | numeric | Coverage snaps played while covering the slot. |
+| `coverage_snaps_per_reception` | numeric | Coverage snaps played per reception allowed while covering the slot. |
+| `coverage_snaps_per_target` | numeric | Coverage snaps played per target into the player's coverage while covering the slot. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `interceptions` | numeric | The number of interceptions thrown. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `player` | character | Player name |
-| `player_game_count` | numeric |  |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 | `position` | character | Primary position as reported by NFL.com |
-| `qb_rating_against` | numeric |  |
+| `qb_rating_against` | numeric | NFL passer rating allowed on targets into the player's coverage while covering the slot. |
 | `receptions` | numeric | The number of pass receptions. Lateral receptions officially don't count as reception. |
 | `targets` | numeric | The number of pass plays where the player was the targeted receiver. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `touchdowns` | numeric |  |
+| `touchdowns` | numeric | Touchdowns allowed into the player's coverage while covering the slot. |
 | `yards` | numeric | The number of receiving yards |
 | `yards_after_catch` | numeric | Numeric value for distance in yards perpendicular to the yard line where the receiver made the reception to where the play ended. |
-| `yards_per_coverage_snap` | numeric |  |
+| `yards_per_coverage_snap` | numeric | Receiving yards allowed per coverage snap while covering the slot. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3458,12 +3458,12 @@ Facet report /signature/pass-blocking/efficiency/line (By Position leaderboard; 
 |---|---|---|
 | `attempts` | numeric | The number of pass attempts as defined by the NFL. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `hits_allowed` | numeric |  |
-| `hurries_allowed` | numeric |  |
-| `pass_snaps` | numeric |  |
-| `pbe` | numeric |  |
-| `player_game_count` | numeric |  |
-| `pressures_allowed` | numeric |  |
+| `hits_allowed` | numeric | Quarterback hits allowed. |
+| `hurries_allowed` | numeric | Quarterback hurries allowed. |
+| `pass_snaps` | numeric | Pass-play snaps. |
+| `pbe` | numeric | PFF Pass Blocking Efficiency rating, pressures allowed per pass-blocking snap weighted toward sacks. |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
+| `pressures_allowed` | numeric | Total pressures allowed (sacks, hits, and hurries). |
 | `sacks_allowed` | numeric | Opponent sacks. |
 | `season_id` | numeric | Unique season identifier. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
@@ -3500,50 +3500,50 @@ Facet report /signature/defense/outside_pass_rush (By Position leaderboard; add 
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `lhs_sacks` | numeric |  |
-| `rhs_hits` | numeric |  |
-| `rhs_prp` | numeric |  |
-| `draft_season` | numeric |  |
-| `pass_snaps` | numeric |  |
-| `lhs_hurries` | numeric |  |
+| `lhs_sacks` | numeric | Sacks recorded when rushing from the left side. |
+| `rhs_hits` | numeric | Quarterback hits recorded when rushing from the right side. |
+| `rhs_prp` | numeric | PFF Pass Rush Productivity rating, pressure generated per pass-rush snap weighted toward sacks when rushing from the right side. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `pass_snaps` | numeric | Pass-play snaps. |
+| `lhs_hurries` | numeric | Quarterback hurries recorded when rushing from the left side. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `prp` | numeric |  |
+| `prp` | numeric | PFF Pass Rush Productivity rating, pressure generated per pass-rush snap weighted toward sacks. |
 | `tackles` | numeric | Team tackles. |
-| `rhs_pressures` | numeric |  |
-| `rhs_pass_rush_percent` | numeric |  |
+| `rhs_pressures` | numeric | Total pressures generated (sacks, hits, and hurries) when rushing from the right side. |
+| `rhs_pass_rush_percent` | numeric | Share of pass-play snaps spent rushing the passer when rushing from the right side. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `lhs_pass_rush_percent` | numeric |  |
-| `lhs_pass_rush_snaps` | numeric |  |
+| `lhs_pass_rush_percent` | numeric | Share of pass-play snaps spent rushing the passer when rushing from the left side. |
+| `lhs_pass_rush_snaps` | numeric | Pass-rush snaps played when rushing from the left side. |
 | `sacks` | numeric | The Number of times sacked. |
-| `lhs_assists` | numeric |  |
-| `player_game_count` | numeric |  |
-| `eligible_season` | numeric |  |
-| `lhs_pressures` | numeric |  |
-| `pass_rush_snaps` | numeric |  |
-| `hurries` | numeric |  |
-| `rhs_pass_rush_snaps` | numeric |  |
-| `lhs_prp` | numeric |  |
+| `lhs_assists` | numeric | Assisted tackles when rushing from the left side. |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `lhs_pressures` | numeric | Total pressures generated (sacks, hits, and hurries) when rushing from the left side. |
+| `pass_rush_snaps` | numeric | Pass-rush snaps played. |
+| `hurries` | numeric | Quarterback hurries recorded. |
+| `rhs_pass_rush_snaps` | numeric | Pass-rush snaps played when rushing from the right side. |
+| `lhs_prp` | numeric | PFF Pass Rush Productivity rating, pressure generated per pass-rush snap weighted toward sacks when rushing from the left side. |
 | `hits` | numeric | Hits. |
-| `lhs_hits` | numeric |  |
-| `rhs_tackles` | numeric |  |
-| `lhs_stops` | numeric |  |
+| `lhs_hits` | numeric | Quarterback hits recorded when rushing from the left side. |
+| `rhs_tackles` | numeric | Tackles made when rushing from the right side. |
+| `lhs_stops` | numeric | Stops, PFF's tackles that constitute a failed play for the offense when rushing from the left side. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `stops` | numeric |  |
-| `rhs_misses` | numeric |  |
+| `stops` | numeric | Stops, PFF's tackles that constitute a failed play for the offense. |
+| `rhs_misses` | numeric | Missed tackles when rushing from the right side. |
 | `position` | character | Primary position as reported by NFL.com |
-| `pressures` | numeric |  |
-| `misses` | numeric |  |
+| `pressures` | numeric | Total pressures generated (sacks, hits, and hurries). |
+| `misses` | numeric | Missed tackles. |
 | `player` | character | Player name |
-| `rhs_sacks` | numeric |  |
+| `rhs_sacks` | numeric | Sacks recorded when rushing from the right side. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `pass_rush_percent` | numeric |  |
-| `rhs_hurries` | numeric |  |
-| `rhs_assists` | numeric |  |
-| `rhs_stops` | numeric |  |
+| `pass_rush_percent` | numeric | Share of pass-play snaps spent rushing the passer. |
+| `rhs_hurries` | numeric | Quarterback hurries recorded when rushing from the right side. |
+| `rhs_assists` | numeric | Assisted tackles when rushing from the right side. |
+| `rhs_stops` | numeric | Stops, PFF's tackles that constitute a failed play for the offense when rushing from the right side. |
 | `assists` | numeric | Total assists. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
-| `lhs_tackles` | numeric |  |
-| `lhs_misses` | numeric |  |
+| `lhs_tackles` | numeric | Tackles made when rushing from the left side. |
+| `lhs_misses` | numeric | Missed tackles when rushing from the left side. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3577,80 +3577,80 @@ Facet report /receiving/scheme (By Position leaderboard; add franchiseId for By 
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `man_contested_catch_rate` | numeric |  |
-| `man_touchdowns` | numeric |  |
-| `zone_targets_percent` | numeric |  |
-| `man_interceptions` | numeric |  |
-| `zone_epa` | numeric |  |
-| `man_avg_depth_of_target` | numeric |  |
-| `zone_pass_blocks` | numeric |  |
-| `zone_avoided_tackles` | numeric |  |
-| `man_targeted_qb_rating` | numeric |  |
-| `draft_season` | numeric |  |
-| `zone_positive_epa_percent` | numeric |  |
-| `man_targets_percent` | numeric |  |
-| `man_yards_per_reception` | numeric |  |
+| `man_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught against man coverage. |
+| `man_touchdowns` | numeric | Receiving touchdowns scored against man coverage. |
+| `zone_targets_percent` | numeric | Share of the team's targets thrown to the player against zone coverage. |
+| `man_interceptions` | numeric | Interceptions thrown on passes targeting the player against man coverage. |
+| `zone_epa` | numeric | Total expected points added on targets to the player against zone coverage. |
+| `man_avg_depth_of_target` | numeric | Average depth of target in yards downfield against man coverage. |
+| `zone_pass_blocks` | numeric | Pass-play snaps spent pass blocking against zone coverage. |
+| `zone_avoided_tackles` | numeric | Tackles avoided after the catch against zone coverage. |
+| `man_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player against man coverage. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `zone_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added against zone coverage. |
+| `man_targets_percent` | numeric | Share of the team's targets thrown to the player against man coverage. |
+| `man_yards_per_reception` | numeric | Average yards per reception against man coverage. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `man_drop_rate` | numeric |  |
-| `zone_grades_pass_route` | numeric |  |
+| `man_drop_rate` | numeric | Share of catchable targets the player dropped against man coverage. |
+| `zone_grades_pass_route` | numeric | PFF route-running (receiving) grade against zone coverage, 0-100. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `zone_fumbles` | numeric |  |
-| `man_pass_block_rate` | numeric |  |
-| `zone_yards` | numeric |  |
-| `man_yprr` | numeric |  |
-| `player_game_count` | numeric |  |
-| `eligible_season` | numeric |  |
-| `zone_drops` | numeric |  |
-| `zone_receptions` | numeric |  |
-| `man_pass_plays` | numeric |  |
-| `man_epa` | numeric |  |
-| `zone_yards_per_reception` | numeric |  |
-| `man_contested_targets` | numeric |  |
-| `man_longest` | numeric |  |
-| `zone_yards_after_catch` | numeric |  |
-| `man_receptions` | numeric |  |
-| `man_avoided_tackles` | numeric |  |
-| `man_first_downs` | numeric |  |
-| `base_targets` | numeric |  |
-| `zone_contested_catch_rate` | numeric |  |
-| `zone_targeted_qb_rating` | numeric |  |
-| `man_routes` | numeric |  |
-| `zone_grades_hands_drop` | numeric |  |
-| `man_route_rate` | numeric |  |
-| `zone_pass_block_rate` | numeric |  |
-| `man_grades_pass_route` | numeric |  |
+| `zone_fumbles` | numeric | Fumbles by the player after the catch against zone coverage. |
+| `man_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking against man coverage. |
+| `zone_yards` | numeric | Receiving yards gained against zone coverage. |
+| `man_yprr` | numeric | Yards per route run against man coverage. |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `zone_drops` | numeric | PFF-charted drops against zone coverage. |
+| `zone_receptions` | numeric | Receptions made against zone coverage. |
+| `man_pass_plays` | numeric | Pass-play snaps against man coverage. |
+| `man_epa` | numeric | Total expected points added on targets to the player against man coverage. |
+| `zone_yards_per_reception` | numeric | Average yards per reception against zone coverage. |
+| `man_contested_targets` | numeric | PFF-charted contested targets against man coverage. |
+| `man_longest` | numeric | Longest reception in yards against man coverage. |
+| `zone_yards_after_catch` | numeric | Yards gained after the catch against zone coverage. |
+| `man_receptions` | numeric | Receptions made against man coverage. |
+| `man_avoided_tackles` | numeric | Tackles avoided after the catch against man coverage. |
+| `man_first_downs` | numeric | Receptions that converted a first down against man coverage. |
+| `base_targets` | numeric | Total targets from the facet's unsplit base row, across all coverage schemes. |
+| `zone_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught against zone coverage. |
+| `zone_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player against zone coverage. |
+| `man_routes` | numeric | Pass routes run by the player against man coverage. |
+| `zone_grades_hands_drop` | numeric | PFF hands/drop grade against zone coverage, 0-100. |
+| `man_route_rate` | numeric | Share of pass-play snaps on which the player ran a route against man coverage. |
+| `zone_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking against zone coverage. |
+| `man_grades_pass_route` | numeric | PFF route-running (receiving) grade against man coverage, 0-100. |
 | `penalties` | numeric | Total number of penalties. |
-| `zone_first_downs` | numeric |  |
-| `zone_yprr` | numeric |  |
-| `man_drops` | numeric |  |
-| `zone_caught_percent` | numeric |  |
+| `zone_first_downs` | numeric | Receptions that converted a first down against zone coverage. |
+| `zone_yprr` | numeric | Yards per route run against zone coverage. |
+| `man_drops` | numeric | PFF-charted drops against man coverage. |
+| `zone_caught_percent` | numeric | Percentage of targets caught against zone coverage. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `man_fumbles` | numeric |  |
-| `declined_penalties` | numeric |  |
-| `man_yards_after_catch` | numeric |  |
-| `man_yards` | numeric |  |
-| `zone_pass_plays` | numeric |  |
+| `man_fumbles` | numeric | Fumbles by the player after the catch against man coverage. |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `man_yards_after_catch` | numeric | Yards gained after the catch against man coverage. |
+| `man_yards` | numeric | Receiving yards gained against man coverage. |
+| `zone_pass_plays` | numeric | Pass-play snaps against zone coverage. |
 | `position` | character | Primary position as reported by NFL.com |
-| `man_targets` | numeric |  |
-| `man_grades_hands_drop` | numeric |  |
-| `man_pass_blocks` | numeric |  |
-| `zone_touchdowns` | numeric |  |
-| `zone_route_rate` | numeric |  |
-| `zone_yards_after_catch_per_reception` | numeric |  |
-| `zone_avg_depth_of_target` | numeric |  |
+| `man_targets` | numeric | Pass targets to the player against man coverage. |
+| `man_grades_hands_drop` | numeric | PFF hands/drop grade against man coverage, 0-100. |
+| `man_pass_blocks` | numeric | Pass-play snaps spent pass blocking against man coverage. |
+| `zone_touchdowns` | numeric | Receiving touchdowns scored against zone coverage. |
+| `zone_route_rate` | numeric | Share of pass-play snaps on which the player ran a route against zone coverage. |
+| `zone_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception against zone coverage. |
+| `zone_avg_depth_of_target` | numeric | Average depth of target in yards downfield against zone coverage. |
 | `player` | character | Player name |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `zone_contested_targets` | numeric |  |
-| `zone_contested_receptions` | numeric |  |
-| `man_contested_receptions` | numeric |  |
-| `man_yards_after_catch_per_reception` | numeric |  |
-| `zone_targets` | numeric |  |
-| `zone_longest` | numeric |  |
-| `man_caught_percent` | numeric |  |
-| `zone_drop_rate` | numeric |  |
-| `zone_interceptions` | numeric |  |
-| `man_positive_epa_percent` | numeric |  |
-| `zone_routes` | numeric |  |
+| `zone_contested_targets` | numeric | PFF-charted contested targets against zone coverage. |
+| `zone_contested_receptions` | numeric | Catches made on PFF-charted contested targets against zone coverage. |
+| `man_contested_receptions` | numeric | Catches made on PFF-charted contested targets against man coverage. |
+| `man_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception against man coverage. |
+| `zone_targets` | numeric | Pass targets to the player against zone coverage. |
+| `zone_longest` | numeric | Longest reception in yards against zone coverage. |
+| `man_caught_percent` | numeric | Percentage of targets caught against man coverage. |
+| `zone_drop_rate` | numeric | Share of catchable targets the player dropped against zone coverage. |
+| `zone_interceptions` | numeric | Interceptions thrown on passes targeting the player against zone coverage. |
+| `man_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added against man coverage. |
+| `zone_routes` | numeric | Pass routes run by the player against zone coverage. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -3685,121 +3685,121 @@ Facet report /signature/passing/time_in_pocket (By Position leaderboard; add fra
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `more_btt_rate` | numeric |  |
-| `more_grades_run` | numeric |  |
-| `more_ypa` | numeric |  |
-| `more_passing_snaps` | numeric |  |
-| `more_pressure_to_sack_rate` | numeric |  |
-| `less_def_gen_pressures` | numeric |  |
-| `dropbacks` | numeric |  |
-| `less_sack_percent` | numeric |  |
-| `less_first_downs` | numeric |  |
-| `less_ypa` | numeric |  |
-| `draft_season` | numeric |  |
-| `more_grades_pass_route` | character |  |
-| `less_pressure_to_sack_rate` | numeric |  |
-| `less_aimed_passes` | numeric |  |
-| `more_dropbacks_percent` | numeric |  |
-| `less_positive_epa_percent` | numeric |  |
+| `more_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on dropbacks with time in pocket of 2.5 seconds or more, per PFF charting. |
+| `more_grades_run` | numeric | PFF rushing grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_ypa` | numeric | Yards gained per pass attempt on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_passing_snaps` | numeric | Number of passing snaps played on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on dropbacks with time in pocket under 2.5 seconds, as charted by PFF. |
+| `dropbacks` | numeric | Number of dropbacks. |
+| `less_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on dropbacks with time in pocket under 2.5 seconds. |
+| `less_first_downs` | numeric | Number of passing first downs gained on dropbacks with time in pocket under 2.5 seconds. |
+| `less_ypa` | numeric | Yards gained per pass attempt on dropbacks with time in pocket under 2.5 seconds. |
+| `draft_season` | numeric | NFL season (year) in which the player was drafted, per PFF player metadata. |
+| `more_grades_pass_route` | character | PFF receiving (route) grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_pressure_to_sack_rate` | numeric | Percentage of pressured dropbacks that ended in a sack on dropbacks with time in pocket under 2.5 seconds. |
+| `less_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on dropbacks with time in pocket under 2.5 seconds, as charted by PFF. |
+| `more_dropbacks_percent` | numeric | Share of the player's total dropbacks that came on dropbacks with time in pocket of 2.5 seconds or more, expressed as a percentage. |
+| `less_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on dropbacks with time in pocket under 2.5 seconds. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `avg_ttt_scrambles` | numeric |  |
-| `more_yards` | numeric |  |
-| `more_accuracy_percent` | numeric |  |
-| `less_attempts` | numeric |  |
-| `less_drop_rate` | numeric |  |
+| `avg_ttt_scrambles` | numeric | Average time in the pocket in seconds on dropbacks ending in a scramble. |
+| `more_yards` | numeric | Passing yards gained on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_attempts` | numeric | Number of pass attempts on dropbacks with time in pocket under 2.5 seconds. |
+| `less_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on dropbacks with time in pocket under 2.5 seconds. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `more_turnover_worthy_plays` | numeric |  |
-| `more_interceptions` | numeric |  |
-| `more_sack_percent` | numeric |  |
-| `more_twp_rate` | numeric |  |
-| `less_completions` | numeric |  |
-| `more_thrown_aways` | numeric |  |
-| `less_btt_rate` | numeric |  |
-| `more_big_time_throws` | numeric |  |
-| `less_qb_rating` | numeric |  |
-| `less_hit_as_threw` | numeric |  |
-| `more_attempts` | numeric |  |
-| `player_game_count` | numeric |  |
-| `less_spikes` | numeric |  |
-| `eligible_season` | numeric |  |
-| `less_dropbacks_percent` | numeric |  |
-| `more_qb_rating` | numeric |  |
-| `less_dropbacks` | numeric |  |
-| `more_grades_hands_fumble` | numeric |  |
-| `more_avg_depth_of_target` | numeric |  |
-| `less_scrambles` | numeric |  |
-| `more_positive_epa_percent` | numeric |  |
-| `less_sacks` | numeric |  |
-| `less_grades_pass` | numeric |  |
-| `less_drops` | numeric |  |
-| `more_sacks` | numeric |  |
-| `more_first_downs` | numeric |  |
-| `less_big_time_throws` | numeric |  |
-| `avg_ttt_attempts` | numeric |  |
-| `more_aimed_passes` | numeric |  |
-| `less_accuracy_percent` | numeric |  |
-| `more_scrambles` | numeric |  |
-| `less_epa` | numeric |  |
-| `more_spikes` | numeric |  |
-| `less_grades_pass_route` | character |  |
-| `less_grades_offense` | numeric |  |
-| `avg_ttt_sacks` | numeric |  |
-| `more_grades_offense_penalty` | numeric |  |
+| `more_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on dropbacks with time in pocket of 2.5 seconds or more, plays PFF charts as deserving of a turnover. |
+| `more_interceptions` | numeric | Number of passes intercepted on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_sack_percent` | numeric | Percentage of dropbacks that ended in a sack on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on dropbacks with time in pocket of 2.5 seconds or more, per PFF charting. |
+| `less_completions` | numeric | Number of completed passes on dropbacks with time in pocket under 2.5 seconds. |
+| `more_thrown_aways` | numeric | Number of intentional throwaways on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_btt_rate` | numeric | Big-time throws as a percentage of qualifying attempts on dropbacks with time in pocket under 2.5 seconds, per PFF charting. |
+| `more_big_time_throws` | numeric | Number of big-time throws on dropbacks with time in pocket of 2.5 seconds or more, per PFF's highest-value, highest-difficulty throw designation. |
+| `less_qb_rating` | numeric | Traditional NFL passer rating on dropbacks with time in pocket under 2.5 seconds. |
+| `less_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on dropbacks with time in pocket under 2.5 seconds, as charted by PFF. |
+| `more_attempts` | numeric | Number of pass attempts on dropbacks with time in pocket of 2.5 seconds or more. |
+| `player_game_count` | numeric | Number of games the player appeared in during the period covered. |
+| `less_spikes` | numeric | Number of clock-stopping spikes on dropbacks with time in pocket under 2.5 seconds. |
+| `eligible_season` | numeric | Season (year) of the player's NFL draft eligibility, per PFF player metadata. |
+| `less_dropbacks_percent` | numeric | Share of the player's total dropbacks that came on dropbacks with time in pocket under 2.5 seconds, expressed as a percentage. |
+| `more_qb_rating` | numeric | Traditional NFL passer rating on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_dropbacks` | numeric | Number of dropbacks on dropbacks with time in pocket under 2.5 seconds. |
+| `more_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_avg_depth_of_target` | numeric | Average depth of target in air yards on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_scrambles` | numeric | Number of scrambles on dropbacks with time in pocket under 2.5 seconds. |
+| `more_positive_epa_percent` | numeric | Percentage of dropbacks with positive expected points added on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_sacks` | numeric | Number of sacks taken on dropbacks with time in pocket under 2.5 seconds. |
+| `less_grades_pass` | numeric | PFF passing grade (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `less_drops` | numeric | Number of catchable passes dropped by receivers on dropbacks with time in pocket under 2.5 seconds. |
+| `more_sacks` | numeric | Number of sacks taken on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_first_downs` | numeric | Number of passing first downs gained on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_big_time_throws` | numeric | Number of big-time throws on dropbacks with time in pocket under 2.5 seconds, per PFF's highest-value, highest-difficulty throw designation. |
+| `avg_ttt_attempts` | numeric | Average time from snap to release in seconds on dropbacks ending in a pass attempt. |
+| `more_aimed_passes` | numeric | Number of aimed passes (attempts excluding spikes and throwaways) on dropbacks with time in pocket of 2.5 seconds or more, as charted by PFF. |
+| `less_accuracy_percent` | numeric | Percentage of aimed passes charted as accurate by PFF on dropbacks with time in pocket under 2.5 seconds. |
+| `more_scrambles` | numeric | Number of scrambles on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on dropbacks with time in pocket under 2.5 seconds. |
+| `more_spikes` | numeric | Number of clock-stopping spikes on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_grades_pass_route` | character | PFF receiving (route) grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `less_grades_offense` | numeric | PFF overall offense grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `avg_ttt_sacks` | numeric | Average time from snap to sack in seconds on dropbacks ending in a sack. |
+| `more_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `less_bats` | numeric |  |
-| `less_grades_run` | numeric |  |
+| `less_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on dropbacks with time in pocket under 2.5 seconds. |
+| `less_grades_run` | numeric | PFF rushing grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
 | `position` | character | Primary position as reported by NFL.com |
-| `less_touchdowns` | numeric |  |
-| `less_yards` | numeric |  |
-| `less_grades_run_block` | character |  |
-| `less_grades_hands_fumble` | numeric |  |
-| `more_hit_as_threw` | numeric |  |
-| `more_epa` | numeric |  |
+| `less_touchdowns` | numeric | Number of passing touchdowns thrown on dropbacks with time in pocket under 2.5 seconds. |
+| `less_yards` | numeric | Passing yards gained on dropbacks with time in pocket under 2.5 seconds. |
+| `less_grades_run_block` | character | PFF run-blocking grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `less_grades_hands_fumble` | numeric | PFF hands (fumble) grade for the player, reflecting ball security (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `more_hit_as_threw` | numeric | Number of attempts on which the passer was hit as he threw on dropbacks with time in pocket of 2.5 seconds or more, as charted by PFF. |
+| `more_epa` | numeric | Total expected points added (EPA) on the player's dropbacks on dropbacks with time in pocket of 2.5 seconds or more. |
 | `avg_time_to_throw` | numeric | Average time elapsed from the time of snap to throw on every pass attempt for a passer (sacks excluded). |
-| `less_turnover_worthy_plays` | numeric |  |
-| `less_completion_percent` | numeric |  |
-| `more_drops` | numeric |  |
+| `less_turnover_worthy_plays` | numeric | Number of turnover-worthy plays on dropbacks with time in pocket under 2.5 seconds, plays PFF charts as deserving of a turnover. |
+| `less_completion_percent` | numeric | Percentage of pass attempts completed on dropbacks with time in pocket under 2.5 seconds. |
+| `more_drops` | numeric | Number of catchable passes dropped by receivers on dropbacks with time in pocket of 2.5 seconds or more. |
 | `player` | character | Player name |
-| `more_touchdowns` | numeric |  |
+| `more_touchdowns` | numeric | Number of passing touchdowns thrown on dropbacks with time in pocket of 2.5 seconds or more. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `more_drop_rate` | numeric |  |
-| `less_twp_rate` | numeric |  |
-| `more_grades_offense` | numeric |  |
-| `less_thrown_aways` | numeric |  |
-| `less_avg_depth_of_target` | numeric |  |
-| `less_avg_time_to_throw` | numeric |  |
-| `less_grades_offense_penalty` | numeric |  |
-| `less_interceptions` | numeric |  |
-| `more_def_gen_pressures` | numeric |  |
-| `more_avg_time_to_throw` | numeric |  |
-| `more_dropbacks` | numeric |  |
-| `more_grades_pass` | numeric |  |
+| `more_drop_rate` | numeric | Percentage of catchable passes dropped by receivers on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_twp_rate` | numeric | Turnover-worthy plays as a percentage of qualifying attempts on dropbacks with time in pocket under 2.5 seconds, per PFF charting. |
+| `more_grades_offense` | numeric | PFF overall offense grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_thrown_aways` | numeric | Number of intentional throwaways on dropbacks with time in pocket under 2.5 seconds. |
+| `less_avg_depth_of_target` | numeric | Average depth of target in air yards on dropbacks with time in pocket under 2.5 seconds. |
+| `less_avg_time_to_throw` | numeric | Average time from snap to release in seconds on dropbacks with time in pocket under 2.5 seconds. |
+| `less_grades_offense_penalty` | numeric | PFF offensive penalty grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `less_interceptions` | numeric | Number of passes intercepted on dropbacks with time in pocket under 2.5 seconds. |
+| `more_def_gen_pressures` | numeric | Number of defense-generated pressures on the player's dropbacks on dropbacks with time in pocket of 2.5 seconds or more, as charted by PFF. |
+| `more_avg_time_to_throw` | numeric | Average time from snap to release in seconds on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_dropbacks` | numeric | Number of dropbacks on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_grades_pass` | numeric | PFF passing grade (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
-| `less_passing_snaps` | numeric |  |
-| `more_completions` | numeric |  |
-| `more_grades_run_block` | character |  |
-| `more_bats` | numeric |  |
-| `more_completion_percent` | numeric |  |
-| `more_grades_hands_drop` | character |  |
-| `less_grades_hands_drop` | character |  |
-| `less_grades_pass_block` | character |  |
-| `more_grades_pass_block` | character |  |
-| `less_grades_screen_block` | character |  |
-| `more_grades_screen_block` | character |  |
-| `less_grades_defense_penalty` | character |  |
-| `less_grades_coverage_defense` | character |  |
-| `more_grades_defense_penalty` | character |  |
-| `more_grades_defense` | character |  |
-| `more_grades_coverage_defense` | character |  |
-| `less_grades_defense` | character |  |
-| `less_grades_overall_tackle` | character |  |
-| `more_grades_pass_rush_defense` | character |  |
-| `more_grades_run_defense` | character |  |
-| `more_grades_tackle` | character |  |
-| `less_grades_pass_rush_defense` | character |  |
-| `less_grades_tackle` | character |  |
-| `more_grades_overall_tackle` | character |  |
-| `less_grades_run_defense` | character |  |
+| `less_passing_snaps` | numeric | Number of passing snaps played on dropbacks with time in pocket under 2.5 seconds. |
+| `more_completions` | numeric | Number of completed passes on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_grades_run_block` | character | PFF run-blocking grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_bats` | numeric | Number of pass attempts batted down at the line of scrimmage on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_completion_percent` | numeric | Percentage of pass attempts completed on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_grades_hands_drop` | character | PFF hands (drop) grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_grades_hands_drop` | character | PFF hands (drop) grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `less_grades_pass_block` | character | PFF pass-blocking grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `more_grades_pass_block` | character | PFF pass-blocking grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_grades_screen_block` | character | PFF screen-blocking grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `more_grades_screen_block` | character | PFF screen-blocking grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_grades_defense_penalty` | character | PFF defensive penalty grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `less_grades_coverage_defense` | character | PFF coverage grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `more_grades_defense_penalty` | character | PFF defensive penalty grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_grades_defense` | character | PFF overall defense grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_grades_coverage_defense` | character | PFF coverage grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_grades_defense` | character | PFF overall defense grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `less_grades_overall_tackle` | character | PFF overall tackling grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `more_grades_pass_rush_defense` | character | PFF pass-rush grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_grades_run_defense` | character | PFF run-defense grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `more_grades_tackle` | character | PFF tackling grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_grades_pass_rush_defense` | character | PFF pass-rush grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `less_grades_tackle` | character | PFF tackling grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
+| `more_grades_overall_tackle` | character | PFF overall tackling grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more. |
+| `less_grades_run_defense` | character | PFF run-defense grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3833,80 +3833,80 @@ Facet report /receiving/concept (By Position leaderboard; add franchiseId for By
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `screen_caught_percent` | numeric |  |
-| `screen_targeted_qb_rating` | numeric |  |
-| `slot_grades_pass_route` | numeric |  |
-| `slot_avg_depth_of_target` | numeric |  |
-| `slot_positive_epa_percent` | numeric |  |
-| `screen_yprr` | numeric |  |
-| `draft_season` | numeric |  |
-| `slot_routes` | numeric |  |
+| `screen_caught_percent` | numeric | Percentage of targets caught on screen concepts. |
+| `screen_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on screen concepts. |
+| `slot_grades_pass_route` | numeric | PFF route-running (receiving) grade when aligned in the slot, 0-100. |
+| `slot_avg_depth_of_target` | numeric | Average depth of target in yards downfield when aligned in the slot. |
+| `slot_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added when aligned in the slot. |
+| `screen_yprr` | numeric | Yards per route run on screen concepts. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `slot_routes` | numeric | Pass routes run by the player when aligned in the slot. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `screen_grades_hands_drop` | numeric |  |
+| `screen_grades_hands_drop` | numeric | PFF hands/drop grade on screen concepts, 0-100. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `screen_contested_catch_rate` | numeric |  |
-| `slot_yards_per_reception` | numeric |  |
-| `screen_interceptions` | numeric |  |
-| `slot_targets_percent` | numeric |  |
-| `screen_longest` | numeric |  |
-| `slot_avoided_tackles` | numeric |  |
-| `slot_yards_after_catch` | numeric |  |
-| `slot_grades_hands_drop` | numeric |  |
-| `player_game_count` | numeric |  |
-| `screen_contested_targets` | numeric |  |
-| `eligible_season` | numeric |  |
-| `screen_yards_after_catch_per_reception` | numeric |  |
-| `screen_yards` | numeric |  |
-| `slot_route_rate` | numeric |  |
-| `screen_drop_rate` | numeric |  |
-| `screen_epa` | numeric |  |
-| `screen_grades_pass_route` | numeric |  |
-| `screen_drops` | numeric |  |
-| `screen_fumbles` | numeric |  |
-| `slot_interceptions` | numeric |  |
-| `screen_yards_after_catch` | numeric |  |
-| `screen_avg_depth_of_target` | numeric |  |
-| `screen_pass_block_rate` | numeric |  |
-| `slot_pass_block_rate` | numeric |  |
-| `slot_yprr` | numeric |  |
-| `base_targets` | numeric |  |
-| `slot_longest` | numeric |  |
-| `slot_drops` | numeric |  |
-| `screen_routes` | numeric |  |
-| `slot_fumbles` | numeric |  |
+| `screen_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on screen concepts. |
+| `slot_yards_per_reception` | numeric | Average yards per reception when aligned in the slot. |
+| `screen_interceptions` | numeric | Interceptions thrown on passes targeting the player on screen concepts. |
+| `slot_targets_percent` | numeric | Share of the team's targets thrown to the player when aligned in the slot. |
+| `screen_longest` | numeric | Longest reception in yards on screen concepts. |
+| `slot_avoided_tackles` | numeric | Tackles avoided after the catch when aligned in the slot. |
+| `slot_yards_after_catch` | numeric | Yards gained after the catch when aligned in the slot. |
+| `slot_grades_hands_drop` | numeric | PFF hands/drop grade when aligned in the slot, 0-100. |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
+| `screen_contested_targets` | numeric | PFF-charted contested targets on screen concepts. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `screen_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on screen concepts. |
+| `screen_yards` | numeric | Receiving yards gained on screen concepts. |
+| `slot_route_rate` | numeric | Share of pass-play snaps on which the player ran a route when aligned in the slot. |
+| `screen_drop_rate` | numeric | Share of catchable targets the player dropped on screen concepts. |
+| `screen_epa` | numeric | Total expected points added on targets to the player on screen concepts. |
+| `screen_grades_pass_route` | numeric | PFF route-running (receiving) grade on screen concepts, 0-100. |
+| `screen_drops` | numeric | PFF-charted drops on screen concepts. |
+| `screen_fumbles` | numeric | Fumbles by the player after the catch on screen concepts. |
+| `slot_interceptions` | numeric | Interceptions thrown on passes targeting the player when aligned in the slot. |
+| `screen_yards_after_catch` | numeric | Yards gained after the catch on screen concepts. |
+| `screen_avg_depth_of_target` | numeric | Average depth of target in yards downfield on screen concepts. |
+| `screen_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on screen concepts. |
+| `slot_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking when aligned in the slot. |
+| `slot_yprr` | numeric | Yards per route run when aligned in the slot. |
+| `base_targets` | numeric | Total targets from the facet's unsplit base row, across all concepts. |
+| `slot_longest` | numeric | Longest reception in yards when aligned in the slot. |
+| `slot_drops` | numeric | PFF-charted drops when aligned in the slot. |
+| `screen_routes` | numeric | Pass routes run by the player on screen concepts. |
+| `slot_fumbles` | numeric | Fumbles by the player after the catch when aligned in the slot. |
 | `penalties` | numeric | Total number of penalties. |
-| `slot_contested_catch_rate` | numeric |  |
-| `slot_pass_plays` | numeric |  |
+| `slot_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught when aligned in the slot. |
+| `slot_pass_plays` | numeric | Pass-play snaps when aligned in the slot. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `declined_penalties` | numeric |  |
-| `screen_positive_epa_percent` | numeric |  |
-| `slot_first_downs` | numeric |  |
-| `screen_route_rate` | numeric |  |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `screen_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on screen concepts. |
+| `slot_first_downs` | numeric | Receptions that converted a first down when aligned in the slot. |
+| `screen_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on screen concepts. |
 | `position` | character | Primary position as reported by NFL.com |
-| `screen_pass_blocks` | numeric |  |
-| `slot_targets` | numeric |  |
-| `slot_pass_blocks` | numeric |  |
-| `slot_receptions` | numeric |  |
-| `screen_first_downs` | numeric |  |
-| `slot_caught_percent` | numeric |  |
-| `screen_avoided_tackles` | numeric |  |
+| `screen_pass_blocks` | numeric | Pass-play snaps spent pass blocking on screen concepts. |
+| `slot_targets` | numeric | Pass targets to the player when aligned in the slot. |
+| `slot_pass_blocks` | numeric | Pass-play snaps spent pass blocking when aligned in the slot. |
+| `slot_receptions` | numeric | Receptions made when aligned in the slot. |
+| `screen_first_downs` | numeric | Receptions that converted a first down on screen concepts. |
+| `slot_caught_percent` | numeric | Percentage of targets caught when aligned in the slot. |
+| `screen_avoided_tackles` | numeric | Tackles avoided after the catch on screen concepts. |
 | `player` | character | Player name |
-| `slot_epa` | numeric |  |
-| `slot_drop_rate` | numeric |  |
+| `slot_epa` | numeric | Total expected points added on targets to the player when aligned in the slot. |
+| `slot_drop_rate` | numeric | Share of catchable targets the player dropped when aligned in the slot. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `slot_touchdowns` | numeric |  |
-| `slot_yards_after_catch_per_reception` | numeric |  |
-| `screen_receptions` | numeric |  |
-| `slot_targeted_qb_rating` | numeric |  |
-| `slot_contested_targets` | numeric |  |
-| `screen_yards_per_reception` | numeric |  |
-| `slot_contested_receptions` | numeric |  |
-| `screen_pass_plays` | numeric |  |
-| `screen_contested_receptions` | numeric |  |
-| `screen_touchdowns` | numeric |  |
-| `screen_targets` | numeric |  |
-| `screen_targets_percent` | numeric |  |
-| `slot_yards` | numeric |  |
+| `slot_touchdowns` | numeric | Receiving touchdowns scored when aligned in the slot. |
+| `slot_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception when aligned in the slot. |
+| `screen_receptions` | numeric | Receptions made on screen concepts. |
+| `slot_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player when aligned in the slot. |
+| `slot_contested_targets` | numeric | PFF-charted contested targets when aligned in the slot. |
+| `screen_yards_per_reception` | numeric | Average yards per reception on screen concepts. |
+| `slot_contested_receptions` | numeric | Catches made on PFF-charted contested targets when aligned in the slot. |
+| `screen_pass_plays` | numeric | Pass-play snaps on screen concepts. |
+| `screen_contested_receptions` | numeric | Catches made on PFF-charted contested targets on screen concepts. |
+| `screen_touchdowns` | numeric | Receiving touchdowns scored on screen concepts. |
+| `screen_targets` | numeric | Pass targets to the player on screen concepts. |
+| `screen_targets_percent` | numeric | Share of the team's targets thrown to the player on screen concepts. |
+| `slot_yards` | numeric | Receiving yards gained when aligned in the slot. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -3942,36 +3942,36 @@ Facet report /special/summary (By Position leaderboard; add franchiseId for By T
 | col_name | type | description |
 |---|---|---|
 | `assists` | numeric | Total assists. |
-| `declined_penalties` | numeric |  |
-| `draft_season` | numeric |  |
-| `eligible_season` | numeric |  |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `grades_fgep_kicker` | numeric |  |
-| `grades_kickoff_kicker` | numeric |  |
-| `grades_misc_st` | numeric |  |
-| `grades_special_teams_penalty` | numeric |  |
+| `grades_fgep_kicker` | numeric | PFF field-goal and extra-point kicking grade, 0-100. |
+| `grades_kickoff_kicker` | numeric | PFF kickoff kicking grade, 0-100. |
+| `grades_misc_st` | numeric | PFF miscellaneous special-teams grade, 0-100. |
+| `grades_special_teams_penalty` | numeric | PFF special-teams penalty grade, 0-100. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `missed_tackles` | numeric |  |
+| `missed_tackles` | numeric | Missed tackles on special-teams plays. |
 | `penalties` | numeric | Total number of penalties. |
 | `player` | character | Player name |
-| `player_game_count` | numeric |  |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 | `position` | character | Primary position as reported by NFL.com |
-| `snap_counts_field_goal` | numeric |  |
-| `snap_counts_field_goal_blocking` | numeric |  |
-| `snap_counts_kickoff` | numeric |  |
-| `snap_counts_kickoff_return` | numeric |  |
-| `snap_counts_punt_coverage` | numeric |  |
-| `snap_counts_punt_return` | numeric |  |
+| `snap_counts_field_goal` | numeric | Snaps on the field-goal and extra-point unit. |
+| `snap_counts_field_goal_blocking` | numeric | Snaps on the field-goal and extra-point block unit. |
+| `snap_counts_kickoff` | numeric | Snaps on the kickoff coverage unit. |
+| `snap_counts_kickoff_return` | numeric | Snaps on the kickoff return unit. |
+| `snap_counts_punt_coverage` | numeric | Snaps on the punt coverage unit. |
+| `snap_counts_punt_return` | numeric | Snaps on the punt return unit. |
 | `tackles` | numeric | Team tackles. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `grades_fgep_defense` | numeric |  |
-| `grades_fgep_offense` | numeric |  |
-| `grades_long_snap` | numeric |  |
-| `grades_punter` | numeric |  |
-| `grades_kick_return` | numeric |  |
-| `grades_punt_return` | numeric |  |
+| `grades_fgep_defense` | numeric | PFF grade on field-goal and extra-point defense, 0-100. |
+| `grades_fgep_offense` | numeric | PFF grade on the field-goal and extra-point protection unit, 0-100. |
+| `grades_long_snap` | numeric | PFF long-snapping grade, 0-100. |
+| `grades_punter` | numeric | PFF punting grade, 0-100. |
+| `grades_kick_return` | numeric | PFF kickoff-return grade, 0-100. |
+| `grades_punt_return` | numeric | PFF punt-return grade, 0-100. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -4005,515 +4005,515 @@ Facet report /receiving/depth (By Position leaderboard; add franchiseId for By T
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `left_deep_route_rate` | numeric |  |
-| `center_short_first_downs` | numeric |  |
-| `center_short_routes` | numeric |  |
-| `right_behind_los_positive_epa_percent` | numeric |  |
-| `left_behind_los_yards_after_catch` | numeric |  |
-| `center_behind_los_contested_targets` | numeric |  |
-| `right_short_routes` | numeric |  |
-| `right_deep_pass_block_rate` | numeric |  |
-| `medium_interceptions` | numeric |  |
-| `right_short_targets_percent` | numeric |  |
-| `left_deep_contested_catch_rate` | numeric |  |
-| `right_medium_grades_hands_drop` | numeric |  |
-| `left_short_targeted_qb_rating` | numeric |  |
-| `right_medium_contested_catch_rate` | numeric |  |
-| `short_targets` | numeric |  |
-| `deep_contested_catch_rate` | numeric |  |
-| `center_behind_los_drops` | numeric |  |
-| `center_behind_los_interceptions` | numeric |  |
-| `left_behind_los_interceptions` | numeric |  |
-| `left_deep_first_downs` | numeric |  |
-| `left_behind_los_contested_targets` | numeric |  |
-| `center_deep_avg_depth_of_target` | numeric |  |
-| `center_short_drops` | numeric |  |
-| `right_behind_los_targets` | numeric |  |
-| `right_behind_los_yards_after_catch_per_reception` | numeric |  |
-| `center_deep_first_downs` | numeric |  |
-| `behind_los_yards_after_catch_per_reception` | numeric |  |
-| `right_deep_grades_pass_route` | numeric |  |
-| `left_short_fumbles` | numeric |  |
-| `right_short_positive_epa_percent` | numeric |  |
-| `center_deep_pass_block_rate` | numeric |  |
-| `left_behind_los_avoided_tackles` | numeric |  |
-| `center_short_longest` | numeric |  |
-| `left_deep_drop_rate` | numeric |  |
-| `center_short_contested_receptions` | numeric |  |
-| `left_deep_routes` | numeric |  |
-| `deep_drops` | numeric |  |
-| `deep_contested_receptions` | numeric |  |
-| `center_behind_los_touchdowns` | numeric |  |
-| `center_medium_targeted_qb_rating` | numeric |  |
-| `left_short_yards_per_reception` | numeric |  |
-| `deep_touchdowns` | numeric |  |
-| `left_short_yprr` | numeric |  |
-| `center_deep_drop_rate` | numeric |  |
-| `center_behind_los_pass_plays` | numeric |  |
-| `right_short_first_downs` | numeric |  |
-| `right_behind_los_first_downs` | numeric |  |
-| `right_behind_los_grades_pass_route` | numeric |  |
-| `short_interceptions` | numeric |  |
-| `behind_los_routes` | numeric |  |
-| `right_behind_los_contested_targets` | numeric |  |
-| `left_medium_grades_pass_route` | numeric |  |
-| `right_short_contested_catch_rate` | numeric |  |
-| `draft_season` | numeric |  |
-| `center_short_grades_hands_drop` | numeric |  |
-| `deep_receptions` | numeric |  |
-| `center_deep_pass_blocks` | numeric |  |
-| `left_short_yards_after_catch_per_reception` | numeric |  |
-| `center_medium_avoided_tackles` | numeric |  |
-| `center_medium_grades_pass_route` | numeric |  |
-| `center_behind_los_positive_epa_percent` | numeric |  |
-| `medium_yards_after_catch_per_reception` | numeric |  |
-| `medium_receptions` | numeric |  |
-| `deep_pass_blocks` | numeric |  |
-| `right_deep_yards_per_reception` | numeric |  |
-| `center_medium_longest` | numeric |  |
-| `center_deep_contested_catch_rate` | numeric |  |
-| `medium_epa` | numeric |  |
-| `left_short_route_rate` | numeric |  |
-| `right_deep_grades_hands_drop` | numeric |  |
-| `center_deep_targets` | numeric |  |
-| `short_contested_receptions` | numeric |  |
-| `center_deep_pass_plays` | numeric |  |
-| `left_medium_routes` | numeric |  |
-| `deep_yards_after_catch_per_reception` | numeric |  |
-| `center_deep_contested_receptions` | numeric |  |
-| `center_short_pass_blocks` | numeric |  |
+| `left_deep_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on deep passes (20 or more yards downfield) to the left third of the field. |
+| `center_short_first_downs` | numeric | Receptions that converted a first down on short passes (0-9 yards downfield) to the middle of the field. |
+| `center_short_routes` | numeric | Pass routes run by the player on short passes (0-9 yards downfield) to the middle of the field. |
+| `right_behind_los_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on passes thrown behind the line of scrimmage to the right third of the field. |
+| `left_behind_los_yards_after_catch` | numeric | Yards gained after the catch on passes thrown behind the line of scrimmage to the left third of the field. |
+| `center_behind_los_contested_targets` | numeric | PFF-charted contested targets on passes thrown behind the line of scrimmage to the middle of the field. |
+| `right_short_routes` | numeric | Pass routes run by the player on short passes (0-9 yards downfield) to the right third of the field. |
+| `right_deep_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on deep passes (20 or more yards downfield) to the right third of the field. |
+| `medium_interceptions` | numeric | Interceptions thrown on passes targeting the player on medium passes (10-19 yards downfield). |
+| `right_short_targets_percent` | numeric | Share of the team's targets thrown to the player on short passes (0-9 yards downfield) to the right third of the field. |
+| `left_deep_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on deep passes (20 or more yards downfield) to the left third of the field. |
+| `right_medium_grades_hands_drop` | numeric | PFF hands/drop grade on medium passes (10-19 yards downfield) to the right third of the field, 0-100. |
+| `left_short_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on short passes (0-9 yards downfield) to the left third of the field. |
+| `right_medium_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on medium passes (10-19 yards downfield) to the right third of the field. |
+| `short_targets` | numeric | Pass targets to the player on short passes (0-9 yards downfield). |
+| `deep_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on deep passes (20 or more yards downfield). |
+| `center_behind_los_drops` | numeric | PFF-charted drops on passes thrown behind the line of scrimmage to the middle of the field. |
+| `center_behind_los_interceptions` | numeric | Interceptions thrown on passes targeting the player on passes thrown behind the line of scrimmage to the middle of the field. |
+| `left_behind_los_interceptions` | numeric | Interceptions thrown on passes targeting the player on passes thrown behind the line of scrimmage to the left third of the field. |
+| `left_deep_first_downs` | numeric | Receptions that converted a first down on deep passes (20 or more yards downfield) to the left third of the field. |
+| `left_behind_los_contested_targets` | numeric | PFF-charted contested targets on passes thrown behind the line of scrimmage to the left third of the field. |
+| `center_deep_avg_depth_of_target` | numeric | Average depth of target in yards downfield on deep passes (20 or more yards downfield) to the middle of the field. |
+| `center_short_drops` | numeric | PFF-charted drops on short passes (0-9 yards downfield) to the middle of the field. |
+| `right_behind_los_targets` | numeric | Pass targets to the player on passes thrown behind the line of scrimmage to the right third of the field. |
+| `right_behind_los_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on passes thrown behind the line of scrimmage to the right third of the field. |
+| `center_deep_first_downs` | numeric | Receptions that converted a first down on deep passes (20 or more yards downfield) to the middle of the field. |
+| `behind_los_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on passes thrown behind the line of scrimmage. |
+| `right_deep_grades_pass_route` | numeric | PFF route-running (receiving) grade on deep passes (20 or more yards downfield) to the right third of the field, 0-100. |
+| `left_short_fumbles` | numeric | Fumbles by the player after the catch on short passes (0-9 yards downfield) to the left third of the field. |
+| `right_short_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on short passes (0-9 yards downfield) to the right third of the field. |
+| `center_deep_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on deep passes (20 or more yards downfield) to the middle of the field. |
+| `left_behind_los_avoided_tackles` | numeric | Tackles avoided after the catch on passes thrown behind the line of scrimmage to the left third of the field. |
+| `center_short_longest` | numeric | Longest reception in yards on short passes (0-9 yards downfield) to the middle of the field. |
+| `left_deep_drop_rate` | numeric | Share of catchable targets the player dropped on deep passes (20 or more yards downfield) to the left third of the field. |
+| `center_short_contested_receptions` | numeric | Catches made on PFF-charted contested targets on short passes (0-9 yards downfield) to the middle of the field. |
+| `left_deep_routes` | numeric | Pass routes run by the player on deep passes (20 or more yards downfield) to the left third of the field. |
+| `deep_drops` | numeric | PFF-charted drops on deep passes (20 or more yards downfield). |
+| `deep_contested_receptions` | numeric | Catches made on PFF-charted contested targets on deep passes (20 or more yards downfield). |
+| `center_behind_los_touchdowns` | numeric | Receiving touchdowns scored on passes thrown behind the line of scrimmage to the middle of the field. |
+| `center_medium_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on medium passes (10-19 yards downfield) to the middle of the field. |
+| `left_short_yards_per_reception` | numeric | Average yards per reception on short passes (0-9 yards downfield) to the left third of the field. |
+| `deep_touchdowns` | numeric | Receiving touchdowns scored on deep passes (20 or more yards downfield). |
+| `left_short_yprr` | numeric | Yards per route run on short passes (0-9 yards downfield) to the left third of the field. |
+| `center_deep_drop_rate` | numeric | Share of catchable targets the player dropped on deep passes (20 or more yards downfield) to the middle of the field. |
+| `center_behind_los_pass_plays` | numeric | Pass-play snaps on passes thrown behind the line of scrimmage to the middle of the field. |
+| `right_short_first_downs` | numeric | Receptions that converted a first down on short passes (0-9 yards downfield) to the right third of the field. |
+| `right_behind_los_first_downs` | numeric | Receptions that converted a first down on passes thrown behind the line of scrimmage to the right third of the field. |
+| `right_behind_los_grades_pass_route` | numeric | PFF route-running (receiving) grade on passes thrown behind the line of scrimmage to the right third of the field, 0-100. |
+| `short_interceptions` | numeric | Interceptions thrown on passes targeting the player on short passes (0-9 yards downfield). |
+| `behind_los_routes` | numeric | Pass routes run by the player on passes thrown behind the line of scrimmage. |
+| `right_behind_los_contested_targets` | numeric | PFF-charted contested targets on passes thrown behind the line of scrimmage to the right third of the field. |
+| `left_medium_grades_pass_route` | numeric | PFF route-running (receiving) grade on medium passes (10-19 yards downfield) to the left third of the field, 0-100. |
+| `right_short_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on short passes (0-9 yards downfield) to the right third of the field. |
+| `draft_season` | numeric | Season of the player's NFL draft class, per PFF. |
+| `center_short_grades_hands_drop` | numeric | PFF hands/drop grade on short passes (0-9 yards downfield) to the middle of the field, 0-100. |
+| `deep_receptions` | numeric | Receptions made on deep passes (20 or more yards downfield). |
+| `center_deep_pass_blocks` | numeric | Pass-play snaps spent pass blocking on deep passes (20 or more yards downfield) to the middle of the field. |
+| `left_short_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on short passes (0-9 yards downfield) to the left third of the field. |
+| `center_medium_avoided_tackles` | numeric | Tackles avoided after the catch on medium passes (10-19 yards downfield) to the middle of the field. |
+| `center_medium_grades_pass_route` | numeric | PFF route-running (receiving) grade on medium passes (10-19 yards downfield) to the middle of the field, 0-100. |
+| `center_behind_los_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on passes thrown behind the line of scrimmage to the middle of the field. |
+| `medium_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on medium passes (10-19 yards downfield). |
+| `medium_receptions` | numeric | Receptions made on medium passes (10-19 yards downfield). |
+| `deep_pass_blocks` | numeric | Pass-play snaps spent pass blocking on deep passes (20 or more yards downfield). |
+| `right_deep_yards_per_reception` | numeric | Average yards per reception on deep passes (20 or more yards downfield) to the right third of the field. |
+| `center_medium_longest` | numeric | Longest reception in yards on medium passes (10-19 yards downfield) to the middle of the field. |
+| `center_deep_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on deep passes (20 or more yards downfield) to the middle of the field. |
+| `medium_epa` | numeric | Total expected points added on targets to the player on medium passes (10-19 yards downfield). |
+| `left_short_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on short passes (0-9 yards downfield) to the left third of the field. |
+| `right_deep_grades_hands_drop` | numeric | PFF hands/drop grade on deep passes (20 or more yards downfield) to the right third of the field, 0-100. |
+| `center_deep_targets` | numeric | Pass targets to the player on deep passes (20 or more yards downfield) to the middle of the field. |
+| `short_contested_receptions` | numeric | Catches made on PFF-charted contested targets on short passes (0-9 yards downfield). |
+| `center_deep_pass_plays` | numeric | Pass-play snaps on deep passes (20 or more yards downfield) to the middle of the field. |
+| `left_medium_routes` | numeric | Pass routes run by the player on medium passes (10-19 yards downfield) to the left third of the field. |
+| `deep_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on deep passes (20 or more yards downfield). |
+| `center_deep_contested_receptions` | numeric | Catches made on PFF-charted contested targets on deep passes (20 or more yards downfield) to the middle of the field. |
+| `center_short_pass_blocks` | numeric | Pass-play snaps spent pass blocking on short passes (0-9 yards downfield) to the middle of the field. |
 | `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `deep_pass_block_rate` | numeric |  |
-| `short_touchdowns` | numeric |  |
-| `center_medium_drops` | numeric |  |
-| `left_short_pass_blocks` | numeric |  |
-| `right_short_grades_pass_route` | numeric |  |
-| `center_short_positive_epa_percent` | numeric |  |
-| `deep_avg_depth_of_target` | numeric |  |
-| `deep_grades_hands_drop` | numeric |  |
-| `center_behind_los_avg_depth_of_target` | numeric |  |
-| `left_deep_caught_percent` | numeric |  |
-| `right_behind_los_contested_catch_rate` | numeric |  |
-| `center_medium_route_rate` | numeric |  |
-| `short_grades_pass_route` | numeric |  |
-| `center_behind_los_contested_receptions` | numeric |  |
-| `center_short_receptions` | numeric |  |
-| `center_short_yprr` | numeric |  |
-| `medium_pass_blocks` | numeric |  |
-| `medium_yards_per_reception` | numeric |  |
-| `center_deep_yprr` | numeric |  |
-| `right_deep_drop_rate` | numeric |  |
-| `center_short_targets` | numeric |  |
-| `center_medium_pass_block_rate` | numeric |  |
-| `left_behind_los_drop_rate` | numeric |  |
-| `right_behind_los_targets_percent` | numeric |  |
-| `short_contested_catch_rate` | numeric |  |
-| `behind_los_fumbles` | numeric |  |
-| `left_medium_drop_rate` | numeric |  |
-| `left_medium_longest` | numeric |  |
+| `deep_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on deep passes (20 or more yards downfield). |
+| `short_touchdowns` | numeric | Receiving touchdowns scored on short passes (0-9 yards downfield). |
+| `center_medium_drops` | numeric | PFF-charted drops on medium passes (10-19 yards downfield) to the middle of the field. |
+| `left_short_pass_blocks` | numeric | Pass-play snaps spent pass blocking on short passes (0-9 yards downfield) to the left third of the field. |
+| `right_short_grades_pass_route` | numeric | PFF route-running (receiving) grade on short passes (0-9 yards downfield) to the right third of the field, 0-100. |
+| `center_short_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on short passes (0-9 yards downfield) to the middle of the field. |
+| `deep_avg_depth_of_target` | numeric | Average depth of target in yards downfield on deep passes (20 or more yards downfield). |
+| `deep_grades_hands_drop` | numeric | PFF hands/drop grade on deep passes (20 or more yards downfield), 0-100. |
+| `center_behind_los_avg_depth_of_target` | numeric | Average depth of target in yards downfield on passes thrown behind the line of scrimmage to the middle of the field. |
+| `left_deep_caught_percent` | numeric | Percentage of targets caught on deep passes (20 or more yards downfield) to the left third of the field. |
+| `right_behind_los_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on passes thrown behind the line of scrimmage to the right third of the field. |
+| `center_medium_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on medium passes (10-19 yards downfield) to the middle of the field. |
+| `short_grades_pass_route` | numeric | PFF route-running (receiving) grade on short passes (0-9 yards downfield), 0-100. |
+| `center_behind_los_contested_receptions` | numeric | Catches made on PFF-charted contested targets on passes thrown behind the line of scrimmage to the middle of the field. |
+| `center_short_receptions` | numeric | Receptions made on short passes (0-9 yards downfield) to the middle of the field. |
+| `center_short_yprr` | numeric | Yards per route run on short passes (0-9 yards downfield) to the middle of the field. |
+| `medium_pass_blocks` | numeric | Pass-play snaps spent pass blocking on medium passes (10-19 yards downfield). |
+| `medium_yards_per_reception` | numeric | Average yards per reception on medium passes (10-19 yards downfield). |
+| `center_deep_yprr` | numeric | Yards per route run on deep passes (20 or more yards downfield) to the middle of the field. |
+| `right_deep_drop_rate` | numeric | Share of catchable targets the player dropped on deep passes (20 or more yards downfield) to the right third of the field. |
+| `center_short_targets` | numeric | Pass targets to the player on short passes (0-9 yards downfield) to the middle of the field. |
+| `center_medium_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on medium passes (10-19 yards downfield) to the middle of the field. |
+| `left_behind_los_drop_rate` | numeric | Share of catchable targets the player dropped on passes thrown behind the line of scrimmage to the left third of the field. |
+| `right_behind_los_targets_percent` | numeric | Share of the team's targets thrown to the player on passes thrown behind the line of scrimmage to the right third of the field. |
+| `short_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on short passes (0-9 yards downfield). |
+| `behind_los_fumbles` | numeric | Fumbles by the player after the catch on passes thrown behind the line of scrimmage. |
+| `left_medium_drop_rate` | numeric | Share of catchable targets the player dropped on medium passes (10-19 yards downfield) to the left third of the field. |
+| `left_medium_longest` | numeric | Longest reception in yards on medium passes (10-19 yards downfield) to the left third of the field. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `medium_yprr` | numeric |  |
-| `left_short_positive_epa_percent` | numeric |  |
-| `center_behind_los_pass_block_rate` | numeric |  |
-| `right_short_fumbles` | numeric |  |
-| `right_deep_route_rate` | numeric |  |
-| `right_short_pass_blocks` | numeric |  |
-| `left_short_longest` | numeric |  |
-| `medium_contested_targets` | numeric |  |
-| `behind_los_interceptions` | numeric |  |
-| `right_medium_targeted_qb_rating` | numeric |  |
-| `right_deep_drops` | numeric |  |
-| `right_short_route_rate` | numeric |  |
-| `medium_grades_pass_route` | numeric |  |
-| `right_deep_yards` | numeric |  |
-| `right_medium_contested_targets` | numeric |  |
-| `center_medium_targets` | numeric |  |
-| `right_short_avg_depth_of_target` | numeric |  |
-| `center_deep_longest` | numeric |  |
-| `right_behind_los_yards_per_reception` | numeric |  |
-| `left_medium_pass_block_rate` | numeric |  |
-| `right_deep_yards_after_catch` | numeric |  |
-| `right_medium_receptions` | numeric |  |
-| `right_short_targeted_qb_rating` | numeric |  |
-| `left_deep_targets_percent` | numeric |  |
-| `behind_los_pass_blocks` | numeric |  |
-| `right_behind_los_touchdowns` | numeric |  |
-| `right_medium_targets` | numeric |  |
-| `deep_routes` | numeric |  |
-| `left_medium_yprr` | numeric |  |
-| `deep_yards_per_reception` | numeric |  |
-| `center_behind_los_avoided_tackles` | numeric |  |
-| `left_deep_contested_targets` | numeric |  |
-| `medium_avg_depth_of_target` | numeric |  |
-| `short_route_rate` | numeric |  |
-| `left_behind_los_positive_epa_percent` | numeric |  |
-| `left_medium_touchdowns` | numeric |  |
-| `deep_targets_percent` | numeric |  |
-| `behind_los_targets` | numeric |  |
-| `center_short_yards` | numeric |  |
-| `center_medium_routes` | numeric |  |
-| `center_behind_los_grades_pass_route` | numeric |  |
-| `right_deep_yprr` | numeric |  |
-| `center_deep_targeted_qb_rating` | numeric |  |
-| `left_deep_targeted_qb_rating` | numeric |  |
-| `deep_pass_plays` | numeric |  |
-| `center_short_avg_depth_of_target` | numeric |  |
-| `right_short_yards` | numeric |  |
-| `left_medium_first_downs` | numeric |  |
-| `right_medium_positive_epa_percent` | numeric |  |
-| `left_medium_targeted_qb_rating` | numeric |  |
-| `right_short_contested_receptions` | numeric |  |
-| `right_deep_avoided_tackles` | numeric |  |
-| `right_medium_fumbles` | numeric |  |
-| `right_behind_los_fumbles` | numeric |  |
-| `center_deep_drops` | numeric |  |
-| `center_medium_avg_depth_of_target` | numeric |  |
-| `right_behind_los_pass_block_rate` | numeric |  |
-| `left_short_yards_after_catch` | numeric |  |
-| `right_behind_los_pass_blocks` | numeric |  |
-| `left_behind_los_avg_depth_of_target` | numeric |  |
-| `center_medium_epa` | numeric |  |
-| `left_medium_targets_percent` | numeric |  |
-| `left_behind_los_grades_pass_route` | numeric |  |
-| `center_behind_los_yards_per_reception` | numeric |  |
-| `left_deep_targets` | numeric |  |
-| `short_contested_targets` | numeric |  |
-| `left_medium_contested_catch_rate` | numeric |  |
-| `left_deep_yprr` | numeric |  |
-| `right_medium_yards_after_catch_per_reception` | numeric |  |
-| `right_medium_longest` | numeric |  |
-| `behind_los_drop_rate` | numeric |  |
-| `right_behind_los_epa` | numeric |  |
-| `player_game_count` | numeric |  |
-| `left_short_pass_plays` | numeric |  |
-| `right_short_touchdowns` | numeric |  |
-| `behind_los_first_downs` | numeric |  |
-| `right_deep_receptions` | numeric |  |
-| `left_medium_pass_plays` | numeric |  |
-| `eligible_season` | numeric |  |
-| `center_behind_los_yards` | numeric |  |
-| `right_medium_pass_blocks` | numeric |  |
-| `left_short_grades_pass_route` | numeric |  |
-| `left_behind_los_targets_percent` | numeric |  |
-| `behind_los_longest` | numeric |  |
-| `right_medium_first_downs` | numeric |  |
-| `center_deep_yards_after_catch_per_reception` | numeric |  |
-| `deep_contested_targets` | numeric |  |
-| `behind_los_avoided_tackles` | numeric |  |
-| `left_behind_los_receptions` | numeric |  |
-| `right_short_yards_after_catch` | numeric |  |
-| `right_behind_los_yards_after_catch` | numeric |  |
-| `right_short_pass_plays` | numeric |  |
-| `right_deep_epa` | numeric |  |
-| `left_short_caught_percent` | numeric |  |
-| `center_behind_los_contested_catch_rate` | numeric |  |
-| `right_short_yards_after_catch_per_reception` | numeric |  |
-| `right_short_drop_rate` | numeric |  |
-| `left_short_yards` | numeric |  |
-| `right_behind_los_avg_depth_of_target` | numeric |  |
-| `right_deep_first_downs` | numeric |  |
-| `left_deep_positive_epa_percent` | numeric |  |
-| `short_yards_after_catch` | numeric |  |
-| `center_medium_yprr` | numeric |  |
-| `short_pass_blocks` | numeric |  |
-| `left_short_contested_receptions` | numeric |  |
-| `short_fumbles` | numeric |  |
-| `left_short_pass_block_rate` | numeric |  |
-| `center_deep_routes` | numeric |  |
-| `left_medium_avoided_tackles` | numeric |  |
-| `left_behind_los_pass_plays` | numeric |  |
-| `right_deep_touchdowns` | numeric |  |
-| `center_medium_receptions` | numeric |  |
-| `left_behind_los_drops` | numeric |  |
-| `center_short_targets_percent` | numeric |  |
-| `deep_epa` | numeric |  |
-| `medium_touchdowns` | numeric |  |
-| `left_medium_route_rate` | numeric |  |
-| `left_behind_los_grades_hands_drop` | numeric |  |
-| `left_deep_fumbles` | numeric |  |
-| `medium_avoided_tackles` | numeric |  |
-| `center_medium_contested_catch_rate` | numeric |  |
-| `right_behind_los_routes` | numeric |  |
-| `short_targets_percent` | numeric |  |
-| `left_behind_los_yprr` | numeric |  |
-| `medium_route_rate` | numeric |  |
-| `left_short_first_downs` | numeric |  |
-| `short_longest` | numeric |  |
-| `right_behind_los_grades_hands_drop` | numeric |  |
-| `behind_los_contested_targets` | numeric |  |
-| `right_behind_los_avoided_tackles` | numeric |  |
-| `right_deep_longest` | numeric |  |
-| `right_deep_contested_targets` | numeric |  |
-| `right_deep_positive_epa_percent` | numeric |  |
-| `right_behind_los_pass_plays` | numeric |  |
-| `medium_contested_receptions` | numeric |  |
-| `short_targeted_qb_rating` | numeric |  |
-| `right_behind_los_interceptions` | numeric |  |
-| `behind_los_targets_percent` | numeric |  |
-| `center_deep_yards_after_catch` | numeric |  |
-| `behind_los_yards` | numeric |  |
-| `right_deep_targets_percent` | numeric |  |
-| `left_medium_fumbles` | numeric |  |
-| `short_receptions` | numeric |  |
-| `left_short_interceptions` | numeric |  |
-| `right_medium_interceptions` | numeric |  |
-| `left_behind_los_yards` | numeric |  |
-| `medium_first_downs` | numeric |  |
-| `left_short_avg_depth_of_target` | numeric |  |
-| `right_medium_pass_block_rate` | numeric |  |
-| `right_medium_targets_percent` | numeric |  |
-| `left_behind_los_touchdowns` | numeric |  |
-| `right_behind_los_drop_rate` | numeric |  |
-| `right_deep_fumbles` | numeric |  |
-| `left_deep_contested_receptions` | numeric |  |
-| `behind_los_drops` | numeric |  |
-| `short_yards_after_catch_per_reception` | numeric |  |
-| `medium_pass_plays` | numeric |  |
-| `behind_los_pass_plays` | numeric |  |
-| `left_deep_yards` | numeric |  |
-| `center_behind_los_longest` | numeric |  |
-| `center_medium_grades_hands_drop` | numeric |  |
-| `left_behind_los_longest` | numeric |  |
-| `center_short_interceptions` | numeric |  |
-| `short_avg_depth_of_target` | numeric |  |
-| `deep_yprr` | numeric |  |
-| `left_deep_touchdowns` | numeric |  |
-| `base_targets` | numeric |  |
-| `deep_yards` | numeric |  |
-| `center_medium_yards_after_catch` | numeric |  |
-| `left_medium_epa` | numeric |  |
-| `left_deep_avg_depth_of_target` | numeric |  |
-| `deep_first_downs` | numeric |  |
-| `short_drop_rate` | numeric |  |
-| `left_medium_positive_epa_percent` | numeric |  |
-| `center_deep_touchdowns` | numeric |  |
-| `right_behind_los_yprr` | numeric |  |
-| `center_medium_pass_blocks` | numeric |  |
-| `short_positive_epa_percent` | numeric |  |
-| `medium_fumbles` | numeric |  |
-| `center_medium_yards_after_catch_per_reception` | numeric |  |
-| `left_short_routes` | numeric |  |
-| `behind_los_route_rate` | numeric |  |
-| `behind_los_epa` | numeric |  |
-| `right_behind_los_contested_receptions` | numeric |  |
-| `right_medium_yards_after_catch` | numeric |  |
-| `center_short_touchdowns` | numeric |  |
-| `right_medium_drops` | numeric |  |
-| `left_behind_los_routes` | numeric |  |
-| `left_deep_epa` | numeric |  |
-| `left_short_targets` | numeric |  |
-| `left_deep_pass_block_rate` | numeric |  |
-| `right_deep_caught_percent` | numeric |  |
-| `center_short_grades_pass_route` | numeric |  |
-| `left_behind_los_fumbles` | numeric |  |
-| `right_medium_touchdowns` | numeric |  |
-| `center_short_fumbles` | numeric |  |
-| `center_behind_los_routes` | numeric |  |
-| `behind_los_receptions` | numeric |  |
-| `medium_targets_percent` | numeric |  |
-| `left_medium_yards` | numeric |  |
-| `center_medium_touchdowns` | numeric |  |
-| `medium_targeted_qb_rating` | numeric |  |
-| `center_short_drop_rate` | numeric |  |
+| `medium_yprr` | numeric | Yards per route run on medium passes (10-19 yards downfield). |
+| `left_short_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on short passes (0-9 yards downfield) to the left third of the field. |
+| `center_behind_los_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage to the middle of the field. |
+| `right_short_fumbles` | numeric | Fumbles by the player after the catch on short passes (0-9 yards downfield) to the right third of the field. |
+| `right_deep_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on deep passes (20 or more yards downfield) to the right third of the field. |
+| `right_short_pass_blocks` | numeric | Pass-play snaps spent pass blocking on short passes (0-9 yards downfield) to the right third of the field. |
+| `left_short_longest` | numeric | Longest reception in yards on short passes (0-9 yards downfield) to the left third of the field. |
+| `medium_contested_targets` | numeric | PFF-charted contested targets on medium passes (10-19 yards downfield). |
+| `behind_los_interceptions` | numeric | Interceptions thrown on passes targeting the player on passes thrown behind the line of scrimmage. |
+| `right_medium_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on medium passes (10-19 yards downfield) to the right third of the field. |
+| `right_deep_drops` | numeric | PFF-charted drops on deep passes (20 or more yards downfield) to the right third of the field. |
+| `right_short_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on short passes (0-9 yards downfield) to the right third of the field. |
+| `medium_grades_pass_route` | numeric | PFF route-running (receiving) grade on medium passes (10-19 yards downfield), 0-100. |
+| `right_deep_yards` | numeric | Receiving yards gained on deep passes (20 or more yards downfield) to the right third of the field. |
+| `right_medium_contested_targets` | numeric | PFF-charted contested targets on medium passes (10-19 yards downfield) to the right third of the field. |
+| `center_medium_targets` | numeric | Pass targets to the player on medium passes (10-19 yards downfield) to the middle of the field. |
+| `right_short_avg_depth_of_target` | numeric | Average depth of target in yards downfield on short passes (0-9 yards downfield) to the right third of the field. |
+| `center_deep_longest` | numeric | Longest reception in yards on deep passes (20 or more yards downfield) to the middle of the field. |
+| `right_behind_los_yards_per_reception` | numeric | Average yards per reception on passes thrown behind the line of scrimmage to the right third of the field. |
+| `left_medium_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on medium passes (10-19 yards downfield) to the left third of the field. |
+| `right_deep_yards_after_catch` | numeric | Yards gained after the catch on deep passes (20 or more yards downfield) to the right third of the field. |
+| `right_medium_receptions` | numeric | Receptions made on medium passes (10-19 yards downfield) to the right third of the field. |
+| `right_short_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on short passes (0-9 yards downfield) to the right third of the field. |
+| `left_deep_targets_percent` | numeric | Share of the team's targets thrown to the player on deep passes (20 or more yards downfield) to the left third of the field. |
+| `behind_los_pass_blocks` | numeric | Pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage. |
+| `right_behind_los_touchdowns` | numeric | Receiving touchdowns scored on passes thrown behind the line of scrimmage to the right third of the field. |
+| `right_medium_targets` | numeric | Pass targets to the player on medium passes (10-19 yards downfield) to the right third of the field. |
+| `deep_routes` | numeric | Pass routes run by the player on deep passes (20 or more yards downfield). |
+| `left_medium_yprr` | numeric | Yards per route run on medium passes (10-19 yards downfield) to the left third of the field. |
+| `deep_yards_per_reception` | numeric | Average yards per reception on deep passes (20 or more yards downfield). |
+| `center_behind_los_avoided_tackles` | numeric | Tackles avoided after the catch on passes thrown behind the line of scrimmage to the middle of the field. |
+| `left_deep_contested_targets` | numeric | PFF-charted contested targets on deep passes (20 or more yards downfield) to the left third of the field. |
+| `medium_avg_depth_of_target` | numeric | Average depth of target in yards downfield on medium passes (10-19 yards downfield). |
+| `short_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on short passes (0-9 yards downfield). |
+| `left_behind_los_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on passes thrown behind the line of scrimmage to the left third of the field. |
+| `left_medium_touchdowns` | numeric | Receiving touchdowns scored on medium passes (10-19 yards downfield) to the left third of the field. |
+| `deep_targets_percent` | numeric | Share of the team's targets thrown to the player on deep passes (20 or more yards downfield). |
+| `behind_los_targets` | numeric | Pass targets to the player on passes thrown behind the line of scrimmage. |
+| `center_short_yards` | numeric | Receiving yards gained on short passes (0-9 yards downfield) to the middle of the field. |
+| `center_medium_routes` | numeric | Pass routes run by the player on medium passes (10-19 yards downfield) to the middle of the field. |
+| `center_behind_los_grades_pass_route` | numeric | PFF route-running (receiving) grade on passes thrown behind the line of scrimmage to the middle of the field, 0-100. |
+| `right_deep_yprr` | numeric | Yards per route run on deep passes (20 or more yards downfield) to the right third of the field. |
+| `center_deep_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on deep passes (20 or more yards downfield) to the middle of the field. |
+| `left_deep_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on deep passes (20 or more yards downfield) to the left third of the field. |
+| `deep_pass_plays` | numeric | Pass-play snaps on deep passes (20 or more yards downfield). |
+| `center_short_avg_depth_of_target` | numeric | Average depth of target in yards downfield on short passes (0-9 yards downfield) to the middle of the field. |
+| `right_short_yards` | numeric | Receiving yards gained on short passes (0-9 yards downfield) to the right third of the field. |
+| `left_medium_first_downs` | numeric | Receptions that converted a first down on medium passes (10-19 yards downfield) to the left third of the field. |
+| `right_medium_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on medium passes (10-19 yards downfield) to the right third of the field. |
+| `left_medium_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on medium passes (10-19 yards downfield) to the left third of the field. |
+| `right_short_contested_receptions` | numeric | Catches made on PFF-charted contested targets on short passes (0-9 yards downfield) to the right third of the field. |
+| `right_deep_avoided_tackles` | numeric | Tackles avoided after the catch on deep passes (20 or more yards downfield) to the right third of the field. |
+| `right_medium_fumbles` | numeric | Fumbles by the player after the catch on medium passes (10-19 yards downfield) to the right third of the field. |
+| `right_behind_los_fumbles` | numeric | Fumbles by the player after the catch on passes thrown behind the line of scrimmage to the right third of the field. |
+| `center_deep_drops` | numeric | PFF-charted drops on deep passes (20 or more yards downfield) to the middle of the field. |
+| `center_medium_avg_depth_of_target` | numeric | Average depth of target in yards downfield on medium passes (10-19 yards downfield) to the middle of the field. |
+| `right_behind_los_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage to the right third of the field. |
+| `left_short_yards_after_catch` | numeric | Yards gained after the catch on short passes (0-9 yards downfield) to the left third of the field. |
+| `right_behind_los_pass_blocks` | numeric | Pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage to the right third of the field. |
+| `left_behind_los_avg_depth_of_target` | numeric | Average depth of target in yards downfield on passes thrown behind the line of scrimmage to the left third of the field. |
+| `center_medium_epa` | numeric | Total expected points added on targets to the player on medium passes (10-19 yards downfield) to the middle of the field. |
+| `left_medium_targets_percent` | numeric | Share of the team's targets thrown to the player on medium passes (10-19 yards downfield) to the left third of the field. |
+| `left_behind_los_grades_pass_route` | numeric | PFF route-running (receiving) grade on passes thrown behind the line of scrimmage to the left third of the field, 0-100. |
+| `center_behind_los_yards_per_reception` | numeric | Average yards per reception on passes thrown behind the line of scrimmage to the middle of the field. |
+| `left_deep_targets` | numeric | Pass targets to the player on deep passes (20 or more yards downfield) to the left third of the field. |
+| `short_contested_targets` | numeric | PFF-charted contested targets on short passes (0-9 yards downfield). |
+| `left_medium_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on medium passes (10-19 yards downfield) to the left third of the field. |
+| `left_deep_yprr` | numeric | Yards per route run on deep passes (20 or more yards downfield) to the left third of the field. |
+| `right_medium_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on medium passes (10-19 yards downfield) to the right third of the field. |
+| `right_medium_longest` | numeric | Longest reception in yards on medium passes (10-19 yards downfield) to the right third of the field. |
+| `behind_los_drop_rate` | numeric | Share of catchable targets the player dropped on passes thrown behind the line of scrimmage. |
+| `right_behind_los_epa` | numeric | Total expected points added on targets to the player on passes thrown behind the line of scrimmage to the right third of the field. |
+| `player_game_count` | numeric | Number of games the player appeared in over the covered span. |
+| `left_short_pass_plays` | numeric | Pass-play snaps on short passes (0-9 yards downfield) to the left third of the field. |
+| `right_short_touchdowns` | numeric | Receiving touchdowns scored on short passes (0-9 yards downfield) to the right third of the field. |
+| `behind_los_first_downs` | numeric | Receptions that converted a first down on passes thrown behind the line of scrimmage. |
+| `right_deep_receptions` | numeric | Receptions made on deep passes (20 or more yards downfield) to the right third of the field. |
+| `left_medium_pass_plays` | numeric | Pass-play snaps on medium passes (10-19 yards downfield) to the left third of the field. |
+| `eligible_season` | numeric | Season of the player's NFL draft eligibility, per PFF. |
+| `center_behind_los_yards` | numeric | Receiving yards gained on passes thrown behind the line of scrimmage to the middle of the field. |
+| `right_medium_pass_blocks` | numeric | Pass-play snaps spent pass blocking on medium passes (10-19 yards downfield) to the right third of the field. |
+| `left_short_grades_pass_route` | numeric | PFF route-running (receiving) grade on short passes (0-9 yards downfield) to the left third of the field, 0-100. |
+| `left_behind_los_targets_percent` | numeric | Share of the team's targets thrown to the player on passes thrown behind the line of scrimmage to the left third of the field. |
+| `behind_los_longest` | numeric | Longest reception in yards on passes thrown behind the line of scrimmage. |
+| `right_medium_first_downs` | numeric | Receptions that converted a first down on medium passes (10-19 yards downfield) to the right third of the field. |
+| `center_deep_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on deep passes (20 or more yards downfield) to the middle of the field. |
+| `deep_contested_targets` | numeric | PFF-charted contested targets on deep passes (20 or more yards downfield). |
+| `behind_los_avoided_tackles` | numeric | Tackles avoided after the catch on passes thrown behind the line of scrimmage. |
+| `left_behind_los_receptions` | numeric | Receptions made on passes thrown behind the line of scrimmage to the left third of the field. |
+| `right_short_yards_after_catch` | numeric | Yards gained after the catch on short passes (0-9 yards downfield) to the right third of the field. |
+| `right_behind_los_yards_after_catch` | numeric | Yards gained after the catch on passes thrown behind the line of scrimmage to the right third of the field. |
+| `right_short_pass_plays` | numeric | Pass-play snaps on short passes (0-9 yards downfield) to the right third of the field. |
+| `right_deep_epa` | numeric | Total expected points added on targets to the player on deep passes (20 or more yards downfield) to the right third of the field. |
+| `left_short_caught_percent` | numeric | Percentage of targets caught on short passes (0-9 yards downfield) to the left third of the field. |
+| `center_behind_los_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on passes thrown behind the line of scrimmage to the middle of the field. |
+| `right_short_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on short passes (0-9 yards downfield) to the right third of the field. |
+| `right_short_drop_rate` | numeric | Share of catchable targets the player dropped on short passes (0-9 yards downfield) to the right third of the field. |
+| `left_short_yards` | numeric | Receiving yards gained on short passes (0-9 yards downfield) to the left third of the field. |
+| `right_behind_los_avg_depth_of_target` | numeric | Average depth of target in yards downfield on passes thrown behind the line of scrimmage to the right third of the field. |
+| `right_deep_first_downs` | numeric | Receptions that converted a first down on deep passes (20 or more yards downfield) to the right third of the field. |
+| `left_deep_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on deep passes (20 or more yards downfield) to the left third of the field. |
+| `short_yards_after_catch` | numeric | Yards gained after the catch on short passes (0-9 yards downfield). |
+| `center_medium_yprr` | numeric | Yards per route run on medium passes (10-19 yards downfield) to the middle of the field. |
+| `short_pass_blocks` | numeric | Pass-play snaps spent pass blocking on short passes (0-9 yards downfield). |
+| `left_short_contested_receptions` | numeric | Catches made on PFF-charted contested targets on short passes (0-9 yards downfield) to the left third of the field. |
+| `short_fumbles` | numeric | Fumbles by the player after the catch on short passes (0-9 yards downfield). |
+| `left_short_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on short passes (0-9 yards downfield) to the left third of the field. |
+| `center_deep_routes` | numeric | Pass routes run by the player on deep passes (20 or more yards downfield) to the middle of the field. |
+| `left_medium_avoided_tackles` | numeric | Tackles avoided after the catch on medium passes (10-19 yards downfield) to the left third of the field. |
+| `left_behind_los_pass_plays` | numeric | Pass-play snaps on passes thrown behind the line of scrimmage to the left third of the field. |
+| `right_deep_touchdowns` | numeric | Receiving touchdowns scored on deep passes (20 or more yards downfield) to the right third of the field. |
+| `center_medium_receptions` | numeric | Receptions made on medium passes (10-19 yards downfield) to the middle of the field. |
+| `left_behind_los_drops` | numeric | PFF-charted drops on passes thrown behind the line of scrimmage to the left third of the field. |
+| `center_short_targets_percent` | numeric | Share of the team's targets thrown to the player on short passes (0-9 yards downfield) to the middle of the field. |
+| `deep_epa` | numeric | Total expected points added on targets to the player on deep passes (20 or more yards downfield). |
+| `medium_touchdowns` | numeric | Receiving touchdowns scored on medium passes (10-19 yards downfield). |
+| `left_medium_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on medium passes (10-19 yards downfield) to the left third of the field. |
+| `left_behind_los_grades_hands_drop` | numeric | PFF hands/drop grade on passes thrown behind the line of scrimmage to the left third of the field, 0-100. |
+| `left_deep_fumbles` | numeric | Fumbles by the player after the catch on deep passes (20 or more yards downfield) to the left third of the field. |
+| `medium_avoided_tackles` | numeric | Tackles avoided after the catch on medium passes (10-19 yards downfield). |
+| `center_medium_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on medium passes (10-19 yards downfield) to the middle of the field. |
+| `right_behind_los_routes` | numeric | Pass routes run by the player on passes thrown behind the line of scrimmage to the right third of the field. |
+| `short_targets_percent` | numeric | Share of the team's targets thrown to the player on short passes (0-9 yards downfield). |
+| `left_behind_los_yprr` | numeric | Yards per route run on passes thrown behind the line of scrimmage to the left third of the field. |
+| `medium_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on medium passes (10-19 yards downfield). |
+| `left_short_first_downs` | numeric | Receptions that converted a first down on short passes (0-9 yards downfield) to the left third of the field. |
+| `short_longest` | numeric | Longest reception in yards on short passes (0-9 yards downfield). |
+| `right_behind_los_grades_hands_drop` | numeric | PFF hands/drop grade on passes thrown behind the line of scrimmage to the right third of the field, 0-100. |
+| `behind_los_contested_targets` | numeric | PFF-charted contested targets on passes thrown behind the line of scrimmage. |
+| `right_behind_los_avoided_tackles` | numeric | Tackles avoided after the catch on passes thrown behind the line of scrimmage to the right third of the field. |
+| `right_deep_longest` | numeric | Longest reception in yards on deep passes (20 or more yards downfield) to the right third of the field. |
+| `right_deep_contested_targets` | numeric | PFF-charted contested targets on deep passes (20 or more yards downfield) to the right third of the field. |
+| `right_deep_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on deep passes (20 or more yards downfield) to the right third of the field. |
+| `right_behind_los_pass_plays` | numeric | Pass-play snaps on passes thrown behind the line of scrimmage to the right third of the field. |
+| `medium_contested_receptions` | numeric | Catches made on PFF-charted contested targets on medium passes (10-19 yards downfield). |
+| `short_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on short passes (0-9 yards downfield). |
+| `right_behind_los_interceptions` | numeric | Interceptions thrown on passes targeting the player on passes thrown behind the line of scrimmage to the right third of the field. |
+| `behind_los_targets_percent` | numeric | Share of the team's targets thrown to the player on passes thrown behind the line of scrimmage. |
+| `center_deep_yards_after_catch` | numeric | Yards gained after the catch on deep passes (20 or more yards downfield) to the middle of the field. |
+| `behind_los_yards` | numeric | Receiving yards gained on passes thrown behind the line of scrimmage. |
+| `right_deep_targets_percent` | numeric | Share of the team's targets thrown to the player on deep passes (20 or more yards downfield) to the right third of the field. |
+| `left_medium_fumbles` | numeric | Fumbles by the player after the catch on medium passes (10-19 yards downfield) to the left third of the field. |
+| `short_receptions` | numeric | Receptions made on short passes (0-9 yards downfield). |
+| `left_short_interceptions` | numeric | Interceptions thrown on passes targeting the player on short passes (0-9 yards downfield) to the left third of the field. |
+| `right_medium_interceptions` | numeric | Interceptions thrown on passes targeting the player on medium passes (10-19 yards downfield) to the right third of the field. |
+| `left_behind_los_yards` | numeric | Receiving yards gained on passes thrown behind the line of scrimmage to the left third of the field. |
+| `medium_first_downs` | numeric | Receptions that converted a first down on medium passes (10-19 yards downfield). |
+| `left_short_avg_depth_of_target` | numeric | Average depth of target in yards downfield on short passes (0-9 yards downfield) to the left third of the field. |
+| `right_medium_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on medium passes (10-19 yards downfield) to the right third of the field. |
+| `right_medium_targets_percent` | numeric | Share of the team's targets thrown to the player on medium passes (10-19 yards downfield) to the right third of the field. |
+| `left_behind_los_touchdowns` | numeric | Receiving touchdowns scored on passes thrown behind the line of scrimmage to the left third of the field. |
+| `right_behind_los_drop_rate` | numeric | Share of catchable targets the player dropped on passes thrown behind the line of scrimmage to the right third of the field. |
+| `right_deep_fumbles` | numeric | Fumbles by the player after the catch on deep passes (20 or more yards downfield) to the right third of the field. |
+| `left_deep_contested_receptions` | numeric | Catches made on PFF-charted contested targets on deep passes (20 or more yards downfield) to the left third of the field. |
+| `behind_los_drops` | numeric | PFF-charted drops on passes thrown behind the line of scrimmage. |
+| `short_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on short passes (0-9 yards downfield). |
+| `medium_pass_plays` | numeric | Pass-play snaps on medium passes (10-19 yards downfield). |
+| `behind_los_pass_plays` | numeric | Pass-play snaps on passes thrown behind the line of scrimmage. |
+| `left_deep_yards` | numeric | Receiving yards gained on deep passes (20 or more yards downfield) to the left third of the field. |
+| `center_behind_los_longest` | numeric | Longest reception in yards on passes thrown behind the line of scrimmage to the middle of the field. |
+| `center_medium_grades_hands_drop` | numeric | PFF hands/drop grade on medium passes (10-19 yards downfield) to the middle of the field, 0-100. |
+| `left_behind_los_longest` | numeric | Longest reception in yards on passes thrown behind the line of scrimmage to the left third of the field. |
+| `center_short_interceptions` | numeric | Interceptions thrown on passes targeting the player on short passes (0-9 yards downfield) to the middle of the field. |
+| `short_avg_depth_of_target` | numeric | Average depth of target in yards downfield on short passes (0-9 yards downfield). |
+| `deep_yprr` | numeric | Yards per route run on deep passes (20 or more yards downfield). |
+| `left_deep_touchdowns` | numeric | Receiving touchdowns scored on deep passes (20 or more yards downfield) to the left third of the field. |
+| `base_targets` | numeric | Total targets from the facet's unsplit base row, across all depths and directions. |
+| `deep_yards` | numeric | Receiving yards gained on deep passes (20 or more yards downfield). |
+| `center_medium_yards_after_catch` | numeric | Yards gained after the catch on medium passes (10-19 yards downfield) to the middle of the field. |
+| `left_medium_epa` | numeric | Total expected points added on targets to the player on medium passes (10-19 yards downfield) to the left third of the field. |
+| `left_deep_avg_depth_of_target` | numeric | Average depth of target in yards downfield on deep passes (20 or more yards downfield) to the left third of the field. |
+| `deep_first_downs` | numeric | Receptions that converted a first down on deep passes (20 or more yards downfield). |
+| `short_drop_rate` | numeric | Share of catchable targets the player dropped on short passes (0-9 yards downfield). |
+| `left_medium_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on medium passes (10-19 yards downfield) to the left third of the field. |
+| `center_deep_touchdowns` | numeric | Receiving touchdowns scored on deep passes (20 or more yards downfield) to the middle of the field. |
+| `right_behind_los_yprr` | numeric | Yards per route run on passes thrown behind the line of scrimmage to the right third of the field. |
+| `center_medium_pass_blocks` | numeric | Pass-play snaps spent pass blocking on medium passes (10-19 yards downfield) to the middle of the field. |
+| `short_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on short passes (0-9 yards downfield). |
+| `medium_fumbles` | numeric | Fumbles by the player after the catch on medium passes (10-19 yards downfield). |
+| `center_medium_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on medium passes (10-19 yards downfield) to the middle of the field. |
+| `left_short_routes` | numeric | Pass routes run by the player on short passes (0-9 yards downfield) to the left third of the field. |
+| `behind_los_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on passes thrown behind the line of scrimmage. |
+| `behind_los_epa` | numeric | Total expected points added on targets to the player on passes thrown behind the line of scrimmage. |
+| `right_behind_los_contested_receptions` | numeric | Catches made on PFF-charted contested targets on passes thrown behind the line of scrimmage to the right third of the field. |
+| `right_medium_yards_after_catch` | numeric | Yards gained after the catch on medium passes (10-19 yards downfield) to the right third of the field. |
+| `center_short_touchdowns` | numeric | Receiving touchdowns scored on short passes (0-9 yards downfield) to the middle of the field. |
+| `right_medium_drops` | numeric | PFF-charted drops on medium passes (10-19 yards downfield) to the right third of the field. |
+| `left_behind_los_routes` | numeric | Pass routes run by the player on passes thrown behind the line of scrimmage to the left third of the field. |
+| `left_deep_epa` | numeric | Total expected points added on targets to the player on deep passes (20 or more yards downfield) to the left third of the field. |
+| `left_short_targets` | numeric | Pass targets to the player on short passes (0-9 yards downfield) to the left third of the field. |
+| `left_deep_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on deep passes (20 or more yards downfield) to the left third of the field. |
+| `right_deep_caught_percent` | numeric | Percentage of targets caught on deep passes (20 or more yards downfield) to the right third of the field. |
+| `center_short_grades_pass_route` | numeric | PFF route-running (receiving) grade on short passes (0-9 yards downfield) to the middle of the field, 0-100. |
+| `left_behind_los_fumbles` | numeric | Fumbles by the player after the catch on passes thrown behind the line of scrimmage to the left third of the field. |
+| `right_medium_touchdowns` | numeric | Receiving touchdowns scored on medium passes (10-19 yards downfield) to the right third of the field. |
+| `center_short_fumbles` | numeric | Fumbles by the player after the catch on short passes (0-9 yards downfield) to the middle of the field. |
+| `center_behind_los_routes` | numeric | Pass routes run by the player on passes thrown behind the line of scrimmage to the middle of the field. |
+| `behind_los_receptions` | numeric | Receptions made on passes thrown behind the line of scrimmage. |
+| `medium_targets_percent` | numeric | Share of the team's targets thrown to the player on medium passes (10-19 yards downfield). |
+| `left_medium_yards` | numeric | Receiving yards gained on medium passes (10-19 yards downfield) to the left third of the field. |
+| `center_medium_touchdowns` | numeric | Receiving touchdowns scored on medium passes (10-19 yards downfield) to the middle of the field. |
+| `medium_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on medium passes (10-19 yards downfield). |
+| `center_short_drop_rate` | numeric | Share of catchable targets the player dropped on short passes (0-9 yards downfield) to the middle of the field. |
 | `penalties` | numeric | Total number of penalties. |
-| `short_pass_block_rate` | numeric |  |
-| `right_deep_avg_depth_of_target` | numeric |  |
-| `center_deep_yards` | numeric |  |
-| `center_short_yards_after_catch_per_reception` | numeric |  |
-| `right_short_targets` | numeric |  |
-| `behind_los_avg_depth_of_target` | numeric |  |
-| `left_behind_los_contested_catch_rate` | numeric |  |
-| `center_short_targeted_qb_rating` | numeric |  |
-| `left_behind_los_epa` | numeric |  |
-| `deep_route_rate` | numeric |  |
-| `short_yprr` | numeric |  |
-| `deep_caught_percent` | numeric |  |
-| `center_medium_drop_rate` | numeric |  |
-| `center_behind_los_yards_after_catch` | numeric |  |
-| `medium_yards` | numeric |  |
-| `center_deep_avoided_tackles` | numeric |  |
-| `left_short_contested_targets` | numeric |  |
-| `center_behind_los_first_downs` | numeric |  |
-| `center_medium_interceptions` | numeric |  |
-| `center_deep_yards_per_reception` | numeric |  |
-| `center_deep_contested_targets` | numeric |  |
-| `left_short_targets_percent` | numeric |  |
-| `short_grades_hands_drop` | numeric |  |
-| `right_deep_yards_after_catch_per_reception` | numeric |  |
-| `left_medium_contested_receptions` | numeric |  |
-| `center_short_yards_per_reception` | numeric |  |
-| `center_deep_grades_hands_drop` | numeric |  |
-| `deep_longest` | numeric |  |
-| `left_medium_yards_after_catch_per_reception` | numeric |  |
-| `right_short_interceptions` | numeric |  |
-| `center_short_caught_percent` | numeric |  |
-| `left_deep_interceptions` | numeric |  |
-| `short_yards_per_reception` | numeric |  |
+| `short_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on short passes (0-9 yards downfield). |
+| `right_deep_avg_depth_of_target` | numeric | Average depth of target in yards downfield on deep passes (20 or more yards downfield) to the right third of the field. |
+| `center_deep_yards` | numeric | Receiving yards gained on deep passes (20 or more yards downfield) to the middle of the field. |
+| `center_short_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on short passes (0-9 yards downfield) to the middle of the field. |
+| `right_short_targets` | numeric | Pass targets to the player on short passes (0-9 yards downfield) to the right third of the field. |
+| `behind_los_avg_depth_of_target` | numeric | Average depth of target in yards downfield on passes thrown behind the line of scrimmage. |
+| `left_behind_los_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on passes thrown behind the line of scrimmage to the left third of the field. |
+| `center_short_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on short passes (0-9 yards downfield) to the middle of the field. |
+| `left_behind_los_epa` | numeric | Total expected points added on targets to the player on passes thrown behind the line of scrimmage to the left third of the field. |
+| `deep_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on deep passes (20 or more yards downfield). |
+| `short_yprr` | numeric | Yards per route run on short passes (0-9 yards downfield). |
+| `deep_caught_percent` | numeric | Percentage of targets caught on deep passes (20 or more yards downfield). |
+| `center_medium_drop_rate` | numeric | Share of catchable targets the player dropped on medium passes (10-19 yards downfield) to the middle of the field. |
+| `center_behind_los_yards_after_catch` | numeric | Yards gained after the catch on passes thrown behind the line of scrimmage to the middle of the field. |
+| `medium_yards` | numeric | Receiving yards gained on medium passes (10-19 yards downfield). |
+| `center_deep_avoided_tackles` | numeric | Tackles avoided after the catch on deep passes (20 or more yards downfield) to the middle of the field. |
+| `left_short_contested_targets` | numeric | PFF-charted contested targets on short passes (0-9 yards downfield) to the left third of the field. |
+| `center_behind_los_first_downs` | numeric | Receptions that converted a first down on passes thrown behind the line of scrimmage to the middle of the field. |
+| `center_medium_interceptions` | numeric | Interceptions thrown on passes targeting the player on medium passes (10-19 yards downfield) to the middle of the field. |
+| `center_deep_yards_per_reception` | numeric | Average yards per reception on deep passes (20 or more yards downfield) to the middle of the field. |
+| `center_deep_contested_targets` | numeric | PFF-charted contested targets on deep passes (20 or more yards downfield) to the middle of the field. |
+| `left_short_targets_percent` | numeric | Share of the team's targets thrown to the player on short passes (0-9 yards downfield) to the left third of the field. |
+| `short_grades_hands_drop` | numeric | PFF hands/drop grade on short passes (0-9 yards downfield), 0-100. |
+| `right_deep_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on deep passes (20 or more yards downfield) to the right third of the field. |
+| `left_medium_contested_receptions` | numeric | Catches made on PFF-charted contested targets on medium passes (10-19 yards downfield) to the left third of the field. |
+| `center_short_yards_per_reception` | numeric | Average yards per reception on short passes (0-9 yards downfield) to the middle of the field. |
+| `center_deep_grades_hands_drop` | numeric | PFF hands/drop grade on deep passes (20 or more yards downfield) to the middle of the field, 0-100. |
+| `deep_longest` | numeric | Longest reception in yards on deep passes (20 or more yards downfield). |
+| `left_medium_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on medium passes (10-19 yards downfield) to the left third of the field. |
+| `right_short_interceptions` | numeric | Interceptions thrown on passes targeting the player on short passes (0-9 yards downfield) to the right third of the field. |
+| `center_short_caught_percent` | numeric | Percentage of targets caught on short passes (0-9 yards downfield) to the middle of the field. |
+| `left_deep_interceptions` | numeric | Interceptions thrown on passes targeting the player on deep passes (20 or more yards downfield) to the left third of the field. |
+| `short_yards_per_reception` | numeric | Average yards per reception on short passes (0-9 yards downfield). |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `center_short_avoided_tackles` | numeric |  |
-| `behind_los_yards_per_reception` | numeric |  |
-| `short_epa` | numeric |  |
-| `deep_drop_rate` | numeric |  |
-| `left_deep_yards_per_reception` | numeric |  |
-| `right_short_yprr` | numeric |  |
-| `declined_penalties` | numeric |  |
-| `medium_longest` | numeric |  |
-| `left_short_contested_catch_rate` | numeric |  |
-| `right_medium_routes` | numeric |  |
-| `left_short_receptions` | numeric |  |
-| `left_deep_yards_after_catch_per_reception` | numeric |  |
-| `deep_targets` | numeric |  |
-| `left_short_grades_hands_drop` | numeric |  |
-| `right_short_epa` | numeric |  |
-| `left_behind_los_contested_receptions` | numeric |  |
-| `medium_targets` | numeric |  |
-| `behind_los_targeted_qb_rating` | numeric |  |
-| `center_short_contested_targets` | numeric |  |
-| `center_short_route_rate` | numeric |  |
-| `right_medium_route_rate` | numeric |  |
-| `left_short_epa` | numeric |  |
-| `left_deep_avoided_tackles` | numeric |  |
-| `center_behind_los_pass_blocks` | numeric |  |
-| `deep_interceptions` | numeric |  |
-| `right_short_caught_percent` | numeric |  |
-| `center_deep_caught_percent` | numeric |  |
-| `center_medium_fumbles` | numeric |  |
-| `behind_los_grades_hands_drop` | numeric |  |
-| `left_behind_los_targets` | numeric |  |
-| `right_medium_yprr` | numeric |  |
-| `right_short_receptions` | numeric |  |
+| `center_short_avoided_tackles` | numeric | Tackles avoided after the catch on short passes (0-9 yards downfield) to the middle of the field. |
+| `behind_los_yards_per_reception` | numeric | Average yards per reception on passes thrown behind the line of scrimmage. |
+| `short_epa` | numeric | Total expected points added on targets to the player on short passes (0-9 yards downfield). |
+| `deep_drop_rate` | numeric | Share of catchable targets the player dropped on deep passes (20 or more yards downfield). |
+| `left_deep_yards_per_reception` | numeric | Average yards per reception on deep passes (20 or more yards downfield) to the left third of the field. |
+| `right_short_yprr` | numeric | Yards per route run on short passes (0-9 yards downfield) to the right third of the field. |
+| `declined_penalties` | numeric | Penalties committed by the player that were declined. |
+| `medium_longest` | numeric | Longest reception in yards on medium passes (10-19 yards downfield). |
+| `left_short_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on short passes (0-9 yards downfield) to the left third of the field. |
+| `right_medium_routes` | numeric | Pass routes run by the player on medium passes (10-19 yards downfield) to the right third of the field. |
+| `left_short_receptions` | numeric | Receptions made on short passes (0-9 yards downfield) to the left third of the field. |
+| `left_deep_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on deep passes (20 or more yards downfield) to the left third of the field. |
+| `deep_targets` | numeric | Pass targets to the player on deep passes (20 or more yards downfield). |
+| `left_short_grades_hands_drop` | numeric | PFF hands/drop grade on short passes (0-9 yards downfield) to the left third of the field, 0-100. |
+| `right_short_epa` | numeric | Total expected points added on targets to the player on short passes (0-9 yards downfield) to the right third of the field. |
+| `left_behind_los_contested_receptions` | numeric | Catches made on PFF-charted contested targets on passes thrown behind the line of scrimmage to the left third of the field. |
+| `medium_targets` | numeric | Pass targets to the player on medium passes (10-19 yards downfield). |
+| `behind_los_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on passes thrown behind the line of scrimmage. |
+| `center_short_contested_targets` | numeric | PFF-charted contested targets on short passes (0-9 yards downfield) to the middle of the field. |
+| `center_short_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on short passes (0-9 yards downfield) to the middle of the field. |
+| `right_medium_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on medium passes (10-19 yards downfield) to the right third of the field. |
+| `left_short_epa` | numeric | Total expected points added on targets to the player on short passes (0-9 yards downfield) to the left third of the field. |
+| `left_deep_avoided_tackles` | numeric | Tackles avoided after the catch on deep passes (20 or more yards downfield) to the left third of the field. |
+| `center_behind_los_pass_blocks` | numeric | Pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage to the middle of the field. |
+| `deep_interceptions` | numeric | Interceptions thrown on passes targeting the player on deep passes (20 or more yards downfield). |
+| `right_short_caught_percent` | numeric | Percentage of targets caught on short passes (0-9 yards downfield) to the right third of the field. |
+| `center_deep_caught_percent` | numeric | Percentage of targets caught on deep passes (20 or more yards downfield) to the middle of the field. |
+| `center_medium_fumbles` | numeric | Fumbles by the player after the catch on medium passes (10-19 yards downfield) to the middle of the field. |
+| `behind_los_grades_hands_drop` | numeric | PFF hands/drop grade on passes thrown behind the line of scrimmage, 0-100. |
+| `left_behind_los_targets` | numeric | Pass targets to the player on passes thrown behind the line of scrimmage to the left third of the field. |
+| `right_medium_yprr` | numeric | Yards per route run on medium passes (10-19 yards downfield) to the right third of the field. |
+| `right_short_receptions` | numeric | Receptions made on short passes (0-9 yards downfield) to the right third of the field. |
 | `position` | character | Primary position as reported by NFL.com |
-| `right_short_contested_targets` | numeric |  |
-| `center_medium_yards_per_reception` | numeric |  |
-| `right_behind_los_yards` | numeric |  |
-| `center_behind_los_grades_hands_drop` | numeric |  |
-| `right_behind_los_receptions` | numeric |  |
-| `left_medium_caught_percent` | numeric |  |
-| `left_medium_drops` | numeric |  |
-| `short_avoided_tackles` | numeric |  |
-| `center_short_epa` | numeric |  |
-| `center_behind_los_targets` | numeric |  |
-| `left_deep_pass_blocks` | numeric |  |
-| `left_short_drops` | numeric |  |
-| `medium_positive_epa_percent` | numeric |  |
-| `center_deep_receptions` | numeric |  |
-| `right_medium_epa` | numeric |  |
-| `right_short_pass_block_rate` | numeric |  |
-| `center_deep_route_rate` | numeric |  |
-| `center_short_pass_plays` | numeric |  |
-| `center_deep_interceptions` | numeric |  |
-| `left_medium_yards_after_catch` | numeric |  |
-| `left_behind_los_pass_blocks` | numeric |  |
-| `right_behind_los_longest` | numeric |  |
-| `short_yards` | numeric |  |
-| `left_deep_receptions` | numeric |  |
-| `deep_grades_pass_route` | numeric |  |
-| `left_medium_targets` | numeric |  |
-| `behind_los_grades_pass_route` | numeric |  |
-| `right_deep_targeted_qb_rating` | numeric |  |
-| `behind_los_pass_block_rate` | numeric |  |
-| `left_medium_pass_blocks` | numeric |  |
+| `right_short_contested_targets` | numeric | PFF-charted contested targets on short passes (0-9 yards downfield) to the right third of the field. |
+| `center_medium_yards_per_reception` | numeric | Average yards per reception on medium passes (10-19 yards downfield) to the middle of the field. |
+| `right_behind_los_yards` | numeric | Receiving yards gained on passes thrown behind the line of scrimmage to the right third of the field. |
+| `center_behind_los_grades_hands_drop` | numeric | PFF hands/drop grade on passes thrown behind the line of scrimmage to the middle of the field, 0-100. |
+| `right_behind_los_receptions` | numeric | Receptions made on passes thrown behind the line of scrimmage to the right third of the field. |
+| `left_medium_caught_percent` | numeric | Percentage of targets caught on medium passes (10-19 yards downfield) to the left third of the field. |
+| `left_medium_drops` | numeric | PFF-charted drops on medium passes (10-19 yards downfield) to the left third of the field. |
+| `short_avoided_tackles` | numeric | Tackles avoided after the catch on short passes (0-9 yards downfield). |
+| `center_short_epa` | numeric | Total expected points added on targets to the player on short passes (0-9 yards downfield) to the middle of the field. |
+| `center_behind_los_targets` | numeric | Pass targets to the player on passes thrown behind the line of scrimmage to the middle of the field. |
+| `left_deep_pass_blocks` | numeric | Pass-play snaps spent pass blocking on deep passes (20 or more yards downfield) to the left third of the field. |
+| `left_short_drops` | numeric | PFF-charted drops on short passes (0-9 yards downfield) to the left third of the field. |
+| `medium_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on medium passes (10-19 yards downfield). |
+| `center_deep_receptions` | numeric | Receptions made on deep passes (20 or more yards downfield) to the middle of the field. |
+| `right_medium_epa` | numeric | Total expected points added on targets to the player on medium passes (10-19 yards downfield) to the right third of the field. |
+| `right_short_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on short passes (0-9 yards downfield) to the right third of the field. |
+| `center_deep_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on deep passes (20 or more yards downfield) to the middle of the field. |
+| `center_short_pass_plays` | numeric | Pass-play snaps on short passes (0-9 yards downfield) to the middle of the field. |
+| `center_deep_interceptions` | numeric | Interceptions thrown on passes targeting the player on deep passes (20 or more yards downfield) to the middle of the field. |
+| `left_medium_yards_after_catch` | numeric | Yards gained after the catch on medium passes (10-19 yards downfield) to the left third of the field. |
+| `left_behind_los_pass_blocks` | numeric | Pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage to the left third of the field. |
+| `right_behind_los_longest` | numeric | Longest reception in yards on passes thrown behind the line of scrimmage to the right third of the field. |
+| `short_yards` | numeric | Receiving yards gained on short passes (0-9 yards downfield). |
+| `left_deep_receptions` | numeric | Receptions made on deep passes (20 or more yards downfield) to the left third of the field. |
+| `deep_grades_pass_route` | numeric | PFF route-running (receiving) grade on deep passes (20 or more yards downfield), 0-100. |
+| `left_medium_targets` | numeric | Pass targets to the player on medium passes (10-19 yards downfield) to the left third of the field. |
+| `behind_los_grades_pass_route` | numeric | PFF route-running (receiving) grade on passes thrown behind the line of scrimmage, 0-100. |
+| `right_deep_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on deep passes (20 or more yards downfield) to the right third of the field. |
+| `behind_los_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage. |
+| `left_medium_pass_blocks` | numeric | Pass-play snaps spent pass blocking on medium passes (10-19 yards downfield) to the left third of the field. |
 | `player` | character | Player name |
-| `left_medium_avg_depth_of_target` | numeric |  |
-| `deep_avoided_tackles` | numeric |  |
-| `center_behind_los_yprr` | numeric |  |
-| `center_behind_los_epa` | numeric |  |
-| `right_behind_los_route_rate` | numeric |  |
-| `center_deep_fumbles` | numeric |  |
-| `left_medium_grades_hands_drop` | numeric |  |
-| `right_medium_yards` | numeric |  |
-| `left_deep_yards_after_catch` | numeric |  |
-| `left_deep_pass_plays` | numeric |  |
-| `center_short_yards_after_catch` | numeric |  |
-| `center_behind_los_route_rate` | numeric |  |
-| `right_medium_drop_rate` | numeric |  |
-| `medium_grades_hands_drop` | numeric |  |
-| `right_deep_pass_blocks` | numeric |  |
-| `medium_contested_catch_rate` | numeric |  |
+| `left_medium_avg_depth_of_target` | numeric | Average depth of target in yards downfield on medium passes (10-19 yards downfield) to the left third of the field. |
+| `deep_avoided_tackles` | numeric | Tackles avoided after the catch on deep passes (20 or more yards downfield). |
+| `center_behind_los_yprr` | numeric | Yards per route run on passes thrown behind the line of scrimmage to the middle of the field. |
+| `center_behind_los_epa` | numeric | Total expected points added on targets to the player on passes thrown behind the line of scrimmage to the middle of the field. |
+| `right_behind_los_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on passes thrown behind the line of scrimmage to the right third of the field. |
+| `center_deep_fumbles` | numeric | Fumbles by the player after the catch on deep passes (20 or more yards downfield) to the middle of the field. |
+| `left_medium_grades_hands_drop` | numeric | PFF hands/drop grade on medium passes (10-19 yards downfield) to the left third of the field, 0-100. |
+| `right_medium_yards` | numeric | Receiving yards gained on medium passes (10-19 yards downfield) to the right third of the field. |
+| `left_deep_yards_after_catch` | numeric | Yards gained after the catch on deep passes (20 or more yards downfield) to the left third of the field. |
+| `left_deep_pass_plays` | numeric | Pass-play snaps on deep passes (20 or more yards downfield) to the left third of the field. |
+| `center_short_yards_after_catch` | numeric | Yards gained after the catch on short passes (0-9 yards downfield) to the middle of the field. |
+| `center_behind_los_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on passes thrown behind the line of scrimmage to the middle of the field. |
+| `right_medium_drop_rate` | numeric | Share of catchable targets the player dropped on medium passes (10-19 yards downfield) to the right third of the field. |
+| `medium_grades_hands_drop` | numeric | PFF hands/drop grade on medium passes (10-19 yards downfield), 0-100. |
+| `right_deep_pass_blocks` | numeric | Pass-play snaps spent pass blocking on deep passes (20 or more yards downfield) to the right third of the field. |
+| `medium_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on medium passes (10-19 yards downfield). |
 | `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
-| `center_behind_los_caught_percent` | numeric |  |
-| `right_behind_los_caught_percent` | numeric |  |
-| `short_pass_plays` | numeric |  |
-| `center_behind_los_targeted_qb_rating` | numeric |  |
-| `deep_targeted_qb_rating` | numeric |  |
-| `center_short_pass_block_rate` | numeric |  |
-| `right_short_avoided_tackles` | numeric |  |
-| `left_short_drop_rate` | numeric |  |
-| `left_medium_yards_per_reception` | numeric |  |
-| `left_medium_receptions` | numeric |  |
-| `right_medium_pass_plays` | numeric |  |
-| `center_medium_contested_targets` | numeric |  |
-| `short_first_downs` | numeric |  |
-| `center_medium_targets_percent` | numeric |  |
-| `right_short_longest` | numeric |  |
-| `left_deep_longest` | numeric |  |
-| `right_short_drops` | numeric |  |
-| `right_medium_contested_receptions` | numeric |  |
-| `right_deep_contested_catch_rate` | numeric |  |
-| `center_behind_los_receptions` | numeric |  |
-| `right_medium_caught_percent` | numeric |  |
-| `right_deep_targets` | numeric |  |
-| `center_medium_positive_epa_percent` | numeric |  |
-| `medium_drops` | numeric |  |
-| `left_deep_grades_hands_drop` | numeric |  |
-| `behind_los_positive_epa_percent` | numeric |  |
-| `left_short_avoided_tackles` | numeric |  |
-| `right_medium_grades_pass_route` | numeric |  |
-| `right_short_grades_hands_drop` | numeric |  |
-| `left_behind_los_yards_per_reception` | numeric |  |
-| `medium_yards_after_catch` | numeric |  |
-| `center_medium_pass_plays` | numeric |  |
-| `left_behind_los_caught_percent` | numeric |  |
-| `left_medium_contested_targets` | numeric |  |
-| `center_medium_contested_receptions` | numeric |  |
-| `behind_los_contested_catch_rate` | numeric |  |
-| `behind_los_yards_after_catch` | numeric |  |
-| `left_deep_drops` | numeric |  |
-| `center_deep_positive_epa_percent` | numeric |  |
-| `left_behind_los_yards_after_catch_per_reception` | numeric |  |
-| `right_deep_routes` | numeric |  |
-| `center_deep_grades_pass_route` | numeric |  |
-| `deep_yards_after_catch` | numeric |  |
-| `center_behind_los_drop_rate` | numeric |  |
-| `short_drops` | numeric |  |
-| `right_deep_contested_receptions` | numeric |  |
-| `left_behind_los_targeted_qb_rating` | numeric |  |
-| `right_medium_avg_depth_of_target` | numeric |  |
-| `right_medium_avoided_tackles` | numeric |  |
-| `center_medium_caught_percent` | numeric |  |
-| `center_behind_los_fumbles` | numeric |  |
-| `center_medium_first_downs` | numeric |  |
-| `behind_los_caught_percent` | numeric |  |
-| `short_routes` | numeric |  |
-| `left_deep_grades_pass_route` | numeric |  |
-| `medium_routes` | numeric |  |
-| `medium_caught_percent` | numeric |  |
-| `behind_los_contested_receptions` | numeric |  |
-| `behind_los_yprr` | numeric |  |
-| `left_short_touchdowns` | numeric |  |
-| `medium_drop_rate` | numeric |  |
+| `center_behind_los_caught_percent` | numeric | Percentage of targets caught on passes thrown behind the line of scrimmage to the middle of the field. |
+| `right_behind_los_caught_percent` | numeric | Percentage of targets caught on passes thrown behind the line of scrimmage to the right third of the field. |
+| `short_pass_plays` | numeric | Pass-play snaps on short passes (0-9 yards downfield). |
+| `center_behind_los_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on passes thrown behind the line of scrimmage to the middle of the field. |
+| `deep_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on deep passes (20 or more yards downfield). |
+| `center_short_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on short passes (0-9 yards downfield) to the middle of the field. |
+| `right_short_avoided_tackles` | numeric | Tackles avoided after the catch on short passes (0-9 yards downfield) to the right third of the field. |
+| `left_short_drop_rate` | numeric | Share of catchable targets the player dropped on short passes (0-9 yards downfield) to the left third of the field. |
+| `left_medium_yards_per_reception` | numeric | Average yards per reception on medium passes (10-19 yards downfield) to the left third of the field. |
+| `left_medium_receptions` | numeric | Receptions made on medium passes (10-19 yards downfield) to the left third of the field. |
+| `right_medium_pass_plays` | numeric | Pass-play snaps on medium passes (10-19 yards downfield) to the right third of the field. |
+| `center_medium_contested_targets` | numeric | PFF-charted contested targets on medium passes (10-19 yards downfield) to the middle of the field. |
+| `short_first_downs` | numeric | Receptions that converted a first down on short passes (0-9 yards downfield). |
+| `center_medium_targets_percent` | numeric | Share of the team's targets thrown to the player on medium passes (10-19 yards downfield) to the middle of the field. |
+| `right_short_longest` | numeric | Longest reception in yards on short passes (0-9 yards downfield) to the right third of the field. |
+| `left_deep_longest` | numeric | Longest reception in yards on deep passes (20 or more yards downfield) to the left third of the field. |
+| `right_short_drops` | numeric | PFF-charted drops on short passes (0-9 yards downfield) to the right third of the field. |
+| `right_medium_contested_receptions` | numeric | Catches made on PFF-charted contested targets on medium passes (10-19 yards downfield) to the right third of the field. |
+| `right_deep_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on deep passes (20 or more yards downfield) to the right third of the field. |
+| `center_behind_los_receptions` | numeric | Receptions made on passes thrown behind the line of scrimmage to the middle of the field. |
+| `right_medium_caught_percent` | numeric | Percentage of targets caught on medium passes (10-19 yards downfield) to the right third of the field. |
+| `right_deep_targets` | numeric | Pass targets to the player on deep passes (20 or more yards downfield) to the right third of the field. |
+| `center_medium_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on medium passes (10-19 yards downfield) to the middle of the field. |
+| `medium_drops` | numeric | PFF-charted drops on medium passes (10-19 yards downfield). |
+| `left_deep_grades_hands_drop` | numeric | PFF hands/drop grade on deep passes (20 or more yards downfield) to the left third of the field, 0-100. |
+| `behind_los_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on passes thrown behind the line of scrimmage. |
+| `left_short_avoided_tackles` | numeric | Tackles avoided after the catch on short passes (0-9 yards downfield) to the left third of the field. |
+| `right_medium_grades_pass_route` | numeric | PFF route-running (receiving) grade on medium passes (10-19 yards downfield) to the right third of the field, 0-100. |
+| `right_short_grades_hands_drop` | numeric | PFF hands/drop grade on short passes (0-9 yards downfield) to the right third of the field, 0-100. |
+| `left_behind_los_yards_per_reception` | numeric | Average yards per reception on passes thrown behind the line of scrimmage to the left third of the field. |
+| `medium_yards_after_catch` | numeric | Yards gained after the catch on medium passes (10-19 yards downfield). |
+| `center_medium_pass_plays` | numeric | Pass-play snaps on medium passes (10-19 yards downfield) to the middle of the field. |
+| `left_behind_los_caught_percent` | numeric | Percentage of targets caught on passes thrown behind the line of scrimmage to the left third of the field. |
+| `left_medium_contested_targets` | numeric | PFF-charted contested targets on medium passes (10-19 yards downfield) to the left third of the field. |
+| `center_medium_contested_receptions` | numeric | Catches made on PFF-charted contested targets on medium passes (10-19 yards downfield) to the middle of the field. |
+| `behind_los_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on passes thrown behind the line of scrimmage. |
+| `behind_los_yards_after_catch` | numeric | Yards gained after the catch on passes thrown behind the line of scrimmage. |
+| `left_deep_drops` | numeric | PFF-charted drops on deep passes (20 or more yards downfield) to the left third of the field. |
+| `center_deep_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on deep passes (20 or more yards downfield) to the middle of the field. |
+| `left_behind_los_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on passes thrown behind the line of scrimmage to the left third of the field. |
+| `right_deep_routes` | numeric | Pass routes run by the player on deep passes (20 or more yards downfield) to the right third of the field. |
+| `center_deep_grades_pass_route` | numeric | PFF route-running (receiving) grade on deep passes (20 or more yards downfield) to the middle of the field, 0-100. |
+| `deep_yards_after_catch` | numeric | Yards gained after the catch on deep passes (20 or more yards downfield). |
+| `center_behind_los_drop_rate` | numeric | Share of catchable targets the player dropped on passes thrown behind the line of scrimmage to the middle of the field. |
+| `short_drops` | numeric | PFF-charted drops on short passes (0-9 yards downfield). |
+| `right_deep_contested_receptions` | numeric | Catches made on PFF-charted contested targets on deep passes (20 or more yards downfield) to the right third of the field. |
+| `left_behind_los_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on passes thrown behind the line of scrimmage to the left third of the field. |
+| `right_medium_avg_depth_of_target` | numeric | Average depth of target in yards downfield on medium passes (10-19 yards downfield) to the right third of the field. |
+| `right_medium_avoided_tackles` | numeric | Tackles avoided after the catch on medium passes (10-19 yards downfield) to the right third of the field. |
+| `center_medium_caught_percent` | numeric | Percentage of targets caught on medium passes (10-19 yards downfield) to the middle of the field. |
+| `center_behind_los_fumbles` | numeric | Fumbles by the player after the catch on passes thrown behind the line of scrimmage to the middle of the field. |
+| `center_medium_first_downs` | numeric | Receptions that converted a first down on medium passes (10-19 yards downfield) to the middle of the field. |
+| `behind_los_caught_percent` | numeric | Percentage of targets caught on passes thrown behind the line of scrimmage. |
+| `short_routes` | numeric | Pass routes run by the player on short passes (0-9 yards downfield). |
+| `left_deep_grades_pass_route` | numeric | PFF route-running (receiving) grade on deep passes (20 or more yards downfield) to the left third of the field, 0-100. |
+| `medium_routes` | numeric | Pass routes run by the player on medium passes (10-19 yards downfield). |
+| `medium_caught_percent` | numeric | Percentage of targets caught on medium passes (10-19 yards downfield). |
+| `behind_los_contested_receptions` | numeric | Catches made on PFF-charted contested targets on passes thrown behind the line of scrimmage. |
+| `behind_los_yprr` | numeric | Yards per route run on passes thrown behind the line of scrimmage. |
+| `left_short_touchdowns` | numeric | Receiving touchdowns scored on short passes (0-9 yards downfield) to the left third of the field. |
+| `medium_drop_rate` | numeric | Share of catchable targets the player dropped on medium passes (10-19 yards downfield). |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
-| `left_behind_los_pass_block_rate` | numeric |  |
-| `right_deep_pass_plays` | numeric |  |
-| `short_caught_percent` | numeric |  |
-| `right_medium_yards_per_reception` | numeric |  |
-| `center_medium_yards` | numeric |  |
-| `center_deep_epa` | numeric |  |
-| `left_medium_interceptions` | numeric |  |
-| `right_deep_interceptions` | numeric |  |
-| `deep_positive_epa_percent` | numeric |  |
-| `deep_fumbles` | numeric |  |
-| `center_short_contested_catch_rate` | numeric |  |
-| `center_behind_los_targets_percent` | numeric |  |
-| `right_short_yards_per_reception` | numeric |  |
-| `center_deep_targets_percent` | numeric |  |
-| `center_behind_los_yards_after_catch_per_reception` | numeric |  |
-| `behind_los_touchdowns` | numeric |  |
-| `medium_pass_block_rate` | numeric |  |
-| `left_behind_los_route_rate` | numeric |  |
-| `right_behind_los_targeted_qb_rating` | numeric |  |
-| `right_behind_los_drops` | numeric |  |
-| `left_behind_los_first_downs` | numeric |  |
+| `left_behind_los_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage to the left third of the field. |
+| `right_deep_pass_plays` | numeric | Pass-play snaps on deep passes (20 or more yards downfield) to the right third of the field. |
+| `short_caught_percent` | numeric | Percentage of targets caught on short passes (0-9 yards downfield). |
+| `right_medium_yards_per_reception` | numeric | Average yards per reception on medium passes (10-19 yards downfield) to the right third of the field. |
+| `center_medium_yards` | numeric | Receiving yards gained on medium passes (10-19 yards downfield) to the middle of the field. |
+| `center_deep_epa` | numeric | Total expected points added on targets to the player on deep passes (20 or more yards downfield) to the middle of the field. |
+| `left_medium_interceptions` | numeric | Interceptions thrown on passes targeting the player on medium passes (10-19 yards downfield) to the left third of the field. |
+| `right_deep_interceptions` | numeric | Interceptions thrown on passes targeting the player on deep passes (20 or more yards downfield) to the right third of the field. |
+| `deep_positive_epa_percent` | numeric | Percentage of the player's targets producing positive expected points added on deep passes (20 or more yards downfield). |
+| `deep_fumbles` | numeric | Fumbles by the player after the catch on deep passes (20 or more yards downfield). |
+| `center_short_contested_catch_rate` | numeric | Percentage of PFF-charted contested targets caught on short passes (0-9 yards downfield) to the middle of the field. |
+| `center_behind_los_targets_percent` | numeric | Share of the team's targets thrown to the player on passes thrown behind the line of scrimmage to the middle of the field. |
+| `right_short_yards_per_reception` | numeric | Average yards per reception on short passes (0-9 yards downfield) to the right third of the field. |
+| `center_deep_targets_percent` | numeric | Share of the team's targets thrown to the player on deep passes (20 or more yards downfield) to the middle of the field. |
+| `center_behind_los_yards_after_catch_per_reception` | numeric | Average yards after the catch per reception on passes thrown behind the line of scrimmage to the middle of the field. |
+| `behind_los_touchdowns` | numeric | Receiving touchdowns scored on passes thrown behind the line of scrimmage. |
+| `medium_pass_block_rate` | numeric | Share of pass-play snaps spent pass blocking on medium passes (10-19 yards downfield). |
+| `left_behind_los_route_rate` | numeric | Share of pass-play snaps on which the player ran a route on passes thrown behind the line of scrimmage to the left third of the field. |
+| `right_behind_los_targeted_qb_rating` | numeric | NFL passer rating on throws targeting the player on passes thrown behind the line of scrimmage to the right third of the field. |
+| `right_behind_los_drops` | numeric | PFF-charted drops on passes thrown behind the line of scrimmage to the right third of the field. |
+| `left_behind_los_first_downs` | numeric | Receptions that converted a first down on passes thrown behind the line of scrimmage to the left third of the field. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -4775,15 +4775,15 @@ Leagues + seasons + week groups (bootstrap)
 | col_name | type | description |
 |---|---|---|
 | `abbreviation` | character | Metric abbreviation. |
-| `default_season` | numeric |  |
-| `default_week` | numeric |  |
-| `default_week_group` | character |  |
+| `default_season` | numeric | Season the source API currently treats as the default for this league. |
+| `default_week` | numeric | Week number the source API currently treats as the default for this league. |
+| `default_week_group` | character | Identifier of the week grouping (e.g., regular season or postseason phase) currently set as the league default. |
 | `id` | numeric | ID of the player in the 'name' column. |
 | `name` | character | Name, as reported by MFL but reordered into FirstName LastName instead of Last, First |
 | `seasons` | list | NBA seasons played. |
 | `slug` | character | URL slug for the team. |
-| `week_groups` | list |  |
-| `weeks` | list |  |
+| `week_groups` | list | Nested list of week-group objects (phase label and week span) defined for the league. |
+| `weeks` | list | Nested list of week objects available for the league. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -4813,7 +4813,7 @@ Teams / franchise groups + games for a league-season
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `heirarchy` | list |  |
+| `heirarchy` | list | Nested hierarchy of franchise groupings as returned by the PFF API; the field name's spelling follows the source. |
 | `id` | numeric | ID of the player in the 'name' column. |
 | `name` | character | Name, as reported by MFL but reordered into FirstName LastName instead of Last, First |
 | `slug` | character | URL slug for the team. |
@@ -4851,21 +4851,21 @@ Team overview table (By Team landing)
 | `franchise_id` | numeric | PFF franchise (team) id (integer join key). |
 | `grades_coverage_defense` | numeric | PFF team coverage grade (0-100). |
 | `grades_defense` | numeric | PFF team defense grade (0-100). |
-| `grades_misc_st` | numeric |  |
+| `grades_misc_st` | numeric | Team-level PFF miscellaneous special-teams grade, 0-100. |
 | `grades_offense` | numeric | PFF team offense grade (0-100). |
-| `grades_overall` | numeric |  |
-| `grades_pass` | numeric |  |
-| `grades_pass_block` | numeric |  |
-| `grades_pass_route` | numeric |  |
-| `grades_pass_rush_defense` | numeric |  |
-| `grades_run` | numeric |  |
-| `grades_run_block` | numeric |  |
-| `grades_run_defense` | numeric |  |
-| `grades_tackle` | numeric |  |
+| `grades_overall` | numeric | Team-level PFF overall grade, 0-100. |
+| `grades_pass` | numeric | Team-level PFF passing grade, 0-100. |
+| `grades_pass_block` | numeric | Team-level PFF pass-blocking grade, 0-100. |
+| `grades_pass_route` | numeric | Team-level PFF receiving (route-running) grade, 0-100. |
+| `grades_pass_rush_defense` | numeric | Team-level PFF pass-rush grade, 0-100. |
+| `grades_run` | numeric | Team-level PFF rushing grade, 0-100. |
+| `grades_run_block` | numeric | Team-level PFF run-blocking grade, 0-100. |
+| `grades_run_defense` | numeric | Team-level PFF run-defense grade, 0-100. |
+| `grades_tackle` | numeric | Team-level PFF tackling grade, 0-100. |
 | `losses` | numeric | Losses against the spread in the split. |
 | `name` | character | Name, as reported by MFL but reordered into FirstName LastName instead of Last, First |
 | `points_allowed` | numeric | Points for the opponent. |
-| `points_scored` | numeric |  |
+| `points_scored` | numeric | Total points scored by the team over the covered span. |
 | `ties` | numeric | Number of ties in the series. |
 | `wins` | numeric | Wins against the spread in the split. |
 
@@ -4943,10 +4943,10 @@ Player search (name=) or lookup (id=)
 | col_name | type | description |
 |---|---|---|
 | `college` | character | Official college (usually the last one attended) |
-| `current_class` | character |  |
-| `current_eligible_year` | numeric |  |
+| `current_class` | character | Player's current college class designation (e.g., Freshman, Senior), per PFF. |
+| `current_eligible_year` | numeric | Year the player is or was first draft-eligible, per PFF. |
 | `dob` | character | Player date of birth. |
-| `draft` | list |  |
+| `draft` | list | Nested draft-selection details for the player (year, round, pick, and franchise) as returned by the source API. |
 | `first_name` | character | First name of player |
 | `height` | numeric | Official height, in inches |
 | `id` | numeric | ID of the player in the 'name' column. |

--- a/docs/docs/nhl/reference/loaders.md
+++ b/docs/docs/nhl/reference/loaders.md
@@ -751,7 +751,7 @@ Release: [nhl_schedules](https://github.com/sportsdataverse/sportsdataverse-data
 | `away_score` | Int32 | Away team final score. |
 | `game_state` | String | Game state (e.g., FINAL, LIVE). |
 | `venue` | String | Venue where the game was played. |
-| `series_letter` | String |  |
+| `series_letter` | String | NHL API letter code identifying the playoff series the game belongs to (null for regular-season games). |
 | `playoff_round` | Int32 | Playoff round identifier. |
 | `series_game_number` | Int32 | Series game number. |
 | `season` | Int32 | Season year (echoed from arg). |
@@ -766,8 +766,8 @@ Release: [nhl_schedules](https://github.com/sportsdataverse/sportsdataverse-data
 | `game_rosters` | Boolean | Whether game rosters data is available. |
 | `scoring` | Boolean | TRUE when the play results in a score (TD, FG, safety, two-point conversion). |
 | `penalties` | Boolean | Penalty count. |
-| `scratches` | Boolean |  |
-| `linescore` | Boolean |  |
+| `scratches` | Boolean | Flag indicating a scratches payload was captured for this game in the NHL raw store. |
+| `linescore` | Boolean | Flag indicating a period-by-period linescore payload was captured for this game in the NHL raw store. |
 | `three_stars` | Boolean | Whether three stars data is available. |
 | `shifts` | Boolean | Number of shifts. |
 | `officials` | Boolean | Whether officials data is available. |
@@ -832,7 +832,7 @@ Release: [nhl_scoring](https://github.com/sportsdataverse/sportsdataverse-data/r
 | `game_id` | Int64 | Unique game identifier. |
 | `period_number` | Int64 | Period number (1-3 regulation, 4+ OT). |
 | `period_type` | String | Period type (REG/OT/SO). |
-| `goalInGame` | Int64 |  |
+| `goalInGame` | Int64 | Running goal count credited to the scorer within this game at the time of the goal. |
 
 ```python
 load_nhl_scoring(seasons=2024)
@@ -919,9 +919,9 @@ Release: [nhl_shootout](https://github.com/sportsdataverse/sportsdataverse-data/
 | `discreteClip` | Int64 | Discrete clip identifier. |
 | `discreteClipFr` | Int64 | Numeric NHL video identifier of the French-language clip of the shootout attempt, distinct from the id in discreteClip. |
 | `highlightClipSharingUrl` | String | Shareable URL for the goal highlight clip. |
-| `highlightClipSharingUrlFr` | String |  |
+| `highlightClipSharingUrlFr` | String | Shareable URL of the French-language broadcast highlight clip for the shootout attempt. |
 | `highlightClip` | Int64 | Highlight clip identifier. |
-| `highlightClipFr` | Int64 |  |
+| `highlightClipFr` | Int64 | NHL video identifier of the French-language highlight clip for the shootout attempt. |
 
 ```python
 load_nhl_shootout(seasons=2025)

--- a/docs/docs/pwhl/reference/loaders.md
+++ b/docs/docs/pwhl/reference/loaders.md
@@ -536,8 +536,8 @@ Release: [pwhl_pbp](https://github.com/sportsdataverse/sportsdataverse-data/rele
 | `on_ice_away` | String | Comma-joined sorted player_ids on ice for the away team. |
 | `skaters_home` | Int64 | Number of home skaters on the ice for the event, derived from HockeyTech shift data. |
 | `skaters_away` | Int64 | Number of away skaters on the ice for the event, derived from HockeyTech shift data. |
-| `strength_state` | String | Strength state (e.g. 5v5, 5v4). |
-| `strength_state_valid` | Boolean | Flag that the shift-derived strength state reconciles cleanly and can be trusted for this event. |
+| `strength_state` | String | Skater-strength state formatted home-first as skaters_home v skaters_away (5v4 = home has the extra skater), derived from shift data. |
+| `strength_state_valid` | Boolean | True when both shift-derived skater counts are between 3 and 6 inclusive; false when a count falls outside that range; null when a count is unavailable. |
 
 ```python
 load_pwhl_pbp(seasons=2024)

--- a/docs/docs/pwhl/reference/loaders.md
+++ b/docs/docs/pwhl/reference/loaders.md
@@ -534,10 +534,10 @@ Release: [pwhl_pbp](https://github.com/sportsdataverse/sportsdataverse-data/rele
 | `scoring_chance` | Boolean | TRUE when event is a shot-type within 25 ft of the net. |
 | `on_ice_home` | String | Comma-joined sorted player_ids on ice for the home team. |
 | `on_ice_away` | String | Comma-joined sorted player_ids on ice for the away team. |
-| `skaters_home` | Int64 |  |
-| `skaters_away` | Int64 |  |
+| `skaters_home` | Int64 | Number of home skaters on the ice for the event, derived from HockeyTech shift data. |
+| `skaters_away` | Int64 | Number of away skaters on the ice for the event, derived from HockeyTech shift data. |
 | `strength_state` | String | Strength state (e.g. 5v5, 5v4). |
-| `strength_state_valid` | Boolean |  |
+| `strength_state_valid` | Boolean | Flag that the shift-derived strength state reconciles cleanly and can be trusted for this event. |
 
 ```python
 load_pwhl_pbp(seasons=2024)

--- a/docs/docs/wbb/reference/loaders.md
+++ b/docs/docs/wbb/reference/loaders.md
@@ -69,8 +69,8 @@ Release: [espn_womens_college_basketball_pbp](https://github.com/sportsdataverse
 | `shooting_play` | Boolean | TRUE if the play was a shooting attempt. |
 | `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
 | `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
-| `points_attempted` | Int32 |  |
-| `short_description` | String |  |
+| `points_attempted` | Int32 | Point value at stake on the shot attempt (3 for threes, 2 for other field goals, 1 for free throws), from the ESPN play type. |
+| `short_description` | String | Shortened version of ESPN's play description text, without score context. |
 | `team_id` | Int32 | Unique team identifier. |
 | `athlete_id_1` | Int32 | Primary athlete identifier (e.g. shooter). |
 | `athlete_id_2` | Int32 | Secondary athlete identifier (e.g. assister / fouler). |
@@ -95,8 +95,8 @@ Release: [espn_womens_college_basketball_pbp](https://github.com/sportsdataverse
 | `time` | String | Time left within the period |
 | `clock_minutes` | Int32 | Clock minutes split from seconds for developer convenience |
 | `clock_seconds` | Int32 | Clock seconds split from minutes for developer convenience |
-| `home_timeout_called` | Boolean |  |
-| `away_timeout_called` | Boolean |  |
+| `home_timeout_called` | Boolean | Flag set on plays where a timeout was charged to the home team. |
+| `away_timeout_called` | Boolean | Flag set on plays where a timeout was charged to the away team. |
 | `half` | Int32 | Half of the game |
 | `game_half` | Int32 | Half of the game |
 | `lag_qtr` | Int32 | A lag column on the quarter |
@@ -114,9 +114,9 @@ Release: [espn_womens_college_basketball_pbp](https://github.com/sportsdataverse
 | `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
 | `game_date` | Date | Game date (YYYY-MM-DD). |
 | `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
-| `athlete_name_1` | String |  |
-| `athlete_name_2` | String |  |
-| `athlete_name_3` | String |  |
+| `athlete_name_1` | String | Display name of the first athlete in the ESPN play participants (e.g., the shooter on a shot attempt). |
+| `athlete_name_2` | String | Display name of the second athlete in the ESPN play participants (e.g., the assisting player), when present. |
+| `athlete_name_3` | String | Display name of the third athlete in the ESPN play participants, when present. |
 
 ```python
 load_wbb_pbp(seasons=2024)
@@ -245,9 +245,9 @@ Release: [espn_womens_college_basketball_schedules](https://github.com/sportsdat
 | `home_conference_id` | Int32 | Unique identifier for home conference. |
 | `home_score` | Int32 | Home team score at the time of the play. |
 | `home_winner` | Boolean | Home team's winner. |
-| `home_current_rank` | Float64 |  |
-| `home_linescores` | String |  |
-| `home_records` | String |  |
+| `home_current_rank` | Float64 | Poll ranking ESPN listed for the home team at game time (unranked teams carry a sentinel value). |
+| `home_linescores` | String | Period-by-period scores for the home team as a delimited string from ESPN's schedule feed. |
+| `home_records` | String | Record strings (overall and split records) for the home team from ESPN's schedule feed. |
 | `away_id` | Int32 | Unique identifier for away. |
 | `away_uid` | String | Away team's uid. |
 | `away_location` | String | Away team's location. |
@@ -263,9 +263,9 @@ Release: [espn_womens_college_basketball_schedules](https://github.com/sportsdat
 | `away_conference_id` | Int32 | Unique identifier for away conference. |
 | `away_score` | Int32 | Away team score at the time of the play. |
 | `away_winner` | Boolean | Away team's winner. |
-| `away_current_rank` | Float64 |  |
-| `away_linescores` | String |  |
-| `away_records` | String |  |
+| `away_current_rank` | Float64 | Poll ranking ESPN listed for the away team at game time (unranked teams carry a sentinel value). |
+| `away_linescores` | String | Period-by-period scores for the away team as a delimited string from ESPN's schedule feed. |
+| `away_records` | String | Record strings (overall and split records) for the away team from ESPN's schedule feed. |
 | `game_id` | Int32 | Unique game identifier. |
 | `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
@@ -326,7 +326,7 @@ Release: [espn_womens_college_basketball_team_boxscores](https://github.com/spor
 | `free_throws_attempted` | Int32 | Free throw attempts. |
 | `largest_lead` | String | Largest lead during the game. |
 | `lead_changes` | String | Lead changes. |
-| `lead_percentage` | String |  |
+| `lead_percentage` | String | Share of game time the team held the lead, as reported in ESPN's team boxscore. |
 | `offensive_rebounds` | Int32 | Offensive rebounds. |
 | `points_in_paint` | String | Points scored in the paint. |
 | `steals` | Int32 | Total steals. |
@@ -555,10 +555,10 @@ Release: [espn_womens_college_basketball_shots](https://github.com/sportsdataver
 | `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
 | `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
 | `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
-| `athlete_name_1` | String |  |
-| `athlete_name_2` | String |  |
+| `athlete_name_1` | String | Display name of the shooter credited on the attempt in ESPN's play participants. |
+| `athlete_name_2` | String | Display name of the second athlete tied to the attempt (typically the assister), when present. |
 | `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
-| `team_mascot` | String |  |
+| `team_mascot` | String | Mascot/nickname of the shooting team from ESPN's team record. |
 | `team_abbrev` | String | Abbreviation for team. |
 
 ```python
@@ -779,81 +779,81 @@ Release: [ncaa_wbb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `away_score` | Int64 | Away team score at the time of the play. |
 | `event_team` | String | Team associated with the shift change. |
 | `event_description` | String | Human-readable event description. |
-| `player_1` | String |  |
-| `player_2` | String |  |
+| `player_1` | String | Name of the primary player credited on the event (shooter, fouler, rebounder, etc.), as scraped from stats.ncaa.org. |
+| `player_2` | String | Name of the secondary player on the event (e.g., the assister or the player subbed for), when present. |
 | `event_type` | String | Event / play type code (V2 PBP). |
-| `event_result` | String |  |
+| `event_result` | String | Outcome of the event, e.g. made or missed for shot attempts. |
 | `shot_value` | Int64 | Point value of the shot (2 or 3). |
-| `event_length` | Int64 |  |
-| `poss_num` | Int64 |  |
-| `poss_team` | String |  |
-| `poss_length` | Int64 |  |
-| `is_transition` | Boolean |  |
-| `home_1` | String |  |
-| `home_2` | String |  |
-| `home_3` | String |  |
-| `home_4` | String |  |
-| `home_5` | String |  |
-| `away_1` | String |  |
-| `away_2` | String |  |
-| `away_3` | String |  |
-| `away_4` | String |  |
-| `away_5` | String |  |
+| `event_length` | Int64 | Seconds elapsed between this event and the previous event in the game. |
+| `poss_num` | Int64 | Sequential possession number within the game that the event belongs to. |
+| `poss_team` | String | Name of the team in possession when the event occurred. |
+| `poss_length` | Int64 | Duration of the enclosing possession in seconds. |
+| `is_transition` | Boolean | Flag marking events that occurred in transition, within the opening seconds of the possession. |
+| `home_1` | String | Name of the home team's on-floor player in lineup slot 1 for the event, from the substitution walk-forward. |
+| `home_2` | String | Name of the home team's on-floor player in lineup slot 2 for the event, from the substitution walk-forward. |
+| `home_3` | String | Name of the home team's on-floor player in lineup slot 3 for the event, from the substitution walk-forward. |
+| `home_4` | String | Name of the home team's on-floor player in lineup slot 4 for the event, from the substitution walk-forward. |
+| `home_5` | String | Name of the home team's on-floor player in lineup slot 5 for the event, from the substitution walk-forward. |
+| `away_1` | String | Name of the away team's on-floor player in lineup slot 1 for the event, from the substitution walk-forward. |
+| `away_2` | String | Name of the away team's on-floor player in lineup slot 2 for the event, from the substitution walk-forward. |
+| `away_3` | String | Name of the away team's on-floor player in lineup slot 3 for the event, from the substitution walk-forward. |
+| `away_4` | String | Name of the away team's on-floor player in lineup slot 4 for the event, from the substitution walk-forward. |
+| `away_5` | String | Name of the away team's on-floor player in lineup slot 5 for the event, from the substitution walk-forward. |
 | `status` | String | Status label. |
-| `is_garbage_time` | Boolean |  |
-| `sub_deviate` | Int64 |  |
+| `is_garbage_time` | Boolean | Flag marking events in garbage time under the score-margin and clock rule of the pbp builder. |
+| `sub_deviate` | Int64 | Per-game count of substitution-tracking deviations found while walking lineups forward; nonzero flags imperfect substitution data. |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
-| `home_ncaa_team_id` | String |  |
+| `home_ncaa_team_id` | String | stats.ncaa.org team identifier for the home team. |
 | `home_espn_team_id` | String | ESPN home team id (NA for bart-only rows). |
-| `away_ncaa_team_id` | String |  |
+| `away_ncaa_team_id` | String | stats.ncaa.org team identifier for the away team. |
 | `away_espn_team_id` | String | ESPN away team id (NA for bart-only rows). |
-| `event_team_ncaa_team_id` | String |  |
-| `event_team_espn_team_id` | String |  |
-| `poss_team_ncaa_team_id` | String |  |
-| `poss_team_espn_team_id` | String |  |
-| `player_1_id` | String |  |
-| `player_1_clean_name` | String |  |
-| `player_2_id` | String |  |
-| `player_2_clean_name` | String |  |
-| `home_1_player_id` | String |  |
-| `home_1_clean_name` | String |  |
-| `home_2_player_id` | String |  |
-| `home_2_clean_name` | String |  |
-| `home_3_player_id` | String |  |
-| `home_3_clean_name` | String |  |
-| `home_4_player_id` | String |  |
-| `home_4_clean_name` | String |  |
-| `home_5_player_id` | String |  |
-| `home_5_clean_name` | String |  |
-| `away_1_player_id` | String |  |
-| `away_1_clean_name` | String |  |
-| `away_2_player_id` | String |  |
-| `away_2_clean_name` | String |  |
-| `away_3_player_id` | String |  |
-| `away_3_clean_name` | String |  |
-| `away_4_player_id` | String |  |
-| `away_4_clean_name` | String |  |
-| `away_5_player_id` | String |  |
-| `away_5_clean_name` | String |  |
+| `event_team_ncaa_team_id` | String | stats.ncaa.org team identifier of the team credited with the event. |
+| `event_team_espn_team_id` | String | ESPN team identifier of the team credited with the event, via the NCAA-to-ESPN crosswalk. |
+| `poss_team_ncaa_team_id` | String | stats.ncaa.org team identifier of the team in possession. |
+| `poss_team_espn_team_id` | String | ESPN team identifier of the team in possession, via the NCAA-to-ESPN crosswalk. |
+| `player_1_id` | String | stats.ncaa.org player identifier for player_1, resolved through the roster name matcher. |
+| `player_1_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name for player_1. |
+| `player_2_id` | String | stats.ncaa.org player identifier for player_2, resolved through the roster name matcher. |
+| `player_2_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name for player_2. |
+| `home_1_player_id` | String | stats.ncaa.org player identifier for the home slot-1 on-floor player. |
+| `home_1_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-1 on-floor player. |
+| `home_2_player_id` | String | stats.ncaa.org player identifier for the home slot-2 on-floor player. |
+| `home_2_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-2 on-floor player. |
+| `home_3_player_id` | String | stats.ncaa.org player identifier for the home slot-3 on-floor player. |
+| `home_3_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-3 on-floor player. |
+| `home_4_player_id` | String | stats.ncaa.org player identifier for the home slot-4 on-floor player. |
+| `home_4_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-4 on-floor player. |
+| `home_5_player_id` | String | stats.ncaa.org player identifier for the home slot-5 on-floor player. |
+| `home_5_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-5 on-floor player. |
+| `away_1_player_id` | String | stats.ncaa.org player identifier for the away slot-1 on-floor player. |
+| `away_1_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-1 on-floor player. |
+| `away_2_player_id` | String | stats.ncaa.org player identifier for the away slot-2 on-floor player. |
+| `away_2_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-2 on-floor player. |
+| `away_3_player_id` | String | stats.ncaa.org player identifier for the away slot-3 on-floor player. |
+| `away_3_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-3 on-floor player. |
+| `away_4_player_id` | String | stats.ncaa.org player identifier for the away slot-4 on-floor player. |
+| `away_4_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-4 on-floor player. |
+| `away_5_player_id` | String | stats.ncaa.org player identifier for the away slot-5 on-floor player. |
+| `away_5_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-5 on-floor player. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
-| `is_fastbreak` | Boolean |  |
-| `is_from_turnover` | Boolean |  |
-| `is_paint` | Boolean |  |
-| `is_second_chance` | Boolean |  |
-| `assist_player` | String |  |
-| `ft_number` | Int64 |  |
-| `ft_attempts` | Int64 |  |
-| `foul_class` | String |  |
-| `is_shooting_foul` | Boolean |  |
-| `is_looseball_foul` | Boolean |  |
-| `is_one_and_one` | Boolean |  |
-| `is_flagrant` | Boolean |  |
-| `foul_tech_class` | String |  |
-| `ft_awarded` | Int64 |  |
-| `turnover_type` | String |  |
-| `is_team_turnover` | Boolean |  |
-| `timeout_type` | String |  |
-| `challenge_outcome` | String |  |
+| `is_fastbreak` | Boolean | Flag marking the shot as a fast-break attempt, from the stats.ncaa.org play text. |
+| `is_from_turnover` | Boolean | Flag marking an attempt generated off an opponent turnover. |
+| `is_paint` | Boolean | Flag marking the shot as attempted in the paint. |
+| `is_second_chance` | Boolean | Flag marking a second-chance attempt following an offensive rebound. |
+| `assist_player` | String | Name of the player credited with the assist on a made shot, when present. |
+| `ft_number` | Int64 | Which free throw of the trip this attempt is (1 of 2, 2 of 2, etc.). |
+| `ft_attempts` | Int64 | Total free throws in the trip this attempt belongs to. |
+| `foul_class` | String | Parsed category of the foul event (e.g. personal, offensive). |
+| `is_shooting_foul` | Boolean | Flag marking the foul as a shooting foul. |
+| `is_looseball_foul` | Boolean | Flag marking the foul as a loose-ball foul. |
+| `is_one_and_one` | Boolean | Flag marking a bonus one-and-one free-throw trip. |
+| `is_flagrant` | Boolean | Flag marking the foul as flagrant. |
+| `foul_tech_class` | String | Parsed technical-foul class for technical foul events, when present. |
+| `ft_awarded` | Int64 | Number of free throws awarded by the foul. |
+| `turnover_type` | String | Parsed turnover subtype (e.g. lost ball, bad pass, travel). |
+| `is_team_turnover` | Boolean | Flag marking a turnover charged to the team rather than an individual player. |
+| `timeout_type` | String | Type of timeout called (e.g. full, 30-second, media). |
+| `challenge_outcome` | String | Outcome of a coach's challenge or video-review event, when present. |
 | `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
 ```python
@@ -891,124 +891,124 @@ Release: [ncaa_wbb_player_box](https://github.com/sportsdataverse/sportsdatavers
 | `away` | String | Away record. |
 | `team` | String | Team-side label or team identifier. |
 | `player` | String | Player name. |
-| `mins` | Float64 |  |
-| `o_poss` | Float64 |  |
+| `mins` | Float64 | Minutes played, derived from the lineup walk-forward through the play-by-play. |
+| `o_poss` | Float64 | Offensive possessions the player was on the floor for. |
 | `pts` | Float64 | Points scored. |
-| `orb` | Float64 |  |
-| `drb` | Float64 |  |
+| `orb` | Float64 | Offensive rebounds. |
+| `drb` | Float64 | Defensive rebounds. |
 | `ast` | Float64 | Assists. |
 | `stl` | Float64 | Steals. |
 | `blk` | Float64 | Blocks. |
 | `tov` | Float64 | Turnovers. |
 | `pf` | Float64 | Personal fouls. |
 | `ts_pct` | Float64 | True shooting percentage (0-1). |
-| `efg_pct` | Float64 |  |
+| `efg_pct` | Float64 | Effective field-goal percentage, weighting made threes at 1.5. |
 | `fgm` | Float64 | Field goals made. |
 | `fga` | Float64 | Field goal attempts. |
 | `fg_pct` | Float64 | Field goal percentage (0-1). |
-| `tpm` | Float64 |  |
-| `tpa` | Float64 |  |
-| `tp_pct` | Float64 |  |
+| `tpm` | Float64 | Three-point field goals made. |
+| `tpa` | Float64 | Three-point field goals attempted. |
+| `tp_pct` | Float64 | Three-point field-goal percentage. |
 | `ftm` | Float64 | Free throws made. |
 | `fta` | Float64 | Free throw attempts. |
 | `ft_pct` | Float64 | Free throw percentage (0-1). |
-| `rimm` | Float64 |  |
-| `rima` | Float64 |  |
-| `rim_pct` | Float64 |  |
-| `midm` | Float64 |  |
-| `mida` | Float64 |  |
-| `mid_pct` | Float64 |  |
-| `pbackm` | Float64 |  |
-| `pbacka` | Float64 |  |
-| `pback_pct` | Float64 |  |
-| `blk_rim` | Float64 |  |
-| `blk_mid` | Float64 |  |
-| `blk_three` | Float64 |  |
-| `pct_fga_trans` | Float64 |  |
-| `pct_tpa_trans` | Float64 |  |
-| `pct_rima_trans` | Float64 |  |
-| `pct_fgm_trans` | Float64 |  |
-| `pct_tpm_trans` | Float64 |  |
-| `pct_rimm_trans` | Float64 |  |
-| `pct_fgm_ast` | Float64 |  |
-| `pct_tpm_ast` | Float64 |  |
-| `pct_rimm_ast` | Float64 |  |
-| `pts_trans` | Float64 |  |
-| `orb_trans` | Float64 |  |
-| `drb_trans` | Float64 |  |
-| `ast_trans` | Float64 |  |
-| `stl_trans` | Float64 |  |
-| `blk_trans` | Float64 |  |
-| `tov_trans` | Float64 |  |
-| `ts_pct_trans` | Float64 |  |
-| `efg_pct_trans` | Float64 |  |
-| `fgm_trans` | Float64 |  |
-| `fga_trans` | Float64 |  |
-| `fg_pct_trans` | Float64 |  |
-| `tpm_trans` | Float64 |  |
-| `tpa_trans` | Float64 |  |
-| `tp_pct_trans` | Float64 |  |
-| `ftm_trans` | Float64 |  |
-| `fta_trans` | Float64 |  |
-| `ft_pct_trans` | Float64 |  |
-| `rimm_trans` | Float64 |  |
-| `rima_trans` | Float64 |  |
-| `rim_pct_trans` | Float64 |  |
-| `midm_trans` | Float64 |  |
-| `mida_trans` | Float64 |  |
-| `mid_pct_trans` | Float64 |  |
-| `pts_half` | Float64 |  |
-| `orb_half` | Float64 |  |
-| `drb_half` | Float64 |  |
-| `ast_half` | Float64 |  |
-| `stl_half` | Float64 |  |
-| `blk_half` | Float64 |  |
-| `tov_half` | Float64 |  |
-| `ts_pct_half` | Float64 |  |
-| `efg_pct_half` | Float64 |  |
-| `fgm_half` | Float64 |  |
-| `fga_half` | Float64 |  |
-| `fg_pct_half` | Float64 |  |
-| `tpm_half` | Float64 |  |
-| `tpa_half` | Float64 |  |
-| `tp_pct_half` | Float64 |  |
-| `ftm_half` | Float64 |  |
-| `fta_half` | Float64 |  |
-| `ft_pct_half` | Float64 |  |
-| `rimm_half` | Float64 |  |
-| `rima_half` | Float64 |  |
-| `rim_pct_half` | Float64 |  |
-| `midm_half` | Float64 |  |
-| `mida_half` | Float64 |  |
-| `mid_pct_half` | Float64 |  |
-| `pts_ast` | Float64 |  |
-| `fgm_ast` | Float64 |  |
-| `tpm_ast` | Float64 |  |
-| `rimm_ast` | Float64 |  |
-| `midm_ast` | Float64 |  |
-| `pts_unast` | Float64 |  |
-| `efg_pct_unast` | Float64 |  |
-| `fgm_unast` | Float64 |  |
-| `fga_unast` | Float64 |  |
-| `fg_pct_unast` | Float64 |  |
-| `tpm_unast` | Float64 |  |
-| `tpa_unast` | Float64 |  |
-| `tp_pct_unast` | Float64 |  |
-| `rimm_unast` | Float64 |  |
-| `rima_unast` | Float64 |  |
-| `rim_pct_unast` | Float64 |  |
-| `midm_unast` | Float64 |  |
-| `mida_unast` | Float64 |  |
-| `mid_pct_unast` | Float64 |  |
+| `rimm` | Float64 | Rim shots (dunks, layups, hooks, tip-ins) made. |
+| `rima` | Float64 | Rim shots (dunks, layups, hooks, tip-ins) attempted. |
+| `rim_pct` | Float64 | Field-goal percentage on rim attempts. |
+| `midm` | Float64 | Mid-range (non-rim two-point) shots made. |
+| `mida` | Float64 | Mid-range (non-rim two-point) shots attempted. |
+| `mid_pct` | Float64 | Field-goal percentage on mid-range attempts. |
+| `pbackm` | Float64 | Putbacks made — rim shots immediately following an offensive rebound. |
+| `pbacka` | Float64 | Putbacks attempted — rim shots immediately following an offensive rebound. |
+| `pback_pct` | Float64 | Field-goal percentage on putback attempts. |
+| `blk_rim` | Float64 | Blocks recorded against opponent rim attempts. |
+| `blk_mid` | Float64 | Blocks recorded against opponent mid-range attempts. |
+| `blk_three` | Float64 | Blocks recorded against opponent three-point attempts. |
+| `pct_fga_trans` | Float64 | Share of the player's field-goal attempts taken in transition. |
+| `pct_tpa_trans` | Float64 | Share of the player's three-point attempts taken in transition. |
+| `pct_rima_trans` | Float64 | Share of the player's rim attempts taken in transition. |
+| `pct_fgm_trans` | Float64 | Share of the player's field-goal makes that came in transition. |
+| `pct_tpm_trans` | Float64 | Share of the player's three-point makes that came in transition. |
+| `pct_rimm_trans` | Float64 | Share of the player's rim makes that came in transition. |
+| `pct_fgm_ast` | Float64 | Share of the player's made field goals that were assisted. |
+| `pct_tpm_ast` | Float64 | Share of the player's made threes that were assisted. |
+| `pct_rimm_ast` | Float64 | Share of the player's made rim shots that were assisted. |
+| `pts_trans` | Float64 | Points scored in transition possessions. |
+| `orb_trans` | Float64 | Offensive rebounds in transition possessions. |
+| `drb_trans` | Float64 | Defensive rebounds in transition possessions. |
+| `ast_trans` | Float64 | Assists in transition possessions. |
+| `stl_trans` | Float64 | Steals in transition possessions. |
+| `blk_trans` | Float64 | Blocks in transition possessions. |
+| `tov_trans` | Float64 | Turnovers in transition possessions. |
+| `ts_pct_trans` | Float64 | True-shooting percentage in transition possessions. |
+| `efg_pct_trans` | Float64 | Effective field-goal percentage in transition possessions. |
+| `fgm_trans` | Float64 | Field goals made in transition possessions. |
+| `fga_trans` | Float64 | Field goals attempted in transition possessions. |
+| `fg_pct_trans` | Float64 | Field-goal percentage in transition possessions. |
+| `tpm_trans` | Float64 | Three-pointers made in transition possessions. |
+| `tpa_trans` | Float64 | Three-pointers attempted in transition possessions. |
+| `tp_pct_trans` | Float64 | Three-point percentage in transition possessions. |
+| `ftm_trans` | Float64 | Free throws made in transition possessions. |
+| `fta_trans` | Float64 | Free throws attempted in transition possessions. |
+| `ft_pct_trans` | Float64 | Free-throw percentage in transition possessions. |
+| `rimm_trans` | Float64 | Rim shots made in transition possessions. |
+| `rima_trans` | Float64 | Rim shots attempted in transition possessions. |
+| `rim_pct_trans` | Float64 | Rim field-goal percentage in transition possessions. |
+| `midm_trans` | Float64 | Mid-range shots made in transition possessions. |
+| `mida_trans` | Float64 | Mid-range shots attempted in transition possessions. |
+| `mid_pct_trans` | Float64 | Mid-range field-goal percentage in transition possessions. |
+| `pts_half` | Float64 | Points scored in halfcourt possessions. |
+| `orb_half` | Float64 | Offensive rebounds in halfcourt possessions. |
+| `drb_half` | Float64 | Defensive rebounds in halfcourt possessions. |
+| `ast_half` | Float64 | Assists in halfcourt possessions. |
+| `stl_half` | Float64 | Steals in halfcourt possessions. |
+| `blk_half` | Float64 | Blocks in halfcourt possessions. |
+| `tov_half` | Float64 | Turnovers in halfcourt possessions. |
+| `ts_pct_half` | Float64 | True-shooting percentage in halfcourt possessions. |
+| `efg_pct_half` | Float64 | Effective field-goal percentage in halfcourt possessions. |
+| `fgm_half` | Float64 | Field goals made in halfcourt possessions. |
+| `fga_half` | Float64 | Field goals attempted in halfcourt possessions. |
+| `fg_pct_half` | Float64 | Field-goal percentage in halfcourt possessions. |
+| `tpm_half` | Float64 | Three-pointers made in halfcourt possessions. |
+| `tpa_half` | Float64 | Three-pointers attempted in halfcourt possessions. |
+| `tp_pct_half` | Float64 | Three-point percentage in halfcourt possessions. |
+| `ftm_half` | Float64 | Free throws made in halfcourt possessions. |
+| `fta_half` | Float64 | Free throws attempted in halfcourt possessions. |
+| `ft_pct_half` | Float64 | Free-throw percentage in halfcourt possessions. |
+| `rimm_half` | Float64 | Rim shots made in halfcourt possessions. |
+| `rima_half` | Float64 | Rim shots attempted in halfcourt possessions. |
+| `rim_pct_half` | Float64 | Rim field-goal percentage in halfcourt possessions. |
+| `midm_half` | Float64 | Mid-range shots made in halfcourt possessions. |
+| `mida_half` | Float64 | Mid-range shots attempted in halfcourt possessions. |
+| `mid_pct_half` | Float64 | Mid-range field-goal percentage in halfcourt possessions. |
+| `pts_ast` | Float64 | Points from the player's assisted field-goal makes. |
+| `fgm_ast` | Float64 | Assisted field-goal makes. |
+| `tpm_ast` | Float64 | Assisted three-point makes. |
+| `rimm_ast` | Float64 | Assisted rim makes. |
+| `midm_ast` | Float64 | Assisted mid-range makes. |
+| `pts_unast` | Float64 | Points from the player's unassisted field-goal makes. |
+| `efg_pct_unast` | Float64 | Effective field-goal percentage in the unassisted split (makes not credited with an assist). |
+| `fgm_unast` | Float64 | Field goals made in the unassisted split (makes not credited with an assist). |
+| `fga_unast` | Float64 | Field goals attempted in the unassisted split (makes not credited with an assist). |
+| `fg_pct_unast` | Float64 | Field-goal percentage in the unassisted split (makes not credited with an assist). |
+| `tpm_unast` | Float64 | Three-pointers made in the unassisted split (makes not credited with an assist). |
+| `tpa_unast` | Float64 | Three-pointers attempted in the unassisted split (makes not credited with an assist). |
+| `tp_pct_unast` | Float64 | Three-point percentage in the unassisted split (makes not credited with an assist). |
+| `rimm_unast` | Float64 | Rim shots made in the unassisted split (makes not credited with an assist). |
+| `rima_unast` | Float64 | Rim shots attempted in the unassisted split (makes not credited with an assist). |
+| `rim_pct_unast` | Float64 | Rim field-goal percentage in the unassisted split (makes not credited with an assist). |
+| `midm_unast` | Float64 | Mid-range shots made in the unassisted split (makes not credited with an assist). |
+| `mida_unast` | Float64 | Mid-range shots attempted in the unassisted split (makes not credited with an assist). |
+| `mid_pct_unast` | Float64 | Mid-range field-goal percentage in the unassisted split (makes not credited with an assist). |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
-| `home_ncaa_team_id` | String |  |
+| `home_ncaa_team_id` | String | stats.ncaa.org team identifier for the home team. |
 | `home_espn_team_id` | String | ESPN home team id (NA for bart-only rows). |
-| `away_ncaa_team_id` | String |  |
+| `away_ncaa_team_id` | String | stats.ncaa.org team identifier for the away team. |
 | `away_espn_team_id` | String | ESPN away team id (NA for bart-only rows). |
-| `team_ncaa_team_id` | String |  |
-| `team_espn_team_id` | String |  |
+| `team_ncaa_team_id` | String | stats.ncaa.org team identifier of the player's team. |
+| `team_espn_team_id` | String | ESPN team identifier of the player's team, via the NCAA-to-ESPN crosswalk. |
 | `player_id` | String | Unique player identifier. |
-| `clean_name` | String |  |
+| `clean_name` | String | Normalized (diacritics- and punctuation-cleaned) player name used to join across the NCAA datasets. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
 | `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
@@ -1026,82 +1026,82 @@ Release: [ncaa_wbb_team_box](https://github.com/sportsdataverse/sportsdataverse-
 | `home` | String | Home. |
 | `away` | String | Away record. |
 | `team` | String | Team-side label or team identifier. |
-| `mins` | Float64 |  |
-| `o_mins` | Float64 |  |
-| `d_mins` | Float64 |  |
-| `o_poss` | Float64 |  |
-| `d_poss` | Float64 |  |
-| `ortg` | Float64 |  |
-| `drtg` | Float64 |  |
-| `netrtg` | Float64 |  |
+| `mins` | Float64 | Minutes covered by the team's tracked lineups in the game. |
+| `o_mins` | Float64 | Minutes spent on tracked offensive possessions. |
+| `d_mins` | Float64 | Minutes spent on tracked defensive possessions. |
+| `o_poss` | Float64 | Offensive possessions. |
+| `d_poss` | Float64 | Defensive possessions. |
+| `ortg` | Float64 | Offensive rating — points scored per 100 possessions. |
+| `drtg` | Float64 | Defensive rating — points allowed per 100 possessions. |
+| `netrtg` | Float64 | Net rating — offensive rating minus defensive rating. |
 | `pts` | Float64 | Points scored. |
-| `d_pts` | Float64 |  |
+| `d_pts` | Float64 | Points allowed. |
 | `fga` | Float64 | Field goal attempts. |
-| `d_fga` | Float64 |  |
+| `d_fga` | Float64 | Opponent field-goal attempts. |
 | `fgm` | Float64 | Field goals made. |
-| `d_fgm` | Float64 |  |
-| `tpa` | Float64 |  |
-| `d_tpa` | Float64 |  |
-| `tpm` | Float64 |  |
-| `d_tpm` | Float64 |  |
+| `d_fgm` | Float64 | Opponent field goals made. |
+| `tpa` | Float64 | Three-point attempts. |
+| `d_tpa` | Float64 | Opponent three-point attempts. |
+| `tpm` | Float64 | Three-pointers made. |
+| `d_tpm` | Float64 | Opponent three-pointers made. |
 | `fta` | Float64 | Free throw attempts. |
-| `d_fta` | Float64 |  |
+| `d_fta` | Float64 | Opponent free-throw attempts. |
 | `ftm` | Float64 | Free throws made. |
-| `d_ftm` | Float64 |  |
-| `rima` | Float64 |  |
-| `d_rima` | Float64 |  |
-| `rimm` | Float64 |  |
-| `d_rimm` | Float64 |  |
-| `orb` | Float64 |  |
-| `d_orb` | Float64 |  |
-| `drb` | Float64 |  |
-| `d_drb` | Float64 |  |
+| `d_ftm` | Float64 | Opponent free throws made. |
+| `rima` | Float64 | Rim shots (dunks, layups, hooks, tip-ins) attempted. |
+| `d_rima` | Float64 | Opponent rim shots attempted. |
+| `rimm` | Float64 | Rim shots made. |
+| `d_rimm` | Float64 | Opponent rim shots made. |
+| `orb` | Float64 | Offensive rebounds. |
+| `d_orb` | Float64 | Opponent offensive rebounds. |
+| `drb` | Float64 | Defensive rebounds. |
+| `d_drb` | Float64 | Opponent defensive rebounds. |
 | `blk` | Float64 | Blocks. |
-| `d_blk` | Float64 |  |
+| `d_blk` | Float64 | Opponent blocks (own shots blocked). |
 | `to` | Float64 | To. |
-| `d_to` | Float64 |  |
+| `d_to` | Float64 | Opponent turnovers forced. |
 | `ast` | Float64 | Assists. |
-| `d_ast` | Float64 |  |
-| `e_poss` | Float64 |  |
+| `d_ast` | Float64 | Opponent assists allowed. |
+| `e_poss` | Float64 | Estimated possessions — the average of the team's and the opponent's raw possession counts. |
 | `fg_pct` | Float64 | Field goal percentage (0-1). |
-| `d_fg_pct` | Float64 |  |
-| `tpp` | Float64 |  |
-| `d_tpp` | Float64 |  |
-| `ftp` | Float64 |  |
-| `d_ftp` | Float64 |  |
-| `efg_pct` | Float64 |  |
-| `d_efg_pct` | Float64 |  |
+| `d_fg_pct` | Float64 | Opponent field-goal percentage. |
+| `tpp` | Float64 | Three-point percentage. |
+| `d_tpp` | Float64 | Opponent three-point percentage. |
+| `ftp` | Float64 | Free-throw percentage. |
+| `d_ftp` | Float64 | Opponent free-throw percentage. |
+| `efg_pct` | Float64 | Effective field-goal percentage, weighting made threes at 1.5. |
+| `d_efg_pct` | Float64 | Opponent effective field-goal percentage. |
 | `ts_pct` | Float64 | True shooting percentage (0-1). |
-| `d_ts_pct` | Float64 |  |
-| `rim_pct` | Float64 |  |
-| `d_rim_pct` | Float64 |  |
-| `mid_pct` | Float64 |  |
-| `d_mid_pct` | Float64 |  |
-| `tp_rate` | Float64 |  |
-| `d_tp_rate` | Float64 |  |
-| `rim_rate` | Float64 |  |
-| `d_rim_rate` | Float64 |  |
-| `mid_rate` | Float64 |  |
-| `d_mid_rate` | Float64 |  |
+| `d_ts_pct` | Float64 | Opponent true-shooting percentage. |
+| `rim_pct` | Float64 | Field-goal percentage on rim attempts. |
+| `d_rim_pct` | Float64 | Opponent field-goal percentage on rim attempts. |
+| `mid_pct` | Float64 | Field-goal percentage on mid-range attempts. |
+| `d_mid_pct` | Float64 | Opponent field-goal percentage on mid-range attempts. |
+| `tp_rate` | Float64 | Three-point attempts as a share of field-goal attempts. |
+| `d_tp_rate` | Float64 | Opponent three-point attempts as a share of their field-goal attempts. |
+| `rim_rate` | Float64 | Rim attempts as a share of field-goal attempts. |
+| `d_rim_rate` | Float64 | Opponent rim attempts as a share of their field-goal attempts. |
+| `mid_rate` | Float64 | Mid-range attempts as a share of field-goal attempts. |
+| `d_mid_rate` | Float64 | Opponent mid-range attempts as a share of their field-goal attempts. |
 | `ft_rate` | Float64 | Ft rate. |
-| `d_ft_rate` | Float64 |  |
-| `ast_rate` | Float64 |  |
-| `d_ast_rate` | Float64 |  |
+| `d_ft_rate` | Float64 | Opponent free-throw attempts relative to their field-goal attempts. |
+| `ast_rate` | Float64 | Share of the team's made field goals that were assisted. |
+| `d_ast_rate` | Float64 | Share of opponent made field goals that were assisted. |
 | `to_rate` | Float64 | To rate. |
-| `d_to_rate` | Float64 |  |
-| `blk_rate` | Float64 |  |
-| `o_blk_rate` | Float64 |  |
+| `d_to_rate` | Float64 | Opponent turnovers as a share of their possessions (forced-turnover rate). |
+| `blk_rate` | Float64 | Share of opponent two-point attempts the team blocked. |
+| `o_blk_rate` | Float64 | Share of the team's own two-point attempts blocked by the opponent. |
 | `orb_pct` | Float64 | Offensive rebound percentage. |
 | `drb_pct` | Float64 | Defensive rebound percentage. |
-| `time_per_poss` | Float64 |  |
-| `d_time_per_poss` | Float64 |  |
+| `time_per_poss` | Float64 | Average seconds per offensive possession. |
+| `d_time_per_poss` | Float64 | Average seconds per defensive possession. |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
-| `home_ncaa_team_id` | String |  |
+| `home_ncaa_team_id` | String | stats.ncaa.org team identifier for the home team. |
 | `home_espn_team_id` | String | ESPN home team id (NA for bart-only rows). |
-| `away_ncaa_team_id` | String |  |
+| `away_ncaa_team_id` | String | stats.ncaa.org team identifier for the away team. |
 | `away_espn_team_id` | String | ESPN away team id (NA for bart-only rows). |
-| `team_ncaa_team_id` | String |  |
-| `team_espn_team_id` | String |  |
+| `team_ncaa_team_id` | String | stats.ncaa.org team identifier of the team the row belongs to. |
+| `team_espn_team_id` | String | ESPN team identifier of the team, via the NCAA-to-ESPN crosswalk. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
 | `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
@@ -1137,13 +1137,13 @@ Release: [ncaa_wbb_team_rosters](https://github.com/sportsdataverse/sportsdatave
 | `team` | String | Team-side label or team identifier. |
 | `player_id` | String | Unique player identifier. |
 | `player` | String | Player name. |
-| `clean_name` | String |  |
+| `clean_name` | String | Normalized (diacritics- and punctuation-cleaned) player name used to join across the NCAA datasets. |
 | `name` | String | Display name. |
 | `jersey` | String | Jersey number worn by the player. |
 | `class` | String | College class / draft eligibility note. |
 | `position` | String | Listed roster position (G, F, C, etc.). |
 | `height` | String | Player height (string e.g. '6-2' or inches). |
-| `ht_inches` | Int64 |  |
+| `ht_inches` | Int64 | Player height converted to total inches from the stats.ncaa.org roster listing. |
 | `hometown` | String | Player hometown. |
 | `high_school` | String | High school |
 | `gp` | String | Games played. |
@@ -1180,56 +1180,56 @@ Release: [ncaa_wbb_possessions](https://github.com/sportsdataverse/sportsdataver
 | `home` | String | Home. |
 | `away` | String | Away record. |
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
-| `poss_num` | Int64 |  |
-| `poss_team` | String |  |
-| `home_1` | String |  |
-| `home_2` | String |  |
-| `home_3` | String |  |
-| `home_4` | String |  |
-| `home_5` | String |  |
-| `away_1` | String |  |
-| `away_2` | String |  |
-| `away_3` | String |  |
-| `away_4` | String |  |
-| `away_5` | String |  |
+| `poss_num` | Int64 | Sequential possession number within the game. |
+| `poss_team` | String | Name of the team in possession. |
+| `home_1` | String | Name of the home team's on-floor player in lineup slot 1 for the possession, from the substitution walk-forward. |
+| `home_2` | String | Name of the home team's on-floor player in lineup slot 2 for the possession, from the substitution walk-forward. |
+| `home_3` | String | Name of the home team's on-floor player in lineup slot 3 for the possession, from the substitution walk-forward. |
+| `home_4` | String | Name of the home team's on-floor player in lineup slot 4 for the possession, from the substitution walk-forward. |
+| `home_5` | String | Name of the home team's on-floor player in lineup slot 5 for the possession, from the substitution walk-forward. |
+| `away_1` | String | Name of the away team's on-floor player in lineup slot 1 for the possession, from the substitution walk-forward. |
+| `away_2` | String | Name of the away team's on-floor player in lineup slot 2 for the possession, from the substitution walk-forward. |
+| `away_3` | String | Name of the away team's on-floor player in lineup slot 3 for the possession, from the substitution walk-forward. |
+| `away_4` | String | Name of the away team's on-floor player in lineup slot 4 for the possession, from the substitution walk-forward. |
+| `away_5` | String | Name of the away team's on-floor player in lineup slot 5 for the possession, from the substitution walk-forward. |
 | `home_score` | Int64 | Home team score at the time of the play. |
 | `away_score` | Int64 | Away team score at the time of the play. |
 | `pts` | Int64 | Points scored. |
-| `is_assisted` | Int64 |  |
-| `is_transition` | Int64 |  |
-| `is_garbage_time` | Int64 |  |
-| `start_event_type` | String |  |
-| `first_shot_time` | Int64 |  |
-| `first_shot_type` | String |  |
-| `last_event_time` | Int64 |  |
-| `last_event_type` | String |  |
+| `is_assisted` | Int64 | 1 when the possession's made field goal was assisted, else 0. |
+| `is_transition` | Int64 | 1 for transition possessions, else 0. |
+| `is_garbage_time` | Int64 | 1 for possessions in garbage time under the score-margin and clock rule, else 0. |
+| `start_event_type` | String | Event type that opened the possession (e.g., a defensive rebound or a made-basket inbound). |
+| `first_shot_time` | Int64 | Clock time in seconds at the possession's first shot attempt, from the possession segmentation engine. |
+| `first_shot_type` | String | Shot class of the possession's first attempt (rim, mid-range, or three). |
+| `last_event_time` | Int64 | Clock time in seconds at the possession's final event. |
+| `last_event_type` | String | Event type that ended the possession (e.g., a made shot, turnover, or defensive rebound). |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
-| `home_ncaa_team_id` | String |  |
+| `home_ncaa_team_id` | String | stats.ncaa.org team identifier for the home team. |
 | `home_espn_team_id` | String | ESPN home team id (NA for bart-only rows). |
-| `away_ncaa_team_id` | String |  |
+| `away_ncaa_team_id` | String | stats.ncaa.org team identifier for the away team. |
 | `away_espn_team_id` | String | ESPN away team id (NA for bart-only rows). |
-| `poss_team_ncaa_team_id` | String |  |
-| `poss_team_espn_team_id` | String |  |
-| `home_1_player_id` | String |  |
-| `home_1_clean_name` | String |  |
-| `home_2_player_id` | String |  |
-| `home_2_clean_name` | String |  |
-| `home_3_player_id` | String |  |
-| `home_3_clean_name` | String |  |
-| `home_4_player_id` | String |  |
-| `home_4_clean_name` | String |  |
-| `home_5_player_id` | String |  |
-| `home_5_clean_name` | String |  |
-| `away_1_player_id` | String |  |
-| `away_1_clean_name` | String |  |
-| `away_2_player_id` | String |  |
-| `away_2_clean_name` | String |  |
-| `away_3_player_id` | String |  |
-| `away_3_clean_name` | String |  |
-| `away_4_player_id` | String |  |
-| `away_4_clean_name` | String |  |
-| `away_5_player_id` | String |  |
-| `away_5_clean_name` | String |  |
+| `poss_team_ncaa_team_id` | String | stats.ncaa.org team identifier of the team in possession. |
+| `poss_team_espn_team_id` | String | ESPN team identifier of the team in possession, via the NCAA-to-ESPN crosswalk. |
+| `home_1_player_id` | String | stats.ncaa.org player identifier for the home slot-1 on-floor player. |
+| `home_1_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-1 on-floor player. |
+| `home_2_player_id` | String | stats.ncaa.org player identifier for the home slot-2 on-floor player. |
+| `home_2_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-2 on-floor player. |
+| `home_3_player_id` | String | stats.ncaa.org player identifier for the home slot-3 on-floor player. |
+| `home_3_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-3 on-floor player. |
+| `home_4_player_id` | String | stats.ncaa.org player identifier for the home slot-4 on-floor player. |
+| `home_4_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-4 on-floor player. |
+| `home_5_player_id` | String | stats.ncaa.org player identifier for the home slot-5 on-floor player. |
+| `home_5_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the home slot-5 on-floor player. |
+| `away_1_player_id` | String | stats.ncaa.org player identifier for the away slot-1 on-floor player. |
+| `away_1_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-1 on-floor player. |
+| `away_2_player_id` | String | stats.ncaa.org player identifier for the away slot-2 on-floor player. |
+| `away_2_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-2 on-floor player. |
+| `away_3_player_id` | String | stats.ncaa.org player identifier for the away slot-3 on-floor player. |
+| `away_3_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-3 on-floor player. |
+| `away_4_player_id` | String | stats.ncaa.org player identifier for the away slot-4 on-floor player. |
+| `away_4_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-4 on-floor player. |
+| `away_5_player_id` | String | stats.ncaa.org player identifier for the away slot-5 on-floor player. |
+| `away_5_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-5 on-floor player. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
 | `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
@@ -1244,81 +1244,81 @@ Release: [ncaa_wbb_lineups](https://github.com/sportsdataverse/sportsdataverse-d
 
 | col_name | type | description |
 |---|---|---|
-| `lineup_key` | String |  |
+| `lineup_key` | String | Sorted player-code key identifying the five-player unit on the floor (hoop-explorer convention). |
 | `date` | String | Date in YYYY-MM-DD format. |
-| `location_type` | String |  |
+| `location_type` | String | Whether the lineup's team was the Home or Away side in the game. |
 | `team` | String | Team-side label or team identifier. |
-| `team_year` | Int64 |  |
+| `team_year` | Int64 | Season year of the team-season the lineup row belongs to. |
 | `opponent` | String | Opponent. |
-| `lineup_id` | String |  |
-| `start_min` | Float64 |  |
-| `end_min` | Float64 |  |
-| `duration_mins` | Float64 |  |
-| `player_1` | String |  |
-| `player_2` | String |  |
-| `player_3` | String |  |
-| `player_4` | String |  |
-| `player_5` | String |  |
-| `players_in` | String |  |
-| `players_out` | String |  |
-| `start_scored` | Int64 |  |
-| `start_allowed` | Int64 |  |
-| `end_scored` | Int64 |  |
-| `end_allowed` | Int64 |  |
-| `start_diff` | Int64 |  |
-| `end_diff` | Int64 |  |
-| `player_count_error` | Null |  |
+| `lineup_id` | String | Sorted-name identifier of the five-player lineup, joined from the on-floor player names. |
+| `start_min` | Float64 | Game minute at which the stint began. |
+| `end_min` | Float64 | Game minute at which the stint ended. |
+| `duration_mins` | Float64 | Length of the stint in minutes. |
+| `player_1` | String | Name of the first player (in sorted order) of the five-player lineup. |
+| `player_2` | String | Name of the second player (in sorted order) of the five-player lineup. |
+| `player_3` | String | Name of the third player (in sorted order) of the five-player lineup. |
+| `player_4` | String | Name of the fourth player (in sorted order) of the five-player lineup. |
+| `player_5` | String | Name of the fifth player (in sorted order) of the five-player lineup. |
+| `players_in` | String | Delimited names of the players substituted in at the start of the stint. |
+| `players_out` | String | Delimited names of the players substituted out at the end of the stint. |
+| `start_scored` | Int64 | Team points scored at the moment the stint began. |
+| `start_allowed` | Int64 | Points allowed at the moment the stint began. |
+| `end_scored` | Int64 | Team points scored at the moment the stint ended. |
+| `end_allowed` | Int64 | Points allowed at the moment the stint ended. |
+| `start_diff` | Int64 | Score margin (scored minus allowed) when the stint began. |
+| `end_diff` | Int64 | Score margin (scored minus allowed) when the stint ended. |
+| `player_count_error` | Null | Flag marking stints where the reconciled on-floor count was not exactly five players (all-null when clean). |
 | `poss` | Int64 | Poss. |
 | `pts` | Int64 | Points scored. |
 | `plus_minus` | Int64 | Plus/minus point differential while on court. |
 | `fga` | Int64 | Field goal attempts. |
 | `fgm` | Int64 | Field goals made. |
-| `rima` | Int64 |  |
-| `rimm` | Int64 |  |
-| `rim_ast` | Int64 |  |
-| `mida` | Int64 |  |
-| `midm` | Int64 |  |
-| `mid_ast` | Int64 |  |
-| `fg2a` | Int64 |  |
-| `fg2m` | Int64 |  |
-| `tpa` | Int64 |  |
-| `tpm` | Int64 |  |
-| `tp_ast` | Int64 |  |
+| `rima` | Int64 | Rim shots (dunks, layups, hooks, tip-ins) attempted by the lineup during the stint. |
+| `rimm` | Int64 | Rim shots made by the lineup during the stint. |
+| `rim_ast` | Int64 | Assisted rim makes by the lineup during the stint. |
+| `mida` | Int64 | Mid-range shots attempted by the lineup during the stint. |
+| `midm` | Int64 | Mid-range shots made by the lineup during the stint. |
+| `mid_ast` | Int64 | Assisted mid-range makes by the lineup during the stint. |
+| `fg2a` | Int64 | Two-point field goals attempted by the lineup during the stint. |
+| `fg2m` | Int64 | Two-point field goals made by the lineup during the stint. |
+| `tpa` | Int64 | Three-pointers attempted by the lineup during the stint. |
+| `tpm` | Int64 | Three-pointers made by the lineup during the stint. |
+| `tp_ast` | Int64 | Assisted three-point makes by the lineup during the stint. |
 | `fta` | Int64 | Free throw attempts. |
 | `ftm` | Int64 | Free throws made. |
-| `orb` | Int64 |  |
-| `drb` | Int64 |  |
+| `orb` | Int64 | Offensive rebounds by the lineup during the stint. |
+| `drb` | Int64 | Defensive rebounds by the lineup during the stint. |
 | `to` | Int64 | To. |
 | `stl` | Int64 | Steals. |
 | `blk` | Int64 | Blocks. |
 | `ast` | Int64 | Assists. |
-| `foul` | Int64 |  |
-| `opp_poss` | Int64 |  |
+| `foul` | Int64 | Fouls committed by the lineup during the stint. |
+| `opp_poss` | Int64 | Opponent possessions while the lineup was on the floor during the stint. |
 | `opp_pts` | Int64 | Opponent points. |
-| `opp_plus_minus` | Int64 |  |
-| `opp_fga` | Int64 |  |
-| `opp_fgm` | Int64 |  |
-| `opp_rima` | Int64 |  |
-| `opp_rimm` | Int64 |  |
-| `opp_rim_ast` | Int64 |  |
-| `opp_mida` | Int64 |  |
-| `opp_midm` | Int64 |  |
-| `opp_mid_ast` | Int64 |  |
-| `opp_fg2a` | Int64 |  |
-| `opp_fg2m` | Int64 |  |
-| `opp_tpa` | Int64 |  |
-| `opp_tpm` | Int64 |  |
-| `opp_tp_ast` | Int64 |  |
-| `opp_fta` | Int64 |  |
-| `opp_ftm` | Int64 |  |
-| `opp_orb` | Int64 |  |
-| `opp_drb` | Int64 |  |
-| `opp_to` | Int64 |  |
-| `opp_stl` | Int64 |  |
-| `opp_blk` | Int64 |  |
-| `opp_ast` | Int64 |  |
-| `opp_foul` | Int64 |  |
-| `stint_num` | Int64 |  |
+| `opp_plus_minus` | Int64 | Opponent scoring margin while the lineup was on the floor during the stint. |
+| `opp_fga` | Int64 | Opponent field-goal attempts while the lineup was on the floor during the stint. |
+| `opp_fgm` | Int64 | Opponent field goals made while the lineup was on the floor during the stint. |
+| `opp_rima` | Int64 | Opponent rim shots attempted while the lineup was on the floor during the stint. |
+| `opp_rimm` | Int64 | Opponent rim shots made while the lineup was on the floor during the stint. |
+| `opp_rim_ast` | Int64 | Opponent assisted rim makes while the lineup was on the floor during the stint. |
+| `opp_mida` | Int64 | Opponent mid-range shots attempted while the lineup was on the floor during the stint. |
+| `opp_midm` | Int64 | Opponent mid-range shots made while the lineup was on the floor during the stint. |
+| `opp_mid_ast` | Int64 | Opponent assisted mid-range makes while the lineup was on the floor during the stint. |
+| `opp_fg2a` | Int64 | Opponent two-point attempts while the lineup was on the floor during the stint. |
+| `opp_fg2m` | Int64 | Opponent two-point makes while the lineup was on the floor during the stint. |
+| `opp_tpa` | Int64 | Opponent three-point attempts while the lineup was on the floor during the stint. |
+| `opp_tpm` | Int64 | Opponent three-point makes while the lineup was on the floor during the stint. |
+| `opp_tp_ast` | Int64 | Opponent assisted three-point makes while the lineup was on the floor during the stint. |
+| `opp_fta` | Int64 | Opponent free-throw attempts while the lineup was on the floor during the stint. |
+| `opp_ftm` | Int64 | Opponent free throws made while the lineup was on the floor during the stint. |
+| `opp_orb` | Int64 | Opponent offensive rebounds while the lineup was on the floor during the stint. |
+| `opp_drb` | Int64 | Opponent defensive rebounds while the lineup was on the floor during the stint. |
+| `opp_to` | Int64 | Opponent turnovers while the lineup was on the floor during the stint. |
+| `opp_stl` | Int64 | Opponent steals while the lineup was on the floor during the stint. |
+| `opp_blk` | Int64 | Opponent blocks while the lineup was on the floor during the stint. |
+| `opp_ast` | Int64 | Opponent assists while the lineup was on the floor during the stint. |
+| `opp_foul` | Int64 | Opponent fouls committed while the lineup was on the floor during the stint. |
+| `stint_num` | Int64 | Sequential on-floor stint number for the lineup within the game. |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
 | `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
@@ -1338,34 +1338,34 @@ Release: [ncaa_wbb_matchup_stints](https://github.com/sportsdataverse/sportsdata
 | `game_date` | String | Game date (YYYY-MM-DD). |
 | `home` | String | Home. |
 | `away` | String | Away record. |
-| `game_stint_num` | Int64 |  |
+| `game_stint_num` | Int64 | Sequential stint number within the game, incremented at every substitution by either team. |
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
-| `start_seconds` | Int64 |  |
-| `end_seconds` | Int64 |  |
+| `start_seconds` | Int64 | Elapsed game seconds at which the stint began. |
+| `end_seconds` | Int64 | Elapsed game seconds at which the stint ended. |
 | `duration_seconds` | Int64 | Streak duration in seconds. |
-| `matchup_key` | String |  |
-| `home_lineup_key` | String |  |
-| `away_lineup_key` | String |  |
-| `home_lineup` | String |  |
-| `away_lineup` | String |  |
-| `end_home_score` | Int64 |  |
-| `end_away_score` | Int64 |  |
-| `n_events` | Int64 |  |
-| `n_possessions` | Int64 |  |
-| `start_home_score` | Int64 |  |
-| `start_away_score` | Int64 |  |
-| `home_pts` | Int64 |  |
-| `away_pts` | Int64 |  |
-| `home_1` | String |  |
-| `home_2` | String |  |
-| `home_3` | String |  |
-| `home_4` | String |  |
-| `home_5` | String |  |
-| `away_1` | String |  |
-| `away_2` | String |  |
-| `away_3` | String |  |
-| `away_4` | String |  |
-| `away_5` | String |  |
+| `matchup_key` | String | Combined home-plus-away lineup key identifying the ten-player matchup on the floor. |
+| `home_lineup_key` | String | Sorted player-code key for the home five on the floor. |
+| `away_lineup_key` | String | Sorted player-code key for the away five on the floor. |
+| `home_lineup` | String | Delimited names of the home five on the floor during the stint. |
+| `away_lineup` | String | Delimited names of the away five on the floor during the stint. |
+| `end_home_score` | Int64 | Home team score when the stint ended. |
+| `end_away_score` | Int64 | Away team score when the stint ended. |
+| `n_events` | Int64 | Number of play-by-play events falling within the stint. |
+| `n_possessions` | Int64 | Number of possessions falling within the stint. |
+| `start_home_score` | Int64 | Home team score when the stint began. |
+| `start_away_score` | Int64 | Away team score when the stint began. |
+| `home_pts` | Int64 | Points scored by the home team during the stint. |
+| `away_pts` | Int64 | Points scored by the away team during the stint. |
+| `home_1` | String | Name of the home team's on-floor player in lineup slot 1 for the stint. |
+| `home_2` | String | Name of the home team's on-floor player in lineup slot 2 for the stint. |
+| `home_3` | String | Name of the home team's on-floor player in lineup slot 3 for the stint. |
+| `home_4` | String | Name of the home team's on-floor player in lineup slot 4 for the stint. |
+| `home_5` | String | Name of the home team's on-floor player in lineup slot 5 for the stint. |
+| `away_1` | String | Name of the away team's on-floor player in lineup slot 1 for the stint. |
+| `away_2` | String | Name of the away team's on-floor player in lineup slot 2 for the stint. |
+| `away_3` | String | Name of the away team's on-floor player in lineup slot 3 for the stint. |
+| `away_4` | String | Name of the away team's on-floor player in lineup slot 4 for the stint. |
+| `away_5` | String | Name of the away team's on-floor player in lineup slot 5 for the stint. |
 
 ```python
 load_ncaa_wbb_matchup_stints(seasons=2024)
@@ -1381,21 +1381,21 @@ Release: [ncaa_wbb_shots](https://github.com/sportsdataverse/sportsdataverse-dat
 | `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
 | `team_id` | String | Unique team identifier. |
 | `shooter_id` | String | Unique identifier for shooter. |
-| `shot_x` | Float64 |  |
-| `shot_y` | Float64 |  |
-| `dist_ft` | Float64 |  |
-| `shot_zone` | String |  |
+| `shot_x` | Float64 | Court x-coordinate of the attempt in feet, decoded from the stats.ncaa.org shot-chart map. |
+| `shot_y` | Float64 | Court y-coordinate of the attempt in feet, decoded from the stats.ncaa.org shot-chart map. |
+| `dist_ft` | Float64 | Shot distance from the basket in feet. |
+| `shot_zone` | String | Labeled zone of the attempt (rim, mid-range, or three-point). |
 | `shot_type` | String | Shot type label (e.g. 'Jump Shot', 'Layup'). |
-| `made` | Boolean |  |
-| `point_value` | Int64 |  |
+| `made` | Boolean | Whether the shot was made. |
+| `point_value` | Int64 | Point value of the attempt (2 or 3). |
 | `period` | Null | Period of the game (1-4 quarters; 5+ for OT). |
-| `sec_left` | Null |  |
+| `sec_left` | Null | Seconds remaining in the period when the shot was taken (all-null in current captures). |
 | `source` | String | News source. |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
-| `ncaa_team_id` | String |  |
+| `ncaa_team_id` | String | stats.ncaa.org team identifier of the shooting team. |
 | `espn_team_id` | String | ESPN team id (canonical key). |
-| `shooter_player_id` | String |  |
-| `shooter_clean_name` | String |  |
+| `shooter_player_id` | String | stats.ncaa.org player identifier of the shooter. |
+| `shooter_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the shooter. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
 
 ```python
@@ -1410,12 +1410,12 @@ Release: [ncaa_wbb_rapm_within_team](https://github.com/sportsdataverse/sportsda
 | col_name | type | description |
 |---|---|---|
 | `team` | String | Team-side label or team identifier. |
-| `player_code` | String |  |
-| `rapm_off` | Float64 |  |
-| `rapm_def` | Float64 |  |
-| `team_off_poss` | Float64 |  |
-| `num_players` | Int64 |  |
-| `rapm_net` | Float64 |  |
+| `player_code` | String | Short unique-within-team player code generated from the player's name (hoop-explorer convention). |
+| `rapm_off` | Float64 | Ridge-regressed offensive RAPM per 100 possessions, estimated relative to the player's own teammates. |
+| `rapm_def` | Float64 | Ridge-regressed defensive RAPM per 100 possessions relative to teammates; positive means good defense. |
+| `team_off_poss` | Float64 | Team offensive possessions underlying the within-team fit. |
+| `num_players` | Int64 | Number of players in the team's RAPM design matrix. |
+| `rapm_net` | Float64 | Net RAPM — the sum of the offensive and defensive components, per 100 possessions. |
 | `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
 | `player_id` | String | Unique player identifier. |
 | `team_id` | String | Unique team identifier. |

--- a/docs/docs/wbb/reference/loaders.md
+++ b/docs/docs/wbb/reference/loaders.md
@@ -987,19 +987,19 @@ Release: [ncaa_wbb_player_box](https://github.com/sportsdataverse/sportsdatavers
 | `rimm_ast` | Float64 | Assisted rim makes. |
 | `midm_ast` | Float64 | Assisted mid-range makes. |
 | `pts_unast` | Float64 | Points from the player's unassisted field-goal makes. |
-| `efg_pct_unast` | Float64 | Effective field-goal percentage in the unassisted split (makes not credited with an assist). |
-| `fgm_unast` | Float64 | Field goals made in the unassisted split (makes not credited with an assist). |
-| `fga_unast` | Float64 | Field goals attempted in the unassisted split (makes not credited with an assist). |
-| `fg_pct_unast` | Float64 | Field-goal percentage in the unassisted split (makes not credited with an assist). |
-| `tpm_unast` | Float64 | Three-pointers made in the unassisted split (makes not credited with an assist). |
-| `tpa_unast` | Float64 | Three-pointers attempted in the unassisted split (makes not credited with an assist). |
-| `tp_pct_unast` | Float64 | Three-point percentage in the unassisted split (makes not credited with an assist). |
-| `rimm_unast` | Float64 | Rim shots made in the unassisted split (makes not credited with an assist). |
-| `rima_unast` | Float64 | Rim shots attempted in the unassisted split (makes not credited with an assist). |
-| `rim_pct_unast` | Float64 | Rim field-goal percentage in the unassisted split (makes not credited with an assist). |
-| `midm_unast` | Float64 | Mid-range shots made in the unassisted split (makes not credited with an assist). |
-| `mida_unast` | Float64 | Mid-range shots attempted in the unassisted split (makes not credited with an assist). |
-| `mid_pct_unast` | Float64 | Mid-range field-goal percentage in the unassisted split (makes not credited with an assist). |
+| `efg_pct_unast` | Float64 | Effective field-goal percentage in the unassisted split (makes for which no assist was credited). |
+| `fgm_unast` | Float64 | Field goals made in the unassisted split (makes for which no assist was credited). |
+| `fga_unast` | Float64 | Field goals attempted in the unassisted split (makes for which no assist was credited). |
+| `fg_pct_unast` | Float64 | Field-goal percentage in the unassisted split (makes for which no assist was credited). |
+| `tpm_unast` | Float64 | Three-pointers made in the unassisted split (makes for which no assist was credited). |
+| `tpa_unast` | Float64 | Three-pointers attempted in the unassisted split (makes for which no assist was credited). |
+| `tp_pct_unast` | Float64 | Three-point percentage in the unassisted split (makes for which no assist was credited). |
+| `rimm_unast` | Float64 | Rim shots made in the unassisted split (makes for which no assist was credited). |
+| `rima_unast` | Float64 | Rim shots attempted in the unassisted split (makes for which no assist was credited). |
+| `rim_pct_unast` | Float64 | Rim field-goal percentage in the unassisted split (makes for which no assist was credited). |
+| `midm_unast` | Float64 | Mid-range shots made in the unassisted split (makes for which no assist was credited). |
+| `mida_unast` | Float64 | Mid-range shots attempted in the unassisted split (makes for which no assist was credited). |
+| `mid_pct_unast` | Float64 | Mid-range field-goal percentage in the unassisted split (makes for which no assist was credited). |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
 | `home_ncaa_team_id` | String | stats.ncaa.org team identifier for the home team. |
 | `home_espn_team_id` | String | ESPN home team id (NA for bart-only rows). |
@@ -1342,7 +1342,7 @@ Release: [ncaa_wbb_matchup_stints](https://github.com/sportsdataverse/sportsdata
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
 | `start_seconds` | Int64 | Elapsed game seconds at which the stint began. |
 | `end_seconds` | Int64 | Elapsed game seconds at which the stint ended. |
-| `duration_seconds` | Int64 | Streak duration in seconds. |
+| `duration_seconds` | Int64 | Duration of the lineup stint in seconds. |
 | `matchup_key` | String | Combined home-plus-away lineup key identifying the ten-player matchup on the floor. |
 | `home_lineup_key` | String | Sorted player-code key for the home five on the floor. |
 | `away_lineup_key` | String | Sorted player-code key for the away five on the floor. |

--- a/docs/docs/wnba/reference/loaders.md
+++ b/docs/docs/wnba/reference/loaders.md
@@ -74,8 +74,8 @@ Release: [espn_wnba_pbp](https://github.com/sportsdataverse/sportsdataverse-data
 | `shooting_play` | Boolean | TRUE if the play was a shooting attempt. |
 | `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
 | `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
-| `points_attempted` | Int32 |  |
-| `short_description` | String |  |
+| `points_attempted` | Int32 | Point value at stake on the play's shot attempt (1, 2, or 3); 0 for non-shooting plays. |
+| `short_description` | String | Abbreviated ESPN text description of the play. |
 | `game_id` | Int32 | Unique game identifier. |
 | `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
@@ -97,8 +97,8 @@ Release: [espn_wnba_pbp](https://github.com/sportsdataverse/sportsdataverse-data
 | `time` | String | Time left within the period |
 | `clock_minutes` | Int32 | Clock minutes split from seconds for developer convenience |
 | `clock_seconds` | Float64 | Clock seconds split from minutes for developer convenience |
-| `home_timeout_called` | Boolean |  |
-| `away_timeout_called` | Boolean |  |
+| `home_timeout_called` | Boolean | True when the play is a timeout charged to the home team. |
+| `away_timeout_called` | Boolean | True when the play is a timeout charged to the away team. |
 | `half` | Int32 | Half of the game |
 | `game_half` | Int32 | Half of the game |
 | `lag_qtr` | Int32 | A lag column on the quarter |
@@ -116,9 +116,9 @@ Release: [espn_wnba_pbp](https://github.com/sportsdataverse/sportsdataverse-data
 | `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
 | `game_date` | Date | Game date (YYYY-MM-DD). |
 | `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
-| `athlete_name_1` | String |  |
-| `athlete_name_2` | String |  |
-| `athlete_name_3` | String |  |
+| `athlete_name_1` | String | Display name of the primary athlete on the play (e.g. the shooter, rebounder, or fouler), per ESPN participant order. |
+| `athlete_name_2` | String | Display name of the secondary athlete on the play (e.g. the assister or fouled player), when present. |
+| `athlete_name_3` | String | Display name of the third athlete listed on the play, when present. |
 | `type_abbreviation` | String | Play type abbreviation |
 
 ```python
@@ -249,8 +249,8 @@ Release: [espn_wnba_schedules](https://github.com/sportsdataverse/sportsdatavers
 | `home_logo` | String | Home team logo URL. |
 | `home_score` | Int32 | Home team score at the time of the play. |
 | `home_winner` | Boolean | Home team's winner. |
-| `home_linescores` | String |  |
-| `home_records` | String |  |
+| `home_linescores` | String | Stringified list of the home team's period-by-period scores from the ESPN schedule feed. |
+| `home_records` | String | Stringified list of the home team's record summaries (overall/home/away) from the ESPN schedule feed. |
 | `away_id` | Int32 | Unique identifier for away. |
 | `away_uid` | String | Away team's uid. |
 | `away_location` | String | Away team's location. |
@@ -265,8 +265,8 @@ Release: [espn_wnba_schedules](https://github.com/sportsdataverse/sportsdatavers
 | `away_logo` | String | Away team logo URL. |
 | `away_score` | Int32 | Away team score at the time of the play. |
 | `away_winner` | Boolean | Away team's winner. |
-| `away_linescores` | String |  |
-| `away_records` | String |  |
+| `away_linescores` | String | Stringified list of the away team's period-by-period scores from the ESPN schedule feed. |
+| `away_records` | String | Stringified list of the away team's record summaries (overall/home/away) from the ESPN schedule feed. |
 | `game_id` | Int32 | Unique game identifier. |
 | `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
@@ -323,7 +323,7 @@ Release: [espn_wnba_team_boxscores](https://github.com/sportsdataverse/sportsdat
 | `free_throws_attempted` | Int32 | Free throw attempts. |
 | `largest_lead` | String | Largest lead during the game. |
 | `lead_changes` | String | Lead changes. |
-| `lead_percentage` | String |  |
+| `lead_percentage` | String | Share of game time the team spent in the lead, as reported by ESPN. |
 | `offensive_rebounds` | Int32 | Offensive rebounds. |
 | `points_in_paint` | String | Points scored in the paint. |
 | `steals` | Int32 | Total steals. |
@@ -556,10 +556,10 @@ Release: [espn_wnba_shots](https://github.com/sportsdataverse/sportsdataverse-da
 | `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
 | `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
 | `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
-| `athlete_name_1` | String |  |
-| `athlete_name_2` | String |  |
+| `athlete_name_1` | String | Display name of the shooter, per ESPN participant order. |
+| `athlete_name_2` | String | Display name of the secondary athlete on the shot (typically the assister), when present. |
 | `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
-| `team_mascot` | String |  |
+| `team_mascot` | String | ESPN mascot (nickname) of the shooting team. |
 | `team_abbrev` | String | Abbreviation for team. |
 
 ```python
@@ -645,10 +645,10 @@ Release: [wnba_crosswalk](https://github.com/sportsdataverse/sportsdataverse-dat
 | `espn_full_name` | String | ESPN full name. |
 | `espn_jersey` | String | ESPN jersey number. |
 | `espn_position` | String | ESPN position abbreviation. |
-| `wnba_player_id` | String |  |
-| `wnba_player_name` | String |  |
-| `wnba_jersey_num` | String |  |
-| `wnba_position` | String |  |
+| `wnba_player_id` | String | Player identifier on stats.wnba.com matched to the ESPN player. |
+| `wnba_player_name` | String | Player display name on the stats.wnba.com side of the crosswalk. |
+| `wnba_jersey_num` | String | Jersey number listed on the stats.wnba.com side of the crosswalk. |
+| `wnba_position` | String | Position listed on the stats.wnba.com side of the crosswalk. |
 | `fox_athlete_id` | String | Fox athlete id (NA if unmatched). |
 | `fox_player` | String | Fox player name (NA if unmatched). |
 | `fox_jersey` | String | Fox jersey number (NA if unmatched). |
@@ -676,13 +676,13 @@ Release: [wnba_crosswalk](https://github.com/sportsdataverse/sportsdataverse-dat
 | `home_espn_team_id` | Int32 | ESPN home team id (NA for bart-only rows). |
 | `away_espn_team_id` | Int32 | ESPN away team id (NA for bart-only rows). |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
-| `wnba_game_id` | String |  |
-| `wnba_game_code` | String |  |
-| `wnba_home_team_id` | String |  |
-| `wnba_away_team_id` | String |  |
+| `wnba_game_id` | String | Game identifier on stats.wnba.com matched to the ESPN game. |
+| `wnba_game_code` | String | stats.wnba.com game code (date/matchup slug) for the matched game. |
+| `wnba_home_team_id` | String | Home team identifier on stats.wnba.com for the matched game. |
+| `wnba_away_team_id` | String | Away team identifier on stats.wnba.com for the matched game. |
 | `fox_game_id` | String | Fox game id (NA placeholder). |
-| `fox_home_team_id` | String |  |
-| `fox_away_team_id` | String |  |
+| `fox_home_team_id` | String | Home team identifier on Fox Sports for the matched game. |
+| `fox_away_team_id` | String | Away team identifier on Fox Sports for the matched game. |
 | `yahoo_game_id` | String | Yahoo game id (NA placeholder). |
 | `match_method` | String | Combination of matched sources, e.g. "fox+bart" / "fox_only" / "bart_only" / "espn_only". |
 | `match_confidence` | Float64 | Jaro-Winkler score or 1 for exact (NA if none). |
@@ -785,26 +785,26 @@ Release: [wnba_player_impact](https://github.com/sportsdataverse/sportsdataverse
 | `teams` | String | Nested list of member-team membership spans. |
 | `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
 | `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
-| `o_rapm` | Float64 |  |
-| `d_rapm` | Float64 |  |
-| `rapm` | Float64 |  |
-| `off_poss` | Int64 |  |
-| `def_poss` | Int64 |  |
-| `o_adj_rapm` | Float64 |  |
-| `d_adj_rapm` | Float64 |  |
-| `adj_rapm` | Float64 |  |
-| `ospm` | Float64 |  |
-| `dspm` | Float64 |  |
-| `spm` | Float64 |  |
+| `o_rapm` | Float64 | Offensive RAPM: ridge-regularized on/off impact on team offense, in points per 100 possessions. |
+| `d_rapm` | Float64 | Defensive RAPM: ridge-regularized on/off impact on team defense, in points per 100 possessions. |
+| `rapm` | Float64 | Total RAPM: offensive plus defensive regularized on/off impact, in points per 100 possessions. |
+| `off_poss` | Int64 | Offensive possessions the player was on the floor for in the RAPM sample. |
+| `def_poss` | Int64 | Defensive possessions the player was on the floor for in the RAPM sample. |
+| `o_adj_rapm` | Float64 | Offensive prior-informed RAPM: ridge shrunk toward a box-score prior, in points per 100 possessions. |
+| `d_adj_rapm` | Float64 | Defensive prior-informed RAPM: ridge shrunk toward a box-score prior, in points per 100 possessions. |
+| `adj_rapm` | Float64 | Total prior-informed RAPM (offense plus defense), in points per 100 possessions. |
+| `ospm` | Float64 | Offensive statistical plus-minus: box-score features regressed onto the offensive RAPM target, per 100 possessions. |
+| `dspm` | Float64 | Defensive statistical plus-minus: box-score features regressed onto the defensive RAPM target, per 100 possessions. |
+| `spm` | Float64 | Statistical plus-minus: offensive plus defensive box-score estimate of the RAPM target, per 100 possessions. |
 | `min` | Float64 | Minutes played. |
 | `gp` | Int64 | Games played. |
 | `obpm` | Float64 | Offensive box plus/minus. |
 | `dbpm` | Float64 | Defensive box plus/minus. |
 | `bpm` | Float64 | Career box plus/minus. |
-| `war` | Float64 |  |
-| `darko_filtered_skill` | Float64 |  |
-| `darko_projected_rating` | Float64 |  |
-| `darko_projected_sd` | Float64 |  |
+| `war` | Float64 | Wins above replacement implied by the player's impact and playing time, calibrated from team points-per-win. |
+| `darko_filtered_skill` | Float64 | DARKO-style Kalman-filtered estimate of the player's current skill level. |
+| `darko_projected_rating` | Float64 | DARKO-style projected forward rating, including the empirical aging-curve drift. |
+| `darko_projected_sd` | Float64 | Posterior standard deviation of the DARKO-style projected rating. |
 
 ```python
 load_wnba_player_impact(seasons=2024)
@@ -906,7 +906,7 @@ Release: [wnba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-dat
 
 | col_name | type | description |
 |---|---|---|
-| `order_index` | Int64 |  |
+| `order_index` | Int64 | Stable ordering index of the event within the game's stats.wnba.com play-by-play. |
 | `action_number` | Int64 | Sequential action number within a game (V3 PBP). |
 | `clock` | String | Game clock value. |
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
@@ -933,16 +933,16 @@ Release: [wnba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-dat
 | `game_id` | String | Unique game identifier. |
 | `seconds_remaining` | Float64 | Seconds remaining in the period. |
 | `event_type` | String | Event / play type code (V2 PBP). |
-| `is_made_shot` | Boolean |  |
-| `is_missed_shot` | Boolean |  |
-| `is_free_throw` | Boolean |  |
-| `is_rebound` | Boolean |  |
+| `is_made_shot` | Boolean | True when the event is a made field goal. |
+| `is_missed_shot` | Boolean | True when the event is a missed field goal. |
+| `is_free_throw` | Boolean | True when the event is a free throw attempt. |
+| `is_rebound` | Boolean | True when the event is a rebound (player or team). |
 | `is_turnover` | Boolean | `TRUE` if the play was a turnover. |
-| `is_foul` | Boolean |  |
-| `is_substitution` | Boolean |  |
-| `is_jump_ball` | Boolean |  |
-| `is_timeout` | Boolean |  |
-| `is_period` | Boolean |  |
+| `is_foul` | Boolean | True when the event is a foul. |
+| `is_substitution` | Boolean | True when the event is a substitution. |
+| `is_jump_ball` | Boolean | True when the event is a jump ball. |
+| `is_timeout` | Boolean | True when the event is a timeout. |
+| `is_period` | Boolean | True for period-start and period-end marker events. |
 | `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
 ```python
@@ -960,18 +960,18 @@ Release: [wnba_stats_possessions](https://github.com/sportsdataverse/sportsdatav
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
 | `possession_number` | Int64 | Possession number. |
 | `offense_team_id` | Int64 | Unique identifier for offense team. |
-| `defense_team_id` | Int64 |  |
-| `start_order_index` | Int64 |  |
-| `end_order_index` | Int64 |  |
-| `start_seconds_remaining` | Float64 |  |
-| `end_seconds_remaining` | Float64 |  |
+| `defense_team_id` | Int64 | stats.wnba.com identifier of the defending team for the possession. |
+| `start_order_index` | Int64 | order_index of the first event in the possession; joins to the wnba_stats_pbp table. |
+| `end_order_index` | Int64 | order_index of the last event in the possession; joins to the wnba_stats_pbp table. |
+| `start_seconds_remaining` | Float64 | Seconds remaining in the period when the possession began. |
+| `end_seconds_remaining` | Float64 | Seconds remaining in the period when the possession ended. |
 | `points` | Int64 | Points scored. |
-| `is_second_chance` | Boolean |  |
-| `number_in_period` | Int64 |  |
-| `possession_start_type` | String |  |
-| `count_as_possession` | Boolean |  |
-| `fg2a` | Int64 |  |
-| `fg2m` | Int64 |  |
+| `is_second_chance` | Boolean | True when the possession continued after an offensive rebound (contains a second-chance segment). |
+| `number_in_period` | Int64 | Possession number within the period, resetting to 1 at each period start. |
+| `possession_start_type` | String | How the possession began: OffDeadball, OffTimeout, OffMadeShot, OffMissedShot, or OffLiveBallTurnover. |
+| `count_as_possession` | Boolean | False only for a possession starting with 2 seconds or less left in the period and no made basket before the period ends. |
+| `fg2a` | Int64 | Two-point field goals attempted by the offense during the possession. |
+| `fg2m` | Int64 | Two-point field goals made by the offense during the possession. |
 | `fg3a` | Int64 | Three-point field goal attempts. |
 | `fg3m` | Int64 | Three-point field goals made. |
 | `fta` | Int64 | Free throw attempts. |
@@ -979,16 +979,16 @@ Release: [wnba_stats_possessions](https://github.com/sportsdataverse/sportsdatav
 | `oreb` | Int64 | Offensive rebounds. |
 | `dreb` | Int64 | Defensive rebounds. |
 | `tov` | Int64 | Turnovers. |
-| `off_player_1` | Int64 |  |
-| `off_player_2` | Int64 |  |
-| `off_player_3` | Int64 |  |
-| `off_player_4` | Int64 |  |
-| `off_player_5` | Int64 |  |
-| `def_player_1` | Int64 |  |
-| `def_player_2` | Int64 |  |
-| `def_player_3` | Int64 |  |
-| `def_player_4` | Int64 |  |
-| `def_player_5` | Int64 |  |
+| `off_player_1` | Int64 | stats.wnba.com identifier of offensive on-court player 1 of 5 for the possession (unordered slot). |
+| `off_player_2` | Int64 | stats.wnba.com identifier of offensive on-court player 2 of 5 for the possession (unordered slot). |
+| `off_player_3` | Int64 | stats.wnba.com identifier of offensive on-court player 3 of 5 for the possession (unordered slot). |
+| `off_player_4` | Int64 | stats.wnba.com identifier of offensive on-court player 4 of 5 for the possession (unordered slot). |
+| `off_player_5` | Int64 | stats.wnba.com identifier of offensive on-court player 5 of 5 for the possession (unordered slot). |
+| `def_player_1` | Int64 | stats.wnba.com identifier of defensive on-court player 1 of 5 for the possession (unordered slot). |
+| `def_player_2` | Int64 | stats.wnba.com identifier of defensive on-court player 2 of 5 for the possession (unordered slot). |
+| `def_player_3` | Int64 | stats.wnba.com identifier of defensive on-court player 3 of 5 for the possession (unordered slot). |
+| `def_player_4` | Int64 | stats.wnba.com identifier of defensive on-court player 4 of 5 for the possession (unordered slot). |
+| `def_player_5` | Int64 | stats.wnba.com identifier of defensive on-court player 5 of 5 for the possession (unordered slot). |
 | `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
 ```python
@@ -1005,16 +1005,16 @@ Release: [wnba_stats_game_lineups](https://github.com/sportsdataverse/sportsdata
 | `game_id` | String | Unique game identifier. |
 | `action_number` | Int64 | Sequential action number within a game (V3 PBP). |
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
-| `home_player_1` | Int64 |  |
-| `home_player_2` | Int64 |  |
-| `home_player_3` | Int64 |  |
-| `home_player_4` | Int64 |  |
-| `home_player_5` | Int64 |  |
-| `away_player_1` | Int64 |  |
-| `away_player_2` | Int64 |  |
-| `away_player_3` | Int64 |  |
-| `away_player_4` | Int64 |  |
-| `away_player_5` | Int64 |  |
+| `home_player_1` | Int64 | stats.wnba.com identifier of home on-court player 1 of 5 for the lineup stint. |
+| `home_player_2` | Int64 | stats.wnba.com identifier of home on-court player 2 of 5 for the lineup stint. |
+| `home_player_3` | Int64 | stats.wnba.com identifier of home on-court player 3 of 5 for the lineup stint. |
+| `home_player_4` | Int64 | stats.wnba.com identifier of home on-court player 4 of 5 for the lineup stint. |
+| `home_player_5` | Int64 | stats.wnba.com identifier of home on-court player 5 of 5 for the lineup stint. |
+| `away_player_1` | Int64 | stats.wnba.com identifier of away on-court player 1 of 5 for the lineup stint. |
+| `away_player_2` | Int64 | stats.wnba.com identifier of away on-court player 2 of 5 for the lineup stint. |
+| `away_player_3` | Int64 | stats.wnba.com identifier of away on-court player 3 of 5 for the lineup stint. |
+| `away_player_4` | Int64 | stats.wnba.com identifier of away on-court player 4 of 5 for the lineup stint. |
+| `away_player_5` | Int64 | stats.wnba.com identifier of away on-court player 5 of 5 for the lineup stint. |
 | `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
 ```python
@@ -1108,7 +1108,7 @@ Release: [wnba_stats_player_game_logs](https://github.com/sportsdataverse/sports
 | `player_id` | Int64 | Unique player identifier. |
 | `player_name` | String | Player name. |
 | `fantasy_pts` | Float64 | Fantasy points. |
-| `measure_type` | String |  |
+| `measure_type` | String | Stats API measure-type slice the row was pulled from (e.g. 'Base'). |
 
 ```python
 load_wnba_stats_player_game_logs(seasons=2025)
@@ -1137,7 +1137,7 @@ Release: [wnba_stats_rosters](https://github.com/sportsdataverse/sportsdataverse
 | `school` | String | Player's school / college (when distinct from 'college'). |
 | `player_id` | Int64 | Unique player identifier. |
 | `how_acquired` | String | How the team acquired the player (draft, trade, free agency). |
-| `supplemental_status` | Int64 |  |
+| `supplemental_status` | Int64 | Numeric supplemental roster-status code from the stats.wnba.com roster feed. |
 | `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 
 ```python
@@ -1159,13 +1159,13 @@ Release: [wnba_stats_schedules](https://github.com/sportsdataverse/sportsdataver
 | `home_team_id` | Int64 | Unique identifier for the home team. |
 | `home_team_abbreviation` | String | Home team abbreviation; `team_detail = TRUE` only. |
 | `home_team_name` | String | Home team name. |
-| `home_pts` | Int64 |  |
-| `home_wl` | String |  |
+| `home_pts` | Int64 | Final points scored by the home team. |
+| `home_wl` | String | Result for the home team ('W' or 'L'); null before the game is final. |
 | `away_team_id` | Int64 | Unique identifier for the away team. |
 | `away_team_abbreviation` | String | Away team abbreviation; `team_detail = TRUE` only. |
 | `away_team_name` | String | Away team name. |
-| `away_pts` | Int64 |  |
-| `away_wl` | String |  |
+| `away_pts` | Int64 | Final points scored by the away team. |
+| `away_wl` | String | Result for the away team ('W' or 'L'); null before the game is final. |
 
 ```python
 load_wnba_stats_schedules(seasons=2025)

--- a/docs/docs/wnba/reference/wnba_stats.md
+++ b/docs/docs/wnba/reference/wnba_stats.md
@@ -31,8 +31,8 @@ GET /stats/alltimeleadersgrids
 | `player_id` | integer | Unique player identifier. |
 | `player_name` | character | Player name. |
 | `tov` | numeric | Turnovers. |
-| `tov_rank` | integer |  |
-| `is_active_flag` | character |  |
+| `tov_rank` | integer | All-time league rank of the player's career turnover total on the leaders grid. |
+| `is_active_flag` | character | Flag indicating whether the player is currently active in the league. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -170,27 +170,27 @@ GET /stats/boxscoreadvancedv2
 | `player_id` | integer | Unique player identifier. |
 | `player_name` | character | Player name. |
 | `nickname` | character | Team or athlete nickname. |
-| `start_position` | character |  |
+| `start_position` | character | Position the player started the game at ('F', 'C', or 'G'); empty for bench players. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
 | `min` | character | Minutes played. |
-| `e_off_rating` | numeric |  |
-| `off_rating` | numeric |  |
-| `e_def_rating` | numeric |  |
-| `def_rating` | numeric |  |
-| `e_net_rating` | numeric |  |
+| `e_off_rating` | numeric | Estimated offensive rating: points produced per 100 possessions using the stats API's estimated-possession formula. |
+| `off_rating` | numeric | Points scored per 100 possessions while on the floor. |
+| `e_def_rating` | numeric | Estimated defensive rating: points allowed per 100 possessions using the estimated-possession formula. |
+| `def_rating` | numeric | Points allowed per 100 possessions while on the floor. |
+| `e_net_rating` | numeric | Estimated net rating: estimated offensive rating minus estimated defensive rating. |
 | `net_rating` | numeric | Net rating (off rating - def rating). |
 | `ast_pct` | numeric | Assist percentage. |
-| `ast_tov` | numeric |  |
-| `ast_ratio` | numeric |  |
-| `oreb_pct` | numeric |  |
-| `dreb_pct` | numeric |  |
-| `reb_pct` | numeric |  |
-| `tm_tov_pct` | numeric |  |
-| `efg_pct` | numeric |  |
+| `ast_tov` | numeric | Ratio of assists to turnovers. |
+| `ast_ratio` | numeric | Assists per 100 possessions used. |
+| `oreb_pct` | numeric | Percentage of available offensive rebounds grabbed while on the floor. |
+| `dreb_pct` | numeric | Percentage of available defensive rebounds grabbed while on the floor. |
+| `reb_pct` | numeric | Percentage of all available rebounds grabbed while on the floor. |
+| `tm_tov_pct` | numeric | Turnovers committed per 100 possessions. |
+| `efg_pct` | numeric | Effective field goal percentage: (FGM + 0.5 * FG3M) / FGA. |
 | `ts_pct` | numeric | True shooting percentage (0-1). |
-| `usg_pct` | numeric |  |
-| `e_usg_pct` | numeric |  |
-| `e_pace` | numeric |  |
+| `usg_pct` | numeric | Percentage of team plays used while on the floor. |
+| `e_usg_pct` | numeric | Estimated usage percentage using the stats API's estimated-possession formula. |
+| `e_pace` | numeric | Estimated pace: team possessions per regulation game, from the estimated-possession formula. |
 | `pace` | numeric | Possessions per 48 minutes. |
 | `pace_per40` | numeric | Pace per40. |
 | `poss` | integer | Poss. |
@@ -229,42 +229,42 @@ GET /stats/boxscoreadvancedv3
 | col_name | type | description |
 |---|---|---|
 | `pie` | numeric | Player Impact Estimate (0-1). |
-| `assistpercentage` | numeric |  |
-| `assistratio` | numeric |  |
-| `assisttoturnover` | numeric |  |
+| `assistpercentage` | numeric | Percentage of teammate field goals assisted while on the floor, as a decimal. |
+| `assistratio` | numeric | Assists per 100 possessions used (assist ratio). |
+| `assisttoturnover` | numeric | Ratio of assists to turnovers. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `defensiverating` | numeric |  |
-| `defensivereboundpercentage` | numeric |  |
-| `effectivefieldgoalpercentage` | numeric |  |
-| `estimateddefensiverating` | numeric |  |
-| `estimatednetrating` | numeric |  |
-| `estimatedoffensiverating` | numeric |  |
-| `estimatedpace` | numeric |  |
-| `estimatedusagepercentage` | numeric |  |
-| `familyname` | character |  |
+| `defensiverating` | numeric | Points allowed per 100 possessions while on the floor (defensive rating). |
+| `defensivereboundpercentage` | numeric | Percentage of available defensive rebounds secured while on the floor, as a decimal. |
+| `effectivefieldgoalpercentage` | numeric | Effective field goal percentage (weights made threes at 1.5), as a decimal. |
+| `estimateddefensiverating` | numeric | Estimated defensive rating from the stats API's estimated-metrics family. |
+| `estimatednetrating` | numeric | Estimated net rating (estimated offensive minus defensive rating) from the stats API's estimated-metrics family. |
+| `estimatedoffensiverating` | numeric | Estimated offensive rating from the stats API's estimated-metrics family. |
+| `estimatedpace` | numeric | Estimated pace (possessions per 48 minutes) from the stats API's estimated-metrics family. |
+| `estimatedusagepercentage` | numeric | Estimated percentage of team plays used by the player while on the floor, as a decimal. |
+| `familyname` | character | Player's family (last) name. |
 | `firstname` | character | Firstname. |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `netrating` | numeric |  |
-| `offensiverating` | numeric |  |
-| `offensivereboundpercentage` | numeric |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `netrating` | numeric | Offensive rating minus defensive rating while on the floor (net rating). |
+| `offensiverating` | numeric | Points scored per 100 possessions while on the floor (offensive rating). |
+| `offensivereboundpercentage` | numeric | Percentage of available offensive rebounds secured while on the floor, as a decimal. |
 | `pace` | numeric | Possessions per 48 minutes. |
-| `paceper40` | numeric |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
+| `paceper40` | numeric | Pace normalized to possessions per 40 minutes. |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `possessions` | numeric | Possessions used. |
-| `reboundpercentage` | numeric |  |
+| `reboundpercentage` | numeric | Percentage of all available rebounds secured while on the floor, as a decimal. |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
-| `trueshootingpercentage` | numeric |  |
-| `turnoverratio` | numeric |  |
-| `usagepercentage` | numeric |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
+| `trueshootingpercentage` | numeric | True shooting percentage (accounts for threes and free throws), as a decimal. |
+| `turnoverratio` | numeric | Turnovers per 100 possessions used (turnover ratio). |
+| `usagepercentage` | numeric | Percentage of team plays used by the player while on the floor, as a decimal. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -362,17 +362,17 @@ GET /stats/boxscorefourfactorsv2
 | `player_id` | integer | Unique player identifier. |
 | `player_name` | character | Player name. |
 | `nickname` | character | Team or athlete nickname. |
-| `start_position` | character |  |
+| `start_position` | character | Position the player started the game at ('F', 'C', or 'G'); empty for bench players. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
 | `min` | character | Minutes played. |
-| `efg_pct` | numeric |  |
-| `fta_rate` | numeric |  |
-| `tm_tov_pct` | numeric |  |
-| `oreb_pct` | numeric |  |
-| `opp_efg_pct` | numeric |  |
-| `opp_fta_rate` | numeric |  |
-| `opp_tov_pct` | numeric |  |
-| `opp_oreb_pct` | numeric |  |
+| `efg_pct` | numeric | Effective field goal percentage: (FGM + 0.5 * FG3M) / FGA. |
+| `fta_rate` | numeric | Free throw attempt rate: free throw attempts per field goal attempt. |
+| `tm_tov_pct` | numeric | Turnovers committed per 100 possessions. |
+| `oreb_pct` | numeric | Percentage of available offensive rebounds grabbed while on the floor. |
+| `opp_efg_pct` | numeric | Opponent effective field goal percentage while on the floor. |
+| `opp_fta_rate` | numeric | Opponent free throw attempts per field goal attempt while on the floor. |
+| `opp_tov_pct` | numeric | Opponent turnovers per 100 possessions while on the floor. |
+| `opp_oreb_pct` | numeric | Percentage of available offensive rebounds grabbed by the opponent while on the floor. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -407,28 +407,28 @@ GET /stats/boxscorefourfactorsv3
 | col_name | type | description |
 |---|---|---|
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `effectivefieldgoalpercentage` | numeric |  |
-| `familyname` | character |  |
+| `effectivefieldgoalpercentage` | numeric | Effective field goal percentage four-factor, as a decimal. |
+| `familyname` | character | Player's family (last) name. |
 | `firstname` | character | Firstname. |
-| `freethrowattemptrate` | numeric |  |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
+| `freethrowattemptrate` | numeric | Free throw attempts per field goal attempt (free throw rate four-factor). |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `offensivereboundpercentage` | numeric |  |
-| `oppeffectivefieldgoalpercentage` | numeric |  |
-| `oppfreethrowattemptrate` | numeric |  |
-| `oppoffensivereboundpercentage` | numeric |  |
-| `oppteamturnoverpercentage` | numeric |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `offensivereboundpercentage` | numeric | Offensive rebound percentage four-factor, as a decimal. |
+| `oppeffectivefieldgoalpercentage` | numeric | Opponent's effective field goal percentage while on the floor, as a decimal. |
+| `oppfreethrowattemptrate` | numeric | Opponent's free throw attempt rate while on the floor. |
+| `oppoffensivereboundpercentage` | numeric | Opponent's offensive rebound percentage while on the floor, as a decimal. |
+| `oppteamturnoverpercentage` | numeric | Opponent turnovers forced per 100 possessions while on the floor. |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
-| `teamturnoverpercentage` | numeric |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
+| `teamturnoverpercentage` | numeric | Turnovers committed per 100 possessions (turnover four-factor). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -457,37 +457,37 @@ GET /stats/boxscorehustlev2
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `boxoutplayerrebounds` | integer |  |
-| `boxoutplayerteamrebounds` | integer |  |
-| `boxouts` | integer |  |
-| `chargesdrawn` | integer |  |
+| `boxoutplayerrebounds` | integer | Rebounds the player secured directly off their own box-outs. |
+| `boxoutplayerteamrebounds` | integer | Team rebounds secured following the player's box-outs. |
+| `boxouts` | integer | Total box-outs recorded in the game (hustle stats tracking). |
+| `chargesdrawn` | integer | Offensive charges drawn. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `contestedshots` | integer |  |
-| `contestedshots2pt` | integer |  |
-| `contestedshots3pt` | integer |  |
-| `defensiveboxouts` | integer |  |
+| `contestedshots` | integer | Opponent shot attempts contested in the game. |
+| `contestedshots2pt` | integer | Opponent two-point attempts contested. |
+| `contestedshots3pt` | integer | Opponent three-point attempts contested. |
+| `defensiveboxouts` | integer | Box-outs recorded on the defensive glass. |
 | `deflections` | integer | Defensive deflections. |
-| `familyname` | character |  |
+| `familyname` | character | Player's family (last) name. |
 | `firstname` | character | Firstname. |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
-| `looseballsrecovereddefensive` | integer |  |
-| `looseballsrecoveredoffensive` | integer |  |
-| `looseballsrecoveredtotal` | integer |  |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
+| `looseballsrecovereddefensive` | integer | Loose balls recovered while on defense. |
+| `looseballsrecoveredoffensive` | integer | Loose balls recovered while on offense. |
+| `looseballsrecoveredtotal` | integer | Total loose balls recovered in the game. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `offensiveboxouts` | integer |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `offensiveboxouts` | integer | Box-outs recorded on the offensive glass. |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
 | `points` | integer | Points scored. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
-| `screenassistpoints` | integer |  |
-| `screenassists` | integer |  |
+| `screenassistpoints` | integer | Points teammates scored directly off the player's screen assists. |
+| `screenassists` | integer | Screens that led directly to a teammate's made field goal (screen assists). |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -570,21 +570,21 @@ GET /stats/boxscoremiscv2
 | `player_id` | integer | Unique player identifier. |
 | `player_name` | character | Player name. |
 | `nickname` | character | Team or athlete nickname. |
-| `start_position` | character |  |
+| `start_position` | character | Position the player started the game at ('F', 'C', or 'G'); empty for bench players. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
 | `min` | character | Minutes played. |
-| `pts_off_tov` | integer |  |
-| `pts_2nd_chance` | integer |  |
-| `pts_fb` | integer |  |
-| `pts_paint` | integer |  |
-| `opp_pts_off_tov` | numeric |  |
-| `opp_pts_2nd_chance` | numeric |  |
-| `opp_pts_fb` | numeric |  |
-| `opp_pts_paint` | numeric |  |
+| `pts_off_tov` | integer | Points scored following opponent turnovers. |
+| `pts_2nd_chance` | integer | Second-chance points scored after offensive rebounds. |
+| `pts_fb` | integer | Fast-break points scored. |
+| `pts_paint` | integer | Points scored in the paint. |
+| `opp_pts_off_tov` | numeric | Opponent points scored off turnovers while on the floor. |
+| `opp_pts_2nd_chance` | numeric | Opponent second-chance points scored while on the floor. |
+| `opp_pts_fb` | numeric | Opponent fast-break points scored while on the floor. |
+| `opp_pts_paint` | numeric | Opponent points in the paint scored while on the floor. |
 | `blk` | integer | Blocks. |
-| `blka` | integer |  |
+| `blka` | integer | Number of own field goal attempts that were blocked by opponents. |
 | `pf` | integer | Personal fouls. |
-| `pfd` | integer |  |
+| `pfd` | integer | Personal fouls drawn. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -619,32 +619,32 @@ GET /stats/boxscoremiscv3
 | col_name | type | description |
 |---|---|---|
 | `blocks` | integer | Total blocks. |
-| `blocksagainst` | integer |  |
+| `blocksagainst` | integer | Player's shot attempts that were blocked by opponents. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `familyname` | character |  |
+| `familyname` | character | Player's family (last) name. |
 | `firstname` | character | Firstname. |
-| `foulsdrawn` | integer |  |
-| `foulspersonal` | integer |  |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
+| `foulsdrawn` | integer | Personal fouls drawn. |
+| `foulspersonal` | integer | Personal fouls committed. |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `opppointsfastbreak` | integer |  |
-| `opppointsoffturnovers` | integer |  |
-| `opppointspaint` | integer |  |
-| `opppointssecondchance` | integer |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
-| `pointsfastbreak` | integer |  |
-| `pointsoffturnovers` | integer |  |
-| `pointspaint` | integer |  |
-| `pointssecondchance` | integer |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `opppointsfastbreak` | integer | Opponent fast-break points scored while on the floor. |
+| `opppointsoffturnovers` | integer | Opponent points off turnovers scored while on the floor. |
+| `opppointspaint` | integer | Opponent points in the paint scored while on the floor. |
+| `opppointssecondchance` | integer | Opponent second-chance points scored while on the floor. |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
+| `pointsfastbreak` | integer | Fast-break points scored. |
+| `pointsoffturnovers` | integer | Points scored off opponent turnovers. |
+| `pointspaint` | integer | Points scored in the paint. |
+| `pointssecondchance` | integer | Second-chance points scored after offensive rebounds. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -748,24 +748,24 @@ GET /stats/boxscorescoringv2
 | `player_id` | integer | Unique player identifier. |
 | `player_name` | character | Player name. |
 | `nickname` | character | Team or athlete nickname. |
-| `start_position` | character |  |
+| `start_position` | character | Position the player started the game at ('F', 'C', or 'G'); empty for bench players. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
 | `min` | character | Minutes played. |
-| `pct_fga_2pt` | numeric |  |
-| `pct_fga_3pt` | numeric |  |
-| `pct_pts_2pt` | numeric |  |
-| `pct_pts_2pt_mr` | numeric |  |
-| `pct_pts_3pt` | numeric |  |
-| `pct_pts_fb` | numeric |  |
-| `pct_pts_ft` | numeric |  |
-| `pct_pts_off_tov` | numeric |  |
-| `pct_pts_paint` | numeric |  |
-| `pct_ast_2pm` | numeric |  |
-| `pct_uast_2pm` | numeric |  |
-| `pct_ast_3pm` | numeric |  |
-| `pct_uast_3pm` | numeric |  |
-| `pct_ast_fgm` | numeric |  |
-| `pct_uast_fgm` | numeric |  |
+| `pct_fga_2pt` | numeric | Share of field goal attempts taken as two-pointers. |
+| `pct_fga_3pt` | numeric | Share of field goal attempts taken as three-pointers. |
+| `pct_pts_2pt` | numeric | Share of points scored on two-point field goals. |
+| `pct_pts_2pt_mr` | numeric | Share of points scored on mid-range two-point field goals. |
+| `pct_pts_3pt` | numeric | Share of points scored on three-point field goals. |
+| `pct_pts_fb` | numeric | Share of points scored on the fast break. |
+| `pct_pts_ft` | numeric | Share of points scored on free throws. |
+| `pct_pts_off_tov` | numeric | Share of points scored off opponent turnovers. |
+| `pct_pts_paint` | numeric | Share of points scored in the paint. |
+| `pct_ast_2pm` | numeric | Share of made two-point field goals that were assisted. |
+| `pct_uast_2pm` | numeric | Share of made two-point field goals that were unassisted. |
+| `pct_ast_3pm` | numeric | Share of made three-point field goals that were assisted. |
+| `pct_uast_3pm` | numeric | Share of made three-point field goals that were unassisted. |
+| `pct_ast_fgm` | numeric | Share of all made field goals that were assisted. |
+| `pct_uast_fgm` | numeric | Share of all made field goals that were unassisted. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -800,35 +800,35 @@ GET /stats/boxscorescoringv3
 | col_name | type | description |
 |---|---|---|
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `familyname` | character |  |
+| `familyname` | character | Player's family (last) name. |
 | `firstname` | character | Firstname. |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `percentageassisted2pt` | numeric |  |
-| `percentageassisted3pt` | numeric |  |
-| `percentageassistedfgm` | numeric |  |
-| `percentagefieldgoalsattempted2pt` | numeric |  |
-| `percentagefieldgoalsattempted3pt` | numeric |  |
-| `percentagepoints2pt` | numeric |  |
-| `percentagepoints3pt` | numeric |  |
-| `percentagepointsfastbreak` | numeric |  |
-| `percentagepointsfreethrow` | numeric |  |
-| `percentagepointsmidrange2pt` | numeric |  |
-| `percentagepointsoffturnovers` | numeric |  |
-| `percentagepointspaint` | numeric |  |
-| `percentageunassisted2pt` | numeric |  |
-| `percentageunassisted3pt` | numeric |  |
-| `percentageunassistedfgm` | numeric |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `percentageassisted2pt` | numeric | Percentage of made two-pointers that were assisted, as a decimal. |
+| `percentageassisted3pt` | numeric | Percentage of made three-pointers that were assisted, as a decimal. |
+| `percentageassistedfgm` | numeric | Percentage of made field goals that were assisted, as a decimal. |
+| `percentagefieldgoalsattempted2pt` | numeric | Share of field goal attempts taken as two-pointers, as a decimal. |
+| `percentagefieldgoalsattempted3pt` | numeric | Share of field goal attempts taken as three-pointers, as a decimal. |
+| `percentagepoints2pt` | numeric | Share of points scored on two-pointers, as a decimal. |
+| `percentagepoints3pt` | numeric | Share of points scored on three-pointers, as a decimal. |
+| `percentagepointsfastbreak` | numeric | Share of points scored on fast breaks, as a decimal. |
+| `percentagepointsfreethrow` | numeric | Share of points scored at the free throw line, as a decimal. |
+| `percentagepointsmidrange2pt` | numeric | Share of points scored on mid-range two-pointers, as a decimal. |
+| `percentagepointsoffturnovers` | numeric | Share of points scored off opponent turnovers, as a decimal. |
+| `percentagepointspaint` | numeric | Share of points scored in the paint, as a decimal. |
+| `percentageunassisted2pt` | numeric | Percentage of made two-pointers that were unassisted, as a decimal. |
+| `percentageunassisted3pt` | numeric | Percentage of made three-pointers that were unassisted, as a decimal. |
+| `percentageunassistedfgm` | numeric | Percentage of made field goals that were unassisted, as a decimal. |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -908,19 +908,19 @@ GET /stats/boxscoresummaryv3
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `dummykey` | character |  |
-| `gameid` | character |  |
-| `inbonus` | character |  |
+| `dummykey` | character | Placeholder key emitted by the stats API's box score summary payload; carries no data. |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `inbonus` | character | Whether the team is currently in the bonus (penalty) foul situation, as reported by the stats API. |
 | `score` | integer | Final score. |
-| `seed` | integer |  |
+| `seed` | integer | Team's playoff seed, populated for postseason games. |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
-| `teamlosses` | integer |  |
+| `teamlosses` | integer | Team's loss total entering the game. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
-| `teamwins` | integer |  |
-| `timeoutsremaining` | integer |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
+| `teamwins` | integer | Team's win total entering the game. |
+| `timeoutsremaining` | integer | Timeouts the team has remaining. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -961,7 +961,7 @@ GET /stats/boxscoretraditionalv2
 | `player_id` | integer | Unique player identifier. |
 | `player_name` | character | Player name. |
 | `nickname` | character | Team or athlete nickname. |
-| `start_position` | character |  |
+| `start_position` | character | Position the player started the game at (F, C, or G); empty for reserves. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
 | `min` | character | Minutes played. |
 | `fgm` | integer | Field goals made. |
@@ -1017,76 +1017,76 @@ GET /stats/boxscoretraditionalv3
 | col_name | type | description |
 |---|---|---|
 | `assists` | integer | Total assists. |
-| `bench_assists` | integer |  |
-| `bench_blocks` | integer |  |
-| `bench_fieldgoalsattempted` | integer |  |
-| `bench_fieldgoalsmade` | integer |  |
-| `bench_fieldgoalspercentage` | numeric |  |
-| `bench_foulspersonal` | integer |  |
-| `bench_freethrowsattempted` | integer |  |
-| `bench_freethrowsmade` | integer |  |
-| `bench_freethrowspercentage` | numeric |  |
-| `bench_minutes` | character |  |
+| `bench_assists` | integer | Total assists by the team's bench players. |
+| `bench_blocks` | integer | Total blocked shots by the team's bench players. |
+| `bench_fieldgoalsattempted` | integer | Total field goal attempts by the team's bench players. |
+| `bench_fieldgoalsmade` | integer | Total field goals made by the team's bench players. |
+| `bench_fieldgoalspercentage` | numeric | Combined field goal percentage of the team's bench players. |
+| `bench_foulspersonal` | integer | Total personal fouls by the team's bench players. |
+| `bench_freethrowsattempted` | integer | Total free throw attempts by the team's bench players. |
+| `bench_freethrowsmade` | integer | Total free throws made by the team's bench players. |
+| `bench_freethrowspercentage` | numeric | Combined free throw percentage of the team's bench players. |
+| `bench_minutes` | character | Total minutes played by the team's bench players. |
 | `bench_points` | integer | Points scored by the bench. |
-| `bench_reboundsdefensive` | integer |  |
-| `bench_reboundsoffensive` | integer |  |
-| `bench_reboundstotal` | integer |  |
-| `bench_steals` | integer |  |
-| `bench_threepointersattempted` | integer |  |
-| `bench_threepointersmade` | integer |  |
-| `bench_threepointerspercentage` | numeric |  |
-| `bench_turnovers` | integer |  |
+| `bench_reboundsdefensive` | integer | Total defensive rebounds by the team's bench players. |
+| `bench_reboundsoffensive` | integer | Total offensive rebounds by the team's bench players. |
+| `bench_reboundstotal` | integer | Total rebounds by the team's bench players. |
+| `bench_steals` | integer | Total steals by the team's bench players. |
+| `bench_threepointersattempted` | integer | Total three-point attempts by the team's bench players. |
+| `bench_threepointersmade` | integer | Total three-pointers made by the team's bench players. |
+| `bench_threepointerspercentage` | numeric | Combined three-point percentage of the team's bench players. |
+| `bench_turnovers` | integer | Total turnovers by the team's bench players. |
 | `blocks` | integer | Total blocks. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `familyname` | character |  |
-| `fieldgoalsattempted` | integer |  |
-| `fieldgoalsmade` | integer |  |
-| `fieldgoalspercentage` | numeric |  |
+| `familyname` | character | Player's family (last) name. |
+| `fieldgoalsattempted` | integer | Field goal attempts recorded in the game. |
+| `fieldgoalsmade` | integer | Field goals made recorded in the game. |
+| `fieldgoalspercentage` | numeric | Field goal percentage for the game, as a decimal. |
 | `firstname` | character | Firstname. |
-| `foulspersonal` | integer |  |
-| `freethrowsattempted` | integer |  |
-| `freethrowsmade` | integer |  |
-| `freethrowspercentage` | numeric |  |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
+| `foulspersonal` | integer | Personal fouls recorded in the game. |
+| `freethrowsattempted` | integer | Free throw attempts recorded in the game. |
+| `freethrowsmade` | integer | Free throws made recorded in the game. |
+| `freethrowspercentage` | numeric | Free throw percentage for the game, as a decimal. |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
-| `plusminuspoints` | numeric |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
+| `plusminuspoints` | numeric | Team point differential while the player was on the floor (plus-minus). |
 | `points` | integer | Points scored. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
-| `reboundsdefensive` | integer |  |
-| `reboundsoffensive` | integer |  |
-| `reboundstotal` | integer |  |
-| `starters_assists` | integer |  |
-| `starters_blocks` | integer |  |
-| `starters_fieldgoalsattempted` | integer |  |
-| `starters_fieldgoalsmade` | integer |  |
-| `starters_fieldgoalspercentage` | numeric |  |
-| `starters_foulspersonal` | integer |  |
-| `starters_freethrowsattempted` | integer |  |
-| `starters_freethrowsmade` | integer |  |
-| `starters_freethrowspercentage` | numeric |  |
-| `starters_minutes` | character |  |
-| `starters_points` | integer |  |
-| `starters_reboundsdefensive` | integer |  |
-| `starters_reboundsoffensive` | integer |  |
-| `starters_reboundstotal` | integer |  |
-| `starters_steals` | integer |  |
-| `starters_threepointersattempted` | integer |  |
-| `starters_threepointersmade` | integer |  |
-| `starters_threepointerspercentage` | numeric |  |
-| `starters_turnovers` | integer |  |
+| `reboundsdefensive` | integer | Defensive rebounds recorded in the game. |
+| `reboundsoffensive` | integer | Offensive rebounds recorded in the game. |
+| `reboundstotal` | integer | Total rebounds recorded in the game. |
+| `starters_assists` | integer | Total assists by the team's starters. |
+| `starters_blocks` | integer | Total blocked shots by the team's starters. |
+| `starters_fieldgoalsattempted` | integer | Total field goal attempts by the team's starters. |
+| `starters_fieldgoalsmade` | integer | Total field goals made by the team's starters. |
+| `starters_fieldgoalspercentage` | numeric | Combined field goal percentage of the team's starters. |
+| `starters_foulspersonal` | integer | Total personal fouls by the team's starters. |
+| `starters_freethrowsattempted` | integer | Total free throw attempts by the team's starters. |
+| `starters_freethrowsmade` | integer | Total free throws made by the team's starters. |
+| `starters_freethrowspercentage` | numeric | Combined free throw percentage of the team's starters. |
+| `starters_minutes` | character | Total minutes played by the team's starters. |
+| `starters_points` | integer | Total points by the team's starters. |
+| `starters_reboundsdefensive` | integer | Total defensive rebounds by the team's starters. |
+| `starters_reboundsoffensive` | integer | Total offensive rebounds by the team's starters. |
+| `starters_reboundstotal` | integer | Total rebounds by the team's starters. |
+| `starters_steals` | integer | Total steals by the team's starters. |
+| `starters_threepointersattempted` | integer | Total three-point attempts by the team's starters. |
+| `starters_threepointersmade` | integer | Total three-pointers made by the team's starters. |
+| `starters_threepointerspercentage` | numeric | Combined three-point percentage of the team's starters. |
+| `starters_turnovers` | integer | Total turnovers by the team's starters. |
 | `steals` | integer | Total steals. |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
-| `threepointersattempted` | integer |  |
-| `threepointersmade` | integer |  |
-| `threepointerspercentage` | numeric |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
+| `threepointersattempted` | integer | Three-point attempts recorded in the game. |
+| `threepointersmade` | integer | Three-pointers made recorded in the game. |
+| `threepointerspercentage` | numeric | Three-point percentage for the game, as a decimal. |
 | `turnovers` | integer | Total turnovers. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1128,27 +1128,27 @@ GET /stats/boxscoreusagev2
 | `player_id` | integer | Unique player identifier. |
 | `player_name` | character | Player name. |
 | `nickname` | character | Team or athlete nickname. |
-| `start_position` | character |  |
+| `start_position` | character | Position the player started the game at ('F', 'C', or 'G'); empty for bench players. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
 | `min` | character | Minutes played. |
-| `usg_pct` | numeric |  |
-| `pct_fgm` | numeric |  |
-| `pct_fga` | numeric |  |
-| `pct_fg3m` | numeric |  |
-| `pct_fg3a` | numeric |  |
-| `pct_ftm` | numeric |  |
-| `pct_fta` | numeric |  |
-| `pct_oreb` | numeric |  |
-| `pct_dreb` | numeric |  |
-| `pct_reb` | numeric |  |
-| `pct_ast` | numeric |  |
-| `pct_tov` | numeric |  |
-| `pct_stl` | numeric |  |
-| `pct_blk` | numeric |  |
-| `pct_blka` | numeric |  |
-| `pct_pf` | numeric |  |
-| `pct_pfd` | numeric |  |
-| `pct_pts` | numeric |  |
+| `usg_pct` | numeric | Percentage of team plays used while on the floor. |
+| `pct_fgm` | numeric | Share of the team's field goals made accounted for while on the floor. |
+| `pct_fga` | numeric | Share of the team's field goal attempts accounted for while on the floor. |
+| `pct_fg3m` | numeric | Share of the team's made three-pointers accounted for while on the floor. |
+| `pct_fg3a` | numeric | Share of the team's three-point attempts accounted for while on the floor. |
+| `pct_ftm` | numeric | Share of the team's made free throws accounted for while on the floor. |
+| `pct_fta` | numeric | Share of the team's free throw attempts accounted for while on the floor. |
+| `pct_oreb` | numeric | Share of the team's offensive rebounds accounted for while on the floor. |
+| `pct_dreb` | numeric | Share of the team's defensive rebounds accounted for while on the floor. |
+| `pct_reb` | numeric | Share of the team's total rebounds accounted for while on the floor. |
+| `pct_ast` | numeric | Share of the team's assists accounted for while on the floor. |
+| `pct_tov` | numeric | Share of the team's turnovers accounted for while on the floor. |
+| `pct_stl` | numeric | Share of the team's steals accounted for while on the floor. |
+| `pct_blk` | numeric | Share of the team's blocks accounted for while on the floor. |
+| `pct_blka` | numeric | Share of the team's blocked own attempts accounted for while on the floor. |
+| `pct_pf` | numeric | Share of the team's personal fouls accounted for while on the floor. |
+| `pct_pfd` | numeric | Share of the team's personal fouls drawn accounted for while on the floor. |
+| `pct_pts` | numeric | Share of the team's points accounted for while on the floor. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1183,38 +1183,38 @@ GET /stats/boxscoreusagev3
 | col_name | type | description |
 |---|---|---|
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
-| `familyname` | character |  |
+| `familyname` | character | Player's family (last) name. |
 | `firstname` | character | Firstname. |
-| `gameid` | character |  |
-| `jerseynum` | character |  |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `jerseynum` | character | Player's jersey number. |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
-| `namei` | character |  |
-| `percentageassists` | numeric |  |
-| `percentageblocks` | numeric |  |
-| `percentageblocksallowed` | numeric |  |
-| `percentagefieldgoalsattempted` | numeric |  |
-| `percentagefieldgoalsmade` | numeric |  |
-| `percentagefreethrowsattempted` | numeric |  |
-| `percentagefreethrowsmade` | numeric |  |
-| `percentagepersonalfouls` | numeric |  |
-| `percentagepersonalfoulsdrawn` | numeric |  |
-| `percentagepoints` | numeric |  |
-| `percentagereboundsdefensive` | numeric |  |
-| `percentagereboundsoffensive` | numeric |  |
-| `percentagereboundstotal` | numeric |  |
-| `percentagesteals` | numeric |  |
-| `percentagethreepointersattempted` | numeric |  |
-| `percentagethreepointersmade` | numeric |  |
-| `percentageturnovers` | numeric |  |
-| `personid` | integer |  |
-| `playerslug` | character |  |
+| `namei` | character | Abbreviated player name (first initial and last name). |
+| `percentageassists` | numeric | Share of the team's assists accounted for by the player while on the floor, as a decimal. |
+| `percentageblocks` | numeric | Share of the team's blocked shots accounted for by the player while on the floor, as a decimal. |
+| `percentageblocksallowed` | numeric | Share of the team's shot attempts blocked by opponents accounted for by the player while on the floor, as a decimal. |
+| `percentagefieldgoalsattempted` | numeric | Share of the team's field goal attempts accounted for by the player while on the floor, as a decimal. |
+| `percentagefieldgoalsmade` | numeric | Share of the team's field goals made accounted for by the player while on the floor, as a decimal. |
+| `percentagefreethrowsattempted` | numeric | Share of the team's free throw attempts accounted for by the player while on the floor, as a decimal. |
+| `percentagefreethrowsmade` | numeric | Share of the team's free throws made accounted for by the player while on the floor, as a decimal. |
+| `percentagepersonalfouls` | numeric | Share of the team's personal fouls accounted for by the player while on the floor, as a decimal. |
+| `percentagepersonalfoulsdrawn` | numeric | Share of the team's personal fouls drawn accounted for by the player while on the floor, as a decimal. |
+| `percentagepoints` | numeric | Share of the team's points accounted for by the player while on the floor, as a decimal. |
+| `percentagereboundsdefensive` | numeric | Share of the team's defensive rebounds accounted for by the player while on the floor, as a decimal. |
+| `percentagereboundsoffensive` | numeric | Share of the team's offensive rebounds accounted for by the player while on the floor, as a decimal. |
+| `percentagereboundstotal` | numeric | Share of the team's total rebounds accounted for by the player while on the floor, as a decimal. |
+| `percentagesteals` | numeric | Share of the team's steals accounted for by the player while on the floor, as a decimal. |
+| `percentagethreepointersattempted` | numeric | Share of the team's three-point attempts accounted for by the player while on the floor, as a decimal. |
+| `percentagethreepointersmade` | numeric | Share of the team's three-pointers made accounted for by the player while on the floor, as a decimal. |
+| `percentageturnovers` | numeric | Share of the team's turnovers accounted for by the player while on the floor, as a decimal. |
+| `personid` | integer | Player identifier from the league's stats API. |
+| `playerslug` | character | URL-friendly slug for the player's name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `teamcity` | character | Teamcity. |
 | `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
-| `teamslug` | character |  |
-| `teamtricode` | character |  |
-| `usagepercentage` | numeric |  |
+| `teamslug` | character | URL-friendly slug for the team name. |
+| `teamtricode` | character | Three-letter team abbreviation. |
+| `usagepercentage` | numeric | Percentage of team plays used by the player while on the floor, as a decimal. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1246,12 +1246,12 @@ GET /stats/commonallplayers
 | col_name | type | description |
 |---|---|---|
 | `person_id` | integer | Unique player identifier (V3 endpoints). |
-| `display_last_comma_first` | character |  |
-| `display_first_last` | character |  |
-| `rosterstatus` | integer |  |
+| `display_last_comma_first` | character | Player name formatted as "Last, First". |
+| `display_first_last` | character | Player name formatted as "First Last". |
+| `rosterstatus` | integer | Roster status flag (1 = currently on a roster, 0 = not). |
 | `from_year` | character | First season. |
 | `to_year` | character | Most recent season. |
-| `playercode` | character |  |
+| `playercode` | character | URL-style player code slug used by the league's legacy stats pages. |
 | `player_slug` | character | URL-safe player identifier. |
 | `team_id` | integer | Unique team identifier. |
 | `team_city` | character | Team city or region (e.g. 'Las Vegas'). |
@@ -1259,10 +1259,10 @@ GET /stats/commonallplayers
 | `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
 | `team_code` | character | Internal team code. |
 | `team_slug` | character | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
-| `games_played_flag` | character |  |
-| `otherleague_experience_ch` | character |  |
-| `is_nba_assigned` | integer |  |
-| `nba_assigned_team_id` | integer |  |
+| `games_played_flag` | character | Y/N flag for whether the player has appeared in a league game. |
+| `otherleague_experience_ch` | character | Code for the player's experience in another league (e.g. G League), as reported by the stats API. |
+| `is_nba_assigned` | integer | Flag indicating whether the player is currently on an NBA roster assignment (two-way and G League assignment tracking). |
+| `nba_assigned_team_id` | integer | Team identifier of the NBA team the player is assigned to, when on assignment. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1392,7 +1392,7 @@ GET /stats/commonteamroster
 |---|---|---|
 | `teamid` | integer | Teamid. |
 | `season` | character | Season identifier (4-digit year or 'YYYY-YY' string). |
-| `leagueid` | character |  |
+| `leagueid` | character | League identifier from the stats API ("00" = NBA, "10" = WNBA, "20" = G League). |
 | `player` | character | Player name. |
 | `nickname` | character | Team or athlete nickname. |
 | `player_slug` | character | URL-safe player identifier. |
@@ -1405,7 +1405,7 @@ GET /stats/commonteamroster
 | `exp` | character | Exp. |
 | `school` | character | Player's school / college (when distinct from 'college'). |
 | `player_id` | integer | Unique player identifier. |
-| `how_acquired` | character |  |
+| `how_acquired` | character | How the team acquired the player (e.g. draft, trade, free agency). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1471,54 +1471,54 @@ GET /stats/cumestatsplayer
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `display_fi_last` | character |  |
+| `display_fi_last` | character | Abbreviated player name (first initial and last name). |
 | `person_id` | integer | Unique player identifier (V3 endpoints). |
 | `jersey_num` | character | Jersey number worn by the player. |
 | `gp` | integer | Games played. |
 | `gs` | integer | Games started. |
-| `actual_minutes` | integer |  |
-| `actual_seconds` | integer |  |
-| `fg` | integer |  |
+| `actual_minutes` | integer | Whole minutes of actual playing time accumulated over the aggregated games. |
+| `actual_seconds` | integer | Leftover seconds of actual playing time beyond the whole minutes. |
+| `fg` | integer | Field goals made over the aggregated games. |
 | `fga` | integer | Field goal attempts. |
 | `fg_pct` | numeric | Field goal percentage (0-1). |
-| `fg3` | integer |  |
+| `fg3` | integer | Three-point field goals made over the aggregated games. |
 | `fg3a` | integer | Three-point field goal attempts. |
 | `fg3_pct` | numeric | Three-point field goal percentage (0-1). |
-| `ft` | integer |  |
+| `ft` | integer | Free throws made over the aggregated games. |
 | `fta` | integer | Free throw attempts. |
 | `ft_pct` | numeric | Free throw percentage (0-1). |
-| `off_reb` | integer |  |
-| `def_reb` | integer |  |
-| `tot_reb` | integer |  |
+| `off_reb` | integer | Offensive rebounds over the aggregated games. |
+| `def_reb` | integer | Defensive rebounds over the aggregated games. |
+| `tot_reb` | integer | Total rebounds over the aggregated games. |
 | `ast` | integer | Assists. |
 | `pf` | integer | Personal fouls. |
-| `dq` | integer |  |
+| `dq` | integer | Disqualifications (fouled out) over the aggregated games. |
 | `stl` | integer | Steals. |
 | `turnovers` | integer | Total turnovers. |
 | `blk` | integer | Blocks. |
 | `pts` | integer | Points scored. |
-| `max_actual_minutes` | integer |  |
-| `max_actual_seconds` | integer |  |
-| `max_reb` | integer |  |
-| `max_ast` | integer |  |
-| `max_stl` | integer |  |
-| `max_turnovers` | integer |  |
-| `max_blk` | integer |  |
-| `max_pts` | integer |  |
-| `avg_actual_minutes` | integer |  |
-| `avg_actual_seconds` | numeric |  |
-| `avg_tot_reb` | numeric |  |
-| `avg_ast` | numeric |  |
-| `avg_stl` | numeric |  |
-| `avg_turnovers` | numeric |  |
-| `avg_blk` | numeric |  |
-| `avg_pts` | numeric |  |
-| `per_min_tot_reb` | numeric |  |
-| `per_min_ast` | numeric |  |
-| `per_min_stl` | numeric |  |
-| `per_min_turnovers` | numeric |  |
-| `per_min_blk` | numeric |  |
-| `per_min_pts` | numeric |  |
+| `max_actual_minutes` | integer | Most whole minutes played in any single aggregated game. |
+| `max_actual_seconds` | integer | Seconds component paired with the single-game maximum minutes. |
+| `max_reb` | integer | Most rebounds recorded in any single aggregated game. |
+| `max_ast` | integer | Most assists recorded in any single aggregated game. |
+| `max_stl` | integer | Most steals recorded in any single aggregated game. |
+| `max_turnovers` | integer | Most turnovers recorded in any single aggregated game. |
+| `max_blk` | integer | Most blocked shots recorded in any single aggregated game. |
+| `max_pts` | integer | Most points recorded in any single aggregated game. |
+| `avg_actual_minutes` | integer | Average whole minutes played per aggregated game. |
+| `avg_actual_seconds` | numeric | Average seconds component of playing time per aggregated game. |
+| `avg_tot_reb` | numeric | Average total rebounds per game over the aggregated games. |
+| `avg_ast` | numeric | Average assists per game over the aggregated games. |
+| `avg_stl` | numeric | Average steals per game over the aggregated games. |
+| `avg_turnovers` | numeric | Average turnovers per game over the aggregated games. |
+| `avg_blk` | numeric | Average blocked shots per game over the aggregated games. |
+| `avg_pts` | numeric | Average points per game over the aggregated games. |
+| `per_min_tot_reb` | numeric | Total rebounds per minute played over the aggregated games. |
+| `per_min_ast` | numeric | Assists per minute played over the aggregated games. |
+| `per_min_stl` | numeric | Steals per minute played over the aggregated games. |
+| `per_min_turnovers` | numeric | Turnovers per minute played over the aggregated games. |
+| `per_min_blk` | numeric | Blocked shots per minute played over the aggregated games. |
+| `per_min_pts` | numeric | Points per minute played over the aggregated games. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1595,49 +1595,49 @@ GET /stats/cumestatsteam
 | `team_id` | character | Unique team identifier. |
 | `gp` | character | Games played. |
 | `gs` | character | Games started. |
-| `actual_minutes` | character |  |
-| `actual_seconds` | character |  |
-| `fg` | character |  |
+| `actual_minutes` | character | Whole minutes of actual playing time accumulated over the aggregated games. |
+| `actual_seconds` | character | Leftover seconds of actual playing time beyond the whole minutes. |
+| `fg` | character | Field goals made over the aggregated games. |
 | `fga` | character | Field goal attempts. |
 | `fg_pct` | character | Field goal percentage (0-1). |
-| `fg3` | character |  |
+| `fg3` | character | Three-point field goals made over the aggregated games. |
 | `fg3a` | character | Three-point field goal attempts. |
 | `fg3_pct` | character | Three-point field goal percentage (0-1). |
-| `ft` | character |  |
+| `ft` | character | Free throws made over the aggregated games. |
 | `fta` | character | Free throw attempts. |
 | `ft_pct` | character | Free throw percentage (0-1). |
-| `off_reb` | character |  |
-| `def_reb` | character |  |
-| `tot_reb` | character |  |
+| `off_reb` | character | Offensive rebounds over the aggregated games. |
+| `def_reb` | character | Defensive rebounds over the aggregated games. |
+| `tot_reb` | character | Total rebounds over the aggregated games. |
 | `ast` | character | Assists. |
 | `pf` | character | Personal fouls. |
-| `dq` | character |  |
+| `dq` | character | Disqualifications (fouled out) over the aggregated games. |
 | `stl` | character | Steals. |
 | `turnovers` | character | Total turnovers. |
 | `blk` | character | Blocks. |
 | `pts` | character | Points scored. |
-| `max_actual_minutes` | character |  |
-| `max_actual_seconds` | character |  |
-| `max_reb` | character |  |
-| `max_ast` | character |  |
-| `max_stl` | character |  |
-| `max_turnovers` | character |  |
-| `max_blkp` | character |  |
-| `max_pts` | character |  |
-| `avg_actual_minutes` | character |  |
-| `avg_actual_seconds` | character |  |
-| `avg_reb` | character |  |
-| `avg_ast` | character |  |
-| `avg_stl` | character |  |
-| `avg_turnovers` | character |  |
-| `avg_blkp` | character |  |
-| `avg_pts` | character |  |
-| `per_min_reb` | character |  |
-| `per_min_ast` | character |  |
-| `per_min_stl` | character |  |
-| `per_min_turnovers` | character |  |
-| `per_min_blk` | character |  |
-| `per_min_pts` | character |  |
+| `max_actual_minutes` | character | Most whole minutes played in any single aggregated game. |
+| `max_actual_seconds` | character | Seconds component paired with the single-game maximum minutes. |
+| `max_reb` | character | Most rebounds recorded in any single aggregated game. |
+| `max_ast` | character | Most assists recorded in any single aggregated game. |
+| `max_stl` | character | Most steals recorded in any single aggregated game. |
+| `max_turnovers` | character | Most turnovers recorded in any single aggregated game. |
+| `max_blkp` | character | Most blocked shots recorded in any single aggregated game. |
+| `max_pts` | character | Most points recorded in any single aggregated game. |
+| `avg_actual_minutes` | character | Average whole minutes played per aggregated game. |
+| `avg_actual_seconds` | character | Average seconds component of playing time per aggregated game. |
+| `avg_reb` | character | Average rebounds per game over the aggregated games. |
+| `avg_ast` | character | Average assists per game over the aggregated games. |
+| `avg_stl` | character | Average steals per game over the aggregated games. |
+| `avg_turnovers` | character | Average turnovers per game over the aggregated games. |
+| `avg_blkp` | character | Average blocked shots per game over the aggregated games. |
+| `avg_pts` | character | Average points per game over the aggregated games. |
+| `per_min_reb` | character | Rebounds per minute played over the aggregated games. |
+| `per_min_ast` | character | Assists per minute played over the aggregated games. |
+| `per_min_stl` | character | Steals per minute played over the aggregated games. |
+| `per_min_turnovers` | character | Turnovers per minute played over the aggregated games. |
+| `per_min_blk` | character | Blocked shots per minute played over the aggregated games. |
+| `per_min_pts` | character | Points per minute played over the aggregated games. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1712,47 +1712,47 @@ GET /stats/draftcombinestats
 | `last_name` | character | Player's last name. |
 | `player_name` | character | Player name. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
-| `height_wo_shoes` | numeric |  |
-| `height_wo_shoes_ft_in` | character |  |
-| `height_w_shoes` | character |  |
-| `height_w_shoes_ft_in` | character |  |
+| `height_wo_shoes` | numeric | Height measured without shoes, in inches. |
+| `height_wo_shoes_ft_in` | character | Height without shoes formatted as feet and inches. |
+| `height_w_shoes` | character | Height measured with shoes, in inches. |
+| `height_w_shoes_ft_in` | character | Height with shoes formatted as feet and inches. |
 | `weight` | character | Player weight in pounds. |
-| `wingspan` | numeric |  |
-| `wingspan_ft_in` | character |  |
-| `standing_reach` | numeric |  |
-| `standing_reach_ft_in` | character |  |
-| `body_fat_pct` | character |  |
-| `hand_length` | numeric |  |
-| `hand_width` | numeric |  |
-| `standing_vertical_leap` | numeric |  |
-| `max_vertical_leap` | numeric |  |
-| `lane_agility_time` | numeric |  |
-| `modified_lane_agility_time` | numeric |  |
-| `three_quarter_sprint` | numeric |  |
-| `bench_press` | character |  |
-| `spot_fifteen_corner_left` | character |  |
-| `spot_fifteen_break_left` | character |  |
-| `spot_fifteen_top_key` | character |  |
-| `spot_fifteen_break_right` | character |  |
-| `spot_fifteen_corner_right` | character |  |
-| `spot_college_corner_left` | character |  |
-| `spot_college_break_left` | character |  |
-| `spot_college_top_key` | character |  |
-| `spot_college_break_right` | character |  |
-| `spot_college_corner_right` | character |  |
-| `spot_nba_corner_left` | character |  |
-| `spot_nba_break_left` | character |  |
-| `spot_nba_top_key` | character |  |
-| `spot_nba_break_right` | character |  |
-| `spot_nba_corner_right` | character |  |
-| `off_drib_fifteen_break_left` | character |  |
-| `off_drib_fifteen_top_key` | character |  |
-| `off_drib_fifteen_break_right` | character |  |
-| `off_drib_college_break_left` | character |  |
-| `off_drib_college_top_key` | character |  |
-| `off_drib_college_break_right` | character |  |
-| `on_move_fifteen` | character |  |
-| `on_move_college` | character |  |
+| `wingspan` | numeric | Wingspan measured at the combine, in inches. |
+| `wingspan_ft_in` | character | Wingspan formatted as feet and inches. |
+| `standing_reach` | numeric | Standing reach measured at the combine, in inches. |
+| `standing_reach_ft_in` | character | Standing reach formatted as feet and inches. |
+| `body_fat_pct` | character | Body fat percentage measured at the combine. |
+| `hand_length` | numeric | Hand length measured at the combine, in inches. |
+| `hand_width` | numeric | Hand width measured at the combine, in inches. |
+| `standing_vertical_leap` | numeric | Standing (no-step) vertical leap, in inches. |
+| `max_vertical_leap` | numeric | Maximum (running) vertical leap, in inches. |
+| `lane_agility_time` | numeric | Lane agility drill time, in seconds. |
+| `modified_lane_agility_time` | numeric | Modified (shuttle) lane agility drill time, in seconds. |
+| `three_quarter_sprint` | numeric | Three-quarter-court sprint time, in seconds. |
+| `bench_press` | character | Repetitions of 185 pounds completed on the bench press. |
+| `spot_fifteen_corner_left` | character | Made-attempted result (e.g. "3-5") from the 15-foot left corner spot-up shooting station at the combine. |
+| `spot_fifteen_break_left` | character | Made-attempted result (e.g. "3-5") from the 15-foot left wing (break) spot-up shooting station at the combine. |
+| `spot_fifteen_top_key` | character | Made-attempted result (e.g. "3-5") from the 15-foot top of the key spot-up shooting station at the combine. |
+| `spot_fifteen_break_right` | character | Made-attempted result (e.g. "3-5") from the 15-foot right wing (break) spot-up shooting station at the combine. |
+| `spot_fifteen_corner_right` | character | Made-attempted result (e.g. "3-5") from the 15-foot right corner spot-up shooting station at the combine. |
+| `spot_college_corner_left` | character | Made-attempted result (e.g. "3-5") from the college three-point left corner spot-up shooting station at the combine. |
+| `spot_college_break_left` | character | Made-attempted result (e.g. "3-5") from the college three-point left wing (break) spot-up shooting station at the combine. |
+| `spot_college_top_key` | character | Made-attempted result (e.g. "3-5") from the college three-point top of the key spot-up shooting station at the combine. |
+| `spot_college_break_right` | character | Made-attempted result (e.g. "3-5") from the college three-point right wing (break) spot-up shooting station at the combine. |
+| `spot_college_corner_right` | character | Made-attempted result (e.g. "3-5") from the college three-point right corner spot-up shooting station at the combine. |
+| `spot_nba_corner_left` | character | Made-attempted result (e.g. "3-5") from the NBA three-point left corner spot-up shooting station at the combine. |
+| `spot_nba_break_left` | character | Made-attempted result (e.g. "3-5") from the NBA three-point left wing (break) spot-up shooting station at the combine. |
+| `spot_nba_top_key` | character | Made-attempted result (e.g. "3-5") from the NBA three-point top of the key spot-up shooting station at the combine. |
+| `spot_nba_break_right` | character | Made-attempted result (e.g. "3-5") from the NBA three-point right wing (break) spot-up shooting station at the combine. |
+| `spot_nba_corner_right` | character | Made-attempted result (e.g. "3-5") from the NBA three-point right corner spot-up shooting station at the combine. |
+| `off_drib_fifteen_break_left` | character | Made-attempted result from the 15-foot left wing (break) off-the-dribble shooting station at the combine. |
+| `off_drib_fifteen_top_key` | character | Made-attempted result from the 15-foot top of the key off-the-dribble shooting station at the combine. |
+| `off_drib_fifteen_break_right` | character | Made-attempted result from the 15-foot right wing (break) off-the-dribble shooting station at the combine. |
+| `off_drib_college_break_left` | character | Made-attempted result from the college three-point left wing (break) off-the-dribble shooting station at the combine. |
+| `off_drib_college_top_key` | character | Made-attempted result from the college three-point top of the key off-the-dribble shooting station at the combine. |
+| `off_drib_college_break_right` | character | Made-attempted result from the college three-point right wing (break) off-the-dribble shooting station at the combine. |
+| `on_move_fifteen` | character | Made-attempted result from the 15-foot shooting-on-the-move station at the combine. |
+| `on_move_college` | character | Made-attempted result from the college three-point shooting-on-the-move station at the combine. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1855,8 +1855,8 @@ GET /stats/fantasywidget
 | `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
 | `gp` | integer | Games played. |
 | `min` | numeric | Minutes played. |
-| `fan_duel_pts` | numeric |  |
-| `nba_fantasy_pts` | numeric |  |
+| `fan_duel_pts` | numeric | Fantasy points under FanDuel's scoring formula. |
+| `nba_fantasy_pts` | numeric | Fantasy points under the NBA's fantasy scoring formula. |
 | `pts` | numeric | Points scored. |
 | `reb` | numeric | Total rebounds. |
 | `ast` | numeric | Assists. |
@@ -1993,7 +1993,7 @@ GET /stats/franchiseleaderswrank
 | `person_id` | integer | Unique player identifier (V3 endpoints). |
 | `player` | character | Player name. |
 | `season_type` | character | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
-| `active_with_team` | integer |  |
+| `active_with_team` | integer | Flag indicating whether the franchise leader is still active with the team. |
 | `gp` | integer | Games played. |
 | `minutes` | numeric | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
 | `fgm` | numeric | Field goals made. |
@@ -2014,26 +2014,26 @@ GET /stats/franchiseleaderswrank
 | `tov` | numeric | Turnovers. |
 | `blk` | numeric | Blocks. |
 | `pts` | numeric | Points scored. |
-| `f_rank_gp` | integer |  |
-| `f_rank_minutes` | integer |  |
-| `f_rank_fgm` | integer |  |
-| `f_rank_fga` | integer |  |
-| `f_rank_fg_pct` | integer |  |
-| `f_rank_fg3m` | integer |  |
-| `f_rank_fg3a` | integer |  |
-| `f_rank_fg3_pct` | integer |  |
-| `f_rank_ftm` | integer |  |
-| `f_rank_fta` | integer |  |
-| `f_rank_ft_pct` | integer |  |
-| `f_rank_oreb` | integer |  |
-| `f_rank_dreb` | integer |  |
-| `f_rank_reb` | integer |  |
-| `f_rank_ast` | integer |  |
-| `f_rank_pf` | integer |  |
-| `f_rank_stl` | integer |  |
-| `f_rank_tov` | integer |  |
-| `f_rank_blk` | integer |  |
-| `f_rank_pts` | integer |  |
+| `f_rank_gp` | integer | Franchise all-time rank of the player's career games played. |
+| `f_rank_minutes` | integer | Franchise all-time rank of the player's career minutes played. |
+| `f_rank_fgm` | integer | Franchise all-time rank of the player's career field goals made. |
+| `f_rank_fga` | integer | Franchise all-time rank of the player's career field goals attempted. |
+| `f_rank_fg_pct` | integer | Franchise all-time rank of the player's career field goal percentage. |
+| `f_rank_fg3m` | integer | Franchise all-time rank of the player's career three-point field goals made. |
+| `f_rank_fg3a` | integer | Franchise all-time rank of the player's career three-point field goals attempted. |
+| `f_rank_fg3_pct` | integer | Franchise all-time rank of the player's career three-point field goal percentage. |
+| `f_rank_ftm` | integer | Franchise all-time rank of the player's career free throws made. |
+| `f_rank_fta` | integer | Franchise all-time rank of the player's career free throws attempted. |
+| `f_rank_ft_pct` | integer | Franchise all-time rank of the player's career free throw percentage. |
+| `f_rank_oreb` | integer | Franchise all-time rank of the player's career offensive rebounds. |
+| `f_rank_dreb` | integer | Franchise all-time rank of the player's career defensive rebounds. |
+| `f_rank_reb` | integer | Franchise all-time rank of the player's career total rebounds. |
+| `f_rank_ast` | integer | Franchise all-time rank of the player's career assists. |
+| `f_rank_pf` | integer | Franchise all-time rank of the player's career personal fouls committed. |
+| `f_rank_stl` | integer | Franchise all-time rank of the player's career steals. |
+| `f_rank_tov` | integer | Franchise all-time rank of the player's career turnovers. |
+| `f_rank_blk` | integer | Franchise all-time rank of the player's career blocked shots. |
+| `f_rank_pts` | integer | Franchise all-time rank of the player's career points scored. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2071,7 +2071,7 @@ GET /stats/franchiseplayers
 | `person_id` | integer | Unique player identifier (V3 endpoints). |
 | `player` | character | Player name. |
 | `season_type` | character | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
-| `active_with_team` | integer |  |
+| `active_with_team` | integer | Flag indicating whether the player is still active with the franchise. |
 | `gp` | integer | Games played. |
 | `fgm` | numeric | Field goals made. |
 | `fga` | numeric | Field goal attempts. |
@@ -2174,9 +2174,9 @@ GET /stats/homepageleaders
 | `fg_pct` | numeric | Field goal percentage (0-1). |
 | `fg3_pct` | numeric | Three-point field goal percentage (0-1). |
 | `ft_pct` | numeric | Free throw percentage (0-1). |
-| `efg_pct` | numeric |  |
+| `efg_pct` | numeric | Effective field goal percentage, as a decimal. |
 | `ts_pct` | numeric | True shooting percentage (0-1). |
-| `pts_per48` | character |  |
+| `pts_per48` | character | Points scored per 48 minutes played. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2254,24 +2254,24 @@ GET /stats/hustlestatsboxscore
 | `team_city` | character | Team city or region (e.g. 'Las Vegas'). |
 | `player_id` | character | Unique player identifier. |
 | `player_name` | character | Player name. |
-| `start_position` | character |  |
+| `start_position` | character | Position the player started the game at (F, C, or G); empty for reserves. |
 | `comment` | character | Player status / inactive reason (e.g. 'DNP - Coach's Decision', 'Inactive'). |
 | `minutes` | character | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
 | `pts` | integer | Points scored. |
 | `contested_shots` | numeric | Defensively contested shots. |
-| `contested_shots_2pt` | numeric |  |
-| `contested_shots_3pt` | numeric |  |
+| `contested_shots_2pt` | numeric | Opponent two-point attempts contested. |
+| `contested_shots_3pt` | numeric | Opponent three-point attempts contested. |
 | `deflections` | numeric | Defensive deflections. |
 | `charges_drawn` | numeric | Charges drawn. |
 | `screen_assists` | numeric | Screen assists (resulting in a basket). |
-| `screen_ast_pts` | numeric |  |
-| `off_loose_balls_recovered` | numeric |  |
-| `def_loose_balls_recovered` | numeric |  |
-| `loose_balls_recovered` | numeric |  |
-| `off_boxouts` | numeric |  |
-| `def_boxouts` | numeric |  |
-| `box_out_player_team_rebs` | numeric |  |
-| `box_out_player_rebs` | numeric |  |
+| `screen_ast_pts` | numeric | Points teammates scored directly off the row's screen assists. |
+| `off_loose_balls_recovered` | numeric | Loose balls recovered while on offense. |
+| `def_loose_balls_recovered` | numeric | Loose balls recovered while on defense. |
+| `loose_balls_recovered` | numeric | Total loose balls recovered. |
+| `off_boxouts` | numeric | Box-outs recorded on the offensive glass. |
+| `def_boxouts` | numeric | Box-outs recorded on the defensive glass. |
+| `box_out_player_team_rebs` | numeric | Team rebounds secured following the row's box-outs. |
+| `box_out_player_rebs` | numeric | Rebounds the player secured directly off their own box-outs. |
 | `box_outs` | numeric | Box-outs executed. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -2632,7 +2632,7 @@ GET /stats/leaguedashplayerclutch
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
 | `player_id` | integer | Unique player identifier. |
 | `player_name` | character | Player name. |
 | `nickname` | character | Team or athlete nickname. |
@@ -2660,46 +2660,46 @@ GET /stats/leaguedashplayerclutch
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `nba_fantasy_pts` | numeric |  |
-| `dd2` | integer |  |
-| `td3` | integer |  |
-| `wnba_fantasy_pts` | numeric |  |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
-| `nba_fantasy_pts_rank` | integer |  |
-| `dd2_rank` | integer |  |
-| `td3_rank` | integer |  |
-| `wnba_fantasy_pts_rank` | integer |  |
-| `team_count` | integer |  |
+| `nba_fantasy_pts` | numeric | Fantasy points under the NBA's fantasy scoring formula. |
+| `dd2` | integer | Double-doubles recorded over the split. |
+| `td3` | integer | Triple-doubles recorded over the split. |
+| `wnba_fantasy_pts` | numeric | Fantasy points under the WNBA's fantasy scoring formula. |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
+| `nba_fantasy_pts_rank` | integer | League rank of the row's NBA fantasy points (league scoring formula) for the season and split. |
+| `dd2_rank` | integer | League rank of the row's double-doubles for the season and split. |
+| `td3_rank` | integer | League rank of the row's triple-doubles for the season and split. |
+| `wnba_fantasy_pts_rank` | integer | League rank of the row's WNBA fantasy points (league scoring formula) for the season and split. |
+| `team_count` | integer | Number of distinct teams aggregated into the split row. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2769,33 +2769,33 @@ GET /stats/leaguedashplayershotlocations
 | `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
 | `age` | numeric | Player age (in years). |
 | `nickname` | character | Team or athlete nickname. |
-| `less_than_5_ft_fgm` | numeric |  |
-| `less_than_5_ft_fga` | numeric |  |
-| `less_than_5_ft_fg_pct` | numeric |  |
-| `5-9_ft_fgm` | numeric |  |
-| `5-9_ft_fga` | numeric |  |
-| `5-9_ft_fg_pct` | numeric |  |
-| `10-14_ft_fgm` | numeric |  |
-| `10-14_ft_fga` | numeric |  |
-| `10-14_ft_fg_pct` | numeric |  |
-| `15-19_ft_fgm` | numeric |  |
-| `15-19_ft_fga` | numeric |  |
-| `15-19_ft_fg_pct` | numeric |  |
-| `20-24_ft_fgm` | numeric |  |
-| `20-24_ft_fga` | numeric |  |
-| `20-24_ft_fg_pct` | numeric |  |
-| `25-29_ft_fgm` | numeric |  |
-| `25-29_ft_fga` | numeric |  |
-| `25-29_ft_fg_pct` | numeric |  |
-| `30-34_ft_fgm` | numeric |  |
-| `30-34_ft_fga` | numeric |  |
-| `30-34_ft_fg_pct` | numeric |  |
-| `35-39_ft_fgm` | numeric |  |
-| `35-39_ft_fga` | numeric |  |
-| `35-39_ft_fg_pct` | numeric |  |
-| `40+_ft_fgm` | numeric |  |
-| `40+_ft_fga` | numeric |  |
-| `40+_ft_fg_pct` | numeric |  |
+| `less_than_5_ft_fgm` | numeric | Field goals made from less than 5 feet. |
+| `less_than_5_ft_fga` | numeric | Field goals attempted from less than 5 feet. |
+| `less_than_5_ft_fg_pct` | numeric | Field goal percentage on shots from less than 5 feet, as a decimal. |
+| `5-9_ft_fgm` | numeric | Field goals made from 5-9 feet. |
+| `5-9_ft_fga` | numeric | Field goals attempted from 5-9 feet. |
+| `5-9_ft_fg_pct` | numeric | Field goal percentage on shots from 5-9-f feet, as a decimal. |
+| `10-14_ft_fgm` | numeric | Field goals made from 10-14 feet. |
+| `10-14_ft_fga` | numeric | Field goals attempted from 10-14 feet. |
+| `10-14_ft_fg_pct` | numeric | Field goal percentage on shots from 10-14-f feet, as a decimal. |
+| `15-19_ft_fgm` | numeric | Field goals made from 15-19 feet. |
+| `15-19_ft_fga` | numeric | Field goals attempted from 15-19 feet. |
+| `15-19_ft_fg_pct` | numeric | Field goal percentage on shots from 15-19-f feet, as a decimal. |
+| `20-24_ft_fgm` | numeric | Field goals made from 20-24 feet. |
+| `20-24_ft_fga` | numeric | Field goals attempted from 20-24 feet. |
+| `20-24_ft_fg_pct` | numeric | Field goal percentage on shots from 20-24-f feet, as a decimal. |
+| `25-29_ft_fgm` | numeric | Field goals made from 25-29 feet. |
+| `25-29_ft_fga` | numeric | Field goals attempted from 25-29 feet. |
+| `25-29_ft_fg_pct` | numeric | Field goal percentage on shots from 25-29-f feet, as a decimal. |
+| `30-34_ft_fgm` | numeric | Field goals made from 30-34 feet. |
+| `30-34_ft_fga` | numeric | Field goals attempted from 30-34 feet. |
+| `30-34_ft_fg_pct` | numeric | Field goal percentage on shots from 30-34-f feet, as a decimal. |
+| `35-39_ft_fgm` | numeric | Field goals made from 35-39 feet. |
+| `35-39_ft_fga` | numeric | Field goals attempted from 35-39 feet. |
+| `35-39_ft_fg_pct` | numeric | Field goal percentage on shots from 35-39-f feet, as a decimal. |
+| `40+_ft_fgm` | numeric | Field goals made from 40 feet and beyond, per the stats API's shot-location distance bands. |
+| `40+_ft_fga` | numeric | Field goals attempted from 40 feet and beyond, per the stats API's shot-location distance bands. |
+| `40+_ft_fg_pct` | numeric | Field-goal percentage on attempts from 40 feet and beyond, as a decimal. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3080,37 +3080,37 @@ GET /stats/leaguedashteamclutch
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3170,33 +3170,33 @@ GET /stats/leaguedashteamshotlocations
 |---|---|---|
 | `team_id` | integer | Unique team identifier. |
 | `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
-| `less_than_5_ft_fgm` | numeric |  |
-| `less_than_5_ft_fga` | numeric |  |
-| `less_than_5_ft_fg_pct` | numeric |  |
-| `5-9_ft_fgm` | numeric |  |
-| `5-9_ft_fga` | numeric |  |
-| `5-9_ft_fg_pct` | numeric |  |
-| `10-14_ft_fgm` | numeric |  |
-| `10-14_ft_fga` | numeric |  |
-| `10-14_ft_fg_pct` | numeric |  |
-| `15-19_ft_fgm` | numeric |  |
-| `15-19_ft_fga` | numeric |  |
-| `15-19_ft_fg_pct` | numeric |  |
-| `20-24_ft_fgm` | numeric |  |
-| `20-24_ft_fga` | numeric |  |
-| `20-24_ft_fg_pct` | numeric |  |
-| `25-29_ft_fgm` | numeric |  |
-| `25-29_ft_fga` | numeric |  |
-| `25-29_ft_fg_pct` | numeric |  |
-| `30-34_ft_fgm` | numeric |  |
-| `30-34_ft_fga` | numeric |  |
-| `30-34_ft_fg_pct` | numeric |  |
-| `35-39_ft_fgm` | numeric |  |
-| `35-39_ft_fga` | numeric |  |
-| `35-39_ft_fg_pct` | numeric |  |
-| `40+_ft_fgm` | numeric |  |
-| `40+_ft_fga` | numeric |  |
-| `40+_ft_fg_pct` | numeric |  |
+| `less_than_5_ft_fgm` | numeric | Field goals made from less than 5 feet. |
+| `less_than_5_ft_fga` | numeric | Field goals attempted from less than 5 feet. |
+| `less_than_5_ft_fg_pct` | numeric | Field goal percentage on shots from less than 5 feet, as a decimal. |
+| `5-9_ft_fgm` | numeric | Field goals made from 5-9 feet. |
+| `5-9_ft_fga` | numeric | Field goals attempted from 5-9 feet. |
+| `5-9_ft_fg_pct` | numeric | Field goal percentage on shots from 5-9-f feet, as a decimal. |
+| `10-14_ft_fgm` | numeric | Field goals made from 10-14 feet. |
+| `10-14_ft_fga` | numeric | Field goals attempted from 10-14 feet. |
+| `10-14_ft_fg_pct` | numeric | Field goal percentage on shots from 10-14-f feet, as a decimal. |
+| `15-19_ft_fgm` | numeric | Field goals made from 15-19 feet. |
+| `15-19_ft_fga` | numeric | Field goals attempted from 15-19 feet. |
+| `15-19_ft_fg_pct` | numeric | Field goal percentage on shots from 15-19-f feet, as a decimal. |
+| `20-24_ft_fgm` | numeric | Field goals made from 20-24 feet. |
+| `20-24_ft_fga` | numeric | Field goals attempted from 20-24 feet. |
+| `20-24_ft_fg_pct` | numeric | Field goal percentage on shots from 20-24-f feet, as a decimal. |
+| `25-29_ft_fgm` | numeric | Field goals made from 25-29 feet. |
+| `25-29_ft_fga` | numeric | Field goals attempted from 25-29 feet. |
+| `25-29_ft_fg_pct` | numeric | Field goal percentage on shots from 25-29-f feet, as a decimal. |
+| `30-34_ft_fgm` | numeric | Field goals made from 30-34 feet. |
+| `30-34_ft_fga` | numeric | Field goals attempted from 30-34 feet. |
+| `30-34_ft_fg_pct` | numeric | Field goal percentage on shots from 30-34-f feet, as a decimal. |
+| `35-39_ft_fgm` | numeric | Field goals made from 35-39 feet. |
+| `35-39_ft_fga` | numeric | Field goals attempted from 35-39 feet. |
+| `35-39_ft_fg_pct` | numeric | Field goal percentage on shots from 35-39-f feet, as a decimal. |
+| `40+_ft_fgm` | numeric | Team field goals made from 40 feet and beyond, per the stats API's shot-location distance bands. |
+| `40+_ft_fga` | numeric | Team field goals attempted from 40 feet and beyond, per the stats API's shot-location distance bands. |
+| `40+_ft_fg_pct` | numeric | Team field-goal percentage on attempts from 40 feet and beyond, as a decimal. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3635,26 +3635,26 @@ GET /stats/leaguelineupviz
 | `team_id` | integer | Unique team identifier. |
 | `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
 | `min` | numeric | Minutes played. |
-| `off_rating` | numeric |  |
-| `def_rating` | numeric |  |
+| `off_rating` | numeric | Points scored per 100 possessions with the lineup on the floor (offensive rating). |
+| `def_rating` | numeric | Points allowed per 100 possessions with the lineup on the floor (defensive rating). |
 | `net_rating` | numeric | Net rating (off rating - def rating). |
 | `pace` | numeric | Possessions per 48 minutes. |
 | `ts_pct` | numeric | True shooting percentage (0-1). |
-| `fta_rate` | numeric |  |
-| `tm_ast_pct` | numeric |  |
-| `pct_fga_2pt` | numeric |  |
-| `pct_fga_3pt` | numeric |  |
-| `pct_pts_2pt_mr` | numeric |  |
-| `pct_pts_fb` | numeric |  |
-| `pct_pts_ft` | numeric |  |
-| `pct_pts_paint` | numeric |  |
-| `pct_ast_fgm` | numeric |  |
-| `pct_uast_fgm` | numeric |  |
-| `opp_fg3_pct` | numeric |  |
-| `opp_efg_pct` | numeric |  |
-| `opp_fta_rate` | numeric |  |
-| `opp_tov_pct` | numeric |  |
-| `sum_tm_min` | numeric |  |
+| `fta_rate` | numeric | Free throw attempts per field goal attempt for the lineup. |
+| `tm_ast_pct` | numeric | Percentage of the lineup's made field goals that were assisted, as a decimal. |
+| `pct_fga_2pt` | numeric | Share of field goal attempts taken as two-pointers, as a decimal. |
+| `pct_fga_3pt` | numeric | Share of field goal attempts taken as three-pointers, as a decimal. |
+| `pct_pts_2pt_mr` | numeric | Share of points scored on mid-range two-pointers, as a decimal. |
+| `pct_pts_fb` | numeric | Share of points scored on fast breaks, as a decimal. |
+| `pct_pts_ft` | numeric | Share of points scored at the free throw line, as a decimal. |
+| `pct_pts_paint` | numeric | Share of points scored in the paint, as a decimal. |
+| `pct_ast_fgm` | numeric | Percentage of made field goals that were assisted, as a decimal. |
+| `pct_uast_fgm` | numeric | Percentage of made field goals that were unassisted, as a decimal. |
+| `opp_fg3_pct` | numeric | Opponent three-point percentage against the lineup, as a decimal. |
+| `opp_efg_pct` | numeric | Opponent effective field goal percentage against the lineup, as a decimal. |
+| `opp_fta_rate` | numeric | Opponent free throw attempt rate against the lineup. |
+| `opp_tov_pct` | numeric | Opponent turnover percentage forced by the lineup. |
+| `sum_tm_min` | numeric | Total team minutes summed across the lineup's stints on the floor. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3977,17 +3977,17 @@ GET /stats/playbyplayv2
 | col_name | type | description |
 |---|---|---|
 | `game_id` | character | Unique game identifier. |
-| `eventnum` | integer |  |
-| `eventmsgtype` | integer |  |
-| `eventmsgactiontype` | integer |  |
+| `eventnum` | integer | Sequential event number within the game's play-by-play feed. |
+| `eventmsgtype` | integer | Numeric event type code (1 = made shot, 2 = missed shot, 3 = free throw, 4 = rebound, 5 = turnover, 6 = foul, ...). |
+| `eventmsgactiontype` | integer | Numeric sub-type code refining eventmsgtype (e.g. the specific shot, foul, or turnover variety). |
 | `period` | integer | Period of the game (1-4 quarters; 5+ for OT). |
-| `wctimestring` | character |  |
-| `pctimestring` | character |  |
-| `homedescription` | character |  |
-| `neutraldescription` | character |  |
-| `visitordescription` | character |  |
+| `wctimestring` | character | Wall-clock time of day when the event occurred. |
+| `pctimestring` | character | Game clock remaining in the period when the event occurred (MM:SS). |
+| `homedescription` | character | Text description of the event from the home team's perspective; empty when not a home-team action. |
+| `neutraldescription` | character | Neutral text description of the event (e.g. period start/end); empty for team actions. |
+| `visitordescription` | character | Text description of the event from the visiting team's perspective; empty when not a visitor action. |
 | `score` | character | Final score. |
-| `scoremargin` | character |  |
+| `scoremargin` | character | Score margin after the event ('TIE' when tied); empty on non-scoring events. |
 | `person1type` | integer | Person1type. |
 | `player1_id` | integer | V2 PBP primary player ID (e.g. shooter / fouler). |
 | `player1_name` | character | V2 PBP primary player name. |
@@ -4138,7 +4138,7 @@ GET /stats/playercareerbycollegerollup
 | col_name | type | description |
 |---|---|---|
 | `region` | character | Region label. |
-| `seed` | character |  |
+| `seed` | character | Region seed slot of the college in the stats API's career-by-college rollup grid. |
 | `college` | character | College or school attended. |
 | `players` | character | Nested list of per-player box scores. |
 | `gp` | integer | Games played. |
@@ -4270,7 +4270,7 @@ GET /stats/playercompare
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
 | `description` | character | Long-form description text. |
 | `min` | numeric | Minutes played. |
 | `fgm` | numeric | Field goals made. |
@@ -4289,9 +4289,9 @@ GET /stats/playercompare
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
 
@@ -4796,8 +4796,8 @@ GET /stats/playerdashboardbyopponent
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -4819,46 +4819,46 @@ GET /stats/playerdashboardbyopponent
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `nba_fantasy_pts` | numeric |  |
-| `dd2` | integer |  |
-| `td3` | integer |  |
-| `wnba_fantasy_pts` | numeric |  |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
-| `nba_fantasy_pts_rank` | integer |  |
-| `dd2_rank` | integer |  |
-| `td3_rank` | integer |  |
-| `wnba_fantasy_pts_rank` | integer |  |
-| `team_count` | integer |  |
+| `nba_fantasy_pts` | numeric | Fantasy points under the NBA's fantasy scoring formula. |
+| `dd2` | integer | Double-doubles recorded over the split. |
+| `td3` | integer | Triple-doubles recorded over the split. |
+| `wnba_fantasy_pts` | numeric | Fantasy points under the WNBA's fantasy scoring formula. |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
+| `nba_fantasy_pts_rank` | integer | League rank of the row's NBA fantasy points (league scoring formula) for the season and split. |
+| `dd2_rank` | integer | League rank of the row's double-doubles for the season and split. |
+| `td3_rank` | integer | League rank of the row's triple-doubles for the season and split. |
+| `wnba_fantasy_pts_rank` | integer | League rank of the row's WNBA fantasy points (league scoring formula) for the season and split. |
+| `team_count` | integer | Number of distinct teams aggregated into the split row. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -5324,8 +5324,8 @@ GET /stats/playerfantasyprofile
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `season_year` | character | Season year string ('YYYY-YY' format). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
@@ -5348,15 +5348,15 @@ GET /stats/playerfantasyprofile
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `dd2` | integer |  |
-| `td3` | integer |  |
-| `fan_duel_pts` | numeric |  |
-| `nba_fantasy_pts` | numeric |  |
+| `dd2` | integer | Double-doubles recorded over the split. |
+| `td3` | integer | Triple-doubles recorded over the split. |
+| `fan_duel_pts` | numeric | Fantasy points under FanDuel's scoring formula. |
+| `nba_fantasy_pts` | numeric | Fantasy points under the NBA's fantasy scoring formula. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -5809,14 +5809,14 @@ GET /stats/playernextngames
 | `home_team_id` | integer | Unique identifier for the home team. |
 | `visitor_team_id` | integer | Unique identifier for visitor team. |
 | `home_team_name` | character | Home team name. |
-| `visitor_team_name` | character |  |
+| `visitor_team_name` | character | Full name of the visiting team in the upcoming game. |
 | `home_team_abbreviation` | character | Home team abbreviation; `team_detail = TRUE` only. |
-| `visitor_team_abbreviation` | character |  |
+| `visitor_team_abbreviation` | character | Abbreviation of the visiting team in the upcoming game. |
 | `home_team_nickname` | character | Home team nickname label; `team_detail = TRUE` only. |
-| `visitor_team_nickname` | character |  |
+| `visitor_team_nickname` | character | Nickname of the visiting team in the upcoming game. |
 | `game_time` | character | Game start time. |
-| `home_wl` | character |  |
-| `visitor_wl` | character |  |
+| `home_wl` | character | Home team's win-loss record entering the upcoming game. |
+| `visitor_wl` | character | Visiting team's win-loss record entering the upcoming game. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -5923,12 +5923,12 @@ GET /stats/playervsplayer
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
 | `player_id` | integer | Unique player identifier. |
 | `player_name` | character | Player name. |
-| `vs_player_id` | integer |  |
-| `vs_player_name` | character |  |
-| `court_status` | character |  |
+| `vs_player_id` | integer | Stats API player id of the comparison (vs.) player. |
+| `vs_player_name` | character | Name of the comparison (vs.) player. |
+| `court_status` | character | Whether the split covers minutes with the vs. player on or off the court. |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -5950,12 +5950,12 @@ GET /stats/playervsplayer
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `nba_fantasy_pts` | numeric |  |
+| `nba_fantasy_pts` | numeric | Fantasy points under the NBA's fantasy scoring formula. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -6161,15 +6161,15 @@ GET /stats/scoreboardv2
 | `pts_qtr3` | character | Pts qtr3. |
 | `pts_qtr4` | character | Pts qtr4. |
 | `pts_ot1` | character | Pts ot1. |
-| `pts_ot2` | character |  |
-| `pts_ot3` | character |  |
-| `pts_ot4` | character |  |
-| `pts_ot5` | character |  |
-| `pts_ot6` | character |  |
-| `pts_ot7` | character |  |
-| `pts_ot8` | character |  |
-| `pts_ot9` | character |  |
-| `pts_ot10` | character |  |
+| `pts_ot2` | character | Points scored by the team in overtime period 2. |
+| `pts_ot3` | character | Points scored by the team in overtime period 3. |
+| `pts_ot4` | character | Points scored by the team in overtime period 4. |
+| `pts_ot5` | character | Points scored by the team in overtime period 5. |
+| `pts_ot6` | character | Points scored by the team in overtime period 6. |
+| `pts_ot7` | character | Points scored by the team in overtime period 7. |
+| `pts_ot8` | character | Points scored by the team in overtime period 8. |
+| `pts_ot9` | character | Points scored by the team in overtime period 9. |
+| `pts_ot10` | character | Points scored by the team in overtime period 10. |
 | `pts` | character | Points scored. |
 | `fg_pct` | numeric | Field goal percentage (0-1). |
 | `ft_pct` | numeric | Free throw percentage (0-1). |
@@ -6206,86 +6206,86 @@ GET /stats/scoreboardv3
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `awayteam_inbonus` | character |  |
-| `awayteam_losses` | integer |  |
-| `awayteam_score` | integer |  |
-| `awayteam_seed` | integer |  |
-| `awayteam_teamcity` | character |  |
-| `awayteam_teamid` | integer |  |
-| `awayteam_teamname` | character |  |
-| `awayteam_teamslug` | character |  |
-| `awayteam_teamtricode` | character |  |
-| `awayteam_timeoutsremaining` | integer |  |
-| `awayteam_wins` | integer |  |
-| `gameclock` | character |  |
+| `awayteam_inbonus` | character | Whether the away team is currently in the bonus (penalty) foul situation. |
+| `awayteam_losses` | integer | Away team's loss total entering the game. |
+| `awayteam_score` | integer | Current or final points scored by the away team. |
+| `awayteam_seed` | integer | Playoff seed of the away team, populated for postseason games. |
+| `awayteam_teamcity` | character | City name of the away team. |
+| `awayteam_teamid` | integer | Team identifier of the away team from the league's stats API. |
+| `awayteam_teamname` | character | Nickname of the away team. |
+| `awayteam_teamslug` | character | URL-friendly slug for the away team's name. |
+| `awayteam_teamtricode` | character | Three-letter abbreviation of the away team. |
+| `awayteam_timeoutsremaining` | integer | Timeouts the away team has remaining. |
+| `awayteam_wins` | integer | Away team's win total entering the game. |
+| `gameclock` | character | Current game clock display for a live game. |
 | `gamecode` | character | Gamecode. |
 | `gamedate` | character | Game date as parsed from the source feed. |
-| `gameet` | character |  |
-| `gameid` | character |  |
-| `gamelabel` | character |  |
-| `gameleaders_awayleaders_assists` | integer |  |
-| `gameleaders_awayleaders_jerseynum` | character |  |
-| `gameleaders_awayleaders_name` | character |  |
-| `gameleaders_awayleaders_personid` | integer |  |
-| `gameleaders_awayleaders_playerslug` | character |  |
-| `gameleaders_awayleaders_points` | integer |  |
-| `gameleaders_awayleaders_position` | character |  |
-| `gameleaders_awayleaders_rebounds` | integer |  |
-| `gameleaders_awayleaders_teamtricode` | character |  |
-| `gameleaders_homeleaders_assists` | integer |  |
-| `gameleaders_homeleaders_jerseynum` | character |  |
-| `gameleaders_homeleaders_name` | character |  |
-| `gameleaders_homeleaders_personid` | integer |  |
-| `gameleaders_homeleaders_playerslug` | character |  |
-| `gameleaders_homeleaders_points` | integer |  |
-| `gameleaders_homeleaders_position` | character |  |
-| `gameleaders_homeleaders_rebounds` | integer |  |
-| `gameleaders_homeleaders_teamtricode` | character |  |
-| `gamestatus` | integer |  |
-| `gamestatustext` | character |  |
-| `gamesublabel` | character |  |
-| `gamesubtype` | character |  |
-| `gametimeutc` | character |  |
-| `hometeam_inbonus` | character |  |
-| `hometeam_losses` | integer |  |
-| `hometeam_score` | integer |  |
-| `hometeam_seed` | integer |  |
-| `hometeam_teamcity` | character |  |
-| `hometeam_teamid` | integer |  |
-| `hometeam_teamname` | character |  |
-| `hometeam_teamslug` | character |  |
-| `hometeam_teamtricode` | character |  |
-| `hometeam_timeoutsremaining` | integer |  |
-| `hometeam_wins` | integer |  |
-| `ifnecessary` | logical |  |
-| `isneutral` | logical |  |
-| `leagueid` | character |  |
-| `leaguename` | character |  |
+| `gameet` | character | Scheduled game start time in US Eastern time. |
+| `gameid` | character | Unique 10-character game identifier from the league's stats API. |
+| `gamelabel` | character | Display label for the game (e.g. a playoff series or event name). |
+| `gameleaders_awayleaders_assists` | integer | Assist total of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_jerseynum` | character | Jersey number of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_name` | character | Name of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_personid` | integer | Stats API player id of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_playerslug` | character | URL name slug of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_points` | integer | Point total of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_position` | character | Position of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_rebounds` | integer | Rebound total of the away team's in-game statistical leader. |
+| `gameleaders_awayleaders_teamtricode` | character | Team tricode of the away team's in-game statistical leader. |
+| `gameleaders_homeleaders_assists` | integer | Assist total of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_jerseynum` | character | Jersey number of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_name` | character | Name of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_personid` | integer | Stats API player id of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_playerslug` | character | URL name slug of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_points` | integer | Point total of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_position` | character | Position of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_rebounds` | integer | Rebound total of the home team's in-game statistical leader. |
+| `gameleaders_homeleaders_teamtricode` | character | Team tricode of the home team's in-game statistical leader. |
+| `gamestatus` | integer | Numeric game status code (1 = scheduled, 2 = in progress, 3 = final). |
+| `gamestatustext` | character | Human-readable game status (e.g. "Final", "7:00 pm ET"). |
+| `gamesublabel` | character | Secondary display label for the game (e.g. game number within a series). |
+| `gamesubtype` | character | Subtype code for the game as reported by the stats API (e.g. in-season tournament flags). |
+| `gametimeutc` | character | Scheduled game start time in UTC. |
+| `hometeam_inbonus` | character | Whether the home team is currently in the bonus (penalty) foul situation. |
+| `hometeam_losses` | integer | Home team's loss total entering the game. |
+| `hometeam_score` | integer | Current or final points scored by the home team. |
+| `hometeam_seed` | integer | Playoff seed of the home team, populated for postseason games. |
+| `hometeam_teamcity` | character | City name of the home team. |
+| `hometeam_teamid` | integer | Team identifier of the home team from the league's stats API. |
+| `hometeam_teamname` | character | Nickname of the home team. |
+| `hometeam_teamslug` | character | URL-friendly slug for the home team's name. |
+| `hometeam_teamtricode` | character | Three-letter abbreviation of the home team. |
+| `hometeam_timeoutsremaining` | integer | Timeouts the home team has remaining. |
+| `hometeam_wins` | integer | Home team's win total entering the game. |
+| `ifnecessary` | logical | Whether the game is an if-necessary playoff series game. |
+| `isneutral` | logical | Whether the game is played at a neutral site. |
+| `leagueid` | character | League identifier from the stats API ("00" = NBA, "10" = WNBA). |
+| `leaguename` | character | Display name of the league. |
 | `period` | integer | Period of the game (1-4 quarters; 5+ for OT). |
-| `porounddesc` | character |  |
-| `regulationperiods` | integer |  |
-| `seriesconference` | character |  |
-| `seriesgamenumber` | character |  |
-| `seriestext` | character |  |
-| `teamleaders_awayleaders_assists` | numeric |  |
-| `teamleaders_awayleaders_jerseynum` | character |  |
-| `teamleaders_awayleaders_name` | character |  |
-| `teamleaders_awayleaders_personid` | integer |  |
-| `teamleaders_awayleaders_playerslug` | character |  |
-| `teamleaders_awayleaders_points` | numeric |  |
-| `teamleaders_awayleaders_position` | character |  |
-| `teamleaders_awayleaders_rebounds` | numeric |  |
-| `teamleaders_awayleaders_teamtricode` | character |  |
-| `teamleaders_homeleaders_assists` | numeric |  |
-| `teamleaders_homeleaders_jerseynum` | character |  |
-| `teamleaders_homeleaders_name` | character |  |
-| `teamleaders_homeleaders_personid` | integer |  |
-| `teamleaders_homeleaders_playerslug` | character |  |
-| `teamleaders_homeleaders_points` | numeric |  |
-| `teamleaders_homeleaders_position` | character |  |
-| `teamleaders_homeleaders_rebounds` | numeric |  |
-| `teamleaders_homeleaders_teamtricode` | character |  |
-| `teamleaders_seasonleadersflag` | integer |  |
+| `porounddesc` | character | Playoff round description (e.g. Conference Finals). |
+| `regulationperiods` | integer | Number of regulation periods for the game (4). |
+| `seriesconference` | character | Conference of the playoff series the game belongs to. |
+| `seriesgamenumber` | character | Game number within the playoff series. |
+| `seriestext` | character | Display text summarizing the series state (e.g. "BOS leads 2-1"). |
+| `teamleaders_awayleaders_assists` | numeric | Assist total of the away team's season statistical leader. |
+| `teamleaders_awayleaders_jerseynum` | character | Jersey number of the away team's season statistical leader. |
+| `teamleaders_awayleaders_name` | character | Name of the away team's season statistical leader. |
+| `teamleaders_awayleaders_personid` | integer | Stats API player id of the away team's season statistical leader. |
+| `teamleaders_awayleaders_playerslug` | character | URL name slug of the away team's season statistical leader. |
+| `teamleaders_awayleaders_points` | numeric | Point total of the away team's season statistical leader. |
+| `teamleaders_awayleaders_position` | character | Position of the away team's season statistical leader. |
+| `teamleaders_awayleaders_rebounds` | numeric | Rebound total of the away team's season statistical leader. |
+| `teamleaders_awayleaders_teamtricode` | character | Team tricode of the away team's season statistical leader. |
+| `teamleaders_homeleaders_assists` | numeric | Assist total of the home team's season statistical leader. |
+| `teamleaders_homeleaders_jerseynum` | character | Jersey number of the home team's season statistical leader. |
+| `teamleaders_homeleaders_name` | character | Name of the home team's season statistical leader. |
+| `teamleaders_homeleaders_personid` | integer | Stats API player id of the home team's season statistical leader. |
+| `teamleaders_homeleaders_playerslug` | character | URL name slug of the home team's season statistical leader. |
+| `teamleaders_homeleaders_points` | numeric | Point total of the home team's season statistical leader. |
+| `teamleaders_homeleaders_position` | character | Position of the home team's season statistical leader. |
+| `teamleaders_homeleaders_rebounds` | numeric | Rebound total of the home team's season statistical leader. |
+| `teamleaders_homeleaders_teamtricode` | character | Team tricode of the home team's season statistical leader. |
+| `teamleaders_seasonleadersflag` | integer | Flag indicating the team-leaders block carries season-long leaders rather than in-game leaders. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -6344,7 +6344,7 @@ GET /stats/shotchartdetail
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `grid_type` | character |  |
+| `grid_type` | character | Shot chart grid type label returned by the stats API (e.g. "Shot Chart Detail"). |
 | `game_id` | character | Unique game identifier. |
 | `game_event_id` | character | Unique identifier for game event. |
 | `player_id` | character | Unique player identifier. |
@@ -6366,8 +6366,8 @@ GET /stats/shotchartdetail
 | `shot_attempted_flag` | character | 1 if a shot was attempted on this event. |
 | `shot_made_flag` | character | 1 if the shot was made; 0 if missed. |
 | `game_date` | character | Game date (YYYY-MM-DD). |
-| `htm` | character |  |
-| `vtm` | character |  |
+| `htm` | character | Home team abbreviation for the game. |
+| `vtm` | character | Visiting team abbreviation for the game. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -6451,7 +6451,7 @@ GET /stats/shotchartlineupdetail
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `grid_type` | character |  |
+| `grid_type` | character | Shot chart grid type label returned by the stats API (e.g. "Shot Chart Detail"). |
 | `game_id` | character | Unique game identifier. |
 | `game_event_id` | character | Unique identifier for game event. |
 | `group_id` | character | ESPN group id. |
@@ -6475,8 +6475,8 @@ GET /stats/shotchartlineupdetail
 | `shot_attempted_flag` | character | 1 if a shot was attempted on this event. |
 | `shot_made_flag` | character | 1 if the shot was made; 0 if missed. |
 | `game_date` | character | Game date (YYYY-MM-DD). |
-| `htm` | character |  |
-| `vtm` | character |  |
+| `htm` | character | Home team abbreviation for the game. |
+| `vtm` | character | Visiting team abbreviation for the game. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -6527,8 +6527,8 @@ GET /stats/teamdashboardbyclutch
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -6550,37 +6550,37 @@ GET /stats/teamdashboardbyclutch
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -6631,8 +6631,8 @@ GET /stats/teamdashboardbygamesplits
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -6654,37 +6654,37 @@ GET /stats/teamdashboardbygamesplits
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -6840,8 +6840,8 @@ GET /stats/teamdashboardbylastngames
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -6863,37 +6863,37 @@ GET /stats/teamdashboardbylastngames
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -6944,8 +6944,8 @@ GET /stats/teamdashboardbyopponent
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -6967,37 +6967,37 @@ GET /stats/teamdashboardbyopponent
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -7129,10 +7129,10 @@ GET /stats/teamdashboardbyteamperformance
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value_order` | integer |  |
-| `group_value` | character |  |
-| `group_value_2` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value_order` | integer | Sort order of the split value within its group. |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
+| `group_value_2` | character | Secondary split value for the row when the group uses two dimensions. |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -7154,37 +7154,37 @@ GET /stats/teamdashboardbyteamperformance
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -7235,8 +7235,8 @@ GET /stats/teamdashboardbyyearoveryear
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
@@ -7258,37 +7258,37 @@ GET /stats/teamdashboardbyyearoveryear
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -7429,14 +7429,14 @@ GET /stats/teamdetails
 | `team_id` | integer | Unique team identifier. |
 | `abbreviation` | character | Short abbreviation. |
 | `nickname` | character | Team or athlete nickname. |
-| `yearfounded` | integer |  |
+| `yearfounded` | integer | Year the franchise was founded. |
 | `city` | character | Venue city. |
 | `arena` | character | Arena. |
-| `arenacapacity` | character |  |
-| `owner` | character |  |
-| `generalmanager` | character |  |
-| `headcoach` | character |  |
-| `dleagueaffiliation` | character |  |
+| `arenacapacity` | character | Seating capacity of the team's home arena. |
+| `owner` | character | Name of the team's owner or ownership group. |
+| `generalmanager` | character | Name of the team's general manager. |
+| `headcoach` | character | Name of the team's head coach. |
+| `dleagueaffiliation` | character | Name of the team's G League (formerly D-League) affiliate. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -7698,15 +7698,15 @@ GET /stats/teaminfocommon
 | `team_city` | character | Team city or region (e.g. 'Las Vegas'). |
 | `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
 | `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
-| `team_conference` | character |  |
-| `team_division` | character |  |
+| `team_conference` | character | Conference the team belongs to. |
+| `team_division` | character | Division the team belongs to. |
 | `team_code` | character | Internal team code. |
 | `team_slug` | character | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
 | `w` | integer | Wins. |
 | `l` | integer | Losses. |
 | `pct` | numeric | Win percentage. |
-| `conf_rank` | integer |  |
-| `div_rank` | integer |  |
+| `conf_rank` | integer | Team's current rank within its conference. |
+| `div_rank` | integer | Team's current rank within its division. |
 | `min_year` | character | Minimum year queried (echoes `min_year`). |
 | `max_year` | character | Maximum year queried (echoes `max_year`). |
 
@@ -8086,8 +8086,8 @@ GET /stats/teamvsplayer
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `group_set` | character |  |
-| `group_value` | character |  |
+| `group_set` | character | Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month). |
+| `group_value` | character | Value of the split within the group (e.g. a specific opponent, month, or result). |
 | `player_id` | integer | Unique player identifier. |
 | `gp` | integer | Games played. |
 | `w` | integer | Wins. |
@@ -8110,46 +8110,46 @@ GET /stats/teamvsplayer
 | `tov` | numeric | Turnovers. |
 | `stl` | numeric | Steals. |
 | `blk` | numeric | Blocks. |
-| `blka` | numeric |  |
+| `blka` | numeric | Shot attempts blocked by opponents (blocks against). |
 | `pf` | numeric | Personal fouls. |
-| `pfd` | numeric |  |
+| `pfd` | numeric | Personal fouls drawn. |
 | `pts` | numeric | Points scored. |
 | `plus_minus` | numeric | Plus/minus point differential while on court. |
-| `nba_fantasy_pts` | numeric |  |
-| `dd2` | integer |  |
-| `td3` | integer |  |
-| `wnba_fantasy_pts` | numeric |  |
-| `gp_rank` | integer |  |
-| `w_rank` | integer |  |
-| `l_rank` | integer |  |
-| `w_pct_rank` | integer |  |
-| `min_rank` | integer |  |
-| `fgm_rank` | integer |  |
-| `fga_rank` | integer |  |
-| `fg_pct_rank` | integer |  |
-| `fg3m_rank` | integer |  |
-| `fg3a_rank` | integer |  |
-| `fg3_pct_rank` | integer |  |
-| `ftm_rank` | integer |  |
-| `fta_rank` | integer |  |
-| `ft_pct_rank` | integer |  |
-| `oreb_rank` | integer |  |
-| `dreb_rank` | integer |  |
-| `reb_rank` | integer |  |
-| `ast_rank` | integer |  |
-| `tov_rank` | integer |  |
-| `stl_rank` | integer |  |
-| `blk_rank` | integer |  |
-| `blka_rank` | integer |  |
-| `pf_rank` | integer |  |
-| `pfd_rank` | integer |  |
-| `pts_rank` | integer |  |
-| `plus_minus_rank` | integer |  |
-| `nba_fantasy_pts_rank` | integer |  |
-| `dd2_rank` | integer |  |
-| `td3_rank` | integer |  |
-| `wnba_fantasy_pts_rank` | integer |  |
-| `team_count` | integer |  |
+| `nba_fantasy_pts` | numeric | Fantasy points under the NBA's fantasy scoring formula. |
+| `dd2` | integer | Double-doubles recorded over the split. |
+| `td3` | integer | Triple-doubles recorded over the split. |
+| `wnba_fantasy_pts` | numeric | Fantasy points under the WNBA's fantasy scoring formula. |
+| `gp_rank` | integer | League rank of the row's games played for the season and split. |
+| `w_rank` | integer | League rank of the row's wins for the season and split. |
+| `l_rank` | integer | League rank of the row's losses for the season and split. |
+| `w_pct_rank` | integer | League rank of the row's win percentage for the season and split. |
+| `min_rank` | integer | League rank of the row's minutes played for the season and split. |
+| `fgm_rank` | integer | League rank of the row's field goals made for the season and split. |
+| `fga_rank` | integer | League rank of the row's field goals attempted for the season and split. |
+| `fg_pct_rank` | integer | League rank of the row's field goal percentage for the season and split. |
+| `fg3m_rank` | integer | League rank of the row's three-point field goals made for the season and split. |
+| `fg3a_rank` | integer | League rank of the row's three-point field goals attempted for the season and split. |
+| `fg3_pct_rank` | integer | League rank of the row's three-point field goal percentage for the season and split. |
+| `ftm_rank` | integer | League rank of the row's free throws made for the season and split. |
+| `fta_rank` | integer | League rank of the row's free throws attempted for the season and split. |
+| `ft_pct_rank` | integer | League rank of the row's free throw percentage for the season and split. |
+| `oreb_rank` | integer | League rank of the row's offensive rebounds for the season and split. |
+| `dreb_rank` | integer | League rank of the row's defensive rebounds for the season and split. |
+| `reb_rank` | integer | League rank of the row's total rebounds for the season and split. |
+| `ast_rank` | integer | League rank of the row's assists for the season and split. |
+| `tov_rank` | integer | League rank of the row's turnovers for the season and split. |
+| `stl_rank` | integer | League rank of the row's steals for the season and split. |
+| `blk_rank` | integer | League rank of the row's blocked shots for the season and split. |
+| `blka_rank` | integer | League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split. |
+| `pf_rank` | integer | League rank of the row's personal fouls committed for the season and split. |
+| `pfd_rank` | integer | League rank of the row's personal fouls drawn for the season and split. |
+| `pts_rank` | integer | League rank of the row's points scored for the season and split. |
+| `plus_minus_rank` | integer | League rank of the row's plus-minus point differential while on the floor for the season and split. |
+| `nba_fantasy_pts_rank` | integer | League rank of the row's NBA fantasy points (league scoring formula) for the season and split. |
+| `dd2_rank` | integer | League rank of the row's double-doubles for the season and split. |
+| `td3_rank` | integer | League rank of the row's triple-doubles for the season and split. |
+| `wnba_fantasy_pts_rank` | integer | League rank of the row's WNBA fantasy points (league scoring formula) for the season and split. |
+| `team_count` | integer | Number of distinct teams aggregated into the split row. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -8189,13 +8189,13 @@ GET /stats/teamyearbyyearstats
 | `wins` | integer | Total wins. |
 | `losses` | integer | Total losses. |
 | `win_pct` | numeric | Win percentage (0-1 decimal). |
-| `conf_rank` | integer |  |
-| `div_rank` | integer |  |
-| `po_wins` | integer |  |
-| `po_losses` | integer |  |
-| `conf_count` | integer |  |
-| `div_count` | integer |  |
-| `nba_finals_appearance` | character |  |
+| `conf_rank` | integer | Team's final rank within its conference for the season. |
+| `div_rank` | integer | Team's final rank within its division for the season. |
+| `po_wins` | integer | Playoff wins recorded by the team that season. |
+| `po_losses` | integer | Playoff losses recorded by the team that season. |
+| `conf_count` | integer | Number of teams in the team's conference that season. |
+| `div_count` | integer | Number of teams in the team's division that season. |
+| `nba_finals_appearance` | character | Whether the team reached the league finals that season (e.g. "FINALS APPEARANCE" or "N/A"). |
 | `fgm` | numeric | Field goals made. |
 | `fga` | numeric | Field goal attempts. |
 | `fg_pct` | numeric | Field goal percentage (0-1). |
@@ -8214,7 +8214,7 @@ GET /stats/teamyearbyyearstats
 | `tov` | numeric | Turnovers. |
 | `blk` | numeric | Blocks. |
 | `pts` | numeric | Points scored. |
-| `pts_rank` | integer |  |
+| `pts_rank` | integer | League rank of the team's points scored for the season. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -8247,16 +8247,16 @@ GET /stats/videostatus
 | `game_id` | integer | Unique game identifier. |
 | `game_date` | character | Game date (YYYY-MM-DD). |
 | `visitor_team_id` | integer | Unique identifier for visitor team. |
-| `visitor_team_city` | character |  |
-| `visitor_team_name` | character |  |
-| `visitor_team_abbreviation` | character |  |
+| `visitor_team_city` | character | City name of the visiting team. |
+| `visitor_team_name` | character | Nickname of the visiting team. |
+| `visitor_team_abbreviation` | character | Abbreviation of the visiting team. |
 | `home_team_id` | integer | Unique identifier for the home team. |
 | `home_team_city` | character | Home team city / location. |
 | `home_team_name` | character | Home team name. |
 | `home_team_abbreviation` | character | Home team abbreviation; `team_detail = TRUE` only. |
 | `game_status` | character | Game status label. |
 | `game_status_text` | character | Game status display text (e.g. 'Final', '4:32 - 4th'). |
-| `is_available` | character |  |
+| `is_available` | character | Flag indicating whether game video is available in the league's stats video system. |
 | `pt_xyz_available` | character | Pt xyz available. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -5584,18 +5584,6 @@ collective_groups:
   website_name: Display name of the collective's website.
   website_url: URL of the collective's website.
   youtube_handle: Collective's YouTube channel handle.
-collective_groups_deals:
-  amount: Reported dollar amount of the NIL deal.
-  collective_group: Nested On3 record for the collective brokering the deal (stringified).
-  company: Nested On3 record for the company on the other side of the NIL deal (stringified).
-  key: On3 RDB key for the NIL deal record.
-  nil_status: Status of the athlete's On3 NIL valuation (e.g. active, inactive).
-  nil_value: Athlete's On3 NIL valuation in dollars.
-  person: Nested On3 person object for the athlete in the deal (stringified).
-  roster_rating: Nested On3 roster rating object for the athlete at deal time (stringified).
-  rpm: Nested On3 Recruiting Prediction Machine (RPM) data for the athlete (stringified).
-  source_url: URL of the source reporting the deal.
-  verified: Whether On3 verified the deal.
 collective_groups_key:
   annual_goal_amount: Collective's annual fundraising goal in dollars, as reported to On3.
   confirmed_raised_amount: Dollar amount the collective has confirmed raising, per On3.
@@ -6063,40 +6051,6 @@ draftcombinestats:
   three_quarter_sprint: Three-quarter-court sprint time, in seconds.
   wingspan: Wingspan measured at the combine, in inches.
   wingspan_ft_in: Wingspan formatted as feet and inches.
-drafts:
-  college_organization: Nested On3 organization object for the college the player attended (stringified).
-  compensatory: Whether the selection was a compensatory draft pick.
-  drafted_from_organization: Nested On3 organization object for the school the player was drafted out of (stringified).
-  forfeited: Whether the pick was forfeited.
-  high_school_organization: Nested On3 organization object for the player's high school (stringified).
-  key: On3 RDB key for the draft-pick record.
-  person: Nested On3 person object for the drafted player (stringified).
-  recruitment_key: On3 RDB recruitment key linking the draft pick back to the player's recruitment record.
-  supplementary: Whether the selection came in a supplemental draft.
-  through_organization_one: First intermediate organization the pick passed through in trades before being exercised (On3
-    RDB).
-  through_organization_three: Third intermediate organization the pick passed through in trades before being exercised (On3
-    RDB).
-  through_organization_two: Second intermediate organization the pick passed through in trades before being exercised (On3
-    RDB).
-  trading_organization: Pro organization that traded the pick away, when it changed hands (On3 RDB).
-drafts_players:
-  college_organization: Nested On3 organization object for the college the player attended (stringified).
-  compensatory: Whether the selection was a compensatory draft pick.
-  drafted_from_organization: Nested On3 organization object for the school the player was drafted out of (stringified).
-  forfeited: Whether the pick was forfeited.
-  high_school_organization: Nested On3 organization object for the player's high school (stringified).
-  key: On3 RDB key for the draft-pick record.
-  person: Nested On3 person object for the drafted player (stringified).
-  recruitment_key: On3 RDB recruitment key linking the draft pick back to the player's recruitment record.
-  supplementary: Whether the selection came in a supplemental draft.
-  through_organization_one: First intermediate organization the pick passed through in trades before being exercised (On3
-    RDB).
-  through_organization_three: Third intermediate organization the pick passed through in trades before being exercised (On3
-    RDB).
-  through_organization_two: Second intermediate organization the pick passed through in trades before being exercised (On3
-    RDB).
-  trading_organization: Pro organization that traded the pick away, when it changed hands (On3 RDB).
 fantasywidget:
   fan_duel_pts: Fantasy points under FanDuel's scoring formula.
   nba_fantasy_pts: Fantasy points under the NBA's fantasy scoring formula.
@@ -6342,349 +6296,6 @@ load_cfb_game_rosters:
   statistics_href: ESPN Core v2 API reference URL for this athlete's stat line in this game, null for the roughly 71 percent
     of listed players who recorded no stats.
   team_alternate_ids_sdr: The team's Sportradar alternate identifier, which maps one-to-one with team_id.
-load_cfb_pbp:
-  A_score_diff: Away team's score minus the home team's, from the away perspective.
-  EPA_explosive: True when the play was explosive.
-  EPA_explosive_pass: True when the pass play was explosive.
-  EPA_explosive_rush: True when the rush play was explosive.
-  EPA_fg: EPA credited to the play on field-goal attempts.
-  EPA_kickoff: EPA credited to the play on kickoff plays.
-  EPA_middle_8_success: True when the play in the middle eight was successful by EPA.
-  EPA_middle_8_success_pass: True when the pass play in the middle eight was successful by EPA.
-  EPA_middle_8_success_rush: True when the rush play in the middle eight was successful by EPA.
-  EPA_non_explosive: EPA credited to the play on non-explosive plays.
-  EPA_pass: EPA credited to the play on pass plays.
-  EPA_penalty: EPA credited to the play attributable to penalties.
-  EPA_punt: EPA credited to the play on punt plays.
-  EPA_rush: EPA credited to the play on rush plays.
-  EPA_scrimmage: EPA credited to the play on plays from scrimmage.
-  EPA_sp: EPA credited to the play on special-teams plays.
-  EPA_success: True when the play was successful by EPA.
-  EPA_success_EPA: EPA on successful plays.
-  EPA_success_early_down: True when the play on an early down was successful by EPA.
-  EPA_success_early_down_pass: True when the pass play on an early down was successful by EPA.
-  EPA_success_early_down_rush: True when the rush play on an early down was successful by EPA.
-  EPA_success_late_down: True when the play on a late down was successful by EPA.
-  EPA_success_late_down_pass: True when the pass play on a late down was successful by EPA.
-  EPA_success_late_down_rush: True when the rush play on a late down was successful by EPA.
-  EPA_success_pass: True when the pass play was successful by EPA.
-  EPA_success_pass_EPA: EPA on successful pass plays.
-  EPA_success_passing_down: True when the play on a passing down was successful by EPA.
-  EPA_success_passing_down_EPA: EPA on successful plays on a passing down.
-  EPA_success_rush: True when the rush play was successful by EPA.
-  EPA_success_rush_EPA: EPA on successful rush plays.
-  EPA_success_standard_down: True when the play on a standard down was successful by EPA.
-  EPA_success_standard_down_EPA: EPA on successful plays on a standard down.
-  EP_between: Change in expected points across the play, before penalty adjustment.
-  EP_end: Expected points for the offense at the end of the play.
-  EP_start: Expected points for the offense at the start of the play.
-  EP_start_touchback: Expected points the offense would have had from a touchback on this play.
-  HA_score_diff: Home score minus away score for the play.
-  H_score_diff: Home team's score minus the away team's, from the home perspective.
-  TFL: True when the play was a tackle for loss.
-  TFL_pass: True when the play was a tackle for loss on a pass play (a sack).
-  TFL_rush: True when the play was a tackle for loss on a rush play.
-  action_play: True when the play advanced the game state -- excludes timeouts, end-of-period markers and other non-action
-    rows.
-  adj_rush_yardage: Rushing yards capped at 8, the input to the line-yards decomposition.
-  air_yardsToEndzone: Yards to the endzone at the catch spot, parsed from the 2025+ vendor catch-spot text; null before 2025
-    or when unresolvable.
-  awayTeamAbbrev: ESPN's away-team Abbrev for the game, stamped on every play.
-  awayTeamId: ESPN's away-team Id for the game, stamped on every play.
-  awayTeamMascot: ESPN's away-team Mascot for the game, stamped on every play.
-  awayTeamName: ESPN's away-team Name for the game, stamped on every play.
-  awayTeamNameAlt: ESPN's away-team NameAlt for the game, stamped on every play.
-  awayTimeoutCalled: True when the away team called a timeout on the play.
-  away_wp_after_naive: End-of-play naive win probability mapped to the away team.
-  away_wp_before_naive: Pre-snap naive win probability mapped to the away team.
-  cleaned_text: Play description with overturned-call prefixes stripped; the text the name and team extractors run against.
-  clock.displayValue: Game clock at the play, as the displayed mm:ss string.
-  clock.minutes: Minutes remaining on the game clock at the play.
-  clock.seconds: Seconds component of the game clock at the play.
-  def_fumble_lost: Whether the defending team (e.g. a returner after a takeaway) fumbled and lost the ball back.
-  def_wp_after_naive: End-of-play defense win probability under the naive model.
-  def_wp_before_naive: Pre-snap defense win probability under the naive model (1 - wp_before_naive).
-  down_1: True when it is 1st down at the start of the play.
-  down_1_end: True when it is 1st down at the end of the play.
-  down_2: True when it is 2nd down at the start of the play.
-  down_2_end: True when it is 2nd down at the end of the play.
-  down_3: True when it is 3rd down at the start of the play.
-  down_3_end: True when it is 3rd down at the end of the play.
-  down_4: True when it is 4th down at the start of the play.
-  down_4_end: True when it is 4th down at the end of the play.
-  drive.description: ESPN's `description` field for the drive containing this play.
-  drive.displayResult: ESPN's `displayResult` field for the drive containing this play.
-  drive.end.clock.displayValue: ESPN's `end.clock.displayValue` field for the drive containing this play.
-  drive.end.period.number: ESPN's `end.period.number` field for the drive containing this play.
-  drive.end.period.type: ESPN's `end.period.type` field for the drive containing this play.
-  drive.end.yardLine: ESPN's `end.yardLine` field for the drive containing this play.
-  drive.id: ESPN's `id` field for the drive containing this play.
-  drive.isScore: ESPN's `isScore` field for the drive containing this play.
-  drive.offensivePlays: ESPN's `offensivePlays` field for the drive containing this play.
-  drive.result: ESPN's `result` field for the drive containing this play.
-  drive.shortDisplayResult: ESPN's `shortDisplayResult` field for the drive containing this play.
-  drive.start.clock.displayValue: ESPN's `start.clock.displayValue` field for the drive containing this play.
-  drive.start.period.number: ESPN's `start.period.number` field for the drive containing this play.
-  drive.start.period.type: ESPN's `start.period.type` field for the drive containing this play.
-  drive.start.text: ESPN's `start.text` field for the drive containing this play.
-  drive.start.yardLine: ESPN's `start.yardLine` field for the drive containing this play.
-  drive.team.abbreviation: ESPN's `team.abbreviation` field for the drive containing this play.
-  drive.team.displayName: ESPN's `team.displayName` field for the drive containing this play.
-  drive.team.name: ESPN's `team.name` field for the drive containing this play.
-  drive.team.shortDisplayName: ESPN's `team.shortDisplayName` field for the drive containing this play.
-  drive.timeElapsed.displayValue: ESPN's `timeElapsed.displayValue` field for the drive containing this play.
-  drive.yards: ESPN's `yards` field for the drive containing this play.
-  drive_offense_plays: Offensive plays run on the drive.
-  drive_offense_yards: Offensive yards gained on the drive.
-  drive_play_index: Sequence number of the play within its drive.
-  drive_start: Yard line at which the drive began.
-  drive_stopped: True when the play ended the drive.
-  drive_total_yards: Total yards gained on the drive.
-  early_down: True when the play is a scrimmage play on first or second down.
-  early_down_pass: True when the play is a pass on an early down.
-  early_down_rush: True when the play is a rush on an early down.
-  end.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the end of the play.
-  end.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the end of the play.
-  end.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the end of the play.
-  end.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the end of the play.
-  end.awayScore: ESPN's `awayScore` value for the play state at the end of the play.
-  end.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the end of the play.
-  end.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the end of the play.
-  end.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the end of the play.
-  end.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the end of the play.
-  end.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the end of the play.
-  end.distance: ESPN's `distance` value for the play state at the end of the play.
-  end.down: ESPN's `down` value for the play state at the end of the play.
-  end.downDistanceText: ESPN's `downDistanceText` value for the play state at the end of the play.
-  end.elapsed_share: ESPN's `elapsed_share` value for the play state at the end of the play.
-  end.homeScore: ESPN's `homeScore` value for the play state at the end of the play.
-  end.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the end of the play.
-  end.is_home: ESPN's `is_home` value for the play state at the end of the play.
-  end.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the end of the play.
-  end.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the end of the play.
-  end.pos_team.id: ESPN's `pos_team.id` value for the play state at the end of the play.
-  end.pos_team.name: ESPN's `pos_team.name` value for the play state at the end of the play.
-  end.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the end of the play.
-  end.pos_team_score: ESPN's `pos_team_score` value for the play state at the end of the play.
-  end.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the end of the play.
-  end.possessionText: ESPN's `possessionText` value for the play state at the end of the play.
-  end.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the end of the play.
-  end.spread_time: ESPN's `spread_time` value for the play state at the end of the play.
-  end.team.id: ESPN's `team.id` value for the play state at the end of the play.
-  end.yard: ESPN's `yard` value for the play state at the end of the play.
-  end.yardLine: ESPN's `yardLine` value for the play state at the end of the play.
-  end.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the end of the play.
-  end_state_missing: Flag that ESPN's end-of-play state (end.team.id) was absent and the end state was imputed.
-  fg_attempt: True when the play was a field-goal attempt.
-  fg_block_player_id: ESPN athlete id of the player who blocked the field goal.
-  fg_kicker_player_id: ESPN athlete id of the field-goal kicker.
-  fg_return_player_id: ESPN athlete id of the player who returned the blocked or missed field goal.
-  fg_team: Team id attempting the field goal (the kicking team).
-  fg_wp: Make-probability-weighted win probability of attempting the field goal.
-  fg_wp_diff: fg_wp minus the recommended option's WP (0 when the field goal is the recommendation, otherwise <= 0).
-  firstHalfKickoffTeamId: ESPN id of the team that received the opening kickoff.
-  first_down_created: True when the play produced a first down for the offense.
-  first_down_prob: Modeled probability of converting the fourth down when going for it.
-  forced_fumble: True when the defense forced a fumble on the play.
-  forced_fumble_team: Team id credited with forcing the fumble -- the side opposite the fumbling player (the covering team
-    on returns).
-  fourth_down_recommendation: Max-WP fourth-down choice among "go", "punt", and "field_goal".
-  fumble_or_muff: Whether the play includes a fumble or a muffed kick or punt (widened beyond ESPN's fumble play types).
-  fumble_recovered: True when a fumble on the play was recovered.
-  fumble_recovery_team: Team id that recovered the fumble or muff, from parsed text with a giveaway / own-recovery fallback.
-  fumbling_team: Team id of the side that fumbled or muffed the ball, parsed from the play text.
-  gameSpread: Point spread used as an input to the win-probability model.
-  gameSpreadAvailable: True when a spread was available for the game.
-  go_boost: 'cfb4th''s headline number: 100 * (go_wp - max(fg_wp, punt_wp)), in percentage points.'
-  go_wp: 'Win probability from going for it on fourth down: conversion-probability-weighted mean of the success and failure
-    states (cfb4th port).'
-  go_wp_diff: go_wp minus the recommended option's WP (0 when going for it is the recommendation, otherwise <= 0).
-  havoc: 'True when the defense disrupted the play: a pass breakup, tackle for loss, interception or forced fumble.'
-  highlight_run: True when the rush gained 8 or more yards.
-  highlight_yards: Second-level plus open-field yards -- the yardage credited to the carrier.
-  homeFavorite: True when the home team was favoured by the spread.
-  homeTeamAbbrev: ESPN's home-team Abbrev for the game, stamped on every play.
-  homeTeamId: ESPN's home-team Id for the game, stamped on every play.
-  homeTeamMascot: ESPN's home-team Mascot for the game, stamped on every play.
-  homeTeamName: ESPN's home-team Name for the game, stamped on every play.
-  homeTeamNameAlt: ESPN's home-team NameAlt for the game, stamped on every play.
-  homeTeamSpread: ESPN's home-team Spread for the game, stamped on every play.
-  homeTimeoutCalled: True when the home team called a timeout on the play.
-  home_wp_after_naive: End-of-play naive win probability mapped to the home team.
-  home_wp_before_naive: Pre-snap naive win probability mapped to the home team.
-  int_turnover: Whether the play is an interception giveaway.
-  interception_team: Team id credited with the interception (the defense).
-  isPenalty: ESPN's per-play flag that a penalty occurred on the play.
-  isTurnover: ESPN's per-play turnover flag as shipped in the plays feed (broader than the giveaway-based is_turnover derivation).
-  is_blocked_fg_turnover: Blocked-field-goal possession loss (blocked-FG TD, or the defense recovered); kept out of is_turnover
-    to match ESPN's giveaway-only box.
-  is_blocked_punt_turnover: Blocked-punt possession loss (blocked-punt TD, or the defense recovered); kept out of is_turnover
-    to match ESPN's giveaway-only box.
-  is_def_pos_team_turnover: Whether the defending team gave the ball back via a lost fumble.
-  is_pos_team_turnover: Whether the possession team committed a giveaway (interception or fumble lost).
-  is_st_turnover: Whether the giveaway happened on a special-teams play (kick or punt snap, or a return).
-  kick_return_team: Team id of the kick-returning side.
-  kicking_team: Team id of the kicking team on kickoff, punt, and field-goal plays.
-  kickoff_player_id: ESPN athlete id of the player kicking off.
-  kickoff_return_player_id: ESPN athlete id of the kickoff returner.
-  kneel_down: Whether the play is an offensive kneel, from explicit kneel text plus an end-of-half TEAM-rush heuristic.
-  lag_EP_end: Value of EP_end on the previous play, used for sequence-aware derivations.
-  lag_HA_score_diff: Value of HA_score_diff on the previous play, used for sequence-aware derivations.
-  lag_awayScore: Value of awayScore on the previous play, used for sequence-aware derivations.
-  lag_change_of_pos_team: Value of change_of_pos_team on the previous play, used for sequence-aware derivations.
-  lag_half: Value of half on the previous play, used for sequence-aware derivations.
-  lag_homeScore: Value of homeScore on the previous play, used for sequence-aware derivations.
-  lag_pos_score_diff: Value of pos_score_diff on the previous play, used for sequence-aware derivations.
-  lag_pos_team: Value of pos_team on the previous play, used for sequence-aware derivations.
-  lag_scoringPlay: Value of scoringPlay on the previous play, used for sequence-aware derivations.
-  late_down: True when the play is a scrimmage play on third or fourth down.
-  late_down_pass: True when the play is a pass on a late down.
-  late_down_rush: True when the play is a rush on a late down.
-  lead_half: Value of half on the next play, used for sequence-aware derivations.
-  lead_play_type: Value of play_type on the next play, used for sequence-aware derivations.
-  lead_pos_team: Value of pos_team on the next play, used for sequence-aware derivations.
-  lead_pos_team2: Value of pos_team 2 plays ahead, used for sequence-aware derivations.
-  lead_scoringPlay: Value of scoringPlay on the next play, used for sequence-aware derivations.
-  lead_start_distance: Value of start_distance on the next play, used for sequence-aware derivations.
-  lead_start_down: Value of start_down on the next play, used for sequence-aware derivations.
-  lead_start_team: Value of start_team on the next play, used for sequence-aware derivations.
-  lead_start_yardsToEndzone: Value of start_yardsToEndzone on the next play, used for sequence-aware derivations.
-  lead_text: Value of text on the next play, used for sequence-aware derivations.
-  lead_wp_before: Value of wp_before on the next play, used for sequence-aware derivations.
-  lead_wp_before2: Value of wp_before 2 plays ahead, used for sequence-aware derivations.
-  lead_wp_before2_naive: Pre-snap naive win probability two plays ahead, used where the immediately following row is a non-play.
-  lead_wp_before_naive: Next play's pre-snap naive win probability, used in the end-of-half and change-of-possession adjustments.
-  line_yards: 'Yards credited to the offensive line on a rush, using the standard sliding scale: 1.2x the capped yardage on
-    a loss, all of it through 3 yards, half of each yard from 4 to 8, and a 5.5-yard ceiling beyond that.'
-  make_fg_wp: Win probability given the field-goal attempt is made.
-  miss_fg_wp: Win probability given the field-goal attempt misses.
-  net_HA_score_pts: Net points the play added to the home-minus-away score margin.
-  new_distance: Distance to go after the play, including any penalty enforcement.
-  new_down: Down after the play, including any penalty enforcement.
-  non_fumble_sack: True when the play was a sack that did not produce a fumble.
-  open_field_yards: Rushing yards gained beyond 8, credited to the ball carrier rather than the line.
-  opp_highlight_yards: Highlight yards earned on opportunity runs, isolating carrier production on carries where the blocking
-    succeeded. Assets published before the 2026-08 fix are identically 0 here, because the inverted opportunity_run gate could
-    never co-occur with non-zero highlight yards.
-  opportunity_run: True when a rush reached 4 yards -- the carries on which the blocking did its job. Matches cfbfastR's espn_cfb_15
-    definition. Assets published before the 2026-08 fix carry the inverted (4 yards or fewer) flag.
-  overUnder: Over/under total used as a model input.
-  pass_breakup: True when a defender broke up the pass.
-  pass_breakup_team: Team id credited with the pass breakup (the defense).
-  pass_depth: Thrown-pass depth parsed from ESPN play text ("short" or "deep"); null when the text omits it (sacks, screens,
-    pre-2025 text).
-  pass_direction: Pass direction parsed from ESPN play text ("left", "middle", or "right"); null when the text omits it.
-  pass_epa: EPA credited to the play when it is a pass.
-  pass_weight: Weighting applied to the pass component of the play.
-  passing_down: True when the offense is behind schedule for the series -- second down needing 8 or more, or third/fourth
-    down needing 5 or more.
-  pen_epa: EPA attributable to a penalty on the play.
-  pen_weight: Weighting applied to the penalty component of the play.
-  penalized_team: Team id the penalty was assessed against, from the home/away text resolver with a foul-direction fallback.
-  penalty_assessed_on_kickoff: Whether a penalty was assessed on a kickoff; such plays take the kickoff/touchback win-probability
-    handling.
-  penalty_in_text: True when the play description mentions a penalty.
-  penalty_yards_signed: Penalty yardage parsed from the play text with era-aware bounds; the printed sign is retained but
-    is not a reliable enforcement direction.
-  period.number: Period (quarter) number in which the play occurred.
-  pointAfterAttempt.abbreviation: ESPN abbreviation of the point-after attempt type; drives the extra-point / two-point result
-    derivation.
-  pointAfterAttempt.id: ESPN identifier for the point-after attempt type on the scoring play.
-  pointAfterAttempt.text: ESPN description of the point-after attempt and its result.
-  pointAfterAttempt.value: Points ESPN credits for the point-after attempt (1.0 made extra point, 2.0 made two-point try).
-  pos_fumble_lost: Whether the possession team fumbled and lost the ball.
-  pos_score_diff_end: Score differential from the possessing team's perspective at the end of the play.
-  power_rush_attempt: True when the play is a short-yardage power rushing attempt.
-  power_rush_success: True when a power rushing attempt gained the yardage needed.
-  prob_2pt: Two-point conversion probability from the bundled CFB two-point model.
-  prog_drive_EPA: Cumulative EPA accrued by the drive up to and including this play.
-  prog_drive_WPA: Cumulative win-probability added by the drive up to and including this play.
-  punt_block_player_id: ESPN athlete id of the player who blocked the punt.
-  punt_block_return_player_id: ESPN athlete id of the player who returned the blocked punt.
-  punt_return_player_id: ESPN athlete id of the punt returner.
-  punt_return_team: Team id of the punt-returning side.
-  punt_team: Team id punting the ball (the kicking team).
-  punt_wp: Win probability of punting, from the bundled punt-outcome distribution.
-  punt_wp_diff: punt_wp minus the recommended option's WP (0 when punting is the recommendation, otherwise <= 0).
-  qb_hurry: Whether ESPN's play text says the quarterback was hurried into the throw ("hurried by ...").
-  qbr_epa: EPA variant used as an input to the QBR calculation.
-  recovery_team: Team id parsed from the play text as recovering the fumble or muff.
-  recovery_team_2: Team id of the second recovery in a multi-recovery scramble, parsed from the play text.
-  rush_direction: Rush direction parsed from ESPN play text ("left", "middle", or "right"); null when the text omits it.
-  rush_epa: EPA credited to the play when it is a rush.
-  rush_weight: Weighting applied to the rush component of the play.
-  sack_epa: EPA credited to the play when it is a sack.
-  sack_player_id2: ESPN athlete id of the second sacker on a split sack (regex fallback for an ESPN sidecar blind spot).
-  sack_team: Team id credited with the sack (the defense).
-  sack_weight: Weighting applied to the sack component of the play.
-  scoringPlay: ESPN flag marking the play as a scoring play.
-  scoringType.abbreviation: ESPN's abbreviation for the scoring type.
-  scoringType.displayName: ESPN's display label for the scoring type.
-  scoringType.name: ESPN's name for the scoring type (e.g. touchdown, field goal).
-  scrimmage_play: True when the play is a play from scrimmage rather than a special-teams or administrative row.
-  seasonType: ESPN season type for the game (2 = regular season, 3 = postseason).
-  second_level_yards: Rushing yards earned from 4 to 8, split evenly between line and carrier under the line-yards decomposition.
-  short_rush_attempt: True when the play is a rush in a short-yardage situation.
-  short_rush_success: True when a short-yardage rush gained the yardage needed.
-  standard_down: True when the offense is on schedule for the series -- first down, second down needing fewer than 8, or third/fourth
-    down needing fewer than 5.
-  start.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the start of the play.
-  start.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the start of the play.
-  start.ExpScoreDiff_Time_Ratio_touchback: ESPN's `ExpScoreDiff_Time_Ratio_touchback` value for the play state at the start
-    of the play.
-  start.ExpScoreDiff_touchback: ESPN's `ExpScoreDiff_touchback` value for the play state at the start of the play.
-  start.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the start of the play.
-  start.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the start of the play.
-  start.awayScore: ESPN's `awayScore` value for the play state at the start of the play.
-  start.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the start of the play.
-  start.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the start of the play.
-  start.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the start of the play.
-  start.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the start of the play.
-  start.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the start of the play.
-  start.distance: ESPN's `distance` value for the play state at the start of the play.
-  start.down: ESPN's `down` value for the play state at the start of the play.
-  start.downDistanceText: ESPN's `downDistanceText` value for the play state at the start of the play.
-  start.elapsed_share: ESPN's `elapsed_share` value for the play state at the start of the play.
-  start.homeScore: ESPN's `homeScore` value for the play state at the start of the play.
-  start.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the start of the play.
-  start.is_home: ESPN's `is_home` value for the play state at the start of the play.
-  start.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the start of the play.
-  start.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the start of the play.
-  start.pos_team.id: ESPN's `pos_team.id` value for the play state at the start of the play.
-  start.pos_team.name: ESPN's `pos_team.name` value for the play state at the start of the play.
-  start.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the start of the play.
-  start.pos_team_score: ESPN's `pos_team_score` value for the play state at the start of the play.
-  start.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the start of the play.
-  start.possessionText: ESPN's `possessionText` value for the play state at the start of the play.
-  start.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the start of the play.
-  start.spread_time: ESPN's `spread_time` value for the play state at the start of the play.
-  start.team.id: ESPN's `team.id` value for the play state at the start of the play.
-  start.yard: ESPN's `yard` value for the play state at the start of the play.
-  start.yardLine: ESPN's `yardLine` value for the play state at the start of the play.
-  start.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the start of the play.
-  start.yardsToEndzone.touchback: ESPN's `yardsToEndzone.touchback` value for the play state at the start of the play.
-  statYardage: Yardage ESPN credits to the play for statistical purposes.
-  stopped_run: True when the rush was stopped at or behind the line of scrimmage.
-  td_check: Internal flag used while reconciling whether the play produced a touchdown.
-  teamParticipants: Raw ESPN team-level participants payload carried through from the plays feed (stringified).
-  text_dupe: True when the play description duplicates the previous row's text.
-  turnover_team: Team id charged with the giveaway on the play.
-  two_pt_recommendation: 'Point-after recommendation: "go_for_2" when two_pt_wp exceeds xp_wp, otherwise "kick_xp".'
-  two_pt_wp: 'Win probability of going for two: conversion-probability-weighted mean of the 2-point and 0-point outcomes (cfb4th
-    port).'
-  two_pt_wp_diff: two_pt_wp minus xp_wp; positive favors going for two.
-  type.abbreviation: ESPN's abbreviation for the play type.
-  type.id: ESPN's numeric identifier for the play type.
-  type.text: ESPN's text label for the play type.
-  under_2: Whether the play began with two minutes or less remaining in the half.
-  wp_after_naive: End-of-play possession-team win probability from the naive model, after the game-logic adjustment chain.
-  wp_before_naive: Pre-snap possession-team win probability from the spread-free (naive) WP model.
-  wp_fail: Mean win probability given the fourth-down attempt fails.
-  wp_succeed: Mean win probability across yardage outcomes given the fourth-down attempt converts.
-  wp_touchback: Win probability the offense would have had starting from a touchback.
-  wp_touchback_naive: Naive-model win probability for the kickoff-touchback substitute state, used as the pre-snap WP on kickoffs.
-  wpa_naive: Win probability added on the play under the spread-free (naive) model.
-  xp_wp: Win probability of kicking the extra point, weighting the make by the empirical CFB extra-point make rate.
 load_cfb_pbp_r:
   away_team_pregame_elo: Away team's pregame Elo rating, carried on the cfbfastR-shaped schema.
   home_team_pregame_elo: Home team's pregame Elo rating, carried on the cfbfastR-shaped schema.
@@ -6816,63 +6427,6 @@ load_cfb_play_participants:
   tackler_player_name: Display name of a defender credited with the tackle -- the FIRST participant in that role on the play.
   tackler_player_names: List of the display names of EVERY participant credited as a defender credited with the tackle on
     the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-load_cfb_player_box:
-  adjQBR: Adjusted Total QBR for the quarterback.
-  completions/passingAttempts: Completions and pass attempts, as ESPN's combined string.
-  defensiveTouchdowns: Touchdowns the player scored on defense (ESPN box score).
-  extraPointsMade/extraPointAttempts: Extra points made and attempted, as ESPN's combined string.
-  fieldGoalPct: Field-goal percentage.
-  fieldGoalsMade/fieldGoalAttempts: Field goals made and attempted, as ESPN's combined string.
-  fumbles: Number of times the player fumbled in the game (ESPN box score).
-  fumblesLost: Number of the player's fumbles lost to the opponent (ESPN box score).
-  fumblesRecovered: Number of fumbles the player recovered (ESPN box score).
-  grossAvgPuntYards: Gross average yards per punt, before return yardage.
-  hurries: Quarterback hurries credited to the player (ESPN box score).
-  interceptionTouchdowns: Touchdowns scored on interception returns.
-  interceptionYards: Yards returned on interceptions.
-  kickReturnTouchdowns: Kickoff returns the player took for touchdowns (ESPN box score).
-  kickReturnYards: Total kickoff-return yards by the player (ESPN box score).
-  kickReturns: Number of kickoff returns by the player (ESPN box score).
-  longFieldGoalMade: Longest field goal made, in yards.
-  longKickReturn: Player's longest kickoff return of the game, in yards (ESPN box score).
-  longPunt: Longest punt of the game, in yards.
-  longPuntReturn: Longest punt return of the game, in yards.
-  longReception: Longest reception of the game, in yards.
-  longRushing: Longest rush of the game, in yards.
-  passesDefended: Passes the player broke up or defended (ESPN box score).
-  passingTouchdowns: Passing touchdowns.
-  passingYards: Net passing yards gained.
-  puntReturnTouchdowns: Touchdowns scored on punt returns.
-  puntReturnYards: Yards gained on punt returns.
-  puntReturns: Punt returns attempted.
-  puntYards: Total punt yards.
-  punts: Punts attempted.
-  puntsInside20: Punts downed inside the opponent 20-yard line.
-  receivingTouchdowns: Receiving touchdowns.
-  receivingYards: Receiving yards gained.
-  rushingAttempts: Rushing attempts.
-  rushingTouchdowns: Rushing touchdowns.
-  rushingYards: Net rushing yards gained.
-  soloTackles: Player's solo (unassisted) tackles (ESPN box score).
-  stat_1: First value of ESPN's raw athlete stats array, written only when the category's key list does not line up with the
-    stats list; on those rows the named per-category columns are all null.
-  stat_2: Second value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
-    the named columns could not be filled.
-  stat_3: Third value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
-    the named columns could not be filled.
-  stat_4: Fourth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
-    the named columns could not be filled.
-  stat_5: Fifth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
-    the named columns could not be filled.
-  tacklesForLoss: Player's tackles made behind the line of scrimmage (ESPN box score).
-  totalKickingPoints: Total points scored by kicking.
-  totalTackles: Player's total tackles, solo plus assisted (ESPN box score).
-  touchbacks: Punts or kickoffs that resulted in a touchback.
-  yardsPerKickReturn: Average yards per kickoff return for the player (ESPN box score).
-  yardsPerPassAttempt: Yards gained per pass attempt.
-  yardsPerPuntReturn: Yards gained per punt return.
-  yardsPerReception: Yards gained per reception.
-  yardsPerRushAttempt: Yards gained per rushing attempt.
 load_cfb_recruits:
   team_id_247: 247Sports' own team key for the recruit's committed or signed school; not interchangeable with the ESPN/CFBD
     team id.
@@ -6881,24 +6435,6 @@ load_cfb_returning_production:
   n_returning: Number of returning players counted in the returning-production calculation.
   off_returning: Share of the team's prior-season offensive production returning for the season.
   overall_returning: Usage-weighted blend of the offensive and defensive returning-production shares.
-load_cfb_team_info:
-  logo_2: URL of the team's alternate dark-background 500-pixel logo on ESPN's CDN, null for programs with no dark variant.
-  logos_10: URL of the team's logo variant in slot 10 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  logos_11: URL of the team's logo variant in slot 11 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  logos_12: URL of the team's logo variant in slot 12 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  logos_13: URL of the team's logo variant in slot 13 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  logos_14: URL of the team's logo variant in slot 14 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  logos_15: URL of the team's logo variant in slot 15 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  logos_16: URL of the team's logo variant in slot 16 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  logos_3: URL of the team's logo variant in slot 3 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  logos_4: URL of the team's logo variant in slot 4 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  logos_5: URL of the team's logo variant in slot 5 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  logos_6: URL of the team's logo variant in slot 6 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  logos_7: URL of the team's logo variant in slot 7 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  logos_8: URL of the team's logo variant in slot 8 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  logos_9: URL of the team's logo variant in slot 9 of ESPN's team-info logo list; null when the team publishes fewer variants.
-  twitter: The football program's Twitter/X handle including the leading at sign, populated for only a minority of listed
-    teams.
 load_cfb_team_talent:
   blue_chip_ratio: Share of the team's counted signees rated four or five stars over the rolling class window.
   n_recruits: Number of signees counted in the blue-chip-ratio window.
@@ -7725,33 +7261,6 @@ load_ncaa_mbb_lineups:
   tp_ast: Assisted three-point makes by the lineup during the stint.
   tpa: Three-pointers attempted by the lineup during the stint.
   tpm: Three-pointers made by the lineup during the stint.
-load_ncaa_mbb_matchup_stints:
-  away_1: Name of the away team's on-floor player in lineup slot 1 for the stint.
-  away_2: Name of the away team's on-floor player in lineup slot 2 for the stint.
-  away_3: Name of the away team's on-floor player in lineup slot 3 for the stint.
-  away_4: Name of the away team's on-floor player in lineup slot 4 for the stint.
-  away_5: Name of the away team's on-floor player in lineup slot 5 for the stint.
-  away_lineup: Delimited names of the away five on the floor during the stint.
-  away_lineup_key: Sorted player-code key for the away five on the floor.
-  away_pts: Points scored by the away team during the stint.
-  end_away_score: Away team score when the stint ended.
-  end_home_score: Home team score when the stint ended.
-  end_seconds: Elapsed game seconds at which the stint ended.
-  game_stint_num: Sequential stint number within the game, incremented at every substitution by either team.
-  home_1: Name of the home team's on-floor player in lineup slot 1 for the stint.
-  home_2: Name of the home team's on-floor player in lineup slot 2 for the stint.
-  home_3: Name of the home team's on-floor player in lineup slot 3 for the stint.
-  home_4: Name of the home team's on-floor player in lineup slot 4 for the stint.
-  home_5: Name of the home team's on-floor player in lineup slot 5 for the stint.
-  home_lineup: Delimited names of the home five on the floor during the stint.
-  home_lineup_key: Sorted player-code key for the home five on the floor.
-  home_pts: Points scored by the home team during the stint.
-  matchup_key: Combined home-plus-away lineup key identifying the ten-player matchup on the floor.
-  n_events: Number of play-by-play events falling within the stint.
-  n_possessions: Number of possessions falling within the stint.
-  start_away_score: Away team score when the stint began.
-  start_home_score: Home team score when the stint began.
-  start_seconds: Elapsed game seconds at which the stint began.
 load_ncaa_mbb_pbp:
   assist_player: Name of the player credited with the assist on a made shot, when present.
   away_1: Name of the away team's on-floor player in lineup slot 1 for the event, from the substitution walk-forward.
@@ -7838,17 +7347,17 @@ load_ncaa_mbb_player_box:
   efg_pct: Effective field-goal percentage, weighting made threes at 1.5.
   efg_pct_half: Effective field-goal percentage in halfcourt possessions.
   efg_pct_trans: Effective field-goal percentage in transition possessions.
-  efg_pct_unast: Effective field-goal percentage in the unassisted split (makes not credited with an assist).
+  efg_pct_unast: Effective field-goal percentage in the unassisted split (makes for which no assist was credited).
   fg_pct_half: Field-goal percentage in halfcourt possessions.
   fg_pct_trans: Field-goal percentage in transition possessions.
-  fg_pct_unast: Field-goal percentage in the unassisted split (makes not credited with an assist).
+  fg_pct_unast: Field-goal percentage in the unassisted split (makes for which no assist was credited).
   fga_half: Field goals attempted in halfcourt possessions.
   fga_trans: Field goals attempted in transition possessions.
-  fga_unast: Field goals attempted in the unassisted split (makes not credited with an assist).
+  fga_unast: Field goals attempted in the unassisted split (makes for which no assist was credited).
   fgm_ast: Assisted field-goal makes.
   fgm_half: Field goals made in halfcourt possessions.
   fgm_trans: Field goals made in transition possessions.
-  fgm_unast: Field goals made in the unassisted split (makes not credited with an assist).
+  fgm_unast: Field goals made in the unassisted split (makes for which no assist was credited).
   ft_pct_half: Free-throw percentage in halfcourt possessions.
   ft_pct_trans: Free-throw percentage in transition possessions.
   fta_half: Free throws attempted in halfcourt possessions.
@@ -7859,16 +7368,16 @@ load_ncaa_mbb_player_box:
   mid_pct: Field-goal percentage on mid-range attempts.
   mid_pct_half: Mid-range field-goal percentage in halfcourt possessions.
   mid_pct_trans: Mid-range field-goal percentage in transition possessions.
-  mid_pct_unast: Mid-range field-goal percentage in the unassisted split (makes not credited with an assist).
+  mid_pct_unast: Mid-range field-goal percentage in the unassisted split (makes for which no assist was credited).
   mida: Mid-range (non-rim two-point) shots attempted.
   mida_half: Mid-range shots attempted in halfcourt possessions.
   mida_trans: Mid-range shots attempted in transition possessions.
-  mida_unast: Mid-range shots attempted in the unassisted split (makes not credited with an assist).
+  mida_unast: Mid-range shots attempted in the unassisted split (makes for which no assist was credited).
   midm: Mid-range (non-rim two-point) shots made.
   midm_ast: Assisted mid-range makes.
   midm_half: Mid-range shots made in halfcourt possessions.
   midm_trans: Mid-range shots made in transition possessions.
-  midm_unast: Mid-range shots made in the unassisted split (makes not credited with an assist).
+  midm_unast: Mid-range shots made in the unassisted split (makes for which no assist was credited).
   mins: Minutes played, derived from the lineup walk-forward through the play-by-play.
   o_poss: Offensive possessions the player was on the floor for.
   orb: Offensive rebounds.
@@ -7893,16 +7402,16 @@ load_ncaa_mbb_player_box:
   rim_pct: Field-goal percentage on rim attempts.
   rim_pct_half: Rim field-goal percentage in halfcourt possessions.
   rim_pct_trans: Rim field-goal percentage in transition possessions.
-  rim_pct_unast: Rim field-goal percentage in the unassisted split (makes not credited with an assist).
+  rim_pct_unast: Rim field-goal percentage in the unassisted split (makes for which no assist was credited).
   rima: Rim shots (dunks, layups, hooks, tip-ins) attempted.
   rima_half: Rim shots attempted in halfcourt possessions.
   rima_trans: Rim shots attempted in transition possessions.
-  rima_unast: Rim shots attempted in the unassisted split (makes not credited with an assist).
+  rima_unast: Rim shots attempted in the unassisted split (makes for which no assist was credited).
   rimm: Rim shots (dunks, layups, hooks, tip-ins) made.
   rimm_ast: Assisted rim makes.
   rimm_half: Rim shots made in halfcourt possessions.
   rimm_trans: Rim shots made in transition possessions.
-  rimm_unast: Rim shots made in the unassisted split (makes not credited with an assist).
+  rimm_unast: Rim shots made in the unassisted split (makes for which no assist was credited).
   stl_half: Steals in halfcourt possessions.
   stl_trans: Steals in transition possessions.
   team_espn_team_id: ESPN team identifier of the player's team, via the NCAA-to-ESPN crosswalk.
@@ -7912,16 +7421,16 @@ load_ncaa_mbb_player_box:
   tp_pct: Three-point field-goal percentage.
   tp_pct_half: Three-point percentage in halfcourt possessions.
   tp_pct_trans: Three-point percentage in transition possessions.
-  tp_pct_unast: Three-point percentage in the unassisted split (makes not credited with an assist).
+  tp_pct_unast: Three-point percentage in the unassisted split (makes for which no assist was credited).
   tpa: Three-point field goals attempted.
   tpa_half: Three-pointers attempted in halfcourt possessions.
   tpa_trans: Three-pointers attempted in transition possessions.
-  tpa_unast: Three-pointers attempted in the unassisted split (makes not credited with an assist).
+  tpa_unast: Three-pointers attempted in the unassisted split (makes for which no assist was credited).
   tpm: Three-point field goals made.
   tpm_ast: Assisted three-point makes.
   tpm_half: Three-pointers made in halfcourt possessions.
   tpm_trans: Three-pointers made in transition possessions.
-  tpm_unast: Three-pointers made in the unassisted split (makes not credited with an assist).
+  tpm_unast: Three-pointers made in the unassisted split (makes for which no assist was credited).
   ts_pct_half: True-shooting percentage in halfcourt possessions.
   ts_pct_trans: True-shooting percentage in transition possessions.
 load_ncaa_mbb_possessions:
@@ -8112,33 +7621,6 @@ load_ncaa_wbb_lineups:
   tp_ast: Assisted three-point makes by the lineup during the stint.
   tpa: Three-pointers attempted by the lineup during the stint.
   tpm: Three-pointers made by the lineup during the stint.
-load_ncaa_wbb_matchup_stints:
-  away_1: Name of the away team's on-floor player in lineup slot 1 for the stint.
-  away_2: Name of the away team's on-floor player in lineup slot 2 for the stint.
-  away_3: Name of the away team's on-floor player in lineup slot 3 for the stint.
-  away_4: Name of the away team's on-floor player in lineup slot 4 for the stint.
-  away_5: Name of the away team's on-floor player in lineup slot 5 for the stint.
-  away_lineup: Delimited names of the away five on the floor during the stint.
-  away_lineup_key: Sorted player-code key for the away five on the floor.
-  away_pts: Points scored by the away team during the stint.
-  end_away_score: Away team score when the stint ended.
-  end_home_score: Home team score when the stint ended.
-  end_seconds: Elapsed game seconds at which the stint ended.
-  game_stint_num: Sequential stint number within the game, incremented at every substitution by either team.
-  home_1: Name of the home team's on-floor player in lineup slot 1 for the stint.
-  home_2: Name of the home team's on-floor player in lineup slot 2 for the stint.
-  home_3: Name of the home team's on-floor player in lineup slot 3 for the stint.
-  home_4: Name of the home team's on-floor player in lineup slot 4 for the stint.
-  home_5: Name of the home team's on-floor player in lineup slot 5 for the stint.
-  home_lineup: Delimited names of the home five on the floor during the stint.
-  home_lineup_key: Sorted player-code key for the home five on the floor.
-  home_pts: Points scored by the home team during the stint.
-  matchup_key: Combined home-plus-away lineup key identifying the ten-player matchup on the floor.
-  n_events: Number of play-by-play events falling within the stint.
-  n_possessions: Number of possessions falling within the stint.
-  start_away_score: Away team score when the stint began.
-  start_home_score: Home team score when the stint began.
-  start_seconds: Elapsed game seconds at which the stint began.
 load_ncaa_wbb_pbp:
   assist_player: Name of the player credited with the assist on a made shot, when present.
   away_1: Name of the away team's on-floor player in lineup slot 1 for the event, from the substitution walk-forward.
@@ -8225,17 +7707,17 @@ load_ncaa_wbb_player_box:
   efg_pct: Effective field-goal percentage, weighting made threes at 1.5.
   efg_pct_half: Effective field-goal percentage in halfcourt possessions.
   efg_pct_trans: Effective field-goal percentage in transition possessions.
-  efg_pct_unast: Effective field-goal percentage in the unassisted split (makes not credited with an assist).
+  efg_pct_unast: Effective field-goal percentage in the unassisted split (makes for which no assist was credited).
   fg_pct_half: Field-goal percentage in halfcourt possessions.
   fg_pct_trans: Field-goal percentage in transition possessions.
-  fg_pct_unast: Field-goal percentage in the unassisted split (makes not credited with an assist).
+  fg_pct_unast: Field-goal percentage in the unassisted split (makes for which no assist was credited).
   fga_half: Field goals attempted in halfcourt possessions.
   fga_trans: Field goals attempted in transition possessions.
-  fga_unast: Field goals attempted in the unassisted split (makes not credited with an assist).
+  fga_unast: Field goals attempted in the unassisted split (makes for which no assist was credited).
   fgm_ast: Assisted field-goal makes.
   fgm_half: Field goals made in halfcourt possessions.
   fgm_trans: Field goals made in transition possessions.
-  fgm_unast: Field goals made in the unassisted split (makes not credited with an assist).
+  fgm_unast: Field goals made in the unassisted split (makes for which no assist was credited).
   ft_pct_half: Free-throw percentage in halfcourt possessions.
   ft_pct_trans: Free-throw percentage in transition possessions.
   fta_half: Free throws attempted in halfcourt possessions.
@@ -8246,16 +7728,16 @@ load_ncaa_wbb_player_box:
   mid_pct: Field-goal percentage on mid-range attempts.
   mid_pct_half: Mid-range field-goal percentage in halfcourt possessions.
   mid_pct_trans: Mid-range field-goal percentage in transition possessions.
-  mid_pct_unast: Mid-range field-goal percentage in the unassisted split (makes not credited with an assist).
+  mid_pct_unast: Mid-range field-goal percentage in the unassisted split (makes for which no assist was credited).
   mida: Mid-range (non-rim two-point) shots attempted.
   mida_half: Mid-range shots attempted in halfcourt possessions.
   mida_trans: Mid-range shots attempted in transition possessions.
-  mida_unast: Mid-range shots attempted in the unassisted split (makes not credited with an assist).
+  mida_unast: Mid-range shots attempted in the unassisted split (makes for which no assist was credited).
   midm: Mid-range (non-rim two-point) shots made.
   midm_ast: Assisted mid-range makes.
   midm_half: Mid-range shots made in halfcourt possessions.
   midm_trans: Mid-range shots made in transition possessions.
-  midm_unast: Mid-range shots made in the unassisted split (makes not credited with an assist).
+  midm_unast: Mid-range shots made in the unassisted split (makes for which no assist was credited).
   mins: Minutes played, derived from the lineup walk-forward through the play-by-play.
   o_poss: Offensive possessions the player was on the floor for.
   orb: Offensive rebounds.
@@ -8280,16 +7762,16 @@ load_ncaa_wbb_player_box:
   rim_pct: Field-goal percentage on rim attempts.
   rim_pct_half: Rim field-goal percentage in halfcourt possessions.
   rim_pct_trans: Rim field-goal percentage in transition possessions.
-  rim_pct_unast: Rim field-goal percentage in the unassisted split (makes not credited with an assist).
+  rim_pct_unast: Rim field-goal percentage in the unassisted split (makes for which no assist was credited).
   rima: Rim shots (dunks, layups, hooks, tip-ins) attempted.
   rima_half: Rim shots attempted in halfcourt possessions.
   rima_trans: Rim shots attempted in transition possessions.
-  rima_unast: Rim shots attempted in the unassisted split (makes not credited with an assist).
+  rima_unast: Rim shots attempted in the unassisted split (makes for which no assist was credited).
   rimm: Rim shots (dunks, layups, hooks, tip-ins) made.
   rimm_ast: Assisted rim makes.
   rimm_half: Rim shots made in halfcourt possessions.
   rimm_trans: Rim shots made in transition possessions.
-  rimm_unast: Rim shots made in the unassisted split (makes not credited with an assist).
+  rimm_unast: Rim shots made in the unassisted split (makes for which no assist was credited).
   stl_half: Steals in halfcourt possessions.
   stl_trans: Steals in transition possessions.
   team_espn_team_id: ESPN team identifier of the player's team, via the NCAA-to-ESPN crosswalk.
@@ -8299,16 +7781,16 @@ load_ncaa_wbb_player_box:
   tp_pct: Three-point field-goal percentage.
   tp_pct_half: Three-point percentage in halfcourt possessions.
   tp_pct_trans: Three-point percentage in transition possessions.
-  tp_pct_unast: Three-point percentage in the unassisted split (makes not credited with an assist).
+  tp_pct_unast: Three-point percentage in the unassisted split (makes for which no assist was credited).
   tpa: Three-point field goals attempted.
   tpa_half: Three-pointers attempted in halfcourt possessions.
   tpa_trans: Three-pointers attempted in transition possessions.
-  tpa_unast: Three-pointers attempted in the unassisted split (makes not credited with an assist).
+  tpa_unast: Three-pointers attempted in the unassisted split (makes for which no assist was credited).
   tpm: Three-point field goals made.
   tpm_ast: Assisted three-point makes.
   tpm_half: Three-pointers made in halfcourt possessions.
   tpm_trans: Three-pointers made in transition possessions.
-  tpm_unast: Three-pointers made in the unassisted split (makes not credited with an assist).
+  tpm_unast: Three-pointers made in the unassisted split (makes for which no assist was credited).
   ts_pct_half: True-shooting percentage in halfcourt possessions.
   ts_pct_trans: True-shooting percentage in transition possessions.
 load_ncaa_wbb_possessions:
@@ -8546,10 +8028,6 @@ load_nhl_shootout:
     -- so treat it as an alternate spelling, not a canonical one.
   teamAbbrev.default: Three-letter code of the shooting player's team; null on the per-game summary row that instead carries
     the home and away shootout goal totals.
-load_pwhl_pbp:
-  skaters_away: Number of away skaters on the ice for the event, derived from HockeyTech shift data.
-  skaters_home: Number of home skaters on the ice for the event, derived from HockeyTech shift data.
-  strength_state_valid: Flag that the shift-derived strength state reconciles cleanly and can be trusted for this event.
 load_wbb_pbp:
   athlete_name_1: Display name of the first athlete in the ESPN play participants (e.g., the shooter on a shot attempt).
   athlete_name_2: Display name of the second athlete in the ESPN play participants (e.g., the assisting player), when present.
@@ -8712,13 +8190,6 @@ nil_100:
 nil_100_v2:
   person: Nested On3 person object for the ranked athlete (stringified).
   valuation: Athlete's On3 NIL valuation in dollars.
-nil_compliances_state:
-  current_rules: Text of the state's current NIL rules, as tracked by On3.
-  governing_rule_label: Name of the governing body or rule for NIL in the state.
-  governing_rule_url: URL of the governing NIL rule or policy document.
-  key: On3 RDB key for the state NIL-compliance record.
-  monetization_allowed: Whether the state allows high-school athletes to monetize their NIL.
-  state_key: On3 key of the U.S. state the compliance record covers.
 nil_rankings:
   person: Nested On3 person object for the ranked athlete (stringified).
   valuation: Athlete's On3 NIL valuation in dollars.
@@ -8750,23 +8221,6 @@ offense_summary:
 organizations_draft_ranking_summary:
   span_summary: Nested summary of the organization's draft ranking over the multi-year span (stringified).
   year_summary: Nested summary of the organization's draft ranking for the single year (stringified).
-organizations_drafted_players:
-  college_organization: Nested On3 organization object for the college the player attended (stringified).
-  compensatory: Whether the selection was a compensatory draft pick.
-  drafted_from_organization: Nested On3 organization object for the school the player was drafted out of (stringified).
-  forfeited: Whether the pick was forfeited.
-  high_school_organization: Nested On3 organization object for the player's high school (stringified).
-  key: On3 RDB key for the draft-pick record.
-  person: Nested On3 person object for the drafted player (stringified).
-  recruitment_key: On3 RDB recruitment key linking the draft pick back to the player's recruitment record.
-  supplementary: Whether the selection came in a supplemental draft.
-  through_organization_one: First intermediate organization the pick passed through in trades before being exercised (On3
-    RDB).
-  through_organization_three: Third intermediate organization the pick passed through in trades before being exercised (On3
-    RDB).
-  through_organization_two: Second intermediate organization the pick passed through in trades before being exercised (On3
-    RDB).
-  trading_organization: Pro organization that traded the pick away, when it changed hands (On3 RDB).
 organizations_drafts_by_stars_summary:
   draft_rank: Organization's national rank by draft production.
   five_star_summary: Nested draft summary for the organization's five-star recruits (stringified).
@@ -11527,11 +10981,6 @@ people_track_and_field_measurements:
   top_average_change_percent: Percent difference between the athlete's value and the Top300 average.
   verified: Whether On3 verified the measurement.
   verified_by_user_key: On3 user key of the staffer who verified the measurement.
-people_valuation_growth:
-  date_unix: Unix timestamp of the valuation snapshot.
-  nil_status: Status of the athlete's On3 NIL valuation at the snapshot (e.g. active, inactive).
-  valuation: Athlete's On3 NIL valuation in dollars at the snapshot.
-  valuation_change: Change in the NIL valuation versus the previous snapshot, in dollars.
 person_connections_connection_key:
   connected_person_key: On3 person key of the connected person.
   connected_person_sport: Nested athlete-sport profile of the connected person (stringified).
@@ -11716,13 +11165,6 @@ player_verified:
   sports: Sports the player is profiled in, as a stringified list.
   tier: On3 profile tier classification for the player.
   visibility: Profile visibility setting on On3.
-player_videos:
-  is_featured: Whether the video is featured on the player's On3 profile.
-  key: On3 RDB key for the video record.
-  person_key: On3 person key of the featured athlete.
-  person_sport: Nested athlete-sport profile the video is attached to (stringified).
-  source_url: Source URL of the hosted video.
-  thumbnail: URL of the video's thumbnail image.
 player_visit_center:
   sport: Nested On3 sport object for the visit-center entry (stringified).
   total_visits: Total number of school visits logged for the recruit.
@@ -13156,11 +12598,6 @@ sports247_site_pages_draft_pick:
   pro_team_name: Name of the professional team that made the pick.
   round: Draft round number (1-based) the pick belongs to.
   traded_from_team: Team the pick was traded from, when it changed hands.
-sports247_site_pages_event:
-  default_asset: Nested 247Sports image asset for the event (stringified).
-  default_name: Server-rendered display label for the entity.
-  event_group: Grouping or series the event belongs to (e.g. a camp circuit) on 247Sports.
-  key: Primary key of this entity (the id used in its `.json` route).
 sports247_site_pages_feed:
   main_text: Body text of the feed item.
   redirection_url: URL the feed item links out to.
@@ -13181,13 +12618,6 @@ sports247_site_pages_institution:
   state: FK -> State entity.
   telephone: Institution's telephone number.
   type: Institution type code (college / pro / high school).
-sports247_site_pages_location:
-  city_tax_rate: City income-tax rate for the location, carried on the 247Sports location record.
-  county_tax_rate: County income-tax rate for the location, carried on the 247Sports location record.
-  default_name: Server-rendered display label for the entity.
-  key: Primary key of this entity (the id used in its `.json` route).
-  region_name: Name of the region (state/province) for the location.
-  special_tax_rate: Special-district tax rate for the location, carried on the 247Sports location record.
 sports247_site_pages_player:
   bio: Player biography text authored on 247Sports.
   bio_or_default: Player bio text, falling back to a default blurb when none is authored.
@@ -13217,28 +12647,6 @@ sports247_site_pages_player:
   state_rank: Rank within home state for the class.
   twitter_contact: Player's Twitter/X handle on the 247Sports profile.
   user: 247Sports user account linked to the player profile (nested, stringified).
-sports247_site_pages_player_institution:
-  created_date: Date the player-institution record was created.
-  default_asset: Nested 247Sports image asset for the stint (stringified).
-  default_name: Server-rendered display label for the entity.
-  early_enrollee: Whether the player enrolled early at the institution.
-  early_signee: Whether the player signed in the early signing period.
-  end_year_or_current: Stint's end year, or the current year for an active stint.
-  end_year_or_expected: Stint's end year, or the expected end year for an active stint.
-  hero_asset: Nested 247Sports hero (banner) image asset for the stint (stringified).
-  institution: Nested 247Sports institution for the stint (stringified).
-  key: Primary key of this entity (the id used in its `.json` route).
-  lead_expert: 247Sports expert assigned as the lead on the recruitment (nested, stringified).
-  modified_date: Date the player-institution record was last modified.
-  next_institution_group: Grouping (e.g. conference/division) of the player's next institution, per 247Sports.
-  next_institution_type: Level of the player's next institution (e.g. college, professional), per 247Sports.
-  player_institution_evaluation: Nested 247Sports evaluation attached to this player-institution stint (stringified).
-  primary_player_sport: Nested 247Sports player-sport profile the stint belongs to (stringified).
-  primary_recruitment: Nested 247Sports record for the recruitment behind the stint (stringified).
-  start_year_or_expected: Stint's start year, or the expected start year for a future stint.
-  transfer_eligibility: Player's eligibility status for the transfer, per 247Sports.
-  transfer_institution: Nested institution involved in the player's transfer, for transfer-portal stints (stringified).
-  transfer_season: Season of the player's transfer, when applicable.
 sports247_site_pages_player_institution_evaluation:
   comparison_player: Established player the evaluator compares the prospect to.
   default_name: Server-rendered display label for the entity.
@@ -13263,114 +12671,6 @@ sports247_site_pages_player_institution_prediction:
   score: Expert accuracy score at time of prediction.
   updated_on: Date the prediction was last updated.
   user: 247Sports user account of the predictor (nested, stringified).
-sports247_site_pages_player_sport:
-  average_rank: Player's average rank across the tracked industry services.
-  class_year: Recruiting class year.
-  class_year_override: Override of the player's recruiting class year, when 247Sports reassigns it.
-  composite_rating: 247Sports Composite rating (industry blend).
-  composite_rating_or_default: 247Sports Composite rating, falling back to a default value when unrated.
-  composite_strength: Composite strength points (team-ranking weight).
-  current_player_sport_ranking: Nested current published ranking row for the player (stringified).
-  current_player_sport_year: Current ranking-cycle year for the player-sport profile.
-  default_name: Server-rendered display label for the entity.
-  espn_grade: ESPN source grade (industry composite input).
-  espn_index: ESPN index value for the player, as tracked by 247Sports.
-  espn_rank: Player's rank in the ESPN industry ranking, as tracked by 247Sports.
-  key: Primary key of this entity (the id used in its `.json` route).
-  local_index: 247Sports' own industry-index value for the player, alongside the Rivals and ESPN indexes.
-  player_institution: Nested player-institution stint the player-sport profile points to (stringified).
-  previous_recruitment: Nested record for the player's previous recruitment (stringified).
-  primary: Whether this is the player's primary sport.
-  primary_institution_prediction: Nested leading Crystal Ball institution prediction for the player (stringified).
-  primary_institution_prediction_percentage: Share of Crystal Ball predictions favoring the leading institution.
-  primary_player_position: Nested 247Sports record for the player's primary position (stringified).
-  primary_position: Player's primary position on the 247Sports profile.
-  primary_position_group: Position group the player's primary position belongs to.
-  rating: 247Sports rating string (0-1).
-  rating_or_default: 247Sports in-house rating, falling back to a default value when unrated.
-  recruitment: FK -> Recruitment aggregate for this player-sport.
-  rivals_grade: Rivals source grade (industry composite input).
-  rivals_index: Rivals index value for the player, as tracked by 247Sports.
-  rivals_rank: Player's rank in the Rivals industry ranking, as tracked by 247Sports.
-  secondary_institution_prediction: Nested second-place Crystal Ball institution prediction (stringified).
-  secondary_institution_prediction_percentage: Share of Crystal Ball predictions favoring the second-place institution.
-  show_unranked_rating: 247Sports display flag to show the rating even while the player is unranked.
-  sport: Nested 247Sports sport for the profile (stringified).
-  star_rating: Star tier (2-5).
-  unpublished_player_sport_ranking: Nested not-yet-published ranking row for the player (stringified).
-sports247_site_pages_player_sport_ranking:
-  committed_institution: FK -> committed Institution (null if uncommitted).
-  composite_group_rank: Player's rank within their position group by Composite rating.
-  composite_overall_rank: Player's national rank by 247Sports Composite rating.
-  composite_position_rank: Player's rank at their position by Composite rating.
-  composite_rating: Player's 247Sports Composite rating, blending the major services' ratings.
-  composite_state_rank: Player's rank within their home state by Composite rating.
-  composite_strength: 247Sports field describing the strength of the industry inputs behind the Composite rating.
-  default_name: Server-rendered display label for the entity.
-  institution: Nested institution the player was committed or signed to at ranking time (stringified).
-  institution_group: Grouping (e.g. conference/division) of the player's institution, per 247Sports.
-  key: Primary key of this entity (the id used in its `.json` route).
-  overall_rank: Overall national rank in the snapshot.
-  platoon: 247Sports platoon (side-of-ball grouping) identifier on the ranking row.
-  player_sport: Nested player-sport profile the ranking row belongs to (stringified).
-  position_group_rank: Player's rank within their position group in the 247Sports ranking.
-  position_rank: Rank within position.
-  previous_player_sport_ranking: Nested prior-cycle ranking row for the player (stringified).
-  ranking: FK -> Ranking snapshot.
-  sport: Nested 247Sports sport the ranking row covers (stringified).
-  state_rank: Rank within home state.
-sports247_site_pages_recruit:
-  announcement_date: Date the recruit announced their decision.
-  commited_institution_team_image: Team image asset for the committed institution (the 'commited' spelling is 247Sports' own
-    field name).
-  committed_institution: FK -> committed Institution.
-  committed_recruit_interest: Nested interest record for the school the recruit committed to (stringified).
-  composite_strength: Composite strength points contributed to team ranking.
-  default_name: Server-rendered display label for the entity.
-  final_choice: Whether this entry represents the recruit's final school choice.
-  highest_recruit_interest: Nested interest record carrying the recruit's highest interest signal (stringified).
-  highest_recruit_interest_event: Nested highest-signal event on the recruit's interest timeline (stringified).
-  highest_recruit_interest_event_type: Type of the highest-signal event on the recruit's interest timeline (e.g. commit, signing).
-  institution: Nested institution the recruit row is scoped to (stringified).
-  key: Primary key of this entity (the id used in its `.json` route).
-  player_bio: Player biography text authored on 247Sports.
-  player_bio_or_default: Player bio text, falling back to a default blurb when none is authored.
-  player_birthdate: Player's date of birth, per 247Sports.
-  player_cbs_key: Cross-reference key into the CBS Sports id space.
-  player_college_stat_player: Reference tying the profile to a college stats player record (247Sports field).
-  player_current_player_institution: FK -> PlayerInstitution (current school).
-  player_default_asset: Nested 247Sports image asset for the player's headshot (stringified).
-  player_default_asset_url: URL of the player's headshot image.
-  player_default_name: Server-rendered display label for the entity.
-  player_hero_asset: Nested 247Sports hero (banner) image asset for the player page (stringified).
-  player_hometown_city: City of the player's hometown.
-  player_hometown_state: State of the player's hometown.
-  player_institution: Nested player-institution stint behind the recruit row (stringified).
-  player_key: Primary key of this entity (the id used in its `.json` route).
-  player_last_recruitment_player_institution: Nested player-institution record from the player's most recent recruitment (stringified).
-  player_mobile_phone_contact: Player's mobile phone contact field on the 247Sports record.
-  player_modified_date: Date the player record was last modified.
-  player_modified_user: 247Sports user who last modified the player record.
-  player_national_rank: Overall national rank in the recruit's class.
-  player_player_high_school_name: Name of the player's high school.
-  player_position_rank: Rank within position for the class.
-  player_primary_player_position_abbreviation: Abbreviation of the player's primary position.
-  player_primary_player_sport: FK -> PlayerSport (`/PlayerSport/{id}.json`).
-  player_primary_recruitment: Nested 247Sports record for the player's primary recruitment (stringified).
-  player_pro_stat_player: Reference tying the profile to a professional stats player record (247Sports field).
-  player_quote_asset: Nested 247Sports image asset used alongside the player's quote block (stringified).
-  player_rating: 247Sports numeric rating (0-1 scale) for the primary sport.
-  player_scout_evaluation: 247Sports scouting evaluation text for the player.
-  player_sport: Nested player-sport profile for the recruit (stringified).
-  player_star_rating: Star tier (2-5) derived from the rating.
-  player_state_rank: Rank within home state for the class.
-  player_twitter_contact: Player's Twitter/X handle on the 247Sports profile.
-  player_user: 247Sports user account linked to the player profile (nested, stringified).
-  primary_player_position: Nested 247Sports record for the recruit's primary position (stringified).
-  primary_position: Recruit's primary position on the 247Sports profile.
-  recruit_interest_count: Number of tracked school interests.
-  recruit_interests_url: Site URL to the recruit's interest timeline.
-  signed_institution: Nested institution the recruit signed with (stringified).
 sports247_site_pages_recruit_interest:
   commit_status: Commitment status label (e.g. Committed, Signed).
   decommit: Date the recruit decommitted from the school, when applicable.
@@ -13398,17 +12698,6 @@ sports247_site_pages_recruit_interest:
   signing_date: Date the recruit signed with the school.
   soft_commit: Whether 247Sports marks the commitment as a soft commit.
   walk_on: Whether the recruit would join the program as a walk-on.
-sports247_site_pages_recruit_interest_event:
-  default_name: Server-rendered display label for the entity.
-  institution: Nested 247Sports institution the interest event involves (stringified).
-  key: Primary key of this entity (the id used in its `.json` route).
-  recruit_interest: Nested recruit-interest record the event belongs to (stringified).
-  recruitment: Nested 247Sports recruitment the event belongs to (stringified).
-sports247_site_pages_timeline_event:
-  author_affiliation: Outlet or site the author writes for, per 247Sports.
-  author_first_name: First name of the entry's author.
-  author_last_name: Last name of the entry's author.
-  body: Text body of the timeline entry.
 synergyplaytypes:
   efg_pct: Effective field goal percentage on the play type, as a decimal.
   fgmx: Field goals missed on the play type.
@@ -13905,13 +13194,6 @@ transfers_latest:
   recruitment_key: On3 recruitment key of the player's transfer recruitment.
   roster_rating: Nested On3 roster rating object for the player (stringified).
   sport: Nested On3 sport object for the transfer entry (stringified).
-videos_video_key:
-  is_featured: Whether the video is featured on the player's On3 profile.
-  key: On3 RDB key for the video record.
-  person_key: On3 person key of the featured athlete.
-  person_sport: Nested athlete-sport profile the video is attached to (stringified).
-  source_url: Source URL of the hosted video.
-  thumbnail: URL of the video's thumbnail image.
 videostatus:
   is_available: Flag indicating whether game video is available in the league's stats video system.
   visitor_team_abbreviation: Abbreviation of the visiting team.
@@ -13983,14 +13265,6 @@ draft_organization_rank:
   four_stars: Number of four-star recruits the organization signed over the ranking window.
   percent_drafted: Share of the organization's recruits who went on to be drafted.
   three_stars: Number of three-star recruits the organization signed over the ranking window.
-drafts_by_stars:
-  blue_chip_percent: Percent of the drafted group who were blue-chip (four- or five-star) recruits.
-  five_stars: Number of drafted players who were five-star recruits.
-  four_stars: Number of drafted players who were four-star recruits.
-  population_percent: Percent of the overall recruit population holding this star rating.
-  talent_ratio: Ratio of the star tier's draft share to its population share (On3's talent ratio).
-  three_stars: Number of drafted players who were three-star recruits.
-  zero_stars: Number of drafted players who were unrated (zero-star) recruits.
 drafts_by_stars_summary:
   five_stars: Number of drafted players who were five-star recruits.
   four_stars: Number of drafted players who were four-star recruits.
@@ -14010,42 +13284,6 @@ organizations_draft_count_by_year:
   talent_ratio: Ratio of the group's draft share to its recruit-population share for the year (On3's talent ratio).
   three_stars: Number of the organization's players drafted that year who were three-star recruits.
   zero_stars: Number of the organization's players drafted that year who were unrated (zero-star) recruits.
-sports247_site_pages_coach_ranking:
-  average_rating: Average rating across the coach's credited commits.
-  average_scout_rating: Average 247Sports in-house (scout) rating across the credited commits.
-  commits: Number of commits credited to the coach in the ranking.
-  composite_average_rating: Average 247Sports Composite rating across the credited commits.
-  composite_conference_rank: Coach's conference recruiter rank by Composite points.
-  composite_division_rank: Coach's division recruiter rank by Composite points.
-  composite_five_stars: Number of five-star commits by the 247Sports Composite rating.
-  composite_four_stars: Number of four-star commits by the 247Sports Composite rating.
-  composite_overall_rank: Coach's national recruiter rank by Composite points.
-  composite_rating: Composite class rating for the coach's haul.
-  composite_three_stars: Number of three-star commits by the 247Sports Composite rating.
-  composite_total: Total 247Sports Composite rating points credited to the coach's commits.
-  composite_two_stars: Number of two-star commits by the 247Sports Composite rating.
-  conference_rank: Rank within conference.
-  default_name: Server-rendered display label for the entity.
-  division_rank: Coach's recruiter rank within the division.
-  five_stars: Number of five-star commits credited to the coach.
-  four_stars: Number of four-star commits credited to the coach.
-  institution: Nested 247Sports institution the coach recruited for during the ranking cycle (stringified).
-  key: Primary key of this entity (the id used in its `.json` route).
-  overall_rank: Overall national coach-recruiting rank.
-  previous_coach_ranking: Nested prior-cycle recruiter-ranking row for the coach (stringified).
-  ranking: FK -> the Ranking snapshot this row belongs to.
-  recruitment: Nested 247Sports recruitment record credited to the coach on this row (stringified).
-  scout_conference_rank: Coach's conference recruiter rank by 247Sports' own (scout) points.
-  scout_division_rank: Coach's division recruiter rank by 247Sports' own (scout) points.
-  scout_five_stars: Number of five-star commits by 247Sports' own (scout) rating.
-  scout_four_stars: Number of four-star commits by 247Sports' own (scout) rating.
-  scout_overall_rank: Coach's national recruiter rank by 247Sports' own (scout) points.
-  scout_rating: Total 247Sports in-house (scout) rating points credited to the coach's commits.
-  scout_three_stars: Number of three-star commits by 247Sports' own (scout) rating.
-  scout_two_stars: Number of two-star commits by 247Sports' own (scout) rating.
-  sport: Nested 247Sports sport the ranking covers (stringified).
-  three_stars: Number of three-star commits credited to the coach.
-  two_stars: Number of two-star commits credited to the coach.
 team_ranking:
   applied_average_consensus_rating: Average industry-consensus rating across the counted commits.
   applied_average_rating: Average On3 rating across the counted commits.
@@ -14090,6 +13328,804 @@ team_ranking_consensus_team_rankings:
   key: On3 RDB key for the team's class-ranking row.
   overall_consensus_rank: Team's national class rank by industry-consensus score.
   three_stars: Number of three-star commits by the On3 consensus rating.
+load_cfb_pbp:
+  A_score_diff: Away team's score minus the home team's, from the away perspective.
+  EPA_explosive: True when the play was explosive.
+  EPA_explosive_pass: True when the pass play was explosive.
+  EPA_explosive_rush: True when the rush play was explosive.
+  EPA_fg: EPA credited to the play on field-goal attempts.
+  EPA_kickoff: EPA credited to the play on kickoff plays.
+  EPA_middle_8_success: True when the play in the middle eight was successful by EPA.
+  EPA_middle_8_success_pass: True when the pass play in the middle eight was successful by EPA.
+  EPA_middle_8_success_rush: True when the rush play in the middle eight was successful by EPA.
+  EPA_non_explosive: EPA credited to the play on non-explosive plays.
+  EPA_pass: EPA credited to the play on pass plays.
+  EPA_penalty: EPA credited to the play attributable to penalties.
+  EPA_punt: EPA credited to the play on punt plays.
+  EPA_rush: EPA credited to the play on rush plays.
+  EPA_scrimmage: EPA credited to the play on plays from scrimmage.
+  EPA_sp: EPA credited to the play on special-teams plays.
+  EPA_success: True when the play was successful by EPA.
+  EPA_success_EPA: EPA on successful plays.
+  EPA_success_early_down: True when the play on an early down was successful by EPA.
+  EPA_success_early_down_pass: True when the pass play on an early down was successful by EPA.
+  EPA_success_early_down_rush: True when the rush play on an early down was successful by EPA.
+  EPA_success_late_down: True when the play on a late down was successful by EPA.
+  EPA_success_late_down_pass: True when the pass play on a late down was successful by EPA.
+  EPA_success_late_down_rush: True when the rush play on a late down was successful by EPA.
+  EPA_success_pass: True when the pass play was successful by EPA.
+  EPA_success_pass_EPA: EPA on successful pass plays.
+  EPA_success_passing_down: True when the play on a passing down was successful by EPA.
+  EPA_success_passing_down_EPA: EPA on successful plays on a passing down.
+  EPA_success_rush: True when the rush play was successful by EPA.
+  EPA_success_rush_EPA: EPA on successful rush plays.
+  EPA_success_standard_down: True when the play on a standard down was successful by EPA.
+  EPA_success_standard_down_EPA: EPA on successful plays on a standard down.
+  EP_between: Change in expected points across the play, before penalty adjustment.
+  EP_end: Expected points for the offense at the end of the play.
+  EP_start: Expected points for the offense at the start of the play.
+  EP_start_touchback: Expected points the offense would have had from a touchback on this play.
+  HA_score_diff: Home score minus away score for the play.
+  H_score_diff: Home team's score minus the away team's, from the home perspective.
+  TFL: True when the play was a tackle for loss.
+  TFL_pass: True when the play was a tackle for loss on a pass play (a sack).
+  TFL_rush: True when the play was a tackle for loss on a rush play.
+  action_play: True when the play advanced the game state -- excludes timeouts, end-of-period markers and other non-action
+    rows.
+  adj_rush_yardage: Rushing yards capped at 8, the input to the line-yards decomposition.
+  air_yardsToEndzone: Yards to the endzone at the catch spot, parsed from the 2025+ vendor catch-spot text; null before 2025
+    or when unresolvable.
+  awayTeamAbbrev: ESPN's away-team Abbrev for the game, stamped on every play.
+  awayTeamId: ESPN's away-team Id for the game, stamped on every play.
+  awayTeamMascot: ESPN's away-team Mascot for the game, stamped on every play.
+  awayTeamName: ESPN's away-team Name for the game, stamped on every play.
+  awayTeamNameAlt: ESPN's away-team NameAlt for the game, stamped on every play.
+  awayTimeoutCalled: True when the away team called a timeout on the play.
+  away_wp_after_naive: End-of-play naive win probability mapped to the away team.
+  away_wp_before_naive: Pre-snap naive win probability mapped to the away team.
+  cleaned_text: Play description with overturned-call prefixes stripped; the text the name and team extractors run against.
+  clock.displayValue: Game clock at the play, as the displayed mm:ss string.
+  clock.minutes: Minutes remaining on the game clock at the play.
+  clock.seconds: Seconds component of the game clock at the play.
+  def_fumble_lost: Whether the defending team (e.g. a returner after a takeaway) fumbled and lost the ball back.
+  def_wp_after_naive: End-of-play defense win probability under the naive model.
+  def_wp_before_naive: Pre-snap defense win probability under the naive model (1 - wp_before_naive).
+  down_1: True when it is 1st down at the start of the play.
+  down_1_end: True when it is 1st down at the end of the play.
+  down_2: True when it is 2nd down at the start of the play.
+  down_2_end: True when it is 2nd down at the end of the play.
+  down_3: True when it is 3rd down at the start of the play.
+  down_3_end: True when it is 3rd down at the end of the play.
+  down_4: True when it is 4th down at the start of the play.
+  down_4_end: True when it is 4th down at the end of the play.
+  drive.description: ESPN's `description` field for the drive containing this play.
+  drive.displayResult: ESPN's `displayResult` field for the drive containing this play.
+  drive.end.clock.displayValue: ESPN's `end.clock.displayValue` field for the drive containing this play.
+  drive.end.period.number: ESPN's `end.period.number` field for the drive containing this play.
+  drive.end.period.type: ESPN's `end.period.type` field for the drive containing this play.
+  drive.end.yardLine: ESPN's `end.yardLine` field for the drive containing this play.
+  drive.id: ESPN's `id` field for the drive containing this play.
+  drive.isScore: ESPN's `isScore` field for the drive containing this play.
+  drive.offensivePlays: ESPN's `offensivePlays` field for the drive containing this play.
+  drive.result: ESPN's `result` field for the drive containing this play.
+  drive.shortDisplayResult: ESPN's `shortDisplayResult` field for the drive containing this play.
+  drive.start.clock.displayValue: ESPN's `start.clock.displayValue` field for the drive containing this play.
+  drive.start.period.number: ESPN's `start.period.number` field for the drive containing this play.
+  drive.start.period.type: ESPN's `start.period.type` field for the drive containing this play.
+  drive.start.text: ESPN's `start.text` field for the drive containing this play.
+  drive.start.yardLine: ESPN's `start.yardLine` field for the drive containing this play.
+  drive.team.abbreviation: ESPN's `team.abbreviation` field for the drive containing this play.
+  drive.team.displayName: ESPN's `team.displayName` field for the drive containing this play.
+  drive.team.name: ESPN's `team.name` field for the drive containing this play.
+  drive.team.shortDisplayName: ESPN's `team.shortDisplayName` field for the drive containing this play.
+  drive.timeElapsed.displayValue: ESPN's `timeElapsed.displayValue` field for the drive containing this play.
+  drive.yards: ESPN's `yards` field for the drive containing this play.
+  drive_offense_plays: Offensive plays run on the drive.
+  drive_offense_yards: Offensive yards gained on the drive.
+  drive_play_index: Sequence number of the play within its drive.
+  drive_start: Yard line at which the drive began.
+  drive_stopped: True when the play ended the drive.
+  drive_total_yards: Total yards gained on the drive.
+  early_down: True when the play is a scrimmage play on first or second down.
+  early_down_pass: True when the play is a pass on an early down.
+  early_down_rush: True when the play is a rush on an early down.
+  end.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the end of the play.
+  end.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the end of the play.
+  end.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the end of the play.
+  end.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the end of the play.
+  end.awayScore: ESPN's `awayScore` value for the play state at the end of the play.
+  end.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the end of the play.
+  end.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the end of the play.
+  end.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the end of the play.
+  end.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the end of the play.
+  end.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the end of the play.
+  end.distance: ESPN's `distance` value for the play state at the end of the play.
+  end.down: ESPN's `down` value for the play state at the end of the play.
+  end.downDistanceText: ESPN's `downDistanceText` value for the play state at the end of the play.
+  end.elapsed_share: ESPN's `elapsed_share` value for the play state at the end of the play.
+  end.homeScore: ESPN's `homeScore` value for the play state at the end of the play.
+  end.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the end of the play.
+  end.is_home: ESPN's `is_home` value for the play state at the end of the play.
+  end.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the end of the play.
+  end.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the end of the play.
+  end.pos_team.id: ESPN's `pos_team.id` value for the play state at the end of the play.
+  end.pos_team.name: ESPN's `pos_team.name` value for the play state at the end of the play.
+  end.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the end of the play.
+  end.pos_team_score: ESPN's `pos_team_score` value for the play state at the end of the play.
+  end.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the end of the play.
+  end.possessionText: ESPN's `possessionText` value for the play state at the end of the play.
+  end.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the end of the play.
+  end.spread_time: ESPN's `spread_time` value for the play state at the end of the play.
+  end.team.id: ESPN's `team.id` value for the play state at the end of the play.
+  end.yard: ESPN's `yard` value for the play state at the end of the play.
+  end.yardLine: ESPN's `yardLine` value for the play state at the end of the play.
+  end.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the end of the play.
+  end_state_missing: Flag that ESPN's end-of-play state (end.team.id) was absent and the end state was imputed.
+  fg_attempt: True when the play was a field-goal attempt.
+  fg_block_player_id: ESPN athlete id of the player who blocked the field goal.
+  fg_kicker_player_id: ESPN athlete id of the field-goal kicker.
+  fg_return_player_id: ESPN athlete id of the player who returned the blocked or missed field goal.
+  fg_team: Team id attempting the field goal (the kicking team).
+  fg_wp: Make-probability-weighted win probability of attempting the field goal.
+  fg_wp_diff: fg_wp minus the recommended option's WP (0 when the field goal is the recommendation, otherwise <= 0).
+  firstHalfKickoffTeamId: ESPN id of the team that received the opening kickoff.
+  first_down_created: True when the play produced a first down for the offense.
+  first_down_prob: Modeled probability of converting the fourth down when going for it.
+  forced_fumble: True when the defense forced a fumble on the play.
+  forced_fumble_team: Team id credited with forcing the fumble -- the side opposite the fumbling player (the covering team
+    on returns).
+  fourth_down_recommendation: Max-WP fourth-down choice among "go", "punt", and "field_goal".
+  fumble_or_muff: Whether the play includes a fumble or a muffed kick or punt (widened beyond ESPN's fumble play types).
+  fumble_recovered: True when a fumble on the play was recovered.
+  fumble_recovery_team: Team id that recovered the fumble or muff, from parsed text with a giveaway / own-recovery fallback.
+  fumbling_team: Team id of the side that fumbled or muffed the ball, parsed from the play text.
+  gameSpread: Point spread used as an input to the win-probability model.
+  gameSpreadAvailable: True when a spread was available for the game.
+  go_boost: 'cfb4th''s headline number: 100 * (go_wp - max(fg_wp, punt_wp)), in percentage points.'
+  go_wp: 'Win probability from going for it on fourth down: conversion-probability-weighted mean of the success and failure
+    states (cfb4th port).'
+  go_wp_diff: go_wp minus the recommended option's WP (0 when going for it is the recommendation, otherwise <= 0).
+  havoc: 'True when the defense disrupted the play: a pass breakup, tackle for loss, interception or forced fumble.'
+  highlight_run: True when the rush gained 8 or more yards.
+  highlight_yards: Second-level plus open-field yards -- the yardage credited to the carrier.
+  homeFavorite: True when the home team was favoured by the spread.
+  homeTeamAbbrev: ESPN's home-team Abbrev for the game, stamped on every play.
+  homeTeamId: ESPN's home-team Id for the game, stamped on every play.
+  homeTeamMascot: ESPN's home-team Mascot for the game, stamped on every play.
+  homeTeamName: ESPN's home-team Name for the game, stamped on every play.
+  homeTeamNameAlt: ESPN's home-team NameAlt for the game, stamped on every play.
+  homeTeamSpread: ESPN's home-team Spread for the game, stamped on every play.
+  homeTimeoutCalled: True when the home team called a timeout on the play.
+  home_wp_after_naive: End-of-play naive win probability mapped to the home team.
+  home_wp_before_naive: Pre-snap naive win probability mapped to the home team.
+  int_turnover: Whether the play is an interception giveaway.
+  interception_team: Team id credited with the interception (the defense).
+  isPenalty: ESPN's per-play flag that a penalty occurred on the play.
+  isTurnover: ESPN's per-play turnover flag as shipped in the plays feed (broader than the giveaway-based is_turnover derivation).
+  is_blocked_fg_turnover: Blocked-field-goal possession loss (blocked-FG TD, or the defense recovered); kept out of is_turnover
+    to match ESPN's giveaway-only box.
+  is_blocked_punt_turnover: Blocked-punt possession loss (blocked-punt TD, or the defense recovered); kept out of is_turnover
+    to match ESPN's giveaway-only box.
+  is_def_pos_team_turnover: Whether the defending team gave the ball back via a lost fumble.
+  is_pos_team_turnover: Whether the possession team committed a giveaway (interception or fumble lost).
+  is_st_turnover: Whether the giveaway happened on a special-teams play (kick or punt snap, or a return).
+  is_turnover: True when the play is a giveaway-based turnover (interception thrown or fumble lost); blocked kicks recovered
+    by the defense are carried by the blocked-kick fields instead.
+  kick_return_team: Team id of the kick-returning side.
+  kicking_team: Team id of the kicking team on kickoff, punt, and field-goal plays.
+  kickoff_player_id: ESPN athlete id of the player kicking off.
+  kickoff_return_player_id: ESPN athlete id of the kickoff returner.
+  kneel_down: Whether the play is an offensive kneel, from explicit kneel text plus an end-of-half TEAM-rush heuristic.
+  lag_EP_end: Value of EP_end on the previous play, used for sequence-aware derivations.
+  lag_HA_score_diff: Value of HA_score_diff on the previous play, used for sequence-aware derivations.
+  lag_awayScore: Value of awayScore on the previous play, used for sequence-aware derivations.
+  lag_change_of_pos_team: Value of change_of_pos_team on the previous play, used for sequence-aware derivations.
+  lag_half: Value of half on the previous play, used for sequence-aware derivations.
+  lag_homeScore: Value of homeScore on the previous play, used for sequence-aware derivations.
+  lag_pos_score_diff: Value of pos_score_diff on the previous play, used for sequence-aware derivations.
+  lag_pos_team: Value of pos_team on the previous play, used for sequence-aware derivations.
+  lag_scoringPlay: Value of scoringPlay on the previous play, used for sequence-aware derivations.
+  late_down: True when the play is a scrimmage play on third or fourth down.
+  late_down_pass: True when the play is a pass on a late down.
+  late_down_rush: True when the play is a rush on a late down.
+  lead_half: Value of half on the next play, used for sequence-aware derivations.
+  lead_play_type: Value of play_type on the next play, used for sequence-aware derivations.
+  lead_pos_team: Value of pos_team on the next play, used for sequence-aware derivations.
+  lead_pos_team2: Value of pos_team 2 plays ahead, used for sequence-aware derivations.
+  lead_scoringPlay: Value of scoringPlay on the next play, used for sequence-aware derivations.
+  lead_start_distance: Value of start_distance on the next play, used for sequence-aware derivations.
+  lead_start_down: Value of start_down on the next play, used for sequence-aware derivations.
+  lead_start_team: Value of start_team on the next play, used for sequence-aware derivations.
+  lead_start_yardsToEndzone: Value of start_yardsToEndzone on the next play, used for sequence-aware derivations.
+  lead_text: Value of text on the next play, used for sequence-aware derivations.
+  lead_wp_before: Value of wp_before on the next play, used for sequence-aware derivations.
+  lead_wp_before2: Value of wp_before 2 plays ahead, used for sequence-aware derivations.
+  lead_wp_before2_naive: Pre-snap naive win probability two plays ahead, used where the immediately following row is a non-play.
+  lead_wp_before_naive: Next play's pre-snap naive win probability, used in the end-of-half and change-of-possession adjustments.
+  line_yards: 'Yards credited to the offensive line on a rush, using the standard sliding scale: 1.2x the capped yardage on
+    a loss, all of it through 3 yards, half of each yard from 4 to 8, and a 5.5-yard ceiling beyond that.'
+  make_fg_wp: Win probability given the field-goal attempt is made.
+  miss_fg_wp: Win probability given the field-goal attempt misses.
+  net_HA_score_pts: Net points the play added to the home-minus-away score margin.
+  new_distance: Distance to go after the play, including any penalty enforcement.
+  new_down: Down after the play, including any penalty enforcement.
+  non_fumble_sack: True when the play was a sack that did not produce a fumble.
+  open_field_yards: Rushing yards gained beyond 8, credited to the ball carrier rather than the line.
+  opp_highlight_yards: Highlight yards earned on opportunity runs, isolating carrier production on carries where the blocking
+    succeeded. Assets published before the 2026-08 fix are identically 0 here, because the inverted opportunity_run gate could
+    never co-occur with non-zero highlight yards.
+  opportunity_run: True when a rush reached 4 yards -- the carries on which the blocking did its job. Matches cfbfastR's espn_cfb_15
+    definition. Assets published before the 2026-08 fix carry the inverted (4 yards or fewer) flag.
+  overUnder: Over/under total used as a model input.
+  pass_breakup: True when a defender broke up the pass.
+  pass_breakup_team: Team id credited with the pass breakup (the defense).
+  pass_depth: Thrown-pass depth parsed from ESPN play text ("short" or "deep"); null when the text omits it (sacks, screens,
+    pre-2025 text).
+  pass_direction: Pass direction parsed from ESPN play text ("left", "middle", or "right"); null when the text omits it.
+  pass_epa: EPA credited to the play when it is a pass.
+  pass_weight: Weighting applied to the pass component of the play.
+  passing_down: True when the offense is behind schedule for the series -- second down needing 8 or more, or third/fourth
+    down needing 5 or more.
+  pen_epa: EPA attributable to a penalty on the play.
+  pen_weight: Weighting applied to the penalty component of the play.
+  penalized_team: Team id the penalty was assessed against, from the home/away text resolver with a foul-direction fallback.
+  penalty_assessed_on_kickoff: Whether a penalty was assessed on a kickoff; such plays take the kickoff/touchback win-probability
+    handling.
+  penalty_in_text: True when the play description mentions a penalty.
+  penalty_yards_signed: Penalty yardage parsed from the play text with era-aware bounds; the printed sign is retained but
+    is not a reliable enforcement direction.
+  period.number: Period (quarter) number in which the play occurred.
+  pointAfterAttempt.abbreviation: ESPN abbreviation of the point-after attempt type; drives the extra-point / two-point result
+    derivation.
+  pointAfterAttempt.id: ESPN identifier for the point-after attempt type on the scoring play.
+  pointAfterAttempt.text: ESPN description of the point-after attempt and its result.
+  pointAfterAttempt.value: Points ESPN credits for the point-after attempt (1.0 made extra point, 2.0 made two-point try).
+  pos_fumble_lost: Whether the possession team fumbled and lost the ball.
+  pos_score_diff_end: Score differential from the possessing team's perspective at the end of the play.
+  power_rush_attempt: True when the play is a short-yardage power rushing attempt.
+  power_rush_success: True when a power rushing attempt gained the yardage needed.
+  prob_2pt: Two-point conversion probability from the bundled CFB two-point model.
+  prog_drive_EPA: Cumulative EPA accrued by the drive up to and including this play.
+  prog_drive_WPA: Cumulative win-probability added by the drive up to and including this play.
+  punt_block_player_id: ESPN athlete id of the player who blocked the punt.
+  punt_block_return_player_id: ESPN athlete id of the player who returned the blocked punt.
+  punt_return_player_id: ESPN athlete id of the punt returner.
+  punt_return_team: Team id of the punt-returning side.
+  punt_team: Team id punting the ball (the kicking team).
+  punt_wp: Win probability of punting, from the bundled punt-outcome distribution.
+  punt_wp_diff: punt_wp minus the recommended option's WP (0 when punting is the recommendation, otherwise <= 0).
+  qb_hurry: Whether ESPN's play text says the quarterback was hurried into the throw ("hurried by ...").
+  qbr_epa: EPA variant used as an input to the QBR calculation.
+  recovery_team: Team id parsed from the play text as recovering the fumble or muff.
+  recovery_team_2: Team id of the second recovery in a multi-recovery scramble, parsed from the play text.
+  return_team: Team id of the returning side; set on interception, fumble, kickoff, punt, and blocked-kick returns.
+  rush_direction: Rush direction parsed from ESPN play text ("left", "middle", or "right"); null when the text omits it.
+  rush_epa: EPA credited to the play when it is a rush.
+  rush_weight: Weighting applied to the rush component of the play.
+  sack_epa: EPA credited to the play when it is a sack.
+  sack_player_id2: ESPN athlete id of the second sacker on a split sack (regex fallback for an ESPN sidecar blind spot).
+  sack_team: Team id credited with the sack (the defense).
+  sack_weight: Weighting applied to the sack component of the play.
+  scoringPlay: ESPN flag marking the play as a scoring play.
+  scoringType.abbreviation: ESPN's abbreviation for the scoring type.
+  scoringType.displayName: ESPN's display label for the scoring type.
+  scoringType.name: ESPN's name for the scoring type (e.g. touchdown, field goal).
+  scrimmage_play: True when the play is a play from scrimmage rather than a special-teams or administrative row.
+  seasonType: ESPN season type for the game (2 = regular season, 3 = postseason).
+  second_level_yards: Rushing yards earned from 4 to 8, split evenly between line and carrier under the line-yards decomposition.
+  short_rush_attempt: True when the play is a rush in a short-yardage situation.
+  short_rush_success: True when a short-yardage rush gained the yardage needed.
+  standard_down: True when the offense is on schedule for the series -- first down, second down needing fewer than 8, or third/fourth
+    down needing fewer than 5.
+  start.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the start of the play.
+  start.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the start of the play.
+  start.ExpScoreDiff_Time_Ratio_touchback: ESPN's `ExpScoreDiff_Time_Ratio_touchback` value for the play state at the start
+    of the play.
+  start.ExpScoreDiff_touchback: ESPN's `ExpScoreDiff_touchback` value for the play state at the start of the play.
+  start.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the start of the play.
+  start.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the start of the play.
+  start.awayScore: ESPN's `awayScore` value for the play state at the start of the play.
+  start.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the start of the play.
+  start.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the start of the play.
+  start.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the start of the play.
+  start.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the start of the play.
+  start.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the start of the play.
+  start.distance: ESPN's `distance` value for the play state at the start of the play.
+  start.down: ESPN's `down` value for the play state at the start of the play.
+  start.downDistanceText: ESPN's `downDistanceText` value for the play state at the start of the play.
+  start.elapsed_share: ESPN's `elapsed_share` value for the play state at the start of the play.
+  start.homeScore: ESPN's `homeScore` value for the play state at the start of the play.
+  start.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the start of the play.
+  start.is_home: ESPN's `is_home` value for the play state at the start of the play.
+  start.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the start of the play.
+  start.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the start of the play.
+  start.pos_team.id: ESPN's `pos_team.id` value for the play state at the start of the play.
+  start.pos_team.name: ESPN's `pos_team.name` value for the play state at the start of the play.
+  start.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the start of the play.
+  start.pos_team_score: ESPN's `pos_team_score` value for the play state at the start of the play.
+  start.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the start of the play.
+  start.possessionText: ESPN's `possessionText` value for the play state at the start of the play.
+  start.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the start of the play.
+  start.spread_time: ESPN's `spread_time` value for the play state at the start of the play.
+  start.team.id: ESPN's `team.id` value for the play state at the start of the play.
+  start.yard: ESPN's `yard` value for the play state at the start of the play.
+  start.yardLine: ESPN's `yardLine` value for the play state at the start of the play.
+  start.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the start of the play.
+  start.yardsToEndzone.touchback: ESPN's `yardsToEndzone.touchback` value for the play state at the start of the play.
+  statYardage: Yardage ESPN credits to the play for statistical purposes.
+  stopped_run: True when the rush was stopped at or behind the line of scrimmage.
+  td_check: Internal flag used while reconciling whether the play produced a touchdown.
+  teamParticipants: Raw ESPN team-level participants payload carried through from the plays feed (stringified).
+  text_dupe: True when the play description duplicates the previous row's text.
+  turnover_team: Team id charged with the giveaway on the play.
+  two_point_conv_result: 'String result of the two-point conversion attempt: success, failure, or safety (touchback in the
+    defensive end zone).'
+  two_pt_recommendation: 'Point-after recommendation: "go_for_2" when two_pt_wp exceeds xp_wp, otherwise "kick_xp".'
+  two_pt_wp: 'Win probability of going for two: conversion-probability-weighted mean of the 2-point and 0-point outcomes (cfb4th
+    port).'
+  two_pt_wp_diff: two_pt_wp minus xp_wp; positive favors going for two.
+  type.abbreviation: ESPN's abbreviation for the play type.
+  type.id: ESPN's numeric identifier for the play type.
+  type.text: ESPN's text label for the play type.
+  under_2: Whether the play began with two minutes or less remaining in the half.
+  wp_after_naive: End-of-play possession-team win probability from the naive model, after the game-logic adjustment chain.
+  wp_before_naive: Pre-snap possession-team win probability from the spread-free (naive) WP model.
+  wp_fail: Mean win probability given the fourth-down attempt fails.
+  wp_succeed: Mean win probability across yardage outcomes given the fourth-down attempt converts.
+  wp_touchback: Win probability the offense would have had starting from a touchback.
+  wp_touchback_naive: Naive-model win probability for the kickoff-touchback substitute state, used as the pre-snap WP on kickoffs.
+  wpa_naive: Win probability added on the play under the spread-free (naive) model.
+  xp_wp: Win probability of kicking the extra point, weighting the make by the empirical CFB extra-point make rate.
+load_cfb_player_box:
+  adjQBR: Adjusted Total QBR for the quarterback.
+  completions/passingAttempts: Completions and pass attempts, as ESPN's combined string.
+  defensiveTouchdowns: Touchdowns the player scored on defense (ESPN box score).
+  extraPointsMade/extraPointAttempts: Extra points made and attempted, as ESPN's combined string.
+  fieldGoalPct: Field-goal percentage.
+  fieldGoalsMade/fieldGoalAttempts: Field goals made and attempted, as ESPN's combined string.
+  fumbles: Number of times the player fumbled in the game (ESPN box score).
+  fumblesLost: Number of the player's fumbles lost to the opponent (ESPN box score).
+  fumblesRecovered: Number of fumbles the player recovered (ESPN box score).
+  grossAvgPuntYards: Gross average yards per punt, before return yardage.
+  hurries: Quarterback hurries credited to the player (ESPN box score).
+  interceptionTouchdowns: Touchdowns scored on interception returns.
+  interceptionYards: Yards returned on interceptions.
+  kickReturnTouchdowns: Kickoff returns the player took for touchdowns (ESPN box score).
+  kickReturnYards: Total kickoff-return yards by the player (ESPN box score).
+  kickReturns: Number of kickoff returns by the player (ESPN box score).
+  longFieldGoalMade: Longest field goal made, in yards.
+  longKickReturn: Player's longest kickoff return of the game, in yards (ESPN box score).
+  longPunt: Longest punt of the game, in yards.
+  longPuntReturn: Longest punt return of the game, in yards.
+  longReception: Longest reception of the game, in yards.
+  longRushing: Longest rush of the game, in yards.
+  passesDefended: Passes the player broke up or defended (ESPN box score).
+  passingTouchdowns: Passing touchdowns.
+  passingYards: Net passing yards gained.
+  puntReturnTouchdowns: Touchdowns scored on punt returns.
+  puntReturnYards: Yards gained on punt returns.
+  puntReturns: Punt returns attempted.
+  puntYards: Total punt yards.
+  punts: Punts attempted.
+  puntsInside20: Punts downed inside the opponent 20-yard line.
+  receivingTouchdowns: Receiving touchdowns.
+  receivingYards: Receiving yards gained.
+  rushingAttempts: Rushing attempts.
+  rushingTouchdowns: Rushing touchdowns.
+  rushingYards: Net rushing yards gained.
+  sacks: Sacks credited to the player (ESPN box score).
+  soloTackles: Player's solo (unassisted) tackles (ESPN box score).
+  stat_1: First value of ESPN's raw athlete stats array, written only when the category's key list does not line up with the
+    stats list; on those rows the named per-category columns are all null.
+  stat_2: Second value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  stat_3: Third value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  stat_4: Fourth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  stat_5: Fifth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  tacklesForLoss: Player's tackles made behind the line of scrimmage (ESPN box score).
+  totalKickingPoints: Total points scored by kicking.
+  totalTackles: Player's total tackles, solo plus assisted (ESPN box score).
+  touchbacks: Punts or kickoffs that resulted in a touchback.
+  yardsPerKickReturn: Average yards per kickoff return for the player (ESPN box score).
+  yardsPerPassAttempt: Yards gained per pass attempt.
+  yardsPerPuntReturn: Yards gained per punt return.
+  yardsPerReception: Yards gained per reception.
+  yardsPerRushAttempt: Yards gained per rushing attempt.
+sports247_site_pages_coach_ranking:
+  average_rating: Average rating across the coach's credited commits.
+  average_scout_rating: Average 247Sports in-house (scout) rating across the credited commits.
+  commits: Number of commits credited to the coach in the ranking.
+  composite_average_rating: Average 247Sports Composite rating across the credited commits.
+  composite_conference_rank: Coach's conference recruiter rank by Composite points.
+  composite_division_rank: Coach's division recruiter rank by Composite points.
+  composite_five_stars: Number of five-star commits by the 247Sports Composite rating.
+  composite_four_stars: Number of four-star commits by the 247Sports Composite rating.
+  composite_overall_rank: Coach's national recruiter rank by Composite points.
+  composite_rating: Composite class rating for the coach's haul.
+  composite_three_stars: Number of three-star commits by the 247Sports Composite rating.
+  composite_total: Total 247Sports Composite rating points credited to the coach's commits.
+  composite_two_stars: Number of two-star commits by the 247Sports Composite rating.
+  conference_rank: Rank within conference.
+  default_name: Server-rendered display label for the entity.
+  division_rank: Coach's recruiter rank within the division.
+  five_stars: Number of five-star commits credited to the coach.
+  four_stars: Number of four-star commits credited to the coach.
+  institution: Nested 247Sports institution the coach recruited for during the ranking cycle (stringified).
+  key: Primary key of this entity (the id used in its `.json` route).
+  overall_rank: Overall national coach-recruiting rank.
+  previous_coach_ranking: Nested prior-cycle recruiter-ranking row for the coach (stringified).
+  ranking: FK -> the Ranking snapshot this row belongs to.
+  rating: Overall rating score for the coach's recruiting haul in the 247Sports coach ranking.
+  recruitment: Nested 247Sports recruitment record credited to the coach on this row (stringified).
+  scout_conference_rank: Coach's conference recruiter rank by 247Sports' own (scout) points.
+  scout_division_rank: Coach's division recruiter rank by 247Sports' own (scout) points.
+  scout_five_stars: Number of five-star commits by 247Sports' own (scout) rating.
+  scout_four_stars: Number of four-star commits by 247Sports' own (scout) rating.
+  scout_overall_rank: Coach's national recruiter rank by 247Sports' own (scout) points.
+  scout_rating: Total 247Sports in-house (scout) rating points credited to the coach's commits.
+  scout_three_stars: Number of three-star commits by 247Sports' own (scout) rating.
+  scout_two_stars: Number of two-star commits by 247Sports' own (scout) rating.
+  sport: Nested 247Sports sport the ranking covers (stringified).
+  three_stars: Number of three-star commits credited to the coach.
+  total: Total ranking score for the coach's class, as reported by 247Sports.
+  two_stars: Number of two-star commits credited to the coach.
+sports247_site_pages_event:
+  default_asset: Nested 247Sports image asset for the event (stringified).
+  default_name: Server-rendered display label for the entity.
+  event_group: Grouping or series the event belongs to (e.g. a camp circuit) on 247Sports.
+  event_type: Numeric code for the kind of 247Sports recruiting event on this row.
+  key: Primary key of this entity (the id used in its `.json` route).
+sports247_site_pages_player_sport_ranking:
+  committed_institution: FK -> committed Institution (null if uncommitted).
+  composite_group_rank: Player's rank within their position group by Composite rating.
+  composite_overall_rank: Player's national rank by 247Sports Composite rating.
+  composite_position_rank: Player's rank at their position by Composite rating.
+  composite_rating: Player's 247Sports Composite rating, blending the major services' ratings.
+  composite_state_rank: Player's rank within their home state by Composite rating.
+  composite_strength: 247Sports field describing the strength of the industry inputs behind the Composite rating.
+  default_name: Server-rendered display label for the entity.
+  institution: Nested institution the player was committed or signed to at ranking time (stringified).
+  institution_group: Grouping (e.g. conference/division) of the player's institution, per 247Sports.
+  key: Primary key of this entity (the id used in its `.json` route).
+  order: Display order of the entry within the 247Sports ranking list.
+  overall_rank: Overall national rank in the snapshot.
+  platoon: 247Sports platoon (side-of-ball grouping) identifier on the ranking row.
+  player_sport: Nested player-sport profile the ranking row belongs to (stringified).
+  position_group_rank: Player's rank within their position group in the 247Sports ranking.
+  position_rank: Rank within position.
+  previous_player_sport_ranking: Nested prior-cycle ranking row for the player (stringified).
+  ranking: FK -> Ranking snapshot.
+  rating: Nested 247Sports rating record attached to the ranking row (stringified).
+  region: Nested 247Sports region record for the recruit's home region (stringified).
+  sport: Nested 247Sports sport the ranking row covers (stringified).
+  state: Nested 247Sports state record for the recruit's home state (stringified).
+  state_rank: Rank within home state.
+sports247_site_pages_timeline_event:
+  author_affiliation: Outlet or site the author writes for, per 247Sports.
+  author_first_name: First name of the entry's author.
+  author_last_name: Last name of the entry's author.
+  body: Text body of the timeline entry.
+  date: Date of the institution timeline entry, per 247Sports.
+load_ncaa_mbb_matchup_stints:
+  away_1: Name of the away team's on-floor player in lineup slot 1 for the stint.
+  away_2: Name of the away team's on-floor player in lineup slot 2 for the stint.
+  away_3: Name of the away team's on-floor player in lineup slot 3 for the stint.
+  away_4: Name of the away team's on-floor player in lineup slot 4 for the stint.
+  away_5: Name of the away team's on-floor player in lineup slot 5 for the stint.
+  away_lineup: Delimited names of the away five on the floor during the stint.
+  away_lineup_key: Sorted player-code key for the away five on the floor.
+  away_pts: Points scored by the away team during the stint.
+  duration_seconds: Duration of the lineup stint in seconds.
+  end_away_score: Away team score when the stint ended.
+  end_home_score: Home team score when the stint ended.
+  end_seconds: Elapsed game seconds at which the stint ended.
+  game_stint_num: Sequential stint number within the game, incremented at every substitution by either team.
+  home_1: Name of the home team's on-floor player in lineup slot 1 for the stint.
+  home_2: Name of the home team's on-floor player in lineup slot 2 for the stint.
+  home_3: Name of the home team's on-floor player in lineup slot 3 for the stint.
+  home_4: Name of the home team's on-floor player in lineup slot 4 for the stint.
+  home_5: Name of the home team's on-floor player in lineup slot 5 for the stint.
+  home_lineup: Delimited names of the home five on the floor during the stint.
+  home_lineup_key: Sorted player-code key for the home five on the floor.
+  home_pts: Points scored by the home team during the stint.
+  matchup_key: Combined home-plus-away lineup key identifying the ten-player matchup on the floor.
+  n_events: Number of play-by-play events falling within the stint.
+  n_possessions: Number of possessions falling within the stint.
+  start_away_score: Away team score when the stint began.
+  start_home_score: Home team score when the stint began.
+  start_seconds: Elapsed game seconds at which the stint began.
+load_ncaa_wbb_matchup_stints:
+  away_1: Name of the away team's on-floor player in lineup slot 1 for the stint.
+  away_2: Name of the away team's on-floor player in lineup slot 2 for the stint.
+  away_3: Name of the away team's on-floor player in lineup slot 3 for the stint.
+  away_4: Name of the away team's on-floor player in lineup slot 4 for the stint.
+  away_5: Name of the away team's on-floor player in lineup slot 5 for the stint.
+  away_lineup: Delimited names of the away five on the floor during the stint.
+  away_lineup_key: Sorted player-code key for the away five on the floor.
+  away_pts: Points scored by the away team during the stint.
+  duration_seconds: Duration of the lineup stint in seconds.
+  end_away_score: Away team score when the stint ended.
+  end_home_score: Home team score when the stint ended.
+  end_seconds: Elapsed game seconds at which the stint ended.
+  game_stint_num: Sequential stint number within the game, incremented at every substitution by either team.
+  home_1: Name of the home team's on-floor player in lineup slot 1 for the stint.
+  home_2: Name of the home team's on-floor player in lineup slot 2 for the stint.
+  home_3: Name of the home team's on-floor player in lineup slot 3 for the stint.
+  home_4: Name of the home team's on-floor player in lineup slot 4 for the stint.
+  home_5: Name of the home team's on-floor player in lineup slot 5 for the stint.
+  home_lineup: Delimited names of the home five on the floor during the stint.
+  home_lineup_key: Sorted player-code key for the home five on the floor.
+  home_pts: Points scored by the home team during the stint.
+  matchup_key: Combined home-plus-away lineup key identifying the ten-player matchup on the floor.
+  n_events: Number of play-by-play events falling within the stint.
+  n_possessions: Number of possessions falling within the stint.
+  start_away_score: Away team score when the stint began.
+  start_home_score: Home team score when the stint began.
+  start_seconds: Elapsed game seconds at which the stint began.
+load_pwhl_pbp:
+  skaters_away: Number of away skaters on the ice for the event, derived from HockeyTech shift data.
+  skaters_home: Number of home skaters on the ice for the event, derived from HockeyTech shift data.
+  strength_state: Skater-strength state formatted home-first as skaters_home v skaters_away (5v4 = home has the extra skater),
+    derived from shift data.
+  strength_state_valid: True when both shift-derived skater counts are between 3 and 6 inclusive; false when a count falls
+    outside that range; null when a count is unavailable.
+collective_groups_deals:
+  amount: Reported dollar amount of the NIL deal.
+  collective_group: Nested On3 record for the collective brokering the deal (stringified).
+  company: Nested On3 record for the company on the other side of the NIL deal (stringified).
+  date: Date of the NIL collective deal, per On3.
+  key: On3 RDB key for the NIL deal record.
+  nil_status: Status of the athlete's On3 NIL valuation (e.g. active, inactive).
+  nil_value: Athlete's On3 NIL valuation in dollars.
+  person: Nested On3 person object for the athlete in the deal (stringified).
+  roster_rating: Nested On3 roster rating object for the athlete at deal time (stringified).
+  rpm: Nested On3 Recruiting Prediction Machine (RPM) data for the athlete (stringified).
+  source_url: URL of the source reporting the deal.
+  verified: Whether On3 verified the deal.
+drafts:
+  college_organization: Nested On3 organization object for the college the player attended (stringified).
+  compensatory: Whether the selection was a compensatory draft pick.
+  drafted_from_organization: Nested On3 organization object for the school the player was drafted out of (stringified).
+  forfeited: Whether the pick was forfeited.
+  high_school_organization: Nested On3 organization object for the player's high school (stringified).
+  key: On3 RDB key for the draft-pick record.
+  person: Nested On3 person object for the drafted player (stringified).
+  recruitment_key: On3 RDB recruitment key linking the draft pick back to the player's recruitment record.
+  state: Home state of the drafted player, per On3.
+  supplementary: Whether the selection came in a supplemental draft.
+  through_organization_one: First intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  through_organization_three: Third intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  through_organization_two: Second intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  trading_organization: Pro organization that traded the pick away, when it changed hands (On3 RDB).
+drafts_by_stars:
+  blue_chip_percent: Percent of the drafted group who were blue-chip (four- or five-star) recruits.
+  five_stars: Number of drafted players who were five-star recruits.
+  four_stars: Number of drafted players who were four-star recruits.
+  population_percent: Percent of the overall recruit population holding this star rating.
+  state: Home state associated with the draft row, per On3.
+  talent_ratio: Ratio of the star tier's draft share to its population share (On3's talent ratio).
+  three_stars: Number of drafted players who were three-star recruits.
+  zero_stars: Number of drafted players who were unrated (zero-star) recruits.
+drafts_players:
+  college_organization: Nested On3 organization object for the college the player attended (stringified).
+  compensatory: Whether the selection was a compensatory draft pick.
+  drafted_from_organization: Nested On3 organization object for the school the player was drafted out of (stringified).
+  forfeited: Whether the pick was forfeited.
+  high_school_organization: Nested On3 organization object for the player's high school (stringified).
+  key: On3 RDB key for the draft-pick record.
+  person: Nested On3 person object for the drafted player (stringified).
+  recruitment_key: On3 RDB recruitment key linking the draft pick back to the player's recruitment record.
+  state: Home state of the drafted player, per On3.
+  supplementary: Whether the selection came in a supplemental draft.
+  through_organization_one: First intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  through_organization_three: Third intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  through_organization_two: Second intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  trading_organization: Pro organization that traded the pick away, when it changed hands (On3 RDB).
+load_cfb_team_info:
+  logo_2: URL of the team's alternate dark-background 500-pixel logo on ESPN's CDN, null for programs with no dark variant.
+  logos_10: URL of the team's logo variant in slot 10 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_11: URL of the team's logo variant in slot 11 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_12: URL of the team's logo variant in slot 12 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_13: URL of the team's logo variant in slot 13 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_14: URL of the team's logo variant in slot 14 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_15: URL of the team's logo variant in slot 15 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_16: URL of the team's logo variant in slot 16 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_3: URL of the team's logo variant in slot 3 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_4: URL of the team's logo variant in slot 4 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_5: URL of the team's logo variant in slot 5 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_6: URL of the team's logo variant in slot 6 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_7: URL of the team's logo variant in slot 7 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_8: URL of the team's logo variant in slot 8 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_9: URL of the team's logo variant in slot 9 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  state: U.S. state where the school is located.
+  twitter: The football program's Twitter/X handle including the leading at sign, populated for only a minority of listed
+    teams.
+nil_compliances_state:
+  current_rules: Text of the state's current NIL rules, as tracked by On3.
+  governing_rule_label: Name of the governing body or rule for NIL in the state.
+  governing_rule_url: URL of the governing NIL rule or policy document.
+  key: On3 RDB key for the state NIL-compliance record.
+  monetization_allowed: Whether the state allows high-school athletes to monetize their NIL.
+  state: U.S. state whose NIL compliance rules the record describes.
+  state_key: On3 key of the U.S. state the compliance record covers.
+organizations_draft_class_by_state:
+  state: U.S. state the draft-class grouping covers.
+organizations_drafted_players:
+  college_organization: Nested On3 organization object for the college the player attended (stringified).
+  compensatory: Whether the selection was a compensatory draft pick.
+  drafted_from_organization: Nested On3 organization object for the school the player was drafted out of (stringified).
+  forfeited: Whether the pick was forfeited.
+  high_school_organization: Nested On3 organization object for the player's high school (stringified).
+  key: On3 RDB key for the draft-pick record.
+  person: Nested On3 person object for the drafted player (stringified).
+  recruitment_key: On3 RDB recruitment key linking the draft pick back to the player's recruitment record.
+  state: Home state of the drafted player, per On3.
+  supplementary: Whether the selection came in a supplemental draft.
+  through_organization_one: First intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  through_organization_three: Third intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  through_organization_two: Second intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  trading_organization: Pro organization that traded the pick away, when it changed hands (On3 RDB).
+people_valuation_growth:
+  date: Date of the On3 NIL valuation snapshot.
+  date_unix: Unix timestamp of the valuation snapshot.
+  nil_status: Status of the athlete's On3 NIL valuation at the snapshot (e.g. active, inactive).
+  valuation: Athlete's On3 NIL valuation in dollars at the snapshot.
+  valuation_change: Change in the NIL valuation versus the previous snapshot, in dollars.
+player_videos:
+  date: Publication date of the video, per On3.
+  is_featured: Whether the video is featured on the player's On3 profile.
+  key: On3 RDB key for the video record.
+  person_key: On3 person key of the featured athlete.
+  person_sport: Nested athlete-sport profile the video is attached to (stringified).
+  source_url: Source URL of the hosted video.
+  thumbnail: URL of the video's thumbnail image.
+videos_video_key:
+  date: Publication date of the video, per On3.
+  is_featured: Whether the video is featured on the player's On3 profile.
+  key: On3 RDB key for the video record.
+  person_key: On3 person key of the featured athlete.
+  person_sport: Nested athlete-sport profile the video is attached to (stringified).
+  source_url: Source URL of the hosted video.
+  thumbnail: URL of the video's thumbnail image.
+sports247_site_pages_location:
+  city_tax_rate: City income-tax rate for the location, carried on the 247Sports location record.
+  county_tax_rate: County income-tax rate for the location, carried on the 247Sports location record.
+  default_name: Server-rendered display label for the entity.
+  key: Primary key of this entity (the id used in its `.json` route).
+  region_name: Name of the region (state/province) for the location.
+  special_tax_rate: Special-district tax rate for the location, carried on the 247Sports location record.
+  state: U.S. state of the location record, per 247Sports.
+sports247_site_pages_player_institution:
+  created_date: Date the player-institution record was created.
+  default_asset: Nested 247Sports image asset for the stint (stringified).
+  default_name: Server-rendered display label for the entity.
+  early_enrollee: Whether the player enrolled early at the institution.
+  early_signee: Whether the player signed in the early signing period.
+  end_year_or_current: Stint's end year, or the current year for an active stint.
+  end_year_or_expected: Stint's end year, or the expected end year for an active stint.
+  hero_asset: Nested 247Sports hero (banner) image asset for the stint (stringified).
+  institution: Nested 247Sports institution for the stint (stringified).
+  key: Primary key of this entity (the id used in its `.json` route).
+  lead_expert: 247Sports expert assigned as the lead on the recruitment (nested, stringified).
+  modified_date: Date the player-institution record was last modified.
+  next_institution_group: Grouping (e.g. conference/division) of the player's next institution, per 247Sports.
+  next_institution_type: Level of the player's next institution (e.g. college, professional), per 247Sports.
+  player_institution_evaluation: Nested 247Sports evaluation attached to this player-institution stint (stringified).
+  primary_player_sport: Nested 247Sports player-sport profile the stint belongs to (stringified).
+  primary_recruitment: Nested 247Sports record for the recruitment behind the stint (stringified).
+  start_year_or_expected: Stint's start year, or the expected start year for a future stint.
+  state: Nested 247Sports state record for the institution's location (stringified).
+  transfer_eligibility: Player's eligibility status for the transfer, per 247Sports.
+  transfer_institution: Nested institution involved in the player's transfer, for transfer-portal stints (stringified).
+  transfer_season: Season of the player's transfer, when applicable.
+sports247_site_pages_player_sport:
+  average_rank: Player's average rank across the tracked industry services.
+  class_year: Recruiting class year.
+  class_year_override: Override of the player's recruiting class year, when 247Sports reassigns it.
+  composite_rating: 247Sports Composite rating (industry blend).
+  composite_rating_or_default: 247Sports Composite rating, falling back to a default value when unrated.
+  composite_strength: Composite strength points (team-ranking weight).
+  current_player_sport_ranking: Nested current published ranking row for the player (stringified).
+  current_player_sport_year: Current ranking-cycle year for the player-sport profile.
+  default_name: Server-rendered display label for the entity.
+  espn_grade: ESPN source grade (industry composite input).
+  espn_index: ESPN index value for the player, as tracked by 247Sports.
+  espn_rank: Player's rank in the ESPN industry ranking, as tracked by 247Sports.
+  key: Primary key of this entity (the id used in its `.json` route).
+  local_index: 247Sports' own industry-index value for the player, alongside the Rivals and ESPN indexes.
+  player_institution: Nested player-institution stint the player-sport profile points to (stringified).
+  previous_recruitment: Nested record for the player's previous recruitment (stringified).
+  primary: Whether this is the player's primary sport.
+  primary_institution_prediction: Nested leading Crystal Ball institution prediction for the player (stringified).
+  primary_institution_prediction_percentage: Share of Crystal Ball predictions favoring the leading institution.
+  primary_player_position: Nested 247Sports record for the player's primary position (stringified).
+  primary_position: Player's primary position on the 247Sports profile.
+  primary_position_group: Position group the player's primary position belongs to.
+  rating: 247Sports rating string (0-1).
+  rating_or_default: 247Sports in-house rating, falling back to a default value when unrated.
+  recruitment: FK -> Recruitment aggregate for this player-sport.
+  rivals_grade: Rivals source grade (industry composite input).
+  rivals_index: Rivals index value for the player, as tracked by 247Sports.
+  rivals_rank: Player's rank in the Rivals industry ranking, as tracked by 247Sports.
+  secondary_institution_prediction: Nested second-place Crystal Ball institution prediction (stringified).
+  secondary_institution_prediction_percentage: Share of Crystal Ball predictions favoring the second-place institution.
+  show_unranked_rating: 247Sports display flag to show the rating even while the player is unranked.
+  sport: Nested 247Sports sport for the profile (stringified).
+  star_rating: Star tier (2-5).
+  state: Home state of the recruit, per 247Sports.
+  unpublished_player_sport_ranking: Nested not-yet-published ranking row for the player (stringified).
+sports247_site_pages_recruit:
+  announcement_date: Date the recruit announced their decision.
+  commited_institution_team_image: Team image asset for the committed institution (the 'commited' spelling is 247Sports' own
+    field name).
+  committed_institution: FK -> committed Institution.
+  committed_recruit_interest: Nested interest record for the school the recruit committed to (stringified).
+  composite_strength: Composite strength points contributed to team ranking.
+  default_name: Server-rendered display label for the entity.
+  final_choice: Whether this entry represents the recruit's final school choice.
+  highest_recruit_interest: Nested interest record carrying the recruit's highest interest signal (stringified).
+  highest_recruit_interest_event: Nested highest-signal event on the recruit's interest timeline (stringified).
+  highest_recruit_interest_event_type: Type of the highest-signal event on the recruit's interest timeline (e.g. commit, signing).
+  institution: Nested institution the recruit row is scoped to (stringified).
+  key: Primary key of this entity (the id used in its `.json` route).
+  player_bio: Player biography text authored on 247Sports.
+  player_bio_or_default: Player bio text, falling back to a default blurb when none is authored.
+  player_birthdate: Player's date of birth, per 247Sports.
+  player_cbs_key: Cross-reference key into the CBS Sports id space.
+  player_college_stat_player: Reference tying the profile to a college stats player record (247Sports field).
+  player_current_player_institution: FK -> PlayerInstitution (current school).
+  player_default_asset: Nested 247Sports image asset for the player's headshot (stringified).
+  player_default_asset_url: URL of the player's headshot image.
+  player_default_name: Server-rendered display label for the entity.
+  player_hero_asset: Nested 247Sports hero (banner) image asset for the player page (stringified).
+  player_hometown_city: City of the player's hometown.
+  player_hometown_state: State of the player's hometown.
+  player_institution: Nested player-institution stint behind the recruit row (stringified).
+  player_key: Primary key of this entity (the id used in its `.json` route).
+  player_last_recruitment_player_institution: Nested player-institution record from the player's most recent recruitment (stringified).
+  player_mobile_phone_contact: Player's mobile phone contact field on the 247Sports record.
+  player_modified_date: Date the player record was last modified.
+  player_modified_user: 247Sports user who last modified the player record.
+  player_national_rank: Overall national rank in the recruit's class.
+  player_player_high_school_name: Name of the player's high school.
+  player_position_rank: Rank within position for the class.
+  player_primary_player_position_abbreviation: Abbreviation of the player's primary position.
+  player_primary_player_sport: FK -> PlayerSport (`/PlayerSport/{id}.json`).
+  player_primary_recruitment: Nested 247Sports record for the player's primary recruitment (stringified).
+  player_pro_stat_player: Reference tying the profile to a professional stats player record (247Sports field).
+  player_quote_asset: Nested 247Sports image asset used alongside the player's quote block (stringified).
+  player_rating: 247Sports numeric rating (0-1 scale) for the primary sport.
+  player_scout_evaluation: 247Sports scouting evaluation text for the player.
+  player_sport: Nested player-sport profile for the recruit (stringified).
+  player_star_rating: Star tier (2-5) derived from the rating.
+  player_state_rank: Rank within home state for the class.
+  player_twitter_contact: Player's Twitter/X handle on the 247Sports profile.
+  player_user: 247Sports user account linked to the player profile (nested, stringified).
+  primary_player_position: Nested 247Sports record for the recruit's primary position (stringified).
+  primary_position: Recruit's primary position on the 247Sports profile.
+  recruit_interest_count: Number of tracked school interests.
+  recruit_interests_url: Site URL to the recruit's interest timeline.
+  signed_institution: Nested institution the recruit signed with (stringified).
+  state: Home state of the recruit, per 247Sports.
+sports247_site_pages_recruit_interest_event:
+  date: Date of the recruiting-interest event, per 247Sports.
+  default_name: Server-rendered display label for the entity.
+  institution: Nested 247Sports institution the interest event involves (stringified).
+  key: Primary key of this entity (the id used in its `.json` route).
+  recruit_interest: Nested recruit-interest record the event belongs to (stringified).
+  recruitment: Nested 247Sports recruitment the event belongs to (stringified).
 load_contracts:
   cols: Placeholder column retained in the contracts loader output schema; contains no meaningful data in this context.
 load_depth_charts:

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -12645,7 +12645,7 @@ sports247_site_pages_player:
   scout_evaluation: 247Sports scouting evaluation text for the player.
   star_rating: Star tier (2-5) derived from the rating.
   state_rank: Rank within home state for the class.
-  twitter_contact: Player's Twitter/X handle on the 247Sports profile.
+  twitter_contact: Nested 247Sports contact record for the player's Twitter/X account (stringified).
   user: 247Sports user account linked to the player profile (nested, stringified).
 sports247_site_pages_player_institution_evaluation:
   comparison_player: Established player the evaluator compares the prospect to.
@@ -14111,7 +14111,7 @@ sports247_site_pages_recruit:
   player_sport: Nested player-sport profile for the recruit (stringified).
   player_star_rating: Star tier (2-5) derived from the rating.
   player_state_rank: Rank within home state for the class.
-  player_twitter_contact: Player's Twitter/X handle on the 247Sports profile.
+  player_twitter_contact: Nested 247Sports contact record for the player's Twitter/X account (stringified).
   player_user: 247Sports user account linked to the player profile (nested, stringified).
   primary_player_position: Nested 247Sports record for the recruit's primary position (stringified).
   primary_position: Recruit's primary position on the 247Sports profile.

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -2404,16 +2404,6 @@ leagueplayerondetails:
   vs_player_name: Display name for vs player name associated with this NBA or WNBA Stats row.
   w_pct_rank: Rank for winning percentage within the requested NBA or WNBA Stats leaderboard or split, where 1 is the leader.
   w_rank: Rank for wins within the requested NBA or WNBA Stats leaderboard or split, where 1 is the leader.
-leagues:
-  has_playoff_points: Boolean flag indicating whether this league uses a playoff points system to determine postseason seeding.
-  has_split_season: Boolean flag indicating whether this league divides its season into two halves with separate standings
-    (as used historically in some minor leagues).
-  has_wild_card: Boolean flag indicating whether this league includes a wild card playoff format for postseason eligibility.
-  num_games: The total number of regular-season games scheduled per team in this league for the given season.
-  num_wildcard_teams: The number of wild card berths available for postseason entry in this league for the given season.
-  org_code: The organizational code identifying the parent body (e.g., 'MLB') governing this league within the MLB Stats API
-    hierarchy.
-  season_state: A string describing the current phase of the league's season (e.g., 'inProgress', 'offseason', 'preseason').
 leagueseasonmatchups:
   def_player_id: Stats API identifier for defensive player identifier associated with this NBA or WNBA Stats row.
   def_player_name: Display name for defensive player name associated with this NBA or WNBA Stats row.
@@ -2674,116 +2664,6 @@ load_cfb_percentiles:
   yardsdropback: Value of yards per dropback at the percentile this row reports.
   yardsplay: Value of yards per play at the percentile this row reports.
   yardsrush: Value of yards per rush at the percentile this row reports.
-load_cfb_play_participants:
-  assisted_by_player_id: ESPN athlete id of a defender credited with an assisted tackle -- the FIRST participant in that role
-    on the play.
-  assisted_by_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with an assisted tackle
-    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  assisted_by_player_name: Display name of a defender credited with an assisted tackle -- the FIRST participant in that role
-    on the play.
-  assisted_by_player_names: List of the display names of EVERY participant credited as a defender credited with an assisted
-    tackle on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  forced_by_player_id: ESPN athlete id of the defender who forced the fumble -- the FIRST participant in that role on the
-    play.
-  forced_by_player_ids: List of the athlete ids of EVERY participant credited as the defender who forced the fumble on the
-    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  forced_by_player_name: Display name of the defender who forced the fumble -- the FIRST participant in that role on the play.
-  forced_by_player_names: List of the display names of EVERY participant credited as the defender who forced the fumble on
-    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  kicker_player_id: ESPN athlete id of the kicker -- the FIRST participant in that role on the play.
-  kicker_player_ids: List of the athlete ids of EVERY participant credited as the kicker on the play, so multi-entry roles
-    such as split sacks or gang tackles are not collapsed to one.
-  kicker_player_name: Display name of the kicker -- the FIRST participant in that role on the play.
-  kicker_player_names: List of the display names of EVERY participant credited as the kicker on the play, so multi-entry roles
-    such as split sacks or gang tackles are not collapsed to one.
-  pass_defender_player_id: ESPN athlete id of the defender credited with defending the pass -- the FIRST participant in that
-    role on the play.
-  pass_defender_player_ids: List of the athlete ids of EVERY participant credited as the defender credited with defending
-    the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  pass_defender_player_name: Display name of the defender credited with defending the pass -- the FIRST participant in that
-    role on the play.
-  pass_defender_player_names: List of the display names of EVERY participant credited as the defender credited with defending
-    the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  passer_player_id: ESPN athlete id of the passer -- the FIRST participant in that role on the play.
-  passer_player_ids: List of the athlete ids of EVERY participant credited as the passer on the play, so multi-entry roles
-    such as split sacks or gang tackles are not collapsed to one.
-  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
-  passer_player_names: List of the display names of EVERY participant credited as the passer on the play, so multi-entry roles
-    such as split sacks or gang tackles are not collapsed to one.
-  pat_passer_player_id: ESPN athlete id of the passer on the point-after attempt -- the FIRST participant in that role on
-    the play.
-  pat_passer_player_ids: List of the athlete ids of EVERY participant credited as the passer on the point-after attempt on
-    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  pat_passer_player_name: Display name of the passer on the point-after attempt -- the FIRST participant in that role on the
-    play.
-  pat_passer_player_names: List of the display names of EVERY participant credited as the passer on the point-after attempt
-    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  pat_scorer_player_id: ESPN athlete id of the player credited with the point-after score -- the FIRST participant in that
-    role on the play.
-  pat_scorer_player_ids: List of the athlete ids of EVERY participant credited as the player credited with the point-after
-    score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  pat_scorer_player_name: Display name of the player credited with the point-after score -- the FIRST participant in that
-    role on the play.
-  pat_scorer_player_names: List of the display names of EVERY participant credited as the player credited with the point-after
-    score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  penalized_player_id: ESPN athlete id of the penalized player -- the FIRST participant in that role on the play.
-  penalized_player_ids: List of the athlete ids of EVERY participant credited as the penalized player on the play, so multi-entry
-    roles such as split sacks or gang tackles are not collapsed to one.
-  penalized_player_name: Display name of the penalized player -- the FIRST participant in that role on the play.
-  penalized_player_names: List of the display names of EVERY participant credited as the penalized player on the play, so
-    multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  punter_player_id: ESPN athlete id of the punter -- the FIRST participant in that role on the play.
-  punter_player_ids: List of the athlete ids of EVERY participant credited as the punter on the play, so multi-entry roles
-    such as split sacks or gang tackles are not collapsed to one.
-  punter_player_name: Display name of the punter -- the FIRST participant in that role on the play.
-  punter_player_names: List of the display names of EVERY participant credited as the punter on the play, so multi-entry roles
-    such as split sacks or gang tackles are not collapsed to one.
-  receiver_player_id: ESPN athlete id of the targeted receiver -- the FIRST participant in that role on the play.
-  receiver_player_ids: List of the athlete ids of EVERY participant credited as the targeted receiver on the play, so multi-entry
-    roles such as split sacks or gang tackles are not collapsed to one.
-  receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
-  receiver_player_names: List of the display names of EVERY participant credited as the targeted receiver on the play, so
-    multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  recoverer_player_id: ESPN athlete id of the player who recovered the fumble -- the FIRST participant in that role on the
-    play.
-  recoverer_player_ids: List of the athlete ids of EVERY participant credited as the player who recovered the fumble on the
-    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  recoverer_player_name: Display name of the player who recovered the fumble -- the FIRST participant in that role on the
-    play.
-  recoverer_player_names: List of the display names of EVERY participant credited as the player who recovered the fumble on
-    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  returner_player_id: ESPN athlete id of the player returning the kick or punt -- the FIRST participant in that role on the
-    play.
-  returner_player_ids: List of the athlete ids of EVERY participant credited as the player returning the kick or punt on the
-    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  returner_player_name: Display name of the player returning the kick or punt -- the FIRST participant in that role on the
-    play.
-  returner_player_names: List of the display names of EVERY participant credited as the player returning the kick or punt
-    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  rusher_player_id: ESPN athlete id of the ball carrier on a rush -- the FIRST participant in that role on the play.
-  rusher_player_ids: List of the athlete ids of EVERY participant credited as the ball carrier on a rush on the play, so multi-entry
-    roles such as split sacks or gang tackles are not collapsed to one.
-  rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
-  rusher_player_names: List of the display names of EVERY participant credited as the ball carrier on a rush on the play,
-    so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  sacked_by_player_id: ESPN athlete id of a defender credited with the sack -- the FIRST participant in that role on the play.
-  sacked_by_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with the sack on the
-    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  sacked_by_player_name: Display name of a defender credited with the sack -- the FIRST participant in that role on the play.
-  sacked_by_player_names: List of the display names of EVERY participant credited as a defender credited with the sack on
-    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  scorer_player_id: ESPN athlete id of the player credited with the score -- the FIRST participant in that role on the play.
-  scorer_player_ids: List of the athlete ids of EVERY participant credited as the player credited with the score on the play,
-    so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  scorer_player_name: Display name of the player credited with the score -- the FIRST participant in that role on the play.
-  scorer_player_names: List of the display names of EVERY participant credited as the player credited with the score on the
-    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  tackler_player_id: ESPN athlete id of a defender credited with the tackle -- the FIRST participant in that role on the play.
-  tackler_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with the tackle on the
-    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  tackler_player_name: Display name of a defender credited with the tackle -- the FIRST participant in that role on the play.
-  tackler_player_names: List of the display names of EVERY participant credited as a defender credited with the tackle on
-    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
 load_cfb_drives:
   n_plays: Number of entries in ESPN's raw plays array for the drive, which is generally at least offensive_plays because
     it also counts penalties and other non-offensive snaps.
@@ -2813,49 +2693,6 @@ load_cfb_model_pbp:
   statYardage: Yards gained on the play as ESPN reports it, negative on plays that lost yardage.
   type.text: ESPN's play-type label, for example Rush, Pass Reception, Sack, Punt, Penalty, or Timeout.
   wp_model_version: Version of the win-probability model that scored the play.
-load_cfb_player_box:
-  adjQBR: Adjusted Total QBR for the quarterback.
-  completions/passingAttempts: Completions and pass attempts, as ESPN's combined string.
-  extraPointsMade/extraPointAttempts: Extra points made and attempted, as ESPN's combined string.
-  fieldGoalPct: Field-goal percentage.
-  fieldGoalsMade/fieldGoalAttempts: Field goals made and attempted, as ESPN's combined string.
-  grossAvgPuntYards: Gross average yards per punt, before return yardage.
-  interceptionTouchdowns: Touchdowns scored on interception returns.
-  interceptionYards: Yards returned on interceptions.
-  longFieldGoalMade: Longest field goal made, in yards.
-  longPunt: Longest punt of the game, in yards.
-  longPuntReturn: Longest punt return of the game, in yards.
-  longReception: Longest reception of the game, in yards.
-  longRushing: Longest rush of the game, in yards.
-  passingTouchdowns: Passing touchdowns.
-  passingYards: Net passing yards gained.
-  puntReturnTouchdowns: Touchdowns scored on punt returns.
-  puntReturnYards: Yards gained on punt returns.
-  puntReturns: Punt returns attempted.
-  puntYards: Total punt yards.
-  punts: Punts attempted.
-  puntsInside20: Punts downed inside the opponent 20-yard line.
-  receivingTouchdowns: Receiving touchdowns.
-  receivingYards: Receiving yards gained.
-  rushingAttempts: Rushing attempts.
-  rushingTouchdowns: Rushing touchdowns.
-  rushingYards: Net rushing yards gained.
-  stat_1: First value of ESPN's raw athlete stats array, written only when the category's key list does not line up with the
-    stats list; on those rows the named per-category columns are all null.
-  stat_2: Second value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
-    the named columns could not be filled.
-  stat_3: Third value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
-    the named columns could not be filled.
-  stat_4: Fourth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
-    the named columns could not be filled.
-  stat_5: Fifth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
-    the named columns could not be filled.
-  totalKickingPoints: Total points scored by kicking.
-  touchbacks: Punts or kickoffs that resulted in a touchback.
-  yardsPerPassAttempt: Yards gained per pass attempt.
-  yardsPerPuntReturn: Yards gained per punt return.
-  yardsPerReception: Yards gained per reception.
-  yardsPerRushAttempt: Yards gained per rushing attempt.
 load_cfb_ratings:
   adj_def_epa: Opponent-adjusted EPA per play allowed, netted the same way as the offensive rating, so lower is better because
     it measures EPA surrendered.
@@ -3107,10 +2944,6 @@ load_cfb_team_box:
   yardsPerPass: Net passing yards per pass attempt, netPassingYards divided by the attempt count in completionAttempts and
     rounded to one decimal.
   yardsPerRushAttempt: Yards gained per rushing attempt.
-load_cfb_team_info:
-  logo_2: URL of the team's alternate dark-background 500-pixel logo on ESPN's CDN, null for programs with no dark variant.
-  twitter: The football program's Twitter/X handle including the leading at sign, populated for only a minority of listed
-    teams.
 load_cfb_teams:
   season: 'Season the team row describes. The dataset is season-scoped, so a school''s conference, division and branding are what ESPN published for that year rather than today''s values.'
   team_id: 'ESPN''s team identifier, stable across seasons and the join key to every other ESPN-sourced CFB dataset (schedules, rosters, pbp).'
@@ -3466,258 +3299,6 @@ load_cfb_adv_situational:
   pos_team: Display name of the team on offense (e.g. 'Ohio State Buckeyes').
   pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
   standard_downs: Number of plays the team ran on standard downs (the team ahead of schedule for the series).
-load_cfb_pbp:
-  A_score_diff: Away team's score minus the home team's, from the away perspective.
-  EPA_explosive: True when the play was explosive.
-  EPA_explosive_pass: True when the pass play was explosive.
-  EPA_explosive_rush: True when the rush play was explosive.
-  EPA_fg: EPA credited to the play on field-goal attempts.
-  EPA_kickoff: EPA credited to the play on kickoff plays.
-  EPA_middle_8_success: True when the play in the middle eight was successful by EPA.
-  EPA_middle_8_success_pass: True when the pass play in the middle eight was successful by EPA.
-  EPA_middle_8_success_rush: True when the rush play in the middle eight was successful by EPA.
-  EPA_non_explosive: EPA credited to the play on non-explosive plays.
-  EPA_pass: EPA credited to the play on pass plays.
-  EPA_penalty: EPA credited to the play attributable to penalties.
-  EPA_punt: EPA credited to the play on punt plays.
-  EPA_rush: EPA credited to the play on rush plays.
-  EPA_scrimmage: EPA credited to the play on plays from scrimmage.
-  EPA_sp: EPA credited to the play on special-teams plays.
-  EPA_success: True when the play was successful by EPA.
-  EPA_success_EPA: EPA on successful plays.
-  EPA_success_early_down: True when the play on an early down was successful by EPA.
-  EPA_success_early_down_pass: True when the pass play on an early down was successful by EPA.
-  EPA_success_early_down_rush: True when the rush play on an early down was successful by EPA.
-  EPA_success_late_down: True when the play on a late down was successful by EPA.
-  EPA_success_late_down_pass: True when the pass play on a late down was successful by EPA.
-  EPA_success_late_down_rush: True when the rush play on a late down was successful by EPA.
-  EPA_success_pass: True when the pass play was successful by EPA.
-  EPA_success_pass_EPA: EPA on successful pass plays.
-  EPA_success_passing_down: True when the play on a passing down was successful by EPA.
-  EPA_success_passing_down_EPA: EPA on successful plays on a passing down.
-  EPA_success_rush: True when the rush play was successful by EPA.
-  EPA_success_rush_EPA: EPA on successful rush plays.
-  EPA_success_standard_down: True when the play on a standard down was successful by EPA.
-  EPA_success_standard_down_EPA: EPA on successful plays on a standard down.
-  EP_between: Change in expected points across the play, before penalty adjustment.
-  EP_end: Expected points for the offense at the end of the play.
-  EP_start: Expected points for the offense at the start of the play.
-  EP_start_touchback: Expected points the offense would have had from a touchback on this play.
-  HA_score_diff: Home score minus away score for the play.
-  H_score_diff: Home team's score minus the away team's, from the home perspective.
-  TFL: True when the play was a tackle for loss.
-  TFL_pass: True when the play was a tackle for loss on a pass play (a sack).
-  TFL_rush: True when the play was a tackle for loss on a rush play.
-  action_play: True when the play advanced the game state -- excludes timeouts, end-of-period markers and other non-action
-    rows.
-  adj_rush_yardage: Rushing yards capped at 8, the input to the line-yards decomposition.
-  awayTeamAbbrev: ESPN's away-team Abbrev for the game, stamped on every play.
-  awayTeamId: ESPN's away-team Id for the game, stamped on every play.
-  awayTeamMascot: ESPN's away-team Mascot for the game, stamped on every play.
-  awayTeamName: ESPN's away-team Name for the game, stamped on every play.
-  awayTeamNameAlt: ESPN's away-team NameAlt for the game, stamped on every play.
-  awayTimeoutCalled: True when the away team called a timeout on the play.
-  clock.displayValue: Game clock at the play, as the displayed mm:ss string.
-  clock.minutes: Minutes remaining on the game clock at the play.
-  clock.seconds: Seconds component of the game clock at the play.
-  down_1: True when it is 1st down at the start of the play.
-  down_1_end: True when it is 1st down at the end of the play.
-  down_2: True when it is 2nd down at the start of the play.
-  down_2_end: True when it is 2nd down at the end of the play.
-  down_3: True when it is 3rd down at the start of the play.
-  down_3_end: True when it is 3rd down at the end of the play.
-  down_4: True when it is 4th down at the start of the play.
-  down_4_end: True when it is 4th down at the end of the play.
-  drive.description: ESPN's `description` field for the drive containing this play.
-  drive.displayResult: ESPN's `displayResult` field for the drive containing this play.
-  drive.end.clock.displayValue: ESPN's `end.clock.displayValue` field for the drive containing this play.
-  drive.end.period.number: ESPN's `end.period.number` field for the drive containing this play.
-  drive.end.period.type: ESPN's `end.period.type` field for the drive containing this play.
-  drive.end.yardLine: ESPN's `end.yardLine` field for the drive containing this play.
-  drive.id: ESPN's `id` field for the drive containing this play.
-  drive.isScore: ESPN's `isScore` field for the drive containing this play.
-  drive.offensivePlays: ESPN's `offensivePlays` field for the drive containing this play.
-  drive.result: ESPN's `result` field for the drive containing this play.
-  drive.shortDisplayResult: ESPN's `shortDisplayResult` field for the drive containing this play.
-  drive.start.clock.displayValue: ESPN's `start.clock.displayValue` field for the drive containing this play.
-  drive.start.period.number: ESPN's `start.period.number` field for the drive containing this play.
-  drive.start.period.type: ESPN's `start.period.type` field for the drive containing this play.
-  drive.start.text: ESPN's `start.text` field for the drive containing this play.
-  drive.start.yardLine: ESPN's `start.yardLine` field for the drive containing this play.
-  drive.team.abbreviation: ESPN's `team.abbreviation` field for the drive containing this play.
-  drive.team.displayName: ESPN's `team.displayName` field for the drive containing this play.
-  drive.team.name: ESPN's `team.name` field for the drive containing this play.
-  drive.team.shortDisplayName: ESPN's `team.shortDisplayName` field for the drive containing this play.
-  drive.timeElapsed.displayValue: ESPN's `timeElapsed.displayValue` field for the drive containing this play.
-  drive.yards: ESPN's `yards` field for the drive containing this play.
-  drive_offense_plays: Offensive plays run on the drive.
-  drive_offense_yards: Offensive yards gained on the drive.
-  drive_play_index: Sequence number of the play within its drive.
-  drive_start: Yard line at which the drive began.
-  drive_stopped: True when the play ended the drive.
-  drive_total_yards: Total yards gained on the drive.
-  early_down: True when the play is a scrimmage play on first or second down.
-  early_down_pass: True when the play is a pass on an early down.
-  early_down_rush: True when the play is a rush on an early down.
-  end.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the end of the play.
-  end.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the end of the play.
-  end.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the end of the play.
-  end.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the end of the play.
-  end.awayScore: ESPN's `awayScore` value for the play state at the end of the play.
-  end.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the end of the play.
-  end.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the end of the play.
-  end.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the end of the play.
-  end.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the end of the play.
-  end.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the end of the play.
-  end.distance: ESPN's `distance` value for the play state at the end of the play.
-  end.down: ESPN's `down` value for the play state at the end of the play.
-  end.downDistanceText: ESPN's `downDistanceText` value for the play state at the end of the play.
-  end.elapsed_share: ESPN's `elapsed_share` value for the play state at the end of the play.
-  end.homeScore: ESPN's `homeScore` value for the play state at the end of the play.
-  end.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the end of the play.
-  end.is_home: ESPN's `is_home` value for the play state at the end of the play.
-  end.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the end of the play.
-  end.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the end of the play.
-  end.pos_team.id: ESPN's `pos_team.id` value for the play state at the end of the play.
-  end.pos_team.name: ESPN's `pos_team.name` value for the play state at the end of the play.
-  end.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the end of the play.
-  end.pos_team_score: ESPN's `pos_team_score` value for the play state at the end of the play.
-  end.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the end of the play.
-  end.possessionText: ESPN's `possessionText` value for the play state at the end of the play.
-  end.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the end of the play.
-  end.spread_time: ESPN's `spread_time` value for the play state at the end of the play.
-  end.team.id: ESPN's `team.id` value for the play state at the end of the play.
-  end.yard: ESPN's `yard` value for the play state at the end of the play.
-  end.yardLine: ESPN's `yardLine` value for the play state at the end of the play.
-  end.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the end of the play.
-  fg_attempt: True when the play was a field-goal attempt.
-  firstHalfKickoffTeamId: ESPN id of the team that received the opening kickoff.
-  first_down_created: True when the play produced a first down for the offense.
-  forced_fumble: True when the defense forced a fumble on the play.
-  fumble_recovered: True when a fumble on the play was recovered.
-  gameSpread: Point spread used as an input to the win-probability model.
-  gameSpreadAvailable: True when a spread was available for the game.
-  havoc: 'True when the defense disrupted the play: a pass breakup, tackle for loss, interception or forced fumble.'
-  highlight_run: True when the rush gained 8 or more yards.
-  highlight_yards: Second-level plus open-field yards -- the yardage credited to the carrier.
-  homeFavorite: True when the home team was favoured by the spread.
-  homeTeamAbbrev: ESPN's home-team Abbrev for the game, stamped on every play.
-  homeTeamId: ESPN's home-team Id for the game, stamped on every play.
-  homeTeamMascot: ESPN's home-team Mascot for the game, stamped on every play.
-  homeTeamName: ESPN's home-team Name for the game, stamped on every play.
-  homeTeamNameAlt: ESPN's home-team NameAlt for the game, stamped on every play.
-  homeTeamSpread: ESPN's home-team Spread for the game, stamped on every play.
-  homeTimeoutCalled: True when the home team called a timeout on the play.
-  lag_EP_end: Value of EP_end on the previous play, used for sequence-aware derivations.
-  lag_HA_score_diff: Value of HA_score_diff on the previous play, used for sequence-aware derivations.
-  lag_awayScore: Value of awayScore on the previous play, used for sequence-aware derivations.
-  lag_change_of_pos_team: Value of change_of_pos_team on the previous play, used for sequence-aware derivations.
-  lag_half: Value of half on the previous play, used for sequence-aware derivations.
-  lag_homeScore: Value of homeScore on the previous play, used for sequence-aware derivations.
-  lag_pos_score_diff: Value of pos_score_diff on the previous play, used for sequence-aware derivations.
-  lag_pos_team: Value of pos_team on the previous play, used for sequence-aware derivations.
-  lag_scoringPlay: Value of scoringPlay on the previous play, used for sequence-aware derivations.
-  late_down: True when the play is a scrimmage play on third or fourth down.
-  late_down_pass: True when the play is a pass on a late down.
-  late_down_rush: True when the play is a rush on a late down.
-  lead_half: Value of half on the next play, used for sequence-aware derivations.
-  lead_play_type: Value of play_type on the next play, used for sequence-aware derivations.
-  lead_pos_team: Value of pos_team on the next play, used for sequence-aware derivations.
-  lead_pos_team2: Value of pos_team 2 plays ahead, used for sequence-aware derivations.
-  lead_scoringPlay: Value of scoringPlay on the next play, used for sequence-aware derivations.
-  lead_start_distance: Value of start_distance on the next play, used for sequence-aware derivations.
-  lead_start_down: Value of start_down on the next play, used for sequence-aware derivations.
-  lead_start_team: Value of start_team on the next play, used for sequence-aware derivations.
-  lead_start_yardsToEndzone: Value of start_yardsToEndzone on the next play, used for sequence-aware derivations.
-  lead_text: Value of text on the next play, used for sequence-aware derivations.
-  lead_wp_before: Value of wp_before on the next play, used for sequence-aware derivations.
-  lead_wp_before2: Value of wp_before 2 plays ahead, used for sequence-aware derivations.
-  line_yards: 'Yards credited to the offensive line on a rush, using the standard sliding scale: 1.2x the capped yardage on
-    a loss, all of it through 3 yards, half of each yard from 4 to 8, and a 5.5-yard ceiling beyond that.'
-  net_HA_score_pts: Net points the play added to the home-minus-away score margin.
-  new_distance: Distance to go after the play, including any penalty enforcement.
-  new_down: Down after the play, including any penalty enforcement.
-  non_fumble_sack: True when the play was a sack that did not produce a fumble.
-  open_field_yards: Rushing yards gained beyond 8, credited to the ball carrier rather than the line.
-  opp_highlight_yards: Highlight yards earned on opportunity runs, isolating carrier production on carries where the blocking
-    succeeded. Assets published before the 2026-08 fix are identically 0 here, because the inverted opportunity_run gate could
-    never co-occur with non-zero highlight yards.
-  opportunity_run: True when a rush reached 4 yards -- the carries on which the blocking did its job. Matches cfbfastR's espn_cfb_15
-    definition. Assets published before the 2026-08 fix carry the inverted (4 yards or fewer) flag.
-  overUnder: Over/under total used as a model input.
-  pass_breakup: True when a defender broke up the pass.
-  pass_epa: EPA credited to the play when it is a pass.
-  pass_weight: Weighting applied to the pass component of the play.
-  passing_down: True when the offense is behind schedule for the series -- second down needing 8 or more, or third/fourth
-    down needing 5 or more.
-  pen_epa: EPA attributable to a penalty on the play.
-  pen_weight: Weighting applied to the penalty component of the play.
-  penalty_in_text: True when the play description mentions a penalty.
-  period.number: Period (quarter) number in which the play occurred.
-  pos_score_diff_end: Score differential from the possessing team's perspective at the end of the play.
-  power_rush_attempt: True when the play is a short-yardage power rushing attempt.
-  power_rush_success: True when a power rushing attempt gained the yardage needed.
-  prog_drive_EPA: Cumulative EPA accrued by the drive up to and including this play.
-  prog_drive_WPA: Cumulative win-probability added by the drive up to and including this play.
-  qbr_epa: EPA variant used as an input to the QBR calculation.
-  rush_epa: EPA credited to the play when it is a rush.
-  rush_weight: Weighting applied to the rush component of the play.
-  sack_epa: EPA credited to the play when it is a sack.
-  sack_weight: Weighting applied to the sack component of the play.
-  scoringPlay: ESPN flag marking the play as a scoring play.
-  scoringType.abbreviation: ESPN's abbreviation for the scoring type.
-  scoringType.displayName: ESPN's display label for the scoring type.
-  scoringType.name: ESPN's name for the scoring type (e.g. touchdown, field goal).
-  scrimmage_play: True when the play is a play from scrimmage rather than a special-teams or administrative row.
-  seasonType: ESPN season type for the game (2 = regular season, 3 = postseason).
-  second_level_yards: Rushing yards earned from 4 to 8, split evenly between line and carrier under the line-yards decomposition.
-  short_rush_attempt: True when the play is a rush in a short-yardage situation.
-  short_rush_success: True when a short-yardage rush gained the yardage needed.
-  standard_down: True when the offense is on schedule for the series -- first down, second down needing fewer than 8, or third/fourth
-    down needing fewer than 5.
-  start.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the start of the play.
-  start.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the start of the play.
-  start.ExpScoreDiff_Time_Ratio_touchback: ESPN's `ExpScoreDiff_Time_Ratio_touchback` value for the play state at the start
-    of the play.
-  start.ExpScoreDiff_touchback: ESPN's `ExpScoreDiff_touchback` value for the play state at the start of the play.
-  start.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the start of the play.
-  start.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the start of the play.
-  start.awayScore: ESPN's `awayScore` value for the play state at the start of the play.
-  start.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the start of the play.
-  start.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the start of the play.
-  start.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the start of the play.
-  start.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the start of the play.
-  start.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the start of the play.
-  start.distance: ESPN's `distance` value for the play state at the start of the play.
-  start.down: ESPN's `down` value for the play state at the start of the play.
-  start.downDistanceText: ESPN's `downDistanceText` value for the play state at the start of the play.
-  start.elapsed_share: ESPN's `elapsed_share` value for the play state at the start of the play.
-  start.homeScore: ESPN's `homeScore` value for the play state at the start of the play.
-  start.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the start of the play.
-  start.is_home: ESPN's `is_home` value for the play state at the start of the play.
-  start.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the start of the play.
-  start.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the start of the play.
-  start.pos_team.id: ESPN's `pos_team.id` value for the play state at the start of the play.
-  start.pos_team.name: ESPN's `pos_team.name` value for the play state at the start of the play.
-  start.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the start of the play.
-  start.pos_team_score: ESPN's `pos_team_score` value for the play state at the start of the play.
-  start.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the start of the play.
-  start.possessionText: ESPN's `possessionText` value for the play state at the start of the play.
-  start.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the start of the play.
-  start.spread_time: ESPN's `spread_time` value for the play state at the start of the play.
-  start.team.id: ESPN's `team.id` value for the play state at the start of the play.
-  start.yard: ESPN's `yard` value for the play state at the start of the play.
-  start.yardLine: ESPN's `yardLine` value for the play state at the start of the play.
-  start.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the start of the play.
-  start.yardsToEndzone.touchback: ESPN's `yardsToEndzone.touchback` value for the play state at the start of the play.
-  statYardage: Yardage ESPN credits to the play for statistical purposes.
-  stopped_run: True when the rush was stopped at or behind the line of scrimmage.
-  td_check: Internal flag used while reconciling whether the play produced a touchdown.
-  text_dupe: True when the play description duplicates the previous row's text.
-  type.abbreviation: ESPN's abbreviation for the play type.
-  type.id: ESPN's numeric identifier for the play type.
-  type.text: ESPN's text label for the play type.
-  wp_touchback: Win probability the offense would have had starting from a touchback.
 load_cfb_team_summaries:
   EPAdrive_def: EPA per drive (total EPA divided by drives), with the team on defense (i.e. allowed to opponents).
   EPAdrive_def_pass: EPA per drive (total EPA divided by drives) on pass plays, with the team on defense (i.e. allowed to
@@ -5030,47 +4611,6 @@ load_phf_team_boxscores:
   successful_power_play: Number of power plays on which the team scored.
   total_scoring: Goals the team scored in the game.
   total_shots: Shots the team took in the game.
-load_wbb_pbp:
-  type_text: >-
-    Play type text, passed through verbatim from ESPN. ESPN labels the
-    free-throw play type "MadeFreeThrow" for made AND missed free throws;
-    filter makes vs. misses with scoring_play, not type_text.
-  score_value: >-
-    Point value of the attempt (1 / 2 / 3), carried even on misses (a missed
-    free throw still shows 1); use scoring_play to identify points actually
-    scored.
-load_wnba_pbp:
-  type_text: >-
-    Play type text, passed through verbatim from ESPN. ESPN labels the
-    free-throw play type "MadeFreeThrow" for made AND missed free throws;
-    filter makes vs. misses with scoring_play, not type_text.
-  score_value: >-
-    Point value of the attempt (1 / 2 / 3), carried even on misses (a missed
-    free throw still shows 1); use scoring_play to identify points actually
-    scored.
-load_wnba_stats_pbp:
-load_wnba_stats_player_game_logs:
-  ast: Assists credited.
-  blk: Total shots blocked.
-  dreb: Defensive rebounds collected.
-  fantasy_pts: Fantasy points.
-  fg3_pct: Three-point percentage.
-  fg3a: Three-point field goals attempted.
-  fg3m: Three-point field goals made.
-  fg_pct: Field-goal percentage.
-  fga: Field goals attempted.
-  fgm: Field goals made.
-  ft_pct: Free-throw percentage.
-  fta: Free throws attempted.
-  ftm: Free throws made.
-  min: Minutes played.
-  oreb: Offensive rebounds collected.
-  pf: Personal fouls committed.
-  plus_minus: Plus-minus point differential.
-  pts: Total points scored.
-  reb: Total rebounds collected.
-  stl: Steals recorded.
-  tov: Turnovers committed.
 load_wnba_team_season_stats:
   stat_description: Human-readable description of the statistic the row reports.
 load_cfb_adv_defensive:
@@ -5317,20 +4857,6 @@ load_cfb_betting:
   odds_source: 'Provenance of the spread and over/under used for the game: summary_pickcenter when ESPN''s own pickcenter
     carried them, core_odds_api when they came from the live odds endpoint, default when neither resolved, injected when supplied
     by an offline rebuild.'
-load_cfb_game_rosters:
-  athlete_href: ESPN Core v2 API reference URL for the athlete's season record, ending in the athlete id.
-  birth_country_alternate_id: ESPN's internal alternate identifier for the athlete's birth country, paired with birth_place_country
-    and the flag fields.
-  draft_team_href: 'API link to the team that drafted the player. Sparse: absent entirely from the 2023 and 2024 assets and
-    populated on only a small share of 2025 rows.'
-  flag_alt: Alt text ESPN attaches to the birth-country flag image, which is the country's name spelled out.
-  flag_href: URL of the birth-country flag image hosted on ESPN's CDN under teamlogos/countries.
-  flag_rel: Stringified relationship list ESPN ships with the flag image; the only non-null value observed is a single country-flag
-    entry.
-  position_href: ESPN Core v2 API reference URL for the position resource ESPN lists the athlete at.
-  statistics_href: ESPN Core v2 API reference URL for this athlete's stat line in this game, null for the roughly 71 percent
-    of listed players who recorded no stats.
-  team_alternate_ids_sdr: The team's Sportradar alternate identifier, which maps one-to-one with team_id.
 load_mbb_game_rosters:
   athlete_headshot: URL of the player's ESPN headshot image, whose filename is the athlete_id (verified equal for all 190,365
     non-null rows in 2025); null when ESPN publishes no photo for that player.
@@ -5344,16 +4870,6 @@ load_mbb_officials:
     official in this release rather than a distinct crew chief or umpire designation.
   official_position_id: ESPN's numeric code for the official's role, constant at 40 (Referee) across the entire men's college
     basketball officials release.
-load_mbb_pbp:
-  away_timeout_called: True when the away team called a timeout on the play.
-  end_period_seconds_remaining: Seconds left in the period when the play ended.
-  home_timeout_called: True when the home team called a timeout on the play.
-  lag_period: Period number of the previous play in the same game (period_number shifted forward one row within game_id),
-    and null on each game's first play.
-  lead_period: Period number of the next play in the same game (period_number shifted back one row within game_id), and null
-    on each game's final play.
-  start_period_seconds_remaining: Seconds left in the current period when the play started, computed as 60 times the game
-    clock minutes plus the seconds, so 1200 at the tip of each 20-minute half and 300 at the start of an overtime.
 load_mbb_player_value:
   box_bpm: Total box plus/minus in points per 100 possessions above an average player, exactly box_obpm plus box_dbpm (verified
     to zero residual across all 9,805 rows of 2025).
@@ -5422,7 +4938,6 @@ load_nba_standings:
     splits (Home, Road, vs. Conf., vs. Div.), which ship no abbreviation.
   stat_description: ESPN's prose gloss for the standings statistic on this row; for the clincher stat it is not a fixed label
     but the team's actual status text, such as Clinched Playoff Berth or Eliminated From Playoff.
-load_nba_stats_schedules:
 load_nhl_penalties:
   committedByPlayer.firstName.cs: Alternate given name for the penalized player under the NHL feed's Czech key. Verified against
     the data it is frequently a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei),
@@ -5542,108 +5057,6 @@ load_nhl_schedule:
   shifts: 'CONSTANT false in every published row: the shift-chart block is not carried on this asset. An availability flag,
     not a shift count.'
   three_stars: 'CONSTANT true: marks that the source game record carried a three-stars block.'
-load_nhl_scoring:
-  discreteClipFr: Numeric NHL video identifier of the French-language standalone clip of the goal, always a different asset
-    id from discreteClip.
-  firstName.cs: Alternate given name for the player under the NHL feed's Czech key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.de: Alternate given name for the player under the NHL feed's German key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.default: Given name of the goal scorer as rendered in the NHL feed's default English locale.
-  firstName.es: Alternate given name for the player under the NHL feed's Spanish key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.fi: Alternate given name for the player under the NHL feed's Finnish key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.fr: Alternate given name for the player under the NHL feed's French key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.sk: Alternate given name for the player under the NHL feed's Slovak key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.sv: Alternate given name for the player under the NHL feed's Swedish key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  highlightClipFr: NHL video id of the French-language highlight clip for the goal. Stored as Float64 even though it is a
-    whole 13-digit identifier, so cast before using it as a key.
-  highlightClipSharingUrlFr: Shareable nhl.com URL for the French-language highlight clip; its trailing numeric segment is
-    the same id carried in highlightClipFr.
-  lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.de: Alternate rendering of the player's family name under the NHL feed's German key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.default: Family name of the goal scorer as rendered in the NHL feed's default English locale.
-  lastName.es: Alternate rendering of the player's family name under the NHL feed's Spanish key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  leadingTeamAbbrev.default: Three-letter code of the team ahead on the scoreboard immediately after this goal, null exactly
-    when the goal tied the game and not always the scoring team.
-  name.cs: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.de: Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.default: Abbreviated name of the player as published in the NHL feed's default English locale.
-  name.fi: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.sk: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.sv: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing
-    from the default by diacritics or by an alternate given-name form.
-  teamAbbrev.default: Three-letter code of the team that scored the goal, resolving to the home club exactly when isHome is
-    true and to the visitor otherwise.
-load_nhl_shootout:
-  discreteClipFr: Numeric NHL video identifier of the French-language clip of the shootout attempt, distinct from the id in
-    discreteClip.
-  firstName.cs: Alternate given name published under the NHL feed's Czech key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.de: Alternate given name published under the NHL feed's German key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.default: Given name of the shooter in the feed's default English locale; null on the per-game summary row.
-  firstName.es: Alternate given name published under the NHL feed's Spanish key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.fi: Alternate given name published under the NHL feed's Finnish key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.sk: Alternate given name published under the NHL feed's Slovak key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.sv: Alternate given name published under the NHL feed's Swedish key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  gameWinner: True on the single attempt per shootout credited as the game-deciding goal, false on every other attempt and
-    null on the per-game summary row.
-  lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.default: Family name of the shooter in the feed's default English locale; null on the per-game summary row.
-  lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  teamAbbrev.default: Three-letter code of the shooting player's team; null on the per-game summary row that instead carries
-    the home and away shootout goal totals.
 load_nhl_skater_boxscores:
   shifts: 'CONSTANT false in every published row: the shift-chart block is not carried on this asset. An availability flag,
     not a shift count.'
@@ -5714,10 +5127,6 @@ load_wnba_standings:
 load_wnba_stats_draft:
   draft_type: 'CONSTANT in the published asset: every row reads ''Draft'', so it does not currently distinguish the main draft
     from any other selection event.'
-load_wnba_stats_rosters:
-  num: Jersey number worn by the player.
-  exp: Years of WNBA playing experience entering the season ('R' = rookie).
-  how_acquired: How the team acquired the player (draft, trade, free agency).
 load_cfb_fpi_weekly:
   accomplishment: Reflects chance that an average Top 25 team would have team's record or better, given the schedule. On a
     0 to 100 scale, where 100 is best.
@@ -5806,6 +5215,8881 @@ load_cfb_power_index:
   teamadjgamescore: A measure of how well a team performed compared to their expected performance and the expected performance
     of a typical top 25 team.
   teampredptdiff: Expected margin of victory for the FPI favorite.
+alltimeleadersgrids:
+  is_active_flag: Flag indicating whether the player is currently active in the league.
+  tov_rank: All-time league rank of the player's career turnover total on the leaders grid.
+blocking_summary:
+  block_percent: Share of offensive snaps spent blocking.
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  grades_offense: PFF overall offense grade, 0-100.
+  grades_pass_block: PFF pass-blocking grade, 0-100.
+  grades_run_block: PFF run-blocking grade, 0-100.
+  hits_allowed: Quarterback hits allowed.
+  hurries_allowed: Quarterback hurries allowed.
+  non_spike_pass_block: Pass-blocking snaps excluding spike plays.
+  non_spike_pass_block_percentage: Share of non-spike pass-play snaps spent pass blocking.
+  pass_block_percent: Share of pass-play snaps spent pass blocking.
+  pbe: PFF Pass Blocking Efficiency rating, pressures allowed per pass-blocking snap weighted toward sacks.
+  player_game_count: Number of games the player appeared in over the covered span.
+  pressures_allowed: Total pressures allowed (sacks, hits, and hurries).
+  snap_counts_block: Total blocking snaps played.
+  snap_counts_ce: Snaps aligned at center.
+  snap_counts_lg: Snaps aligned at left guard.
+  snap_counts_lt: Snaps aligned at left tackle.
+  snap_counts_offense: Offensive snaps played.
+  snap_counts_pass_block: Pass-blocking snaps played.
+  snap_counts_pass_play: Pass-play snaps.
+  snap_counts_rg: Snaps aligned at right guard.
+  snap_counts_rt: Snaps aligned at right tackle.
+  snap_counts_run_block: Run-blocking snaps played.
+  snap_counts_te: Snaps aligned at tight end.
+boxscoreadvancedv2:
+  ast_ratio: Assists per 100 possessions used.
+  ast_tov: Ratio of assists to turnovers.
+  def_rating: Points allowed per 100 possessions while on the floor.
+  dreb_pct: Percentage of available defensive rebounds grabbed while on the floor.
+  e_def_rating: 'Estimated defensive rating: points allowed per 100 possessions using the estimated-possession formula.'
+  e_net_rating: 'Estimated net rating: estimated offensive rating minus estimated defensive rating.'
+  e_off_rating: 'Estimated offensive rating: points produced per 100 possessions using the stats API''s estimated-possession
+    formula.'
+  e_pace: 'Estimated pace: team possessions per regulation game, from the estimated-possession formula.'
+  e_usg_pct: Estimated usage percentage using the stats API's estimated-possession formula.
+  efg_pct: 'Effective field goal percentage: (FGM + 0.5 * FG3M) / FGA.'
+  off_rating: Points scored per 100 possessions while on the floor.
+  oreb_pct: Percentage of available offensive rebounds grabbed while on the floor.
+  reb_pct: Percentage of all available rebounds grabbed while on the floor.
+  start_position: Position the player started the game at ('F', 'C', or 'G'); empty for bench players.
+  tm_tov_pct: Turnovers committed per 100 possessions.
+  usg_pct: Percentage of team plays used while on the floor.
+boxscoreadvancedv3:
+  assistpercentage: Percentage of teammate field goals assisted while on the floor, as a decimal.
+  assistratio: Assists per 100 possessions used (assist ratio).
+  assisttoturnover: Ratio of assists to turnovers.
+  defensiverating: Points allowed per 100 possessions while on the floor (defensive rating).
+  defensivereboundpercentage: Percentage of available defensive rebounds secured while on the floor, as a decimal.
+  effectivefieldgoalpercentage: Effective field goal percentage (weights made threes at 1.5), as a decimal.
+  estimateddefensiverating: Estimated defensive rating from the stats API's estimated-metrics family.
+  estimatednetrating: Estimated net rating (estimated offensive minus defensive rating) from the stats API's estimated-metrics
+    family.
+  estimatedoffensiverating: Estimated offensive rating from the stats API's estimated-metrics family.
+  estimatedpace: Estimated pace (possessions per 48 minutes) from the stats API's estimated-metrics family.
+  estimatedusagepercentage: Estimated percentage of team plays used by the player while on the floor, as a decimal.
+  familyname: Player's family (last) name.
+  gameid: Unique 10-character game identifier from the league's stats API.
+  jerseynum: Player's jersey number.
+  namei: Abbreviated player name (first initial and last name).
+  netrating: Offensive rating minus defensive rating while on the floor (net rating).
+  offensiverating: Points scored per 100 possessions while on the floor (offensive rating).
+  offensivereboundpercentage: Percentage of available offensive rebounds secured while on the floor, as a decimal.
+  paceper40: Pace normalized to possessions per 40 minutes.
+  personid: Player identifier from the league's stats API.
+  playerslug: URL-friendly slug for the player's name.
+  reboundpercentage: Percentage of all available rebounds secured while on the floor, as a decimal.
+  teamslug: URL-friendly slug for the team name.
+  teamtricode: Three-letter team abbreviation.
+  trueshootingpercentage: True shooting percentage (accounts for threes and free throws), as a decimal.
+  turnoverratio: Turnovers per 100 possessions used (turnover ratio).
+  usagepercentage: Percentage of team plays used by the player while on the floor, as a decimal.
+boxscorefourfactorsv2:
+  efg_pct: 'Effective field goal percentage: (FGM + 0.5 * FG3M) / FGA.'
+  fta_rate: 'Free throw attempt rate: free throw attempts per field goal attempt.'
+  opp_efg_pct: Opponent effective field goal percentage while on the floor.
+  opp_fta_rate: Opponent free throw attempts per field goal attempt while on the floor.
+  opp_oreb_pct: Percentage of available offensive rebounds grabbed by the opponent while on the floor.
+  opp_tov_pct: Opponent turnovers per 100 possessions while on the floor.
+  oreb_pct: Percentage of available offensive rebounds grabbed while on the floor.
+  start_position: Position the player started the game at ('F', 'C', or 'G'); empty for bench players.
+  tm_tov_pct: Turnovers committed per 100 possessions.
+boxscorefourfactorsv3:
+  effectivefieldgoalpercentage: Effective field goal percentage four-factor, as a decimal.
+  familyname: Player's family (last) name.
+  freethrowattemptrate: Free throw attempts per field goal attempt (free throw rate four-factor).
+  gameid: Unique 10-character game identifier from the league's stats API.
+  jerseynum: Player's jersey number.
+  namei: Abbreviated player name (first initial and last name).
+  offensivereboundpercentage: Offensive rebound percentage four-factor, as a decimal.
+  oppeffectivefieldgoalpercentage: Opponent's effective field goal percentage while on the floor, as a decimal.
+  oppfreethrowattemptrate: Opponent's free throw attempt rate while on the floor.
+  oppoffensivereboundpercentage: Opponent's offensive rebound percentage while on the floor, as a decimal.
+  oppteamturnoverpercentage: Opponent turnovers forced per 100 possessions while on the floor.
+  personid: Player identifier from the league's stats API.
+  playerslug: URL-friendly slug for the player's name.
+  teamslug: URL-friendly slug for the team name.
+  teamtricode: Three-letter team abbreviation.
+  teamturnoverpercentage: Turnovers committed per 100 possessions (turnover four-factor).
+boxscorehustlev2:
+  boxoutplayerrebounds: Rebounds the player secured directly off their own box-outs.
+  boxoutplayerteamrebounds: Team rebounds secured following the player's box-outs.
+  boxouts: Total box-outs recorded in the game (hustle stats tracking).
+  chargesdrawn: Offensive charges drawn.
+  contestedshots: Opponent shot attempts contested in the game.
+  contestedshots2pt: Opponent two-point attempts contested.
+  contestedshots3pt: Opponent three-point attempts contested.
+  defensiveboxouts: Box-outs recorded on the defensive glass.
+  familyname: Player's family (last) name.
+  gameid: Unique 10-character game identifier from the league's stats API.
+  jerseynum: Player's jersey number.
+  looseballsrecovereddefensive: Loose balls recovered while on defense.
+  looseballsrecoveredoffensive: Loose balls recovered while on offense.
+  looseballsrecoveredtotal: Total loose balls recovered in the game.
+  namei: Abbreviated player name (first initial and last name).
+  offensiveboxouts: Box-outs recorded on the offensive glass.
+  personid: Player identifier from the league's stats API.
+  playerslug: URL-friendly slug for the player's name.
+  screenassistpoints: Points teammates scored directly off the player's screen assists.
+  screenassists: Screens that led directly to a teammate's made field goal (screen assists).
+  teamslug: URL-friendly slug for the team name.
+  teamtricode: Three-letter team abbreviation.
+boxscoremiscv2:
+  blka: Number of own field goal attempts that were blocked by opponents.
+  opp_pts_2nd_chance: Opponent second-chance points scored while on the floor.
+  opp_pts_fb: Opponent fast-break points scored while on the floor.
+  opp_pts_off_tov: Opponent points scored off turnovers while on the floor.
+  opp_pts_paint: Opponent points in the paint scored while on the floor.
+  pfd: Personal fouls drawn.
+  pts_2nd_chance: Second-chance points scored after offensive rebounds.
+  pts_fb: Fast-break points scored.
+  pts_off_tov: Points scored following opponent turnovers.
+  pts_paint: Points scored in the paint.
+  start_position: Position the player started the game at ('F', 'C', or 'G'); empty for bench players.
+boxscoremiscv3:
+  blocksagainst: Player's shot attempts that were blocked by opponents.
+  familyname: Player's family (last) name.
+  foulsdrawn: Personal fouls drawn.
+  foulspersonal: Personal fouls committed.
+  gameid: Unique 10-character game identifier from the league's stats API.
+  jerseynum: Player's jersey number.
+  namei: Abbreviated player name (first initial and last name).
+  opppointsfastbreak: Opponent fast-break points scored while on the floor.
+  opppointsoffturnovers: Opponent points off turnovers scored while on the floor.
+  opppointspaint: Opponent points in the paint scored while on the floor.
+  opppointssecondchance: Opponent second-chance points scored while on the floor.
+  personid: Player identifier from the league's stats API.
+  playerslug: URL-friendly slug for the player's name.
+  pointsfastbreak: Fast-break points scored.
+  pointsoffturnovers: Points scored off opponent turnovers.
+  pointspaint: Points scored in the paint.
+  pointssecondchance: Second-chance points scored after offensive rebounds.
+  teamslug: URL-friendly slug for the team name.
+  teamtricode: Three-letter team abbreviation.
+boxscorescoringv2:
+  pct_ast_2pm: Share of made two-point field goals that were assisted.
+  pct_ast_3pm: Share of made three-point field goals that were assisted.
+  pct_ast_fgm: Share of all made field goals that were assisted.
+  pct_fga_2pt: Share of field goal attempts taken as two-pointers.
+  pct_fga_3pt: Share of field goal attempts taken as three-pointers.
+  pct_pts_2pt: Share of points scored on two-point field goals.
+  pct_pts_2pt_mr: Share of points scored on mid-range two-point field goals.
+  pct_pts_3pt: Share of points scored on three-point field goals.
+  pct_pts_fb: Share of points scored on the fast break.
+  pct_pts_ft: Share of points scored on free throws.
+  pct_pts_off_tov: Share of points scored off opponent turnovers.
+  pct_pts_paint: Share of points scored in the paint.
+  pct_uast_2pm: Share of made two-point field goals that were unassisted.
+  pct_uast_3pm: Share of made three-point field goals that were unassisted.
+  pct_uast_fgm: Share of all made field goals that were unassisted.
+  start_position: Position the player started the game at ('F', 'C', or 'G'); empty for bench players.
+boxscorescoringv3:
+  familyname: Player's family (last) name.
+  gameid: Unique 10-character game identifier from the league's stats API.
+  jerseynum: Player's jersey number.
+  namei: Abbreviated player name (first initial and last name).
+  percentageassisted2pt: Percentage of made two-pointers that were assisted, as a decimal.
+  percentageassisted3pt: Percentage of made three-pointers that were assisted, as a decimal.
+  percentageassistedfgm: Percentage of made field goals that were assisted, as a decimal.
+  percentagefieldgoalsattempted2pt: Share of field goal attempts taken as two-pointers, as a decimal.
+  percentagefieldgoalsattempted3pt: Share of field goal attempts taken as three-pointers, as a decimal.
+  percentagepoints2pt: Share of points scored on two-pointers, as a decimal.
+  percentagepoints3pt: Share of points scored on three-pointers, as a decimal.
+  percentagepointsfastbreak: Share of points scored on fast breaks, as a decimal.
+  percentagepointsfreethrow: Share of points scored at the free throw line, as a decimal.
+  percentagepointsmidrange2pt: Share of points scored on mid-range two-pointers, as a decimal.
+  percentagepointsoffturnovers: Share of points scored off opponent turnovers, as a decimal.
+  percentagepointspaint: Share of points scored in the paint, as a decimal.
+  percentageunassisted2pt: Percentage of made two-pointers that were unassisted, as a decimal.
+  percentageunassisted3pt: Percentage of made three-pointers that were unassisted, as a decimal.
+  percentageunassistedfgm: Percentage of made field goals that were unassisted, as a decimal.
+  personid: Player identifier from the league's stats API.
+  playerslug: URL-friendly slug for the player's name.
+  teamslug: URL-friendly slug for the team name.
+  teamtricode: Three-letter team abbreviation.
+boxscoresummaryv3:
+  dummykey: Placeholder key emitted by the stats API's box score summary payload; carries no data.
+  gameid: Unique 10-character game identifier from the league's stats API.
+  inbonus: Whether the team is currently in the bonus (penalty) foul situation, as reported by the stats API.
+  seed: Team's playoff seed, populated for postseason games.
+  teamlosses: Team's loss total entering the game.
+  teamslug: URL-friendly slug for the team name.
+  teamtricode: Three-letter team abbreviation.
+  teamwins: Team's win total entering the game.
+  timeoutsremaining: Timeouts the team has remaining.
+boxscoretraditionalv2:
+  start_position: Position the player started the game at (F, C, or G); empty for reserves.
+boxscoretraditionalv3:
+  bench_assists: Total assists by the team's bench players.
+  bench_blocks: Total blocked shots by the team's bench players.
+  bench_fieldgoalsattempted: Total field goal attempts by the team's bench players.
+  bench_fieldgoalsmade: Total field goals made by the team's bench players.
+  bench_fieldgoalspercentage: Combined field goal percentage of the team's bench players.
+  bench_foulspersonal: Total personal fouls by the team's bench players.
+  bench_freethrowsattempted: Total free throw attempts by the team's bench players.
+  bench_freethrowsmade: Total free throws made by the team's bench players.
+  bench_freethrowspercentage: Combined free throw percentage of the team's bench players.
+  bench_minutes: Total minutes played by the team's bench players.
+  bench_reboundsdefensive: Total defensive rebounds by the team's bench players.
+  bench_reboundsoffensive: Total offensive rebounds by the team's bench players.
+  bench_reboundstotal: Total rebounds by the team's bench players.
+  bench_steals: Total steals by the team's bench players.
+  bench_threepointersattempted: Total three-point attempts by the team's bench players.
+  bench_threepointersmade: Total three-pointers made by the team's bench players.
+  bench_threepointerspercentage: Combined three-point percentage of the team's bench players.
+  bench_turnovers: Total turnovers by the team's bench players.
+  familyname: Player's family (last) name.
+  fieldgoalsattempted: Field goal attempts recorded in the game.
+  fieldgoalsmade: Field goals made recorded in the game.
+  fieldgoalspercentage: Field goal percentage for the game, as a decimal.
+  foulspersonal: Personal fouls recorded in the game.
+  freethrowsattempted: Free throw attempts recorded in the game.
+  freethrowsmade: Free throws made recorded in the game.
+  freethrowspercentage: Free throw percentage for the game, as a decimal.
+  gameid: Unique 10-character game identifier from the league's stats API.
+  jerseynum: Player's jersey number.
+  namei: Abbreviated player name (first initial and last name).
+  personid: Player identifier from the league's stats API.
+  playerslug: URL-friendly slug for the player's name.
+  plusminuspoints: Team point differential while the player was on the floor (plus-minus).
+  reboundsdefensive: Defensive rebounds recorded in the game.
+  reboundsoffensive: Offensive rebounds recorded in the game.
+  reboundstotal: Total rebounds recorded in the game.
+  starters_assists: Total assists by the team's starters.
+  starters_blocks: Total blocked shots by the team's starters.
+  starters_fieldgoalsattempted: Total field goal attempts by the team's starters.
+  starters_fieldgoalsmade: Total field goals made by the team's starters.
+  starters_fieldgoalspercentage: Combined field goal percentage of the team's starters.
+  starters_foulspersonal: Total personal fouls by the team's starters.
+  starters_freethrowsattempted: Total free throw attempts by the team's starters.
+  starters_freethrowsmade: Total free throws made by the team's starters.
+  starters_freethrowspercentage: Combined free throw percentage of the team's starters.
+  starters_minutes: Total minutes played by the team's starters.
+  starters_points: Total points by the team's starters.
+  starters_reboundsdefensive: Total defensive rebounds by the team's starters.
+  starters_reboundsoffensive: Total offensive rebounds by the team's starters.
+  starters_reboundstotal: Total rebounds by the team's starters.
+  starters_steals: Total steals by the team's starters.
+  starters_threepointersattempted: Total three-point attempts by the team's starters.
+  starters_threepointersmade: Total three-pointers made by the team's starters.
+  starters_threepointerspercentage: Combined three-point percentage of the team's starters.
+  starters_turnovers: Total turnovers by the team's starters.
+  teamslug: URL-friendly slug for the team name.
+  teamtricode: Three-letter team abbreviation.
+  threepointersattempted: Three-point attempts recorded in the game.
+  threepointersmade: Three-pointers made recorded in the game.
+  threepointerspercentage: Three-point percentage for the game, as a decimal.
+boxscoreusagev2:
+  pct_ast: Share of the team's assists accounted for while on the floor.
+  pct_blk: Share of the team's blocks accounted for while on the floor.
+  pct_blka: Share of the team's blocked own attempts accounted for while on the floor.
+  pct_dreb: Share of the team's defensive rebounds accounted for while on the floor.
+  pct_fg3a: Share of the team's three-point attempts accounted for while on the floor.
+  pct_fg3m: Share of the team's made three-pointers accounted for while on the floor.
+  pct_fga: Share of the team's field goal attempts accounted for while on the floor.
+  pct_fgm: Share of the team's field goals made accounted for while on the floor.
+  pct_fta: Share of the team's free throw attempts accounted for while on the floor.
+  pct_ftm: Share of the team's made free throws accounted for while on the floor.
+  pct_oreb: Share of the team's offensive rebounds accounted for while on the floor.
+  pct_pf: Share of the team's personal fouls accounted for while on the floor.
+  pct_pfd: Share of the team's personal fouls drawn accounted for while on the floor.
+  pct_pts: Share of the team's points accounted for while on the floor.
+  pct_reb: Share of the team's total rebounds accounted for while on the floor.
+  pct_stl: Share of the team's steals accounted for while on the floor.
+  pct_tov: Share of the team's turnovers accounted for while on the floor.
+  start_position: Position the player started the game at ('F', 'C', or 'G'); empty for bench players.
+  usg_pct: Percentage of team plays used while on the floor.
+boxscoreusagev3:
+  familyname: Player's family (last) name.
+  gameid: Unique 10-character game identifier from the league's stats API.
+  jerseynum: Player's jersey number.
+  namei: Abbreviated player name (first initial and last name).
+  percentageassists: Share of the team's assists accounted for by the player while on the floor, as a decimal.
+  percentageblocks: Share of the team's blocked shots accounted for by the player while on the floor, as a decimal.
+  percentageblocksallowed: Share of the team's shot attempts blocked by opponents accounted for by the player while on the
+    floor, as a decimal.
+  percentagefieldgoalsattempted: Share of the team's field goal attempts accounted for by the player while on the floor, as
+    a decimal.
+  percentagefieldgoalsmade: Share of the team's field goals made accounted for by the player while on the floor, as a decimal.
+  percentagefreethrowsattempted: Share of the team's free throw attempts accounted for by the player while on the floor, as
+    a decimal.
+  percentagefreethrowsmade: Share of the team's free throws made accounted for by the player while on the floor, as a decimal.
+  percentagepersonalfouls: Share of the team's personal fouls accounted for by the player while on the floor, as a decimal.
+  percentagepersonalfoulsdrawn: Share of the team's personal fouls drawn accounted for by the player while on the floor, as
+    a decimal.
+  percentagepoints: Share of the team's points accounted for by the player while on the floor, as a decimal.
+  percentagereboundsdefensive: Share of the team's defensive rebounds accounted for by the player while on the floor, as a
+    decimal.
+  percentagereboundsoffensive: Share of the team's offensive rebounds accounted for by the player while on the floor, as a
+    decimal.
+  percentagereboundstotal: Share of the team's total rebounds accounted for by the player while on the floor, as a decimal.
+  percentagesteals: Share of the team's steals accounted for by the player while on the floor, as a decimal.
+  percentagethreepointersattempted: Share of the team's three-point attempts accounted for by the player while on the floor,
+    as a decimal.
+  percentagethreepointersmade: Share of the team's three-pointers made accounted for by the player while on the floor, as
+    a decimal.
+  percentageturnovers: Share of the team's turnovers accounted for by the player while on the floor, as a decimal.
+  personid: Player identifier from the league's stats API.
+  playerslug: URL-friendly slug for the player's name.
+  teamslug: URL-friendly slug for the team name.
+  teamtricode: Three-letter team abbreviation.
+  usagepercentage: Percentage of team plays used by the player while on the floor, as a decimal.
+coaches_history:
+  end_of_team: On3 RDB flag that the stint ended because the team or program itself ended.
+  fired: Whether the stint ended with the coach being fired.
+  is_present: Whether this is the coach's current (ongoing) stint.
+  latest_pso_key: On3 player-sport-organization (PSO) key for the most recent season of the stint.
+  latest_year: Most recent year of the coaching stint.
+  promoted: Whether the stint ended with the coach being promoted within the organization.
+  resigned: Whether the stint ended with the coach resigning.
+  start_pso_key: On3 player-sport-organization (PSO) key for the first season of the coaching stint.
+coaches_profile:
+  alma_mater: School the coach graduated from.
+  alma_mater_class_year: Coach's graduating class year at their alma mater.
+  default_asset: Nested On3 asset object for the coach's headshot (stringified).
+  degree: Degree the coach earned, when listed.
+  home_town_name: Coach's hometown, as listed by On3.
+  key: On3 RDB key for the coach profile.
+  known_as_name: Name the coach publicly goes by, when it differs from the legal name.
+  org_season_count: Number of seasons the coach has spent with the current organization.
+  primary_position: Nested On3 object for the coach's primary coaching role (stringified).
+  years_active: Span of years the coach has been active, per On3.
+collective_groups:
+  annual_goal_amount: Collective's annual fundraising goal in dollars, as reported to On3.
+  confirmed_raised_amount: Dollar amount the collective has confirmed raising, per On3.
+  default_asset: Nested On3 asset object for the collective's primary logo (stringified).
+  default_asset_key: On3 asset key for the collective's primary logo image.
+  founders: Founders of the collective, as a stringified list.
+  instagram_handle: Collective's Instagram account handle.
+  key: On3 RDB key for the NIL collective group.
+  launch_date: Date the NIL collective launched.
+  linked_in_handle: Collective's LinkedIn account handle.
+  merged_into_group: Nested On3 record for the collective this group merged into (stringified).
+  merged_into_group_key: On3 key of the collective this group merged into, when applicable.
+  mission_statement: Collective's stated mission, as published to On3.
+  organization_key: On3 organization key of the school the collective supports.
+  social_asset: Nested On3 asset object for the collective's social-media image (stringified).
+  social_asset_key: On3 asset key for the collective's social-media image.
+  sports: Sports the collective funds, as a stringified list.
+  tik_tok_handle: Collective's TikTok account handle.
+  twitter_handle: Collective's Twitter/X account handle.
+  website_name: Display name of the collective's website.
+  website_url: URL of the collective's website.
+  youtube_handle: Collective's YouTube channel handle.
+collective_groups_deals:
+  amount: Reported dollar amount of the NIL deal.
+  collective_group: Nested On3 record for the collective brokering the deal (stringified).
+  company: Nested On3 record for the company on the other side of the NIL deal (stringified).
+  key: On3 RDB key for the NIL deal record.
+  nil_status: Status of the athlete's On3 NIL valuation (e.g. active, inactive).
+  nil_value: Athlete's On3 NIL valuation in dollars.
+  person: Nested On3 person object for the athlete in the deal (stringified).
+  roster_rating: Nested On3 roster rating object for the athlete at deal time (stringified).
+  rpm: Nested On3 Recruiting Prediction Machine (RPM) data for the athlete (stringified).
+  source_url: URL of the source reporting the deal.
+  verified: Whether On3 verified the deal.
+collective_groups_key:
+  annual_goal_amount: Collective's annual fundraising goal in dollars, as reported to On3.
+  confirmed_raised_amount: Dollar amount the collective has confirmed raising, per On3.
+  default_asset: Nested On3 asset object for the collective's primary logo (stringified).
+  default_asset_key: On3 asset key for the collective's primary logo image.
+  founders: Founders of the collective, as a stringified list.
+  instagram_handle: Collective's Instagram account handle.
+  key: On3 RDB key for the NIL collective group.
+  launch_date: Date the NIL collective launched.
+  linked_in_handle: Collective's LinkedIn account handle.
+  merged_into_group: Nested On3 record for the collective this group merged into (stringified).
+  merged_into_group_key: On3 key of the collective this group merged into, when applicable.
+  mission_statement: Collective's stated mission, as published to On3.
+  organization_key: On3 organization key of the school the collective supports.
+  social_asset: Nested On3 asset object for the collective's social-media image (stringified).
+  social_asset_key: On3 asset key for the collective's social-media image.
+  sports: Sports the collective funds, as a stringified list.
+  tik_tok_handle: Collective's TikTok account handle.
+  twitter_handle: Collective's Twitter/X account handle.
+  website_name: Display name of the collective's website.
+  website_url: URL of the collective's website.
+  youtube_handle: Collective's YouTube channel handle.
+commonallplayers:
+  display_first_last: Player name formatted as "First Last".
+  display_last_comma_first: Player name formatted as "Last, First".
+  games_played_flag: Y/N flag for whether the player has appeared in a league game.
+  is_nba_assigned: Flag indicating whether the player is currently on an NBA roster assignment (two-way and G League assignment
+    tracking).
+  nba_assigned_team_id: Team identifier of the NBA team the player is assigned to, when on assignment.
+  otherleague_experience_ch: Code for the player's experience in another league (e.g. G League), as reported by the stats
+    API.
+  playercode: URL-style player code slug used by the league's legacy stats pages.
+  rosterstatus: Roster status flag (1 = currently on a roster, 0 = not).
+commonteamroster:
+  how_acquired: How the team acquired the player (e.g. draft, trade, free agency).
+  leagueid: League identifier from the stats API ("00" = NBA, "10" = WNBA, "20" = G League).
+coverage_scheme:
+  base_snap_counts_coverage: Coverage snaps from the facet's unsplit base row, covering all coverage schemes.
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  man_assists: Assisted tackles when in man coverage.
+  man_avg_depth_of_target: Average depth of targets into the player's coverage, in yards downfield when in man coverage.
+  man_catch_rate: Completion percentage allowed on targets into the player's coverage when in man coverage.
+  man_coverage_percent: Share of pass-play snaps spent in coverage when in man coverage.
+  man_coverage_snaps_per_reception: Coverage snaps played per reception allowed when in man coverage.
+  man_coverage_snaps_per_target: Coverage snaps played per target into the player's coverage when in man coverage.
+  man_dropped_ints: Interception chances PFF charted as dropped when in man coverage.
+  man_forced_incompletes: Incompletions forced by the player's coverage, per PFF charting when in man coverage.
+  man_forced_incompletion_rate: Share of targets into the player's coverage with a PFF-charted forced incompletion when in
+    man coverage.
+  man_grades_coverage_defense: PFF coverage grade when in man coverage, 0-100.
+  man_interceptions: Interceptions made in coverage when in man coverage.
+  man_longest: Longest completion allowed, in yards when in man coverage.
+  man_missed_tackle_rate: Share of tackle attempts the player missed when in man coverage.
+  man_missed_tackles: Missed tackles when in man coverage.
+  man_pass_break_ups: Passes broken up when in man coverage.
+  man_qb_rating_against: NFL passer rating allowed on targets into the player's coverage when in man coverage.
+  man_receptions: Receptions allowed into the player's coverage when in man coverage.
+  man_snap_counts_coverage: Coverage snaps played when in man coverage.
+  man_snap_counts_coverage_percent: Share of the player's coverage snaps played when in man coverage.
+  man_snap_counts_pass_play: Pass-play snaps when in man coverage.
+  man_stops: Stops, PFF's tackles that constitute a failed play for the offense when in man coverage.
+  man_tackles: Tackles made when in man coverage.
+  man_targets: Targets into the player's coverage when in man coverage.
+  man_touchdowns: Touchdowns allowed into the player's coverage when in man coverage.
+  man_yards: Receiving yards allowed when in man coverage.
+  man_yards_after_catch: Yards after the catch allowed when in man coverage.
+  man_yards_per_coverage_snap: Receiving yards allowed per coverage snap when in man coverage.
+  man_yards_per_reception: Average yards allowed per reception when in man coverage.
+  player_game_count: Number of games the player appeared in over the covered span.
+  zone_assists: Assisted tackles when in zone coverage.
+  zone_avg_depth_of_target: Average depth of targets into the player's coverage, in yards downfield when in zone coverage.
+  zone_catch_rate: Completion percentage allowed on targets into the player's coverage when in zone coverage.
+  zone_coverage_percent: Share of pass-play snaps spent in coverage when in zone coverage.
+  zone_coverage_snaps_per_reception: Coverage snaps played per reception allowed when in zone coverage.
+  zone_coverage_snaps_per_target: Coverage snaps played per target into the player's coverage when in zone coverage.
+  zone_dropped_ints: Interception chances PFF charted as dropped when in zone coverage.
+  zone_forced_incompletes: Incompletions forced by the player's coverage, per PFF charting when in zone coverage.
+  zone_forced_incompletion_rate: Share of targets into the player's coverage with a PFF-charted forced incompletion when in
+    zone coverage.
+  zone_grades_coverage_defense: PFF coverage grade when in zone coverage, 0-100.
+  zone_interceptions: Interceptions made in coverage when in zone coverage.
+  zone_longest: Longest completion allowed, in yards when in zone coverage.
+  zone_missed_tackle_rate: Share of tackle attempts the player missed when in zone coverage.
+  zone_missed_tackles: Missed tackles when in zone coverage.
+  zone_pass_break_ups: Passes broken up when in zone coverage.
+  zone_qb_rating_against: NFL passer rating allowed on targets into the player's coverage when in zone coverage.
+  zone_receptions: Receptions allowed into the player's coverage when in zone coverage.
+  zone_snap_counts_coverage: Coverage snaps played when in zone coverage.
+  zone_snap_counts_coverage_percent: Share of the player's coverage snaps played when in zone coverage.
+  zone_snap_counts_pass_play: Pass-play snaps when in zone coverage.
+  zone_stops: Stops, PFF's tackles that constitute a failed play for the offense when in zone coverage.
+  zone_tackles: Tackles made when in zone coverage.
+  zone_targets: Targets into the player's coverage when in zone coverage.
+  zone_touchdowns: Touchdowns allowed into the player's coverage when in zone coverage.
+  zone_yards: Receiving yards allowed when in zone coverage.
+  zone_yards_after_catch: Yards after the catch allowed when in zone coverage.
+  zone_yards_per_coverage_snap: Receiving yards allowed per coverage snap when in zone coverage.
+  zone_yards_per_reception: Average yards allowed per reception when in zone coverage.
+coverage_summary:
+  avg_depth_of_target: Average depth of targets into the player's coverage, in yards downfield.
+  catch_rate: Completion percentage allowed on targets into the player's coverage.
+  coverage_percent: Share of pass-play snaps spent in coverage.
+  coverage_snaps_per_reception: Coverage snaps played per reception allowed.
+  coverage_snaps_per_target: Coverage snaps played per target into the player's coverage.
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  dropped_ints: Interception chances PFF charted as dropped.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  forced_incompletes: Incompletions forced by the player's coverage, per PFF charting.
+  forced_incompletion_rate: Share of targets into the player's coverage with a PFF-charted forced incompletion.
+  grades_coverage_defense: PFF coverage grade, 0-100.
+  grades_defense: PFF overall defense grade, 0-100.
+  grades_defense_penalty: PFF defensive penalty grade, 0-100.
+  grades_pass_rush_defense: PFF pass-rush grade, 0-100.
+  grades_run_defense: PFF run-defense grade, 0-100.
+  grades_tackle: PFF tackling grade, 0-100.
+  longest: Longest completion allowed, in yards.
+  missed_tackle_rate: Share of tackle attempts the player missed.
+  missed_tackles: Missed tackles.
+  pass_break_ups: Passes broken up.
+  player_game_count: Number of games the player appeared in over the covered span.
+  qb_rating_against: NFL passer rating allowed on targets into the player's coverage.
+  snap_counts_coverage: Coverage snaps played.
+  snap_counts_pass_play: Pass-play snaps.
+  stops: Stops, PFF's tackles that constitute a failed play for the offense.
+  touchdowns: Touchdowns allowed into the player's coverage.
+  yards_per_coverage_snap: Receiving yards allowed per coverage snap.
+  yards_per_reception: Average yards allowed per reception.
+cumestatsplayer:
+  actual_minutes: Whole minutes of actual playing time accumulated over the aggregated games.
+  actual_seconds: Leftover seconds of actual playing time beyond the whole minutes.
+  avg_actual_minutes: Average whole minutes played per aggregated game.
+  avg_actual_seconds: Average seconds component of playing time per aggregated game.
+  avg_ast: Average assists per game over the aggregated games.
+  avg_blk: Average blocked shots per game over the aggregated games.
+  avg_pts: Average points per game over the aggregated games.
+  avg_stl: Average steals per game over the aggregated games.
+  avg_tot_reb: Average total rebounds per game over the aggregated games.
+  avg_turnovers: Average turnovers per game over the aggregated games.
+  def_reb: Defensive rebounds over the aggregated games.
+  display_fi_last: Abbreviated player name (first initial and last name).
+  dq: Disqualifications (fouled out) over the aggregated games.
+  fg: Field goals made over the aggregated games.
+  fg3: Three-point field goals made over the aggregated games.
+  ft: Free throws made over the aggregated games.
+  max_actual_minutes: Most whole minutes played in any single aggregated game.
+  max_actual_seconds: Seconds component paired with the single-game maximum minutes.
+  max_ast: Most assists recorded in any single aggregated game.
+  max_blk: Most blocked shots recorded in any single aggregated game.
+  max_pts: Most points recorded in any single aggregated game.
+  max_reb: Most rebounds recorded in any single aggregated game.
+  max_stl: Most steals recorded in any single aggregated game.
+  max_turnovers: Most turnovers recorded in any single aggregated game.
+  off_reb: Offensive rebounds over the aggregated games.
+  per_min_ast: Assists per minute played over the aggregated games.
+  per_min_blk: Blocked shots per minute played over the aggregated games.
+  per_min_pts: Points per minute played over the aggregated games.
+  per_min_stl: Steals per minute played over the aggregated games.
+  per_min_tot_reb: Total rebounds per minute played over the aggregated games.
+  per_min_turnovers: Turnovers per minute played over the aggregated games.
+  tot_reb: Total rebounds over the aggregated games.
+cumestatsteam:
+  actual_minutes: Whole minutes of actual playing time accumulated over the aggregated games.
+  actual_seconds: Leftover seconds of actual playing time beyond the whole minutes.
+  avg_actual_minutes: Average whole minutes played per aggregated game.
+  avg_actual_seconds: Average seconds component of playing time per aggregated game.
+  avg_ast: Average assists per game over the aggregated games.
+  avg_blkp: Average blocked shots per game over the aggregated games.
+  avg_pts: Average points per game over the aggregated games.
+  avg_reb: Average rebounds per game over the aggregated games.
+  avg_stl: Average steals per game over the aggregated games.
+  avg_turnovers: Average turnovers per game over the aggregated games.
+  def_reb: Defensive rebounds over the aggregated games.
+  dq: Disqualifications (fouled out) over the aggregated games.
+  fg: Field goals made over the aggregated games.
+  fg3: Three-point field goals made over the aggregated games.
+  ft: Free throws made over the aggregated games.
+  max_actual_minutes: Most whole minutes played in any single aggregated game.
+  max_actual_seconds: Seconds component paired with the single-game maximum minutes.
+  max_ast: Most assists recorded in any single aggregated game.
+  max_blkp: Most blocked shots recorded in any single aggregated game.
+  max_pts: Most points recorded in any single aggregated game.
+  max_reb: Most rebounds recorded in any single aggregated game.
+  max_stl: Most steals recorded in any single aggregated game.
+  max_turnovers: Most turnovers recorded in any single aggregated game.
+  off_reb: Offensive rebounds over the aggregated games.
+  per_min_ast: Assists per minute played over the aggregated games.
+  per_min_blk: Blocked shots per minute played over the aggregated games.
+  per_min_pts: Points per minute played over the aggregated games.
+  per_min_reb: Rebounds per minute played over the aggregated games.
+  per_min_stl: Steals per minute played over the aggregated games.
+  per_min_turnovers: Turnovers per minute played over the aggregated games.
+  tot_reb: Total rebounds over the aggregated games.
+defense_summary:
+  assists: Assisted tackles.
+  batted_passes: Passes batted down at the line of scrimmage.
+  catch_rate: Completion percentage allowed on targets into the player's coverage.
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  forced_fumbles: Forced fumbles.
+  franchise_id: PFF franchise (team) id (integer join key).
+  fumble_recoveries: Opponent fumbles recovered by the player.
+  fumble_recovery_touchdowns: Touchdowns scored on fumble recoveries.
+  grades_coverage_defense: PFF coverage grade (0-100).
+  grades_defense: PFF overall defense grade (0-100).
+  grades_defense_penalty: PFF defensive penalty grade, 0-100.
+  grades_pass_rush_defense: PFF pass-rush grade, 0-100.
+  grades_run_defense: PFF run-defense grade (0-100).
+  grades_tackle: PFF tackling grade, 0-100.
+  hurries: Quarterback hurries recorded.
+  interception_touchdowns: Touchdowns scored on interception returns.
+  interceptions: Interceptions made in coverage.
+  jersey_number: Jersey number (string; zero-padded, e.g. "09").
+  longest: Longest completion allowed, in yards.
+  missed_tackle_rate: Share of tackle attempts the player missed.
+  missed_tackles: Missed tackles.
+  pass_break_ups: Passes broken up.
+  player_game_count: Games with at least one qualifying snap in the requested range.
+  player_id: PFF player id (integer; matches the /players id and every player_id join key).
+  qb_rating_against: NFL passer rating allowed on targets into the player's coverage.
+  sacks: Sacks credited.
+  safeties: Safeties recorded by the player.
+  snap_counts_box: Snaps aligned in the box.
+  snap_counts_corner: Snaps aligned at outside cornerback.
+  snap_counts_coverage: Coverage snaps played.
+  snap_counts_defense: Total defensive snaps played.
+  snap_counts_dl: Snaps aligned on the defensive line.
+  snap_counts_dl_a_gap: Defensive-line snaps aligned in the A gap.
+  snap_counts_dl_b_gap: Defensive-line snaps aligned in the B gap.
+  snap_counts_dl_outside_t: Defensive-line snaps aligned outside the offensive tackle.
+  snap_counts_dl_over_t: Defensive-line snaps aligned head-up over the offensive tackle.
+  snap_counts_fs: Snaps aligned at free safety.
+  snap_counts_offball: Snaps aligned as an off-ball linebacker.
+  snap_counts_pass_rush: Pass-rush snaps played.
+  snap_counts_run_defense: Run-defense snaps played.
+  snap_counts_slot: Snaps aligned in the slot.
+  stops: Tackles that constitute an offensive failure ("stops").
+  tackles: Total tackles made by the defender.
+  team_name: Team abbreviation the player is credited to for the range.
+  total_pressures: Total quarterback pressures (sacks + hits + hurries).
+  touchdowns: Touchdowns allowed into the player's coverage.
+  yards_per_reception: Average yards allowed per reception.
+draft_pick_organization_rank:
+  first_round: Number of the organization's players drafted in the first round.
+  fourth_through_seventh_round: Number of the organization's players drafted in rounds four through seven.
+  second_round: Number of the organization's players drafted in the second round.
+  third_round: Number of the organization's players drafted in the third round.
+draftcombinedrillresults:
+  bench_press: Repetitions of 185 pounds completed on the bench press.
+  lane_agility_time: Lane agility drill time, in seconds.
+  max_vertical_leap: Maximum (running) vertical leap, in inches.
+  modified_lane_agility_time: Modified (shuttle) lane agility drill time, in seconds.
+  standing_vertical_leap: Standing (no-step) vertical leap, in inches.
+  temp_player_id: Temporary combine player identifier assigned by the NBA before a permanent player id exists.
+  three_quarter_sprint: Three-quarter-court sprint time, in seconds.
+draftcombinenonstationaryshooting:
+  off_drib_college_break_left_attempt: Shots attempted from the college three-point left wing (break) spot in the off-the-dribble
+    shooting drill at the combine.
+  off_drib_college_break_left_made: Shots made from the college three-point left wing (break) spot in the off-the-dribble
+    shooting drill at the combine.
+  off_drib_college_break_left_pct: Shooting percentage from the college three-point left wing (break) spot in the off-the-dribble
+    shooting drill, as a decimal.
+  off_drib_college_break_right_attempt: Shots attempted from the college three-point right wing (break) spot in the off-the-dribble
+    shooting drill at the combine.
+  off_drib_college_break_right_made: Shots made from the college three-point right wing (break) spot in the off-the-dribble
+    shooting drill at the combine.
+  off_drib_college_break_right_pct: Shooting percentage from the college three-point right wing (break) spot in the off-the-dribble
+    shooting drill, as a decimal.
+  off_drib_college_top_key_attempt: Shots attempted from the college three-point top of the key spot in the off-the-dribble
+    shooting drill at the combine.
+  off_drib_college_top_key_made: Shots made from the college three-point top of the key spot in the off-the-dribble shooting
+    drill at the combine.
+  off_drib_college_top_key_pct: Shooting percentage from the college three-point top of the key spot in the off-the-dribble
+    shooting drill, as a decimal.
+  off_drib_fifteen_break_left_attempt: Shots attempted from the 15-foot left wing (break) spot in the off-the-dribble shooting
+    drill at the combine.
+  off_drib_fifteen_break_left_made: Shots made from the 15-foot left wing (break) spot in the off-the-dribble shooting drill
+    at the combine.
+  off_drib_fifteen_break_left_pct: Shooting percentage from the 15-foot left wing (break) spot in the off-the-dribble shooting
+    drill, as a decimal.
+  off_drib_fifteen_break_right_attempt: Shots attempted from the 15-foot right wing (break) spot in the off-the-dribble shooting
+    drill at the combine.
+  off_drib_fifteen_break_right_made: Shots made from the 15-foot right wing (break) spot in the off-the-dribble shooting drill
+    at the combine.
+  off_drib_fifteen_break_right_pct: Shooting percentage from the 15-foot right wing (break) spot in the off-the-dribble shooting
+    drill, as a decimal.
+  off_drib_fifteen_top_key_attempt: Shots attempted from the 15-foot top of the key spot in the off-the-dribble shooting drill
+    at the combine.
+  off_drib_fifteen_top_key_made: Shots made from the 15-foot top of the key spot in the off-the-dribble shooting drill at
+    the combine.
+  off_drib_fifteen_top_key_pct: Shooting percentage from the 15-foot top of the key spot in the off-the-dribble shooting drill,
+    as a decimal.
+  on_move_college_attempt: Shots attempted from the college three-point spot in the shooting-on-the-move drill at the combine.
+  on_move_college_made: Shots made from the college three-point spot in the shooting-on-the-move drill at the combine.
+  on_move_college_pct: Shooting percentage from the college three-point spot in the shooting-on-the-move drill, as a decimal.
+  on_move_fifteen_attempt: Shots attempted from the 15-foot spot in the shooting-on-the-move drill at the combine.
+  on_move_fifteen_made: Shots made from the 15-foot spot in the shooting-on-the-move drill at the combine.
+  on_move_fifteen_pct: Shooting percentage from the 15-foot spot in the shooting-on-the-move drill, as a decimal.
+  temp_player_id: Temporary combine player identifier assigned by the NBA before a permanent player id exists.
+draftcombineplayeranthro:
+  body_fat_pct: Body fat percentage measured at the combine.
+  hand_length: Hand length measured at the combine, in inches.
+  hand_width: Hand width measured at the combine, in inches.
+  height_w_shoes: Height measured with shoes, in inches.
+  height_w_shoes_ft_in: Height with shoes formatted as feet and inches.
+  height_wo_shoes: Height measured without shoes, in inches.
+  height_wo_shoes_ft_in: Height without shoes formatted as feet and inches.
+  standing_reach: Standing reach measured at the combine, in inches.
+  standing_reach_ft_in: Standing reach formatted as feet and inches.
+  temp_player_id: Temporary combine player identifier assigned by the NBA before a permanent player id exists.
+  wingspan: Wingspan measured at the combine, in inches.
+  wingspan_ft_in: Wingspan formatted as feet and inches.
+draftcombinespotshooting:
+  college_break_left_attempt: Shots attempted from the college three-point left wing (break) spot in the stationary spot-up
+    shooting drill at the combine.
+  college_break_left_made: Shots made from the college three-point left wing (break) spot in the stationary spot-up shooting
+    drill at the combine.
+  college_break_left_pct: Shooting percentage from the college three-point left wing (break) spot in the stationary spot-up
+    shooting drill, as a decimal.
+  college_break_right_attempt: Shots attempted from the college three-point right wing (break) spot in the stationary spot-up
+    shooting drill at the combine.
+  college_break_right_made: Shots made from the college three-point right wing (break) spot in the stationary spot-up shooting
+    drill at the combine.
+  college_break_right_pct: Shooting percentage from the college three-point right wing (break) spot in the stationary spot-up
+    shooting drill, as a decimal.
+  college_corner_left_attempt: Shots attempted from the college three-point left corner spot in the stationary spot-up shooting
+    drill at the combine.
+  college_corner_left_made: Shots made from the college three-point left corner spot in the stationary spot-up shooting drill
+    at the combine.
+  college_corner_left_pct: Shooting percentage from the college three-point left corner spot in the stationary spot-up shooting
+    drill, as a decimal.
+  college_corner_right_attempt: Shots attempted from the college three-point right corner spot in the stationary spot-up shooting
+    drill at the combine.
+  college_corner_right_made: Shots made from the college three-point right corner spot in the stationary spot-up shooting
+    drill at the combine.
+  college_corner_right_pct: Shooting percentage from the college three-point right corner spot in the stationary spot-up shooting
+    drill, as a decimal.
+  college_top_key_attempt: Shots attempted from the college three-point top of the key spot in the stationary spot-up shooting
+    drill at the combine.
+  college_top_key_made: Shots made from the college three-point top of the key spot in the stationary spot-up shooting drill
+    at the combine.
+  college_top_key_pct: Shooting percentage from the college three-point top of the key spot in the stationary spot-up shooting
+    drill, as a decimal.
+  fifteen_break_left_attempt: Shots attempted from the 15-foot left wing (break) spot in the stationary spot-up shooting drill
+    at the combine.
+  fifteen_break_left_made: Shots made from the 15-foot left wing (break) spot in the stationary spot-up shooting drill at
+    the combine.
+  fifteen_break_left_pct: Shooting percentage from the 15-foot left wing (break) spot in the stationary spot-up shooting drill,
+    as a decimal.
+  fifteen_break_right_attempt: Shots attempted from the 15-foot right wing (break) spot in the stationary spot-up shooting
+    drill at the combine.
+  fifteen_break_right_made: Shots made from the 15-foot right wing (break) spot in the stationary spot-up shooting drill at
+    the combine.
+  fifteen_break_right_pct: Shooting percentage from the 15-foot right wing (break) spot in the stationary spot-up shooting
+    drill, as a decimal.
+  fifteen_corner_left_attempt: Shots attempted from the 15-foot left corner spot in the stationary spot-up shooting drill
+    at the combine.
+  fifteen_corner_left_made: Shots made from the 15-foot left corner spot in the stationary spot-up shooting drill at the combine.
+  fifteen_corner_left_pct: Shooting percentage from the 15-foot left corner spot in the stationary spot-up shooting drill,
+    as a decimal.
+  fifteen_corner_right_attempt: Shots attempted from the 15-foot right corner spot in the stationary spot-up shooting drill
+    at the combine.
+  fifteen_corner_right_made: Shots made from the 15-foot right corner spot in the stationary spot-up shooting drill at the
+    combine.
+  fifteen_corner_right_pct: Shooting percentage from the 15-foot right corner spot in the stationary spot-up shooting drill,
+    as a decimal.
+  fifteen_top_key_attempt: Shots attempted from the 15-foot top of the key spot in the stationary spot-up shooting drill at
+    the combine.
+  fifteen_top_key_made: Shots made from the 15-foot top of the key spot in the stationary spot-up shooting drill at the combine.
+  fifteen_top_key_pct: Shooting percentage from the 15-foot top of the key spot in the stationary spot-up shooting drill,
+    as a decimal.
+  nba_break_left_attempt: Shots attempted from the NBA three-point left wing (break) spot in the stationary spot-up shooting
+    drill at the combine.
+  nba_break_left_made: Shots made from the NBA three-point left wing (break) spot in the stationary spot-up shooting drill
+    at the combine.
+  nba_break_left_pct: Shooting percentage from the NBA three-point left wing (break) spot in the stationary spot-up shooting
+    drill, as a decimal.
+  nba_break_right_attempt: Shots attempted from the NBA three-point right wing (break) spot in the stationary spot-up shooting
+    drill at the combine.
+  nba_break_right_made: Shots made from the NBA three-point right wing (break) spot in the stationary spot-up shooting drill
+    at the combine.
+  nba_break_right_pct: Shooting percentage from the NBA three-point right wing (break) spot in the stationary spot-up shooting
+    drill, as a decimal.
+  nba_corner_left_attempt: Shots attempted from the NBA three-point left corner spot in the stationary spot-up shooting drill
+    at the combine.
+  nba_corner_left_made: Shots made from the NBA three-point left corner spot in the stationary spot-up shooting drill at the
+    combine.
+  nba_corner_left_pct: Shooting percentage from the NBA three-point left corner spot in the stationary spot-up shooting drill,
+    as a decimal.
+  nba_corner_right_attempt: Shots attempted from the NBA three-point right corner spot in the stationary spot-up shooting
+    drill at the combine.
+  nba_corner_right_made: Shots made from the NBA three-point right corner spot in the stationary spot-up shooting drill at
+    the combine.
+  nba_corner_right_pct: Shooting percentage from the NBA three-point right corner spot in the stationary spot-up shooting
+    drill, as a decimal.
+  nba_top_key_attempt: Shots attempted from the NBA three-point top of the key spot in the stationary spot-up shooting drill
+    at the combine.
+  nba_top_key_made: Shots made from the NBA three-point top of the key spot in the stationary spot-up shooting drill at the
+    combine.
+  nba_top_key_pct: Shooting percentage from the NBA three-point top of the key spot in the stationary spot-up shooting drill,
+    as a decimal.
+  temp_player_id: Temporary combine player identifier assigned by the NBA before a permanent player id exists.
+draftcombinestats:
+  bench_press: Repetitions of 185 pounds completed on the bench press.
+  body_fat_pct: Body fat percentage measured at the combine.
+  hand_length: Hand length measured at the combine, in inches.
+  hand_width: Hand width measured at the combine, in inches.
+  height_w_shoes: Height measured with shoes, in inches.
+  height_w_shoes_ft_in: Height with shoes formatted as feet and inches.
+  height_wo_shoes: Height measured without shoes, in inches.
+  height_wo_shoes_ft_in: Height without shoes formatted as feet and inches.
+  lane_agility_time: Lane agility drill time, in seconds.
+  max_vertical_leap: Maximum (running) vertical leap, in inches.
+  modified_lane_agility_time: Modified (shuttle) lane agility drill time, in seconds.
+  off_drib_college_break_left: Made-attempted result from the college three-point left wing (break) off-the-dribble shooting
+    station at the combine.
+  off_drib_college_break_right: Made-attempted result from the college three-point right wing (break) off-the-dribble shooting
+    station at the combine.
+  off_drib_college_top_key: Made-attempted result from the college three-point top of the key off-the-dribble shooting station
+    at the combine.
+  off_drib_fifteen_break_left: Made-attempted result from the 15-foot left wing (break) off-the-dribble shooting station at
+    the combine.
+  off_drib_fifteen_break_right: Made-attempted result from the 15-foot right wing (break) off-the-dribble shooting station
+    at the combine.
+  off_drib_fifteen_top_key: Made-attempted result from the 15-foot top of the key off-the-dribble shooting station at the
+    combine.
+  on_move_college: Made-attempted result from the college three-point shooting-on-the-move station at the combine.
+  on_move_fifteen: Made-attempted result from the 15-foot shooting-on-the-move station at the combine.
+  spot_college_break_left: Made-attempted result (e.g. "3-5") from the college three-point left wing (break) spot-up shooting
+    station at the combine.
+  spot_college_break_right: Made-attempted result (e.g. "3-5") from the college three-point right wing (break) spot-up shooting
+    station at the combine.
+  spot_college_corner_left: Made-attempted result (e.g. "3-5") from the college three-point left corner spot-up shooting station
+    at the combine.
+  spot_college_corner_right: Made-attempted result (e.g. "3-5") from the college three-point right corner spot-up shooting
+    station at the combine.
+  spot_college_top_key: Made-attempted result (e.g. "3-5") from the college three-point top of the key spot-up shooting station
+    at the combine.
+  spot_fifteen_break_left: Made-attempted result (e.g. "3-5") from the 15-foot left wing (break) spot-up shooting station
+    at the combine.
+  spot_fifteen_break_right: Made-attempted result (e.g. "3-5") from the 15-foot right wing (break) spot-up shooting station
+    at the combine.
+  spot_fifteen_corner_left: Made-attempted result (e.g. "3-5") from the 15-foot left corner spot-up shooting station at the
+    combine.
+  spot_fifteen_corner_right: Made-attempted result (e.g. "3-5") from the 15-foot right corner spot-up shooting station at
+    the combine.
+  spot_fifteen_top_key: Made-attempted result (e.g. "3-5") from the 15-foot top of the key spot-up shooting station at the
+    combine.
+  spot_nba_break_left: Made-attempted result (e.g. "3-5") from the NBA three-point left wing (break) spot-up shooting station
+    at the combine.
+  spot_nba_break_right: Made-attempted result (e.g. "3-5") from the NBA three-point right wing (break) spot-up shooting station
+    at the combine.
+  spot_nba_corner_left: Made-attempted result (e.g. "3-5") from the NBA three-point left corner spot-up shooting station at
+    the combine.
+  spot_nba_corner_right: Made-attempted result (e.g. "3-5") from the NBA three-point right corner spot-up shooting station
+    at the combine.
+  spot_nba_top_key: Made-attempted result (e.g. "3-5") from the NBA three-point top of the key spot-up shooting station at
+    the combine.
+  standing_reach: Standing reach measured at the combine, in inches.
+  standing_reach_ft_in: Standing reach formatted as feet and inches.
+  standing_vertical_leap: Standing (no-step) vertical leap, in inches.
+  three_quarter_sprint: Three-quarter-court sprint time, in seconds.
+  wingspan: Wingspan measured at the combine, in inches.
+  wingspan_ft_in: Wingspan formatted as feet and inches.
+drafts:
+  college_organization: Nested On3 organization object for the college the player attended (stringified).
+  compensatory: Whether the selection was a compensatory draft pick.
+  drafted_from_organization: Nested On3 organization object for the school the player was drafted out of (stringified).
+  forfeited: Whether the pick was forfeited.
+  high_school_organization: Nested On3 organization object for the player's high school (stringified).
+  key: On3 RDB key for the draft-pick record.
+  person: Nested On3 person object for the drafted player (stringified).
+  recruitment_key: On3 RDB recruitment key linking the draft pick back to the player's recruitment record.
+  supplementary: Whether the selection came in a supplemental draft.
+  through_organization_one: First intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  through_organization_three: Third intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  through_organization_two: Second intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  trading_organization: Pro organization that traded the pick away, when it changed hands (On3 RDB).
+drafts_players:
+  college_organization: Nested On3 organization object for the college the player attended (stringified).
+  compensatory: Whether the selection was a compensatory draft pick.
+  drafted_from_organization: Nested On3 organization object for the school the player was drafted out of (stringified).
+  forfeited: Whether the pick was forfeited.
+  high_school_organization: Nested On3 organization object for the player's high school (stringified).
+  key: On3 RDB key for the draft-pick record.
+  person: Nested On3 person object for the drafted player (stringified).
+  recruitment_key: On3 RDB recruitment key linking the draft pick back to the player's recruitment record.
+  supplementary: Whether the selection came in a supplemental draft.
+  through_organization_one: First intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  through_organization_three: Third intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  through_organization_two: Second intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  trading_organization: Pro organization that traded the pick away, when it changed hands (On3 RDB).
+fantasywidget:
+  fan_duel_pts: Fantasy points under FanDuel's scoring formula.
+  nba_fantasy_pts: Fantasy points under the NBA's fantasy scoring formula.
+field_goal_summary:
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  fifty_attempts: Field goals attempted from 50 or more yards.
+  fifty_made: Field goals made from 50 or more yards.
+  fifty_percent: Field-goal percentage from 50 or more yards.
+  forty_attempts: Field goals attempted from 40-49 yards.
+  forty_made: Field goals made from 40-49 yards.
+  forty_percent: Field-goal percentage from 40-49 yards.
+  grades_fgep_kicker: PFF field-goal and extra-point kicking grade, 0-100.
+  one_attempts: Field goals attempted from 1-19 yards.
+  one_made: Field goals made from 1-19 yards.
+  one_percent: Field-goal percentage from 1-19 yards.
+  pat_attempts: Extra points attempted.
+  pat_made: Extra points made.
+  pat_percent: Extra-point percentage.
+  player_game_count: Number of games the player appeared in over the covered span.
+  thirty_attempts: Field goals attempted from 30-39 yards.
+  thirty_made: Field goals made from 30-39 yards.
+  thirty_percent: Field-goal percentage from 30-39 yards.
+  total_attempts: Total field goals attempted across all distances.
+  total_made: Total field goals made across all distances.
+  total_percent: Overall field-goal percentage.
+  twenty_attempts: Field goals attempted from 20-29 yards.
+  twenty_made: Field goals made from 20-29 yards.
+  twenty_percent: Field-goal percentage from 20-29 yards.
+filters_conferences:
+  key: On3 RDB key for the conference filter option.
+filters_positions:
+  key: On3 RDB key for the position filter option.
+filters_sports:
+  key: On3 RDB key for the sport filter option.
+filters_teams:
+  conference_key: On3 RDB key of the conference the team belongs to.
+franchise_groups:
+  heirarchy: Nested hierarchy of franchise groupings as returned by the PFF API; the field name's spelling follows the source.
+franchiseleaderswrank:
+  active_with_team: Flag indicating whether the franchise leader is still active with the team.
+  f_rank_ast: Franchise all-time rank of the player's career assists.
+  f_rank_blk: Franchise all-time rank of the player's career blocked shots.
+  f_rank_dreb: Franchise all-time rank of the player's career defensive rebounds.
+  f_rank_fg3_pct: Franchise all-time rank of the player's career three-point field goal percentage.
+  f_rank_fg3a: Franchise all-time rank of the player's career three-point field goals attempted.
+  f_rank_fg3m: Franchise all-time rank of the player's career three-point field goals made.
+  f_rank_fg_pct: Franchise all-time rank of the player's career field goal percentage.
+  f_rank_fga: Franchise all-time rank of the player's career field goals attempted.
+  f_rank_fgm: Franchise all-time rank of the player's career field goals made.
+  f_rank_ft_pct: Franchise all-time rank of the player's career free throw percentage.
+  f_rank_fta: Franchise all-time rank of the player's career free throws attempted.
+  f_rank_ftm: Franchise all-time rank of the player's career free throws made.
+  f_rank_gp: Franchise all-time rank of the player's career games played.
+  f_rank_minutes: Franchise all-time rank of the player's career minutes played.
+  f_rank_oreb: Franchise all-time rank of the player's career offensive rebounds.
+  f_rank_pf: Franchise all-time rank of the player's career personal fouls committed.
+  f_rank_pts: Franchise all-time rank of the player's career points scored.
+  f_rank_reb: Franchise all-time rank of the player's career total rebounds.
+  f_rank_stl: Franchise all-time rank of the player's career steals.
+  f_rank_tov: Franchise all-time rank of the player's career turnovers.
+franchiseplayers:
+  active_with_team: Flag indicating whether the player is still active with the franchise.
+homepageleaders:
+  efg_pct: Effective field goal percentage, as a decimal.
+  pts_per48: Points scored per 48 minutes played.
+hustlestatsboxscore:
+  box_out_player_rebs: Rebounds the player secured directly off their own box-outs.
+  box_out_player_team_rebs: Team rebounds secured following the row's box-outs.
+  contested_shots_2pt: Opponent two-point attempts contested.
+  contested_shots_3pt: Opponent three-point attempts contested.
+  def_boxouts: Box-outs recorded on the defensive glass.
+  def_loose_balls_recovered: Loose balls recovered while on defense.
+  loose_balls_recovered: Total loose balls recovered.
+  off_boxouts: Box-outs recorded on the offensive glass.
+  off_loose_balls_recovered: Loose balls recovered while on offense.
+  screen_ast_pts: Points teammates scored directly off the row's screen assists.
+  start_position: Position the player started the game at (F, C, or G); empty for reserves.
+kicking_summary:
+  attempts_with_hangtime: Kickoffs with a PFF-recorded hangtime.
+  average_distance: Average kickoff distance in yards.
+  average_hangtime: Average kickoff hangtime in seconds.
+  average_starting_field_position: Average opponent starting field position following the player's kickoffs.
+  average_yards_per_return: Average return yards allowed per kickoff returned.
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  fair_catches: Kickoffs fair-caught by the return team.
+  grades_kickoff_kicker: PFF kickoff kicking grade, 0-100.
+  kicked_yards: Total kickoff yards.
+  kicks_returned: Kickoffs returned by the opponent.
+  onside_kicks: Onside kicks attempted.
+  percent_returned: Percentage of the player's kickoffs that were returned.
+  player_game_count: Number of games the player appeared in over the covered span.
+  total_hangtime: Total kickoff hangtime in seconds.
+  touchbacks: Kickoffs resulting in touchbacks.
+leaguedashplayerclutch:
+  ast_rank: League rank of the row's assists for the season and split.
+  blk_rank: League rank of the row's blocked shots for the season and split.
+  blka: Shot attempts blocked by opponents (blocks against).
+  blka_rank: League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split.
+  dd2: Double-doubles recorded over the split.
+  dd2_rank: League rank of the row's double-doubles for the season and split.
+  dreb_rank: League rank of the row's defensive rebounds for the season and split.
+  fg3_pct_rank: League rank of the row's three-point field goal percentage for the season and split.
+  fg3a_rank: League rank of the row's three-point field goals attempted for the season and split.
+  fg3m_rank: League rank of the row's three-point field goals made for the season and split.
+  fg_pct_rank: League rank of the row's field goal percentage for the season and split.
+  fga_rank: League rank of the row's field goals attempted for the season and split.
+  fgm_rank: League rank of the row's field goals made for the season and split.
+  ft_pct_rank: League rank of the row's free throw percentage for the season and split.
+  fta_rank: League rank of the row's free throws attempted for the season and split.
+  ftm_rank: League rank of the row's free throws made for the season and split.
+  gp_rank: League rank of the row's games played for the season and split.
+  group_set: Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month).
+  l_rank: League rank of the row's losses for the season and split.
+  min_rank: League rank of the row's minutes played for the season and split.
+  nba_fantasy_pts: Fantasy points under the NBA's fantasy scoring formula.
+  nba_fantasy_pts_rank: League rank of the row's NBA fantasy points (league scoring formula) for the season and split.
+  oreb_rank: League rank of the row's offensive rebounds for the season and split.
+  pf_rank: League rank of the row's personal fouls committed for the season and split.
+  pfd: Personal fouls drawn.
+  pfd_rank: League rank of the row's personal fouls drawn for the season and split.
+  plus_minus_rank: League rank of the row's plus-minus point differential while on the floor for the season and split.
+  pts_rank: League rank of the row's points scored for the season and split.
+  reb_rank: League rank of the row's total rebounds for the season and split.
+  stl_rank: League rank of the row's steals for the season and split.
+  td3: Triple-doubles recorded over the split.
+  td3_rank: League rank of the row's triple-doubles for the season and split.
+  team_count: Number of distinct teams aggregated into the split row.
+  tov_rank: League rank of the row's turnovers for the season and split.
+  w_pct_rank: League rank of the row's win percentage for the season and split.
+  w_rank: League rank of the row's wins for the season and split.
+  wnba_fantasy_pts: Fantasy points under the WNBA's fantasy scoring formula.
+  wnba_fantasy_pts_rank: League rank of the row's WNBA fantasy points (league scoring formula) for the season and split.
+leaguedashteamclutch:
+  ast_rank: League rank of the row's assists for the season and split.
+  blk_rank: League rank of the row's blocked shots for the season and split.
+  blka: Shot attempts blocked by opponents (blocks against).
+  blka_rank: League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split.
+  dreb_rank: League rank of the row's defensive rebounds for the season and split.
+  fg3_pct_rank: League rank of the row's three-point field goal percentage for the season and split.
+  fg3a_rank: League rank of the row's three-point field goals attempted for the season and split.
+  fg3m_rank: League rank of the row's three-point field goals made for the season and split.
+  fg_pct_rank: League rank of the row's field goal percentage for the season and split.
+  fga_rank: League rank of the row's field goals attempted for the season and split.
+  fgm_rank: League rank of the row's field goals made for the season and split.
+  ft_pct_rank: League rank of the row's free throw percentage for the season and split.
+  fta_rank: League rank of the row's free throws attempted for the season and split.
+  ftm_rank: League rank of the row's free throws made for the season and split.
+  gp_rank: League rank of the row's games played for the season and split.
+  l_rank: League rank of the row's losses for the season and split.
+  min_rank: League rank of the row's minutes played for the season and split.
+  oreb_rank: League rank of the row's offensive rebounds for the season and split.
+  pf_rank: League rank of the row's personal fouls committed for the season and split.
+  pfd: Personal fouls drawn.
+  pfd_rank: League rank of the row's personal fouls drawn for the season and split.
+  plus_minus_rank: League rank of the row's plus-minus point differential while on the floor for the season and split.
+  pts_rank: League rank of the row's points scored for the season and split.
+  reb_rank: League rank of the row's total rebounds for the season and split.
+  stl_rank: League rank of the row's steals for the season and split.
+  tov_rank: League rank of the row's turnovers for the season and split.
+  w_pct_rank: League rank of the row's win percentage for the season and split.
+  w_rank: League rank of the row's wins for the season and split.
+leaguehustlestatsplayer:
+  box_out_player_rebs: Rebounds the player secured directly off their own box-outs.
+  box_out_player_team_rebs: Team rebounds secured following the row's box-outs.
+  contested_shots_2pt: Opponent two-point attempts contested.
+  contested_shots_3pt: Opponent three-point attempts contested.
+  def_boxouts: Box-outs recorded on the defensive glass.
+  def_loose_balls_recovered: Loose balls recovered while on defense.
+  loose_balls_recovered: Total loose balls recovered.
+  off_boxouts: Box-outs recorded on the offensive glass.
+  off_loose_balls_recovered: Loose balls recovered while on offense.
+  pct_box_outs_def: Share of box-outs recorded on the defensive glass, as a decimal.
+  pct_box_outs_off: Share of box-outs recorded on the offensive glass, as a decimal.
+  pct_box_outs_reb: Share of box-outs after which the player secured the rebound, as a decimal.
+  pct_box_outs_team_reb: Share of box-outs after which the team secured the rebound, as a decimal.
+  pct_loose_balls_recovered_def: Share of recovered loose balls that came on defense, as a decimal.
+  pct_loose_balls_recovered_off: Share of recovered loose balls that came on offense, as a decimal.
+  screen_ast_pts: Points teammates scored directly off the row's screen assists.
+leaguehustlestatsteam:
+  contested_shots_2pt: Opponent two-point attempts contested.
+  contested_shots_3pt: Opponent three-point attempts contested.
+  def_boxouts: Box-outs recorded on the defensive glass.
+  def_loose_balls_recovered: Loose balls recovered while on defense.
+  loose_balls_recovered: Total loose balls recovered.
+  off_boxouts: Box-outs recorded on the offensive glass.
+  off_loose_balls_recovered: Loose balls recovered while on offense.
+  pct_box_outs_def: Share of box-outs recorded on the defensive glass, as a decimal.
+  pct_box_outs_off: Share of box-outs recorded on the offensive glass, as a decimal.
+  pct_loose_balls_recovered_def: Share of recovered loose balls that came on defense, as a decimal.
+  pct_loose_balls_recovered_off: Share of recovered loose balls that came on offense, as a decimal.
+  screen_ast_pts: Points teammates scored directly off the row's screen assists.
+leaguelineupviz:
+  def_rating: Points allowed per 100 possessions with the lineup on the floor (defensive rating).
+  fta_rate: Free throw attempts per field goal attempt for the lineup.
+  off_rating: Points scored per 100 possessions with the lineup on the floor (offensive rating).
+  opp_efg_pct: Opponent effective field goal percentage against the lineup, as a decimal.
+  opp_fg3_pct: Opponent three-point percentage against the lineup, as a decimal.
+  opp_fta_rate: Opponent free throw attempt rate against the lineup.
+  opp_tov_pct: Opponent turnover percentage forced by the lineup.
+  pct_ast_fgm: Percentage of made field goals that were assisted, as a decimal.
+  pct_fga_2pt: Share of field goal attempts taken as two-pointers, as a decimal.
+  pct_fga_3pt: Share of field goal attempts taken as three-pointers, as a decimal.
+  pct_pts_2pt_mr: Share of points scored on mid-range two-pointers, as a decimal.
+  pct_pts_fb: Share of points scored on fast breaks, as a decimal.
+  pct_pts_ft: Share of points scored at the free throw line, as a decimal.
+  pct_pts_paint: Share of points scored in the paint, as a decimal.
+  pct_uast_fgm: Percentage of made field goals that were unassisted, as a decimal.
+  sum_tm_min: Total team minutes summed across the lineup's stints on the floor.
+  tm_ast_pct: Percentage of the lineup's made field goals that were assisted, as a decimal.
+leagues:
+  default_season: Season the source API currently treats as the default for this league.
+  default_week: Week number the source API currently treats as the default for this league.
+  default_week_group: Identifier of the week grouping (e.g., regular season or postseason phase) currently set as the league
+    default.
+  has_playoff_points: Boolean flag indicating whether this league uses a playoff points system to determine postseason seeding.
+  has_split_season: Boolean flag indicating whether this league divides its season into two halves with separate standings
+    (as used historically in some minor leagues).
+  has_wild_card: Boolean flag indicating whether this league includes a wild card playoff format for postseason eligibility.
+  num_games: The total number of regular-season games scheduled per team in this league for the given season.
+  num_wildcard_teams: The number of wild card berths available for postseason entry in this league for the given season.
+  org_code: The organizational code identifying the parent body (e.g., 'MLB') governing this league within the MLB Stats API
+    hierarchy.
+  season_state: A string describing the current phase of the league's season (e.g., 'inProgress', 'offseason', 'preseason').
+  week_groups: Nested list of week-group objects (phase label and week span) defined for the league.
+  weeks: Nested list of week objects available for the league.
+load_cfb_game_rosters:
+  athlete_href: ESPN Core v2 API reference URL for the athlete's season record, ending in the athlete id.
+  birth_country_alternate_id: ESPN's internal alternate identifier for the athlete's birth country, paired with birth_place_country
+    and the flag fields.
+  draft_team_href: 'API link to the team that drafted the player. Sparse: absent entirely from the 2023 and 2024 assets and
+    populated on only a small share of 2025 rows.'
+  flag_alt: Alt text ESPN attaches to the birth-country flag image, which is the country's name spelled out.
+  flag_href: URL of the birth-country flag image hosted on ESPN's CDN under teamlogos/countries.
+  flag_rel: Stringified relationship list ESPN ships with the flag image; the only non-null value observed is a single country-flag
+    entry.
+  jersey_right: Secondary or alternate jersey number display string from ESPN's roster record, distinct from the primary jersey
+    number.
+  position_href: ESPN Core v2 API reference URL for the position resource ESPN lists the athlete at.
+  statistics_href: ESPN Core v2 API reference URL for this athlete's stat line in this game, null for the roughly 71 percent
+    of listed players who recorded no stats.
+  team_alternate_ids_sdr: The team's Sportradar alternate identifier, which maps one-to-one with team_id.
+load_cfb_pbp:
+  A_score_diff: Away team's score minus the home team's, from the away perspective.
+  EPA_explosive: True when the play was explosive.
+  EPA_explosive_pass: True when the pass play was explosive.
+  EPA_explosive_rush: True when the rush play was explosive.
+  EPA_fg: EPA credited to the play on field-goal attempts.
+  EPA_kickoff: EPA credited to the play on kickoff plays.
+  EPA_middle_8_success: True when the play in the middle eight was successful by EPA.
+  EPA_middle_8_success_pass: True when the pass play in the middle eight was successful by EPA.
+  EPA_middle_8_success_rush: True when the rush play in the middle eight was successful by EPA.
+  EPA_non_explosive: EPA credited to the play on non-explosive plays.
+  EPA_pass: EPA credited to the play on pass plays.
+  EPA_penalty: EPA credited to the play attributable to penalties.
+  EPA_punt: EPA credited to the play on punt plays.
+  EPA_rush: EPA credited to the play on rush plays.
+  EPA_scrimmage: EPA credited to the play on plays from scrimmage.
+  EPA_sp: EPA credited to the play on special-teams plays.
+  EPA_success: True when the play was successful by EPA.
+  EPA_success_EPA: EPA on successful plays.
+  EPA_success_early_down: True when the play on an early down was successful by EPA.
+  EPA_success_early_down_pass: True when the pass play on an early down was successful by EPA.
+  EPA_success_early_down_rush: True when the rush play on an early down was successful by EPA.
+  EPA_success_late_down: True when the play on a late down was successful by EPA.
+  EPA_success_late_down_pass: True when the pass play on a late down was successful by EPA.
+  EPA_success_late_down_rush: True when the rush play on a late down was successful by EPA.
+  EPA_success_pass: True when the pass play was successful by EPA.
+  EPA_success_pass_EPA: EPA on successful pass plays.
+  EPA_success_passing_down: True when the play on a passing down was successful by EPA.
+  EPA_success_passing_down_EPA: EPA on successful plays on a passing down.
+  EPA_success_rush: True when the rush play was successful by EPA.
+  EPA_success_rush_EPA: EPA on successful rush plays.
+  EPA_success_standard_down: True when the play on a standard down was successful by EPA.
+  EPA_success_standard_down_EPA: EPA on successful plays on a standard down.
+  EP_between: Change in expected points across the play, before penalty adjustment.
+  EP_end: Expected points for the offense at the end of the play.
+  EP_start: Expected points for the offense at the start of the play.
+  EP_start_touchback: Expected points the offense would have had from a touchback on this play.
+  HA_score_diff: Home score minus away score for the play.
+  H_score_diff: Home team's score minus the away team's, from the home perspective.
+  TFL: True when the play was a tackle for loss.
+  TFL_pass: True when the play was a tackle for loss on a pass play (a sack).
+  TFL_rush: True when the play was a tackle for loss on a rush play.
+  action_play: True when the play advanced the game state -- excludes timeouts, end-of-period markers and other non-action
+    rows.
+  adj_rush_yardage: Rushing yards capped at 8, the input to the line-yards decomposition.
+  air_yardsToEndzone: Yards to the endzone at the catch spot, parsed from the 2025+ vendor catch-spot text; null before 2025
+    or when unresolvable.
+  awayTeamAbbrev: ESPN's away-team Abbrev for the game, stamped on every play.
+  awayTeamId: ESPN's away-team Id for the game, stamped on every play.
+  awayTeamMascot: ESPN's away-team Mascot for the game, stamped on every play.
+  awayTeamName: ESPN's away-team Name for the game, stamped on every play.
+  awayTeamNameAlt: ESPN's away-team NameAlt for the game, stamped on every play.
+  awayTimeoutCalled: True when the away team called a timeout on the play.
+  away_wp_after_naive: End-of-play naive win probability mapped to the away team.
+  away_wp_before_naive: Pre-snap naive win probability mapped to the away team.
+  cleaned_text: Play description with overturned-call prefixes stripped; the text the name and team extractors run against.
+  clock.displayValue: Game clock at the play, as the displayed mm:ss string.
+  clock.minutes: Minutes remaining on the game clock at the play.
+  clock.seconds: Seconds component of the game clock at the play.
+  def_fumble_lost: Whether the defending team (e.g. a returner after a takeaway) fumbled and lost the ball back.
+  def_wp_after_naive: End-of-play defense win probability under the naive model.
+  def_wp_before_naive: Pre-snap defense win probability under the naive model (1 - wp_before_naive).
+  down_1: True when it is 1st down at the start of the play.
+  down_1_end: True when it is 1st down at the end of the play.
+  down_2: True when it is 2nd down at the start of the play.
+  down_2_end: True when it is 2nd down at the end of the play.
+  down_3: True when it is 3rd down at the start of the play.
+  down_3_end: True when it is 3rd down at the end of the play.
+  down_4: True when it is 4th down at the start of the play.
+  down_4_end: True when it is 4th down at the end of the play.
+  drive.description: ESPN's `description` field for the drive containing this play.
+  drive.displayResult: ESPN's `displayResult` field for the drive containing this play.
+  drive.end.clock.displayValue: ESPN's `end.clock.displayValue` field for the drive containing this play.
+  drive.end.period.number: ESPN's `end.period.number` field for the drive containing this play.
+  drive.end.period.type: ESPN's `end.period.type` field for the drive containing this play.
+  drive.end.yardLine: ESPN's `end.yardLine` field for the drive containing this play.
+  drive.id: ESPN's `id` field for the drive containing this play.
+  drive.isScore: ESPN's `isScore` field for the drive containing this play.
+  drive.offensivePlays: ESPN's `offensivePlays` field for the drive containing this play.
+  drive.result: ESPN's `result` field for the drive containing this play.
+  drive.shortDisplayResult: ESPN's `shortDisplayResult` field for the drive containing this play.
+  drive.start.clock.displayValue: ESPN's `start.clock.displayValue` field for the drive containing this play.
+  drive.start.period.number: ESPN's `start.period.number` field for the drive containing this play.
+  drive.start.period.type: ESPN's `start.period.type` field for the drive containing this play.
+  drive.start.text: ESPN's `start.text` field for the drive containing this play.
+  drive.start.yardLine: ESPN's `start.yardLine` field for the drive containing this play.
+  drive.team.abbreviation: ESPN's `team.abbreviation` field for the drive containing this play.
+  drive.team.displayName: ESPN's `team.displayName` field for the drive containing this play.
+  drive.team.name: ESPN's `team.name` field for the drive containing this play.
+  drive.team.shortDisplayName: ESPN's `team.shortDisplayName` field for the drive containing this play.
+  drive.timeElapsed.displayValue: ESPN's `timeElapsed.displayValue` field for the drive containing this play.
+  drive.yards: ESPN's `yards` field for the drive containing this play.
+  drive_offense_plays: Offensive plays run on the drive.
+  drive_offense_yards: Offensive yards gained on the drive.
+  drive_play_index: Sequence number of the play within its drive.
+  drive_start: Yard line at which the drive began.
+  drive_stopped: True when the play ended the drive.
+  drive_total_yards: Total yards gained on the drive.
+  early_down: True when the play is a scrimmage play on first or second down.
+  early_down_pass: True when the play is a pass on an early down.
+  early_down_rush: True when the play is a rush on an early down.
+  end.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the end of the play.
+  end.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the end of the play.
+  end.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the end of the play.
+  end.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the end of the play.
+  end.awayScore: ESPN's `awayScore` value for the play state at the end of the play.
+  end.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the end of the play.
+  end.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the end of the play.
+  end.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the end of the play.
+  end.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the end of the play.
+  end.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the end of the play.
+  end.distance: ESPN's `distance` value for the play state at the end of the play.
+  end.down: ESPN's `down` value for the play state at the end of the play.
+  end.downDistanceText: ESPN's `downDistanceText` value for the play state at the end of the play.
+  end.elapsed_share: ESPN's `elapsed_share` value for the play state at the end of the play.
+  end.homeScore: ESPN's `homeScore` value for the play state at the end of the play.
+  end.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the end of the play.
+  end.is_home: ESPN's `is_home` value for the play state at the end of the play.
+  end.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the end of the play.
+  end.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the end of the play.
+  end.pos_team.id: ESPN's `pos_team.id` value for the play state at the end of the play.
+  end.pos_team.name: ESPN's `pos_team.name` value for the play state at the end of the play.
+  end.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the end of the play.
+  end.pos_team_score: ESPN's `pos_team_score` value for the play state at the end of the play.
+  end.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the end of the play.
+  end.possessionText: ESPN's `possessionText` value for the play state at the end of the play.
+  end.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the end of the play.
+  end.spread_time: ESPN's `spread_time` value for the play state at the end of the play.
+  end.team.id: ESPN's `team.id` value for the play state at the end of the play.
+  end.yard: ESPN's `yard` value for the play state at the end of the play.
+  end.yardLine: ESPN's `yardLine` value for the play state at the end of the play.
+  end.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the end of the play.
+  end_state_missing: Flag that ESPN's end-of-play state (end.team.id) was absent and the end state was imputed.
+  fg_attempt: True when the play was a field-goal attempt.
+  fg_block_player_id: ESPN athlete id of the player who blocked the field goal.
+  fg_kicker_player_id: ESPN athlete id of the field-goal kicker.
+  fg_return_player_id: ESPN athlete id of the player who returned the blocked or missed field goal.
+  fg_team: Team id attempting the field goal (the kicking team).
+  fg_wp: Make-probability-weighted win probability of attempting the field goal.
+  fg_wp_diff: fg_wp minus the recommended option's WP (0 when the field goal is the recommendation, otherwise <= 0).
+  firstHalfKickoffTeamId: ESPN id of the team that received the opening kickoff.
+  first_down_created: True when the play produced a first down for the offense.
+  first_down_prob: Modeled probability of converting the fourth down when going for it.
+  forced_fumble: True when the defense forced a fumble on the play.
+  forced_fumble_team: Team id credited with forcing the fumble -- the side opposite the fumbling player (the covering team
+    on returns).
+  fourth_down_recommendation: Max-WP fourth-down choice among "go", "punt", and "field_goal".
+  fumble_or_muff: Whether the play includes a fumble or a muffed kick or punt (widened beyond ESPN's fumble play types).
+  fumble_recovered: True when a fumble on the play was recovered.
+  fumble_recovery_team: Team id that recovered the fumble or muff, from parsed text with a giveaway / own-recovery fallback.
+  fumbling_team: Team id of the side that fumbled or muffed the ball, parsed from the play text.
+  gameSpread: Point spread used as an input to the win-probability model.
+  gameSpreadAvailable: True when a spread was available for the game.
+  go_boost: 'cfb4th''s headline number: 100 * (go_wp - max(fg_wp, punt_wp)), in percentage points.'
+  go_wp: 'Win probability from going for it on fourth down: conversion-probability-weighted mean of the success and failure
+    states (cfb4th port).'
+  go_wp_diff: go_wp minus the recommended option's WP (0 when going for it is the recommendation, otherwise <= 0).
+  havoc: 'True when the defense disrupted the play: a pass breakup, tackle for loss, interception or forced fumble.'
+  highlight_run: True when the rush gained 8 or more yards.
+  highlight_yards: Second-level plus open-field yards -- the yardage credited to the carrier.
+  homeFavorite: True when the home team was favoured by the spread.
+  homeTeamAbbrev: ESPN's home-team Abbrev for the game, stamped on every play.
+  homeTeamId: ESPN's home-team Id for the game, stamped on every play.
+  homeTeamMascot: ESPN's home-team Mascot for the game, stamped on every play.
+  homeTeamName: ESPN's home-team Name for the game, stamped on every play.
+  homeTeamNameAlt: ESPN's home-team NameAlt for the game, stamped on every play.
+  homeTeamSpread: ESPN's home-team Spread for the game, stamped on every play.
+  homeTimeoutCalled: True when the home team called a timeout on the play.
+  home_wp_after_naive: End-of-play naive win probability mapped to the home team.
+  home_wp_before_naive: Pre-snap naive win probability mapped to the home team.
+  int_turnover: Whether the play is an interception giveaway.
+  interception_team: Team id credited with the interception (the defense).
+  isPenalty: ESPN's per-play flag that a penalty occurred on the play.
+  isTurnover: ESPN's per-play turnover flag as shipped in the plays feed (broader than the giveaway-based is_turnover derivation).
+  is_blocked_fg_turnover: Blocked-field-goal possession loss (blocked-FG TD, or the defense recovered); kept out of is_turnover
+    to match ESPN's giveaway-only box.
+  is_blocked_punt_turnover: Blocked-punt possession loss (blocked-punt TD, or the defense recovered); kept out of is_turnover
+    to match ESPN's giveaway-only box.
+  is_def_pos_team_turnover: Whether the defending team gave the ball back via a lost fumble.
+  is_pos_team_turnover: Whether the possession team committed a giveaway (interception or fumble lost).
+  is_st_turnover: Whether the giveaway happened on a special-teams play (kick or punt snap, or a return).
+  kick_return_team: Team id of the kick-returning side.
+  kicking_team: Team id of the kicking team on kickoff, punt, and field-goal plays.
+  kickoff_player_id: ESPN athlete id of the player kicking off.
+  kickoff_return_player_id: ESPN athlete id of the kickoff returner.
+  kneel_down: Whether the play is an offensive kneel, from explicit kneel text plus an end-of-half TEAM-rush heuristic.
+  lag_EP_end: Value of EP_end on the previous play, used for sequence-aware derivations.
+  lag_HA_score_diff: Value of HA_score_diff on the previous play, used for sequence-aware derivations.
+  lag_awayScore: Value of awayScore on the previous play, used for sequence-aware derivations.
+  lag_change_of_pos_team: Value of change_of_pos_team on the previous play, used for sequence-aware derivations.
+  lag_half: Value of half on the previous play, used for sequence-aware derivations.
+  lag_homeScore: Value of homeScore on the previous play, used for sequence-aware derivations.
+  lag_pos_score_diff: Value of pos_score_diff on the previous play, used for sequence-aware derivations.
+  lag_pos_team: Value of pos_team on the previous play, used for sequence-aware derivations.
+  lag_scoringPlay: Value of scoringPlay on the previous play, used for sequence-aware derivations.
+  late_down: True when the play is a scrimmage play on third or fourth down.
+  late_down_pass: True when the play is a pass on a late down.
+  late_down_rush: True when the play is a rush on a late down.
+  lead_half: Value of half on the next play, used for sequence-aware derivations.
+  lead_play_type: Value of play_type on the next play, used for sequence-aware derivations.
+  lead_pos_team: Value of pos_team on the next play, used for sequence-aware derivations.
+  lead_pos_team2: Value of pos_team 2 plays ahead, used for sequence-aware derivations.
+  lead_scoringPlay: Value of scoringPlay on the next play, used for sequence-aware derivations.
+  lead_start_distance: Value of start_distance on the next play, used for sequence-aware derivations.
+  lead_start_down: Value of start_down on the next play, used for sequence-aware derivations.
+  lead_start_team: Value of start_team on the next play, used for sequence-aware derivations.
+  lead_start_yardsToEndzone: Value of start_yardsToEndzone on the next play, used for sequence-aware derivations.
+  lead_text: Value of text on the next play, used for sequence-aware derivations.
+  lead_wp_before: Value of wp_before on the next play, used for sequence-aware derivations.
+  lead_wp_before2: Value of wp_before 2 plays ahead, used for sequence-aware derivations.
+  lead_wp_before2_naive: Pre-snap naive win probability two plays ahead, used where the immediately following row is a non-play.
+  lead_wp_before_naive: Next play's pre-snap naive win probability, used in the end-of-half and change-of-possession adjustments.
+  line_yards: 'Yards credited to the offensive line on a rush, using the standard sliding scale: 1.2x the capped yardage on
+    a loss, all of it through 3 yards, half of each yard from 4 to 8, and a 5.5-yard ceiling beyond that.'
+  make_fg_wp: Win probability given the field-goal attempt is made.
+  miss_fg_wp: Win probability given the field-goal attempt misses.
+  net_HA_score_pts: Net points the play added to the home-minus-away score margin.
+  new_distance: Distance to go after the play, including any penalty enforcement.
+  new_down: Down after the play, including any penalty enforcement.
+  non_fumble_sack: True when the play was a sack that did not produce a fumble.
+  open_field_yards: Rushing yards gained beyond 8, credited to the ball carrier rather than the line.
+  opp_highlight_yards: Highlight yards earned on opportunity runs, isolating carrier production on carries where the blocking
+    succeeded. Assets published before the 2026-08 fix are identically 0 here, because the inverted opportunity_run gate could
+    never co-occur with non-zero highlight yards.
+  opportunity_run: True when a rush reached 4 yards -- the carries on which the blocking did its job. Matches cfbfastR's espn_cfb_15
+    definition. Assets published before the 2026-08 fix carry the inverted (4 yards or fewer) flag.
+  overUnder: Over/under total used as a model input.
+  pass_breakup: True when a defender broke up the pass.
+  pass_breakup_team: Team id credited with the pass breakup (the defense).
+  pass_depth: Thrown-pass depth parsed from ESPN play text ("short" or "deep"); null when the text omits it (sacks, screens,
+    pre-2025 text).
+  pass_direction: Pass direction parsed from ESPN play text ("left", "middle", or "right"); null when the text omits it.
+  pass_epa: EPA credited to the play when it is a pass.
+  pass_weight: Weighting applied to the pass component of the play.
+  passing_down: True when the offense is behind schedule for the series -- second down needing 8 or more, or third/fourth
+    down needing 5 or more.
+  pen_epa: EPA attributable to a penalty on the play.
+  pen_weight: Weighting applied to the penalty component of the play.
+  penalized_team: Team id the penalty was assessed against, from the home/away text resolver with a foul-direction fallback.
+  penalty_assessed_on_kickoff: Whether a penalty was assessed on a kickoff; such plays take the kickoff/touchback win-probability
+    handling.
+  penalty_in_text: True when the play description mentions a penalty.
+  penalty_yards_signed: Penalty yardage parsed from the play text with era-aware bounds; the printed sign is retained but
+    is not a reliable enforcement direction.
+  period.number: Period (quarter) number in which the play occurred.
+  pointAfterAttempt.abbreviation: ESPN abbreviation of the point-after attempt type; drives the extra-point / two-point result
+    derivation.
+  pointAfterAttempt.id: ESPN identifier for the point-after attempt type on the scoring play.
+  pointAfterAttempt.text: ESPN description of the point-after attempt and its result.
+  pointAfterAttempt.value: Points ESPN credits for the point-after attempt (1.0 made extra point, 2.0 made two-point try).
+  pos_fumble_lost: Whether the possession team fumbled and lost the ball.
+  pos_score_diff_end: Score differential from the possessing team's perspective at the end of the play.
+  power_rush_attempt: True when the play is a short-yardage power rushing attempt.
+  power_rush_success: True when a power rushing attempt gained the yardage needed.
+  prob_2pt: Two-point conversion probability from the bundled CFB two-point model.
+  prog_drive_EPA: Cumulative EPA accrued by the drive up to and including this play.
+  prog_drive_WPA: Cumulative win-probability added by the drive up to and including this play.
+  punt_block_player_id: ESPN athlete id of the player who blocked the punt.
+  punt_block_return_player_id: ESPN athlete id of the player who returned the blocked punt.
+  punt_return_player_id: ESPN athlete id of the punt returner.
+  punt_return_team: Team id of the punt-returning side.
+  punt_team: Team id punting the ball (the kicking team).
+  punt_wp: Win probability of punting, from the bundled punt-outcome distribution.
+  punt_wp_diff: punt_wp minus the recommended option's WP (0 when punting is the recommendation, otherwise <= 0).
+  qb_hurry: Whether ESPN's play text says the quarterback was hurried into the throw ("hurried by ...").
+  qbr_epa: EPA variant used as an input to the QBR calculation.
+  recovery_team: Team id parsed from the play text as recovering the fumble or muff.
+  recovery_team_2: Team id of the second recovery in a multi-recovery scramble, parsed from the play text.
+  rush_direction: Rush direction parsed from ESPN play text ("left", "middle", or "right"); null when the text omits it.
+  rush_epa: EPA credited to the play when it is a rush.
+  rush_weight: Weighting applied to the rush component of the play.
+  sack_epa: EPA credited to the play when it is a sack.
+  sack_player_id2: ESPN athlete id of the second sacker on a split sack (regex fallback for an ESPN sidecar blind spot).
+  sack_team: Team id credited with the sack (the defense).
+  sack_weight: Weighting applied to the sack component of the play.
+  scoringPlay: ESPN flag marking the play as a scoring play.
+  scoringType.abbreviation: ESPN's abbreviation for the scoring type.
+  scoringType.displayName: ESPN's display label for the scoring type.
+  scoringType.name: ESPN's name for the scoring type (e.g. touchdown, field goal).
+  scrimmage_play: True when the play is a play from scrimmage rather than a special-teams or administrative row.
+  seasonType: ESPN season type for the game (2 = regular season, 3 = postseason).
+  second_level_yards: Rushing yards earned from 4 to 8, split evenly between line and carrier under the line-yards decomposition.
+  short_rush_attempt: True when the play is a rush in a short-yardage situation.
+  short_rush_success: True when a short-yardage rush gained the yardage needed.
+  standard_down: True when the offense is on schedule for the series -- first down, second down needing fewer than 8, or third/fourth
+    down needing fewer than 5.
+  start.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the start of the play.
+  start.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the start of the play.
+  start.ExpScoreDiff_Time_Ratio_touchback: ESPN's `ExpScoreDiff_Time_Ratio_touchback` value for the play state at the start
+    of the play.
+  start.ExpScoreDiff_touchback: ESPN's `ExpScoreDiff_touchback` value for the play state at the start of the play.
+  start.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the start of the play.
+  start.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the start of the play.
+  start.awayScore: ESPN's `awayScore` value for the play state at the start of the play.
+  start.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the start of the play.
+  start.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the start of the play.
+  start.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the start of the play.
+  start.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the start of the play.
+  start.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the start of the play.
+  start.distance: ESPN's `distance` value for the play state at the start of the play.
+  start.down: ESPN's `down` value for the play state at the start of the play.
+  start.downDistanceText: ESPN's `downDistanceText` value for the play state at the start of the play.
+  start.elapsed_share: ESPN's `elapsed_share` value for the play state at the start of the play.
+  start.homeScore: ESPN's `homeScore` value for the play state at the start of the play.
+  start.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the start of the play.
+  start.is_home: ESPN's `is_home` value for the play state at the start of the play.
+  start.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the start of the play.
+  start.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the start of the play.
+  start.pos_team.id: ESPN's `pos_team.id` value for the play state at the start of the play.
+  start.pos_team.name: ESPN's `pos_team.name` value for the play state at the start of the play.
+  start.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the start of the play.
+  start.pos_team_score: ESPN's `pos_team_score` value for the play state at the start of the play.
+  start.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the start of the play.
+  start.possessionText: ESPN's `possessionText` value for the play state at the start of the play.
+  start.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the start of the play.
+  start.spread_time: ESPN's `spread_time` value for the play state at the start of the play.
+  start.team.id: ESPN's `team.id` value for the play state at the start of the play.
+  start.yard: ESPN's `yard` value for the play state at the start of the play.
+  start.yardLine: ESPN's `yardLine` value for the play state at the start of the play.
+  start.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the start of the play.
+  start.yardsToEndzone.touchback: ESPN's `yardsToEndzone.touchback` value for the play state at the start of the play.
+  statYardage: Yardage ESPN credits to the play for statistical purposes.
+  stopped_run: True when the rush was stopped at or behind the line of scrimmage.
+  td_check: Internal flag used while reconciling whether the play produced a touchdown.
+  teamParticipants: Raw ESPN team-level participants payload carried through from the plays feed (stringified).
+  text_dupe: True when the play description duplicates the previous row's text.
+  turnover_team: Team id charged with the giveaway on the play.
+  two_pt_recommendation: 'Point-after recommendation: "go_for_2" when two_pt_wp exceeds xp_wp, otherwise "kick_xp".'
+  two_pt_wp: 'Win probability of going for two: conversion-probability-weighted mean of the 2-point and 0-point outcomes (cfb4th
+    port).'
+  two_pt_wp_diff: two_pt_wp minus xp_wp; positive favors going for two.
+  type.abbreviation: ESPN's abbreviation for the play type.
+  type.id: ESPN's numeric identifier for the play type.
+  type.text: ESPN's text label for the play type.
+  under_2: Whether the play began with two minutes or less remaining in the half.
+  wp_after_naive: End-of-play possession-team win probability from the naive model, after the game-logic adjustment chain.
+  wp_before_naive: Pre-snap possession-team win probability from the spread-free (naive) WP model.
+  wp_fail: Mean win probability given the fourth-down attempt fails.
+  wp_succeed: Mean win probability across yardage outcomes given the fourth-down attempt converts.
+  wp_touchback: Win probability the offense would have had starting from a touchback.
+  wp_touchback_naive: Naive-model win probability for the kickoff-touchback substitute state, used as the pre-snap WP on kickoffs.
+  wpa_naive: Win probability added on the play under the spread-free (naive) model.
+  xp_wp: Win probability of kicking the extra point, weighting the make by the empirical CFB extra-point make rate.
+load_cfb_pbp_r:
+  away_team_pregame_elo: Away team's pregame Elo rating, carried on the cfbfastR-shaped schema.
+  home_team_pregame_elo: Home team's pregame Elo rating, carried on the cfbfastR-shaped schema.
+  position_completion: Position of the passer credited with the completion (cfbfastR-shaped player-position column).
+  position_fumble: Position of the player who fumbled (cfbfastR-shaped player-position column).
+  position_fumble_forced: Position of the defender who forced the fumble (cfbfastR-shaped player-position column).
+  position_fumble_recovered: Position of the player who recovered the fumble (cfbfastR-shaped player-position column).
+  position_incompletion: Position of the passer charged with the incompletion (cfbfastR-shaped player-position column).
+  position_interception: Position of the defender who made the interception (cfbfastR-shaped player-position column).
+  position_interception_thrown: Position of the passer who threw the interception (cfbfastR-shaped player-position column).
+  position_pass_breakup: Position of the defender credited with the pass breakup (cfbfastR-shaped player-position column).
+  position_reception: Position of the player credited with the reception on the play (cfbfastR-shaped player-position column).
+  position_rush: Position of the player credited with the rush on the play (cfbfastR-shaped player-position column).
+  position_sack: Position of the defender credited with the sack (cfbfastR-shaped player-position column).
+  position_sack_taken: Position of the quarterback who took the sack (cfbfastR-shaped player-position column).
+  position_target: Position of the receiver targeted on the play (cfbfastR-shaped player-position column).
+  position_touchdown: Position of the player who scored the touchdown (cfbfastR-shaped player-position column).
+load_cfb_play_participants:
+  assisted_by_player_id: ESPN athlete id of a defender credited with an assisted tackle -- the FIRST participant in that role
+    on the play.
+  assisted_by_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with an assisted tackle
+    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  assisted_by_player_name: Display name of a defender credited with an assisted tackle -- the FIRST participant in that role
+    on the play.
+  assisted_by_player_names: List of the display names of EVERY participant credited as a defender credited with an assisted
+    tackle on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  forced_by_player_id: ESPN athlete id of the defender who forced the fumble -- the FIRST participant in that role on the
+    play.
+  forced_by_player_ids: List of the athlete ids of EVERY participant credited as the defender who forced the fumble on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  forced_by_player_name: Display name of the defender who forced the fumble -- the FIRST participant in that role on the play.
+  forced_by_player_names: List of the display names of EVERY participant credited as the defender who forced the fumble on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  fumbler_player_id: ESPN athlete id of the first (primary) player who fumbled on the play.
+  fumbler_player_ids: ESPN athlete ids of every player who fumbled on the play, as a list.
+  fumbler_player_name: Display name of the first (primary) player who fumbled on the play, from ESPN's per-play participants.
+  fumbler_player_names: Display names of every player who fumbled on the play, as a list.
+  kicker_player_id: ESPN athlete id of the kicker -- the FIRST participant in that role on the play.
+  kicker_player_ids: List of the athlete ids of EVERY participant credited as the kicker on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  kicker_player_name: Display name of the kicker -- the FIRST participant in that role on the play.
+  kicker_player_names: List of the display names of EVERY participant credited as the kicker on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  pass_defender_player_id: ESPN athlete id of the defender credited with defending the pass -- the FIRST participant in that
+    role on the play.
+  pass_defender_player_ids: List of the athlete ids of EVERY participant credited as the defender credited with defending
+    the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  pass_defender_player_name: Display name of the defender credited with defending the pass -- the FIRST participant in that
+    role on the play.
+  pass_defender_player_names: List of the display names of EVERY participant credited as the defender credited with defending
+    the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  passer_player_id: ESPN athlete id of the passer -- the FIRST participant in that role on the play.
+  passer_player_ids: List of the athlete ids of EVERY participant credited as the passer on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
+  passer_player_names: List of the display names of EVERY participant credited as the passer on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  pat_passer_player_id: ESPN athlete id of the passer on the point-after attempt -- the FIRST participant in that role on
+    the play.
+  pat_passer_player_ids: List of the athlete ids of EVERY participant credited as the passer on the point-after attempt on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  pat_passer_player_name: Display name of the passer on the point-after attempt -- the FIRST participant in that role on the
+    play.
+  pat_passer_player_names: List of the display names of EVERY participant credited as the passer on the point-after attempt
+    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  pat_scorer_player_id: ESPN athlete id of the player credited with the point-after score -- the FIRST participant in that
+    role on the play.
+  pat_scorer_player_ids: List of the athlete ids of EVERY participant credited as the player credited with the point-after
+    score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  pat_scorer_player_name: Display name of the player credited with the point-after score -- the FIRST participant in that
+    role on the play.
+  pat_scorer_player_names: List of the display names of EVERY participant credited as the player credited with the point-after
+    score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  penalized_player_id: ESPN athlete id of the penalized player -- the FIRST participant in that role on the play.
+  penalized_player_ids: List of the athlete ids of EVERY participant credited as the penalized player on the play, so multi-entry
+    roles such as split sacks or gang tackles are not collapsed to one.
+  penalized_player_name: Display name of the penalized player -- the FIRST participant in that role on the play.
+  penalized_player_names: List of the display names of EVERY participant credited as the penalized player on the play, so
+    multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  punter_player_id: ESPN athlete id of the punter -- the FIRST participant in that role on the play.
+  punter_player_ids: List of the athlete ids of EVERY participant credited as the punter on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  punter_player_name: Display name of the punter -- the FIRST participant in that role on the play.
+  punter_player_names: List of the display names of EVERY participant credited as the punter on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  receiver_player_id: ESPN athlete id of the targeted receiver -- the FIRST participant in that role on the play.
+  receiver_player_ids: List of the athlete ids of EVERY participant credited as the targeted receiver on the play, so multi-entry
+    roles such as split sacks or gang tackles are not collapsed to one.
+  receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
+  receiver_player_names: List of the display names of EVERY participant credited as the targeted receiver on the play, so
+    multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  recoverer_player_id: ESPN athlete id of the player who recovered the fumble -- the FIRST participant in that role on the
+    play.
+  recoverer_player_ids: List of the athlete ids of EVERY participant credited as the player who recovered the fumble on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  recoverer_player_name: Display name of the player who recovered the fumble -- the FIRST participant in that role on the
+    play.
+  recoverer_player_names: List of the display names of EVERY participant credited as the player who recovered the fumble on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  returner_player_id: ESPN athlete id of the player returning the kick or punt -- the FIRST participant in that role on the
+    play.
+  returner_player_ids: List of the athlete ids of EVERY participant credited as the player returning the kick or punt on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  returner_player_name: Display name of the player returning the kick or punt -- the FIRST participant in that role on the
+    play.
+  returner_player_names: List of the display names of EVERY participant credited as the player returning the kick or punt
+    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  rusher_player_id: ESPN athlete id of the ball carrier on a rush -- the FIRST participant in that role on the play.
+  rusher_player_ids: List of the athlete ids of EVERY participant credited as the ball carrier on a rush on the play, so multi-entry
+    roles such as split sacks or gang tackles are not collapsed to one.
+  rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
+  rusher_player_names: List of the display names of EVERY participant credited as the ball carrier on a rush on the play,
+    so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  sacked_by_player_id: ESPN athlete id of a defender credited with the sack -- the FIRST participant in that role on the play.
+  sacked_by_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with the sack on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  sacked_by_player_name: Display name of a defender credited with the sack -- the FIRST participant in that role on the play.
+  sacked_by_player_names: List of the display names of EVERY participant credited as a defender credited with the sack on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  scorer_player_id: ESPN athlete id of the player credited with the score -- the FIRST participant in that role on the play.
+  scorer_player_ids: List of the athlete ids of EVERY participant credited as the player credited with the score on the play,
+    so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  scorer_player_name: Display name of the player credited with the score -- the FIRST participant in that role on the play.
+  scorer_player_names: List of the display names of EVERY participant credited as the player credited with the score on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  tackler_player_id: ESPN athlete id of a defender credited with the tackle -- the FIRST participant in that role on the play.
+  tackler_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with the tackle on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  tackler_player_name: Display name of a defender credited with the tackle -- the FIRST participant in that role on the play.
+  tackler_player_names: List of the display names of EVERY participant credited as a defender credited with the tackle on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+load_cfb_player_box:
+  adjQBR: Adjusted Total QBR for the quarterback.
+  completions/passingAttempts: Completions and pass attempts, as ESPN's combined string.
+  defensiveTouchdowns: Touchdowns the player scored on defense (ESPN box score).
+  extraPointsMade/extraPointAttempts: Extra points made and attempted, as ESPN's combined string.
+  fieldGoalPct: Field-goal percentage.
+  fieldGoalsMade/fieldGoalAttempts: Field goals made and attempted, as ESPN's combined string.
+  fumbles: Number of times the player fumbled in the game (ESPN box score).
+  fumblesLost: Number of the player's fumbles lost to the opponent (ESPN box score).
+  fumblesRecovered: Number of fumbles the player recovered (ESPN box score).
+  grossAvgPuntYards: Gross average yards per punt, before return yardage.
+  hurries: Quarterback hurries credited to the player (ESPN box score).
+  interceptionTouchdowns: Touchdowns scored on interception returns.
+  interceptionYards: Yards returned on interceptions.
+  kickReturnTouchdowns: Kickoff returns the player took for touchdowns (ESPN box score).
+  kickReturnYards: Total kickoff-return yards by the player (ESPN box score).
+  kickReturns: Number of kickoff returns by the player (ESPN box score).
+  longFieldGoalMade: Longest field goal made, in yards.
+  longKickReturn: Player's longest kickoff return of the game, in yards (ESPN box score).
+  longPunt: Longest punt of the game, in yards.
+  longPuntReturn: Longest punt return of the game, in yards.
+  longReception: Longest reception of the game, in yards.
+  longRushing: Longest rush of the game, in yards.
+  passesDefended: Passes the player broke up or defended (ESPN box score).
+  passingTouchdowns: Passing touchdowns.
+  passingYards: Net passing yards gained.
+  puntReturnTouchdowns: Touchdowns scored on punt returns.
+  puntReturnYards: Yards gained on punt returns.
+  puntReturns: Punt returns attempted.
+  puntYards: Total punt yards.
+  punts: Punts attempted.
+  puntsInside20: Punts downed inside the opponent 20-yard line.
+  receivingTouchdowns: Receiving touchdowns.
+  receivingYards: Receiving yards gained.
+  rushingAttempts: Rushing attempts.
+  rushingTouchdowns: Rushing touchdowns.
+  rushingYards: Net rushing yards gained.
+  soloTackles: Player's solo (unassisted) tackles (ESPN box score).
+  stat_1: First value of ESPN's raw athlete stats array, written only when the category's key list does not line up with the
+    stats list; on those rows the named per-category columns are all null.
+  stat_2: Second value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  stat_3: Third value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  stat_4: Fourth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  stat_5: Fifth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  tacklesForLoss: Player's tackles made behind the line of scrimmage (ESPN box score).
+  totalKickingPoints: Total points scored by kicking.
+  totalTackles: Player's total tackles, solo plus assisted (ESPN box score).
+  touchbacks: Punts or kickoffs that resulted in a touchback.
+  yardsPerKickReturn: Average yards per kickoff return for the player (ESPN box score).
+  yardsPerPassAttempt: Yards gained per pass attempt.
+  yardsPerPuntReturn: Yards gained per punt return.
+  yardsPerReception: Yards gained per reception.
+  yardsPerRushAttempt: Yards gained per rushing attempt.
+load_cfb_recruits:
+  team_id_247: 247Sports' own team key for the recruit's committed or signed school; not interchangeable with the ESPN/CFBD
+    team id.
+load_cfb_returning_production:
+  def_returning: Share of the team's prior-season defensive production returning for the season.
+  n_returning: Number of returning players counted in the returning-production calculation.
+  off_returning: Share of the team's prior-season offensive production returning for the season.
+  overall_returning: Usage-weighted blend of the offensive and defensive returning-production shares.
+load_cfb_team_info:
+  logo_2: URL of the team's alternate dark-background 500-pixel logo on ESPN's CDN, null for programs with no dark variant.
+  logos_10: URL of the team's logo variant in slot 10 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_11: URL of the team's logo variant in slot 11 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_12: URL of the team's logo variant in slot 12 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_13: URL of the team's logo variant in slot 13 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_14: URL of the team's logo variant in slot 14 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_15: URL of the team's logo variant in slot 15 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_16: URL of the team's logo variant in slot 16 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_3: URL of the team's logo variant in slot 3 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_4: URL of the team's logo variant in slot 4 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_5: URL of the team's logo variant in slot 5 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_6: URL of the team's logo variant in slot 6 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_7: URL of the team's logo variant in slot 7 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_8: URL of the team's logo variant in slot 8 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  logos_9: URL of the team's logo variant in slot 9 of ESPN's team-info logo list; null when the team publishes fewer variants.
+  twitter: The football program's Twitter/X handle including the leading at sign, populated for only a minority of listed
+    teams.
+load_cfb_team_talent:
+  blue_chip_ratio: Share of the team's counted signees rated four or five stars over the rolling class window.
+  n_recruits: Number of signees counted in the blue-chip-ratio window.
+  talent_composite: Sum of composite recruiting ratings across the counted signing classes (the Team Talent measure).
+  talent_rank: Dense rank of talent_composite within the season (1 = most talented roster).
+load_mbb_pbp:
+  athlete_name_1: Display name of the first athlete in the ESPN play participants (e.g., the shooter on a shot attempt).
+  athlete_name_2: Display name of the second athlete in the ESPN play participants (e.g., the assisting player), when present.
+  athlete_name_3: Display name of the third athlete in the ESPN play participants, when present.
+  away_timeout_called: True when the away team called a timeout on the play.
+  end_period_seconds_remaining: Seconds left in the period when the play ended.
+  home_timeout_called: True when the home team called a timeout on the play.
+  lag_period: Period number of the previous play in the same game (period_number shifted forward one row within game_id),
+    and null on each game's first play.
+  lead_period: Period number of the next play in the same game (period_number shifted back one row within game_id), and null
+    on each game's final play.
+  points_attempted: Point value at stake on the shot attempt (3 for threes, 2 for other field goals, 1 for free throws), from
+    the ESPN play type.
+  short_description: Shortened version of ESPN's play description text, without score context.
+  start_period_seconds_remaining: Seconds left in the current period when the play started, computed as 60 times the game
+    clock minutes plus the seconds, so 1200 at the tip of each 20-minute half and 300 at the start of an overtime.
+load_mbb_schedule:
+  away_current_rank: Poll ranking ESPN listed for the away team at game time (unranked teams carry a sentinel value).
+  away_linescores: Period-by-period scores for the away team as a delimited string from ESPN's schedule feed.
+  away_records: Record strings (overall and split records) for the away team from ESPN's schedule feed.
+  home_current_rank: Poll ranking ESPN listed for the home team at game time (unranked teams carry a sentinel value).
+  home_linescores: Period-by-period scores for the home team as a delimited string from ESPN's schedule feed.
+  home_records: Record strings (overall and split records) for the home team from ESPN's schedule feed.
+load_mbb_shots:
+  athlete_name_1: Display name of the shooter credited on the attempt in ESPN's play participants.
+  athlete_name_2: Display name of the second athlete tied to the attempt (typically the assister), when present.
+  team_mascot: Mascot/nickname of the shooting team from ESPN's team record.
+load_mbb_team_boxscore:
+  lead_percentage: Share of game time the team held the lead, as reported in ESPN's team boxscore.
+load_nba_pbp:
+  athlete_name_1: Name of the primary athlete involved in the play (pairs with athlete_id_1).
+  athlete_name_2: Name of the secondary athlete involved in the play (e.g. the assister or fouled player).
+  athlete_name_3: Name of the tertiary athlete involved in the play.
+  away_timeout_called: Whether the play is a timeout called by the away team.
+  home_timeout_called: Whether the play is a timeout called by the home team.
+  points_attempted: Point value attempted on the shot (2 or 3; 1 for a free throw).
+  short_description: Short text description of the play from ESPN.
+load_nba_player_crosswalk:
+  nba_jersey_num: Player's jersey number as listed by the NBA Stats API.
+  nba_player_id: NBA Stats player id side of the ESPN-to-NBA player crosswalk.
+  nba_player_name: Player name as listed by the NBA Stats API.
+  nba_position: Player's position as listed by the NBA Stats API.
+load_nba_schedule:
+  away_linescores: Period-by-period points for the away team, stringified from ESPN's linescores array.
+  away_records: Away team's records at game time (overall, home, away), stringified from ESPN.
+  home_linescores: Period-by-period points for the home team, stringified from ESPN's linescores array.
+  home_records: Home team's records at game time (overall, home, away), stringified from ESPN.
+load_nba_schedule_crosswalk:
+  fox_away_team_id: FOX Sports team id of the away team in the crosswalk.
+  fox_home_team_id: FOX Sports team id of the home team in the crosswalk.
+  nba_away_team_id: NBA Stats team id of the away team.
+  nba_game_code: NBA game code (date and matchup string) from the NBA Stats API.
+  nba_game_id: NBA Stats 10-character game id matched to the ESPN game in the crosswalk.
+  nba_home_team_id: NBA Stats team id of the home team.
+load_nba_shots:
+  athlete_name_1: Name of the shooter on the attempt.
+  athlete_name_2: Name of the secondary athlete on the attempt (e.g. the assister).
+  team_mascot: Mascot (nickname) portion of the shooting team's name.
+load_nba_stats_coaches:
+  coach_name: Coach's full name.
+  coach_type: Coach role description (e.g. "Head Coach", "Assistant Coach").
+  is_assistant: Numeric flag from the NBA Stats API distinguishing assistants from head coaches.
+  sort_sequence: Sort order of the coach within the team's staff listing.
+  sub_sort_sequence: Secondary sort order within the coach type.
+load_nba_stats_game_lineups:
+  away_player_1: NBA Stats player id of the away on-court player 1 of 5 for the row.
+  away_player_2: NBA Stats player id of the away on-court player 2 of 5 for the row.
+  away_player_3: NBA Stats player id of the away on-court player 3 of 5 for the row.
+  away_player_4: NBA Stats player id of the away on-court player 4 of 5 for the row.
+  away_player_5: NBA Stats player id of the away on-court player 5 of 5 for the row.
+  home_player_1: NBA Stats player id of the home on-court player 1 of 5 for the row.
+  home_player_2: NBA Stats player id of the home on-court player 2 of 5 for the row.
+  home_player_3: NBA Stats player id of the home on-court player 3 of 5 for the row.
+  home_player_4: NBA Stats player id of the home on-court player 4 of 5 for the row.
+  home_player_5: NBA Stats player id of the home on-court player 5 of 5 for the row.
+load_nba_stats_lineups:
+  ast_pct_rank: League rank of the row's assist percentage (share of teammate field goals assisted while on the floor) for
+    the season and split.
+  ast_rank: League rank of the row's assists for the season and split.
+  ast_ratio: Assist ratio (assists per 100 possessions used) over the split.
+  ast_ratio_rank: League rank of the row's assist ratio (assists per 100 possessions used) for the season and split.
+  ast_to: Assist-to-turnover ratio over the split.
+  ast_to_rank: League rank of the row's assist-to-turnover ratio for the season and split.
+  blk_rank: League rank of the row's blocked shots for the season and split.
+  blka: Shot attempts blocked by opponents (blocks against).
+  blka_rank: League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split.
+  def_rating: Defensive rating (points allowed per 100 possessions) over the split.
+  def_rating_rank: League rank of the row's defensive rating (points allowed per 100 possessions) for the season and split.
+  dreb_pct: Defensive rebound percentage over the split, as a decimal.
+  dreb_pct_rank: League rank of the row's defensive rebound percentage for the season and split.
+  dreb_rank: League rank of the row's defensive rebounds for the season and split.
+  e_def_rating: Estimated defensive rating (NBA Stats estimated-metrics family) over the split.
+  e_net_rating: Estimated net rating (NBA Stats estimated-metrics family) over the split.
+  e_off_rating: Estimated offensive rating (NBA Stats estimated-metrics family) over the split.
+  e_pace: Estimated pace (NBA Stats estimated-metrics family) over the split.
+  efg_pct: Effective field goal percentage over the split, as a decimal.
+  efg_pct_rank: League rank of the row's effective field goal percentage for the season and split.
+  fg3_pct_rank: League rank of the row's three-point field goal percentage for the season and split.
+  fg3a_rank: League rank of the row's three-point field goals attempted for the season and split.
+  fg3m_rank: League rank of the row's three-point field goals made for the season and split.
+  fg_pct_rank: League rank of the row's field goal percentage for the season and split.
+  fga_rank: League rank of the row's field goals attempted for the season and split.
+  fgm_rank: League rank of the row's field goals made for the season and split.
+  ft_pct_rank: League rank of the row's free throw percentage for the season and split.
+  fta_rank: League rank of the row's free throws attempted for the season and split.
+  ftm_rank: League rank of the row's free throws made for the season and split.
+  gp_rank: League rank of the row's games played for the season and split.
+  group_set: Lineup grouping label from the NBA Stats API (e.g. "Lineups").
+  l_rank: League rank of the row's losses for the season and split.
+  measure_type: NBA Stats measure type the row was pulled from (e.g. Base, Advanced, Misc, Scoring, Opponent, Usage, Defense).
+  min_rank: League rank of the row's minutes played for the season and split.
+  net_rating_rank: League rank of the row's net rating (offensive minus defensive rating) for the season and split.
+  off_rating: Offensive rating (points scored per 100 possessions) over the split.
+  off_rating_rank: League rank of the row's offensive rating (points scored per 100 possessions) for the season and split.
+  opp_ast: Opponent assists allowed over the split.
+  opp_ast_rank: League rank of the row's opponent assists for the season and split.
+  opp_blk: Opponent blocked shots allowed over the split.
+  opp_blk_rank: League rank of the row's opponent blocked shots for the season and split.
+  opp_blka: Opponent shot attempts blocked by opponents (blocks against) allowed over the split.
+  opp_blka_rank: League rank of the row's opponent shot attempts blocked by opponents (blocks against) for the season and
+    split.
+  opp_dreb: Opponent defensive rebounds allowed over the split.
+  opp_dreb_rank: League rank of the row's opponent defensive rebounds for the season and split.
+  opp_fg3_pct: Opponent three-point field goal percentage allowed over the split.
+  opp_fg3_pct_rank: League rank of the row's opponent three-point field goal percentage for the season and split.
+  opp_fg3a: Opponent three-point field goals attempted allowed over the split.
+  opp_fg3a_rank: League rank of the row's opponent three-point field goals attempted for the season and split.
+  opp_fg3m: Opponent three-point field goals made allowed over the split.
+  opp_fg3m_rank: League rank of the row's opponent three-point field goals made for the season and split.
+  opp_fg_pct: Opponent field goal percentage allowed over the split.
+  opp_fg_pct_rank: League rank of the row's opponent field goal percentage for the season and split.
+  opp_fga: Opponent field goals attempted allowed over the split.
+  opp_fga_rank: League rank of the row's opponent field goals attempted for the season and split.
+  opp_fgm: Opponent field goals made allowed over the split.
+  opp_fgm_rank: League rank of the row's opponent field goals made for the season and split.
+  opp_ft_pct: Opponent free throw percentage allowed over the split.
+  opp_ft_pct_rank: League rank of the row's opponent free throw percentage for the season and split.
+  opp_fta: Opponent free throws attempted allowed over the split.
+  opp_fta_rank: League rank of the row's opponent free throws attempted for the season and split.
+  opp_ftm: Opponent free throws made allowed over the split.
+  opp_ftm_rank: League rank of the row's opponent free throws made for the season and split.
+  opp_oreb: Opponent offensive rebounds allowed over the split.
+  opp_oreb_rank: League rank of the row's opponent offensive rebounds for the season and split.
+  opp_pf: Opponent personal fouls committed allowed over the split.
+  opp_pf_rank: League rank of the row's opponent personal fouls committed for the season and split.
+  opp_pfd: Opponent personal fouls drawn allowed over the split.
+  opp_pfd_rank: League rank of the row's opponent personal fouls drawn for the season and split.
+  opp_pts_2nd_chance: Opponent second-chance points allowed over the split.
+  opp_pts_2nd_chance_rank: League rank of the row's opponent second-chance points for the season and split.
+  opp_pts_fb: Opponent fast-break points allowed over the split.
+  opp_pts_fb_rank: League rank of the row's opponent fast-break points for the season and split.
+  opp_pts_off_tov: Opponent points scored off opponent turnovers allowed over the split.
+  opp_pts_off_tov_rank: League rank of the row's opponent points scored off opponent turnovers for the season and split.
+  opp_pts_paint: Opponent points in the paint allowed over the split.
+  opp_pts_paint_rank: League rank of the row's opponent points in the paint for the season and split.
+  opp_pts_rank: League rank of the row's opponent points scored for the season and split.
+  opp_reb: Opponent total rebounds allowed over the split.
+  opp_reb_rank: League rank of the row's opponent total rebounds for the season and split.
+  opp_stl: Opponent steals allowed over the split.
+  opp_stl_rank: League rank of the row's opponent steals for the season and split.
+  opp_tov: Opponent turnovers allowed over the split.
+  opp_tov_rank: League rank of the row's opponent turnovers for the season and split.
+  oreb_pct: Offensive rebound percentage over the split, as a decimal.
+  oreb_pct_rank: League rank of the row's offensive rebound percentage for the season and split.
+  oreb_rank: League rank of the row's offensive rebounds for the season and split.
+  pace_rank: League rank of the row's pace (possessions per 48 minutes) for the season and split.
+  pct_ast_2pm: Percentage of made two-pointers that were assisted, as a decimal.
+  pct_ast_2pm_rank: League rank of the row's percentage of made two-pointers that were assisted for the season and split.
+  pct_ast_3pm: Percentage of made three-pointers that were assisted, as a decimal.
+  pct_ast_3pm_rank: League rank of the row's percentage of made three-pointers that were assisted for the season and split.
+  pct_ast_fgm: Percentage of made field goals that were assisted, as a decimal.
+  pct_ast_fgm_rank: League rank of the row's percentage of made field goals that were assisted for the season and split.
+  pct_fga_2pt: Share of field goal attempts taken as two-pointers, as a decimal.
+  pct_fga_2pt_rank: League rank of the row's share of field goal attempts taken as two-pointers for the season and split.
+  pct_fga_3pt: Share of field goal attempts taken as three-pointers, as a decimal.
+  pct_fga_3pt_rank: League rank of the row's share of field goal attempts taken as three-pointers for the season and split.
+  pct_pts_2pt: Share of points scored on two-point field goals, as a decimal.
+  pct_pts_2pt_mr: Share of points scored on mid-range two-pointers, as a decimal.
+  pct_pts_2pt_mr_rank: League rank of the row's share of points scored on mid-range two-pointers for the season and split.
+  pct_pts_2pt_rank: League rank of the row's share of points scored on two-point field goals for the season and split.
+  pct_pts_3pt: Share of points scored on three-pointers, as a decimal.
+  pct_pts_3pt_rank: League rank of the row's share of points scored on three-pointers for the season and split.
+  pct_pts_fb: Share of points scored on fast breaks, as a decimal.
+  pct_pts_fb_rank: League rank of the row's share of points scored on fast breaks for the season and split.
+  pct_pts_ft: Share of points scored at the free throw line, as a decimal.
+  pct_pts_ft_rank: League rank of the row's share of points scored at the free throw line for the season and split.
+  pct_pts_off_tov: Share of points scored off opponent turnovers, as a decimal.
+  pct_pts_off_tov_rank: League rank of the row's share of points scored off opponent turnovers for the season and split.
+  pct_pts_paint: Share of points scored in the paint, as a decimal.
+  pct_pts_paint_rank: League rank of the row's share of points scored in the paint for the season and split.
+  pct_uast_2pm: Percentage of made two-pointers that were unassisted, as a decimal.
+  pct_uast_2pm_rank: League rank of the row's percentage of made two-pointers that were unassisted for the season and split.
+  pct_uast_3pm: Percentage of made three-pointers that were unassisted, as a decimal.
+  pct_uast_3pm_rank: League rank of the row's percentage of made three-pointers that were unassisted for the season and split.
+  pct_uast_fgm: Percentage of made field goals that were unassisted, as a decimal.
+  pct_uast_fgm_rank: League rank of the row's percentage of made field goals that were unassisted for the season and split.
+  per_mode: NBA Stats per-mode of the row values (e.g. Totals, PerGame, Per100Possessions).
+  pf_rank: League rank of the row's personal fouls committed for the season and split.
+  pfd: Personal fouls drawn.
+  pfd_rank: League rank of the row's personal fouls drawn for the season and split.
+  pie_rank: League rank of the row's Player Impact Estimate (PIE, the NBA Stats catch-all impact metric) for the season and
+    split.
+  plus_minus_rank: League rank of the row's plus-minus point differential while on the floor for the season and split.
+  pts_2nd_chance: Second-chance points over the split.
+  pts_2nd_chance_rank: League rank of the row's second-chance points for the season and split.
+  pts_fb: Fast-break points over the split.
+  pts_fb_rank: League rank of the row's fast-break points for the season and split.
+  pts_off_tov: Points scored off opponent turnovers over the split.
+  pts_off_tov_rank: League rank of the row's points scored off opponent turnovers for the season and split.
+  pts_paint: Points in the paint over the split.
+  pts_paint_rank: League rank of the row's points in the paint for the season and split.
+  pts_rank: League rank of the row's points scored for the season and split.
+  reb_pct: Total rebound percentage over the split, as a decimal.
+  reb_pct_rank: League rank of the row's total rebound percentage for the season and split.
+  reb_rank: League rank of the row's total rebounds for the season and split.
+  stl_rank: League rank of the row's steals for the season and split.
+  sum_time_played: Total time the five-man lineup was on the floor across the split.
+  tm_tov_pct: Team turnover percentage (turnovers per 100 possessions) over the split, as a decimal.
+  tm_tov_pct_rank: League rank of the row's team turnover percentage (turnovers per 100 possessions) for the season and split.
+  tov_rank: League rank of the row's turnovers for the season and split.
+  ts_pct_rank: League rank of the row's true shooting percentage for the season and split.
+  w_pct_rank: League rank of the row's win percentage for the season and split.
+  w_rank: League rank of the row's wins for the season and split.
+load_nba_stats_lineups_v3:
+  away_player_1: NBA Stats player id of the away on-court player 1 of 5 for the row.
+  away_player_2: NBA Stats player id of the away on-court player 2 of 5 for the row.
+  away_player_3: NBA Stats player id of the away on-court player 3 of 5 for the row.
+  away_player_4: NBA Stats player id of the away on-court player 4 of 5 for the row.
+  away_player_5: NBA Stats player id of the away on-court player 5 of 5 for the row.
+  home_player_1: NBA Stats player id of the home on-court player 1 of 5 for the row.
+  home_player_2: NBA Stats player id of the home on-court player 2 of 5 for the row.
+  home_player_3: NBA Stats player id of the home on-court player 3 of 5 for the row.
+  home_player_4: NBA Stats player id of the home on-court player 4 of 5 for the row.
+  home_player_5: NBA Stats player id of the home on-court player 5 of 5 for the row.
+load_nba_stats_pbp:
+  def_player_1: NBA Stats player id of defensive on-court player 1 of 5 during the event.
+  def_player_2: NBA Stats player id of defensive on-court player 2 of 5 during the event.
+  def_player_3: NBA Stats player id of defensive on-court player 3 of 5 during the event.
+  def_player_4: NBA Stats player id of defensive on-court player 4 of 5 during the event.
+  def_player_5: NBA Stats player id of defensive on-court player 5 of 5 during the event.
+  is_foul: Whether the event is a foul.
+  is_free_throw: Whether the event is a free throw attempt.
+  is_jump_ball: Whether the event is a jump ball.
+  is_made_shot: Whether the event is a made field goal.
+  is_missed_shot: Whether the event is a missed field goal.
+  is_period: Whether the event is a period start or end marker.
+  is_rebound: Whether the event is a rebound.
+  is_substitution: Whether the event is a substitution.
+  is_timeout: Whether the event is a timeout.
+  off_player_1: NBA Stats player id of offensive on-court player 1 of 5 during the event.
+  off_player_2: NBA Stats player id of offensive on-court player 2 of 5 during the event.
+  off_player_3: NBA Stats player id of offensive on-court player 3 of 5 during the event.
+  off_player_4: NBA Stats player id of offensive on-court player 4 of 5 during the event.
+  off_player_5: NBA Stats player id of offensive on-court player 5 of 5 during the event.
+  order_index: Stable within-game ordering index for events after pbpstats-style reordering of the raw feed.
+load_nba_stats_pbp_v3:
+  def_player_1: NBA Stats player id of defensive on-court player 1 of 5 during the event.
+  def_player_2: NBA Stats player id of defensive on-court player 2 of 5 during the event.
+  def_player_3: NBA Stats player id of defensive on-court player 3 of 5 during the event.
+  def_player_4: NBA Stats player id of defensive on-court player 4 of 5 during the event.
+  def_player_5: NBA Stats player id of defensive on-court player 5 of 5 during the event.
+  is_foul: Whether the event is a foul.
+  is_free_throw: Whether the event is a free throw attempt.
+  is_jump_ball: Whether the event is a jump ball.
+  is_made_shot: Whether the event is a made field goal.
+  is_missed_shot: Whether the event is a missed field goal.
+  is_period: Whether the event is a period start or end marker.
+  is_rebound: Whether the event is a rebound.
+  is_substitution: Whether the event is a substitution.
+  is_timeout: Whether the event is a timeout.
+  off_player_1: NBA Stats player id of offensive on-court player 1 of 5 during the event.
+  off_player_2: NBA Stats player id of offensive on-court player 2 of 5 during the event.
+  off_player_3: NBA Stats player id of offensive on-court player 3 of 5 during the event.
+  off_player_4: NBA Stats player id of offensive on-court player 4 of 5 during the event.
+  off_player_5: NBA Stats player id of offensive on-court player 5 of 5 during the event.
+  order_index: Stable within-game ordering index for events after pbpstats-style reordering of the raw feed.
+load_nba_stats_player_season_stats:
+  ast_pct_rank: League rank of the row's assist percentage (share of teammate field goals assisted while on the floor) for
+    the season and split.
+  ast_rank: League rank of the row's assists for the season and split.
+  ast_ratio: Assist ratio (assists per 100 possessions used) over the split.
+  ast_ratio_rank: League rank of the row's assist ratio (assists per 100 possessions used) for the season and split.
+  ast_to: Assist-to-turnover ratio over the split.
+  ast_to_rank: League rank of the row's assist-to-turnover ratio for the season and split.
+  blk_rank: League rank of the row's blocked shots for the season and split.
+  blka: Shot attempts blocked by opponents (blocks against).
+  blka_rank: League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split.
+  dd2: Double-doubles recorded over the split.
+  dd2_rank: League rank of the row's double-doubles for the season and split.
+  def_rating: Defensive rating (points allowed per 100 possessions) over the split.
+  def_rating_rank: League rank of the row's defensive rating (points allowed per 100 possessions) for the season and split.
+  def_ws: Defensive win shares credited to the player (NBA Stats defense dashboard metric).
+  def_ws_rank: League rank of the row's defensive win shares (NBA Stats defense dashboard metric) for the season and split.
+  def_ws_raw: Unscaled (raw) defensive win shares value carried alongside def_ws by the NBA Stats API.
+  dreb_pct: Defensive rebound percentage over the split, as a decimal.
+  dreb_pct_rank: League rank of the row's defensive rebound percentage for the season and split.
+  dreb_rank: League rank of the row's defensive rebounds for the season and split.
+  e_def_rating: Estimated defensive rating (NBA Stats estimated-metrics family) over the split.
+  e_def_rating_rank: League rank of the row's estimated defensive rating (NBA Stats estimated-metrics family) for the season
+    and split.
+  e_net_rating: Estimated net rating (NBA Stats estimated-metrics family) over the split.
+  e_net_rating_rank: League rank of the row's estimated net rating (NBA Stats estimated-metrics family) for the season and
+    split.
+  e_off_rating: Estimated offensive rating (NBA Stats estimated-metrics family) over the split.
+  e_off_rating_rank: League rank of the row's estimated offensive rating (NBA Stats estimated-metrics family) for the season
+    and split.
+  e_pace: Estimated pace (NBA Stats estimated-metrics family) over the split.
+  e_pace_rank: League rank of the row's estimated pace (NBA Stats estimated-metrics family) for the season and split.
+  e_tov_pct: Estimated turnover percentage (NBA Stats estimated-metrics family) over the split, as a decimal.
+  e_tov_pct_rank: League rank of the row's estimated turnover percentage (NBA Stats estimated-metrics family) for the season
+    and split.
+  e_usg_pct: Estimated usage percentage (NBA Stats estimated-metrics family) over the split, as a decimal.
+  e_usg_pct_rank: League rank of the row's estimated usage percentage (NBA Stats estimated-metrics family) for the season
+    and split.
+  efg_pct: Effective field goal percentage over the split, as a decimal.
+  efg_pct_rank: League rank of the row's effective field goal percentage for the season and split.
+  fg3_pct_rank: League rank of the row's three-point field goal percentage for the season and split.
+  fg3a_rank: League rank of the row's three-point field goals attempted for the season and split.
+  fg3m_rank: League rank of the row's three-point field goals made for the season and split.
+  fg_pct_rank: League rank of the row's field goal percentage for the season and split.
+  fga_pg: Field goals attempted per game over the split.
+  fga_pg_rank: League rank of the row's field goals attempted per game for the season and split.
+  fga_rank: League rank of the row's field goals attempted for the season and split.
+  fgm_pg: Field goals made per game over the split.
+  fgm_pg_rank: League rank of the row's field goals made per game for the season and split.
+  fgm_rank: League rank of the row's field goals made for the season and split.
+  ft_pct_rank: League rank of the row's free throw percentage for the season and split.
+  fta_rank: League rank of the row's free throws attempted for the season and split.
+  ftm_rank: League rank of the row's free throws made for the season and split.
+  gp_rank: League rank of the row's games played for the season and split.
+  l_rank: League rank of the row's losses for the season and split.
+  measure_type: NBA Stats measure type the row was pulled from (e.g. Base, Advanced, Misc, Scoring, Opponent, Usage, Defense).
+  min_rank: League rank of the row's minutes played for the season and split.
+  nba_fantasy_pts: Fantasy points under the NBA's fantasy scoring formula.
+  nba_fantasy_pts_rank: League rank of the row's NBA fantasy points (league scoring formula) for the season and split.
+  net_rating_rank: League rank of the row's net rating (offensive minus defensive rating) for the season and split.
+  off_rating: Offensive rating (points scored per 100 possessions) over the split.
+  off_rating_rank: League rank of the row's offensive rating (points scored per 100 possessions) for the season and split.
+  opp_pts_2nd_chance: Opponent second-chance points allowed over the split.
+  opp_pts_2nd_chance_rank: League rank of the row's opponent second-chance points for the season and split.
+  opp_pts_fb: Opponent fast-break points allowed over the split.
+  opp_pts_fb_rank: League rank of the row's opponent fast-break points for the season and split.
+  opp_pts_off_tov: Opponent points scored off opponent turnovers allowed over the split.
+  opp_pts_off_tov_rank: League rank of the row's opponent points scored off opponent turnovers for the season and split.
+  opp_pts_paint: Opponent points in the paint allowed over the split.
+  opp_pts_paint_rank: League rank of the row's opponent points in the paint for the season and split.
+  oreb_pct: Offensive rebound percentage over the split, as a decimal.
+  oreb_pct_rank: League rank of the row's offensive rebound percentage for the season and split.
+  oreb_rank: League rank of the row's offensive rebounds for the season and split.
+  pace_rank: League rank of the row's pace (possessions per 48 minutes) for the season and split.
+  pct_ast: Share of the team's assists accounted for by the player while on the floor, as a decimal.
+  pct_ast_2pm: Percentage of made two-pointers that were assisted, as a decimal.
+  pct_ast_2pm_rank: League rank of the row's percentage of made two-pointers that were assisted for the season and split.
+  pct_ast_3pm: Percentage of made three-pointers that were assisted, as a decimal.
+  pct_ast_3pm_rank: League rank of the row's percentage of made three-pointers that were assisted for the season and split.
+  pct_ast_fgm: Percentage of made field goals that were assisted, as a decimal.
+  pct_ast_fgm_rank: League rank of the row's percentage of made field goals that were assisted for the season and split.
+  pct_ast_rank: League rank of the row's share of the team's assists accounted for by the player while on the floor for the
+    season and split.
+  pct_blk: Share of the team's blocked shots accounted for by the player while on the floor, as a decimal.
+  pct_blk_rank: League rank of the row's share of the team's blocked shots accounted for by the player while on the floor
+    for the season and split.
+  pct_blka: Share of the team's shot attempts blocked by opponents (blocks against) accounted for by the player while on the
+    floor, as a decimal.
+  pct_blka_rank: League rank of the row's share of the team's shot attempts blocked by opponents (blocks against) accounted
+    for by the player while on the floor for the season and split.
+  pct_dreb: Share of the team's defensive rebounds accounted for by the player while on the floor, as a decimal.
+  pct_dreb_rank: League rank of the row's share of the team's defensive rebounds accounted for by the player while on the
+    floor for the season and split.
+  pct_fg3a: Share of the team's three-point field goals attempted accounted for by the player while on the floor, as a decimal.
+  pct_fg3a_rank: League rank of the row's share of the team's three-point field goals attempted accounted for by the player
+    while on the floor for the season and split.
+  pct_fg3m: Share of the team's three-point field goals made accounted for by the player while on the floor, as a decimal.
+  pct_fg3m_rank: League rank of the row's share of the team's three-point field goals made accounted for by the player while
+    on the floor for the season and split.
+  pct_fga: Share of the team's field goals attempted accounted for by the player while on the floor, as a decimal.
+  pct_fga_2pt: Share of field goal attempts taken as two-pointers, as a decimal.
+  pct_fga_2pt_rank: League rank of the row's share of field goal attempts taken as two-pointers for the season and split.
+  pct_fga_3pt: Share of field goal attempts taken as three-pointers, as a decimal.
+  pct_fga_3pt_rank: League rank of the row's share of field goal attempts taken as three-pointers for the season and split.
+  pct_fga_rank: League rank of the row's share of the team's field goals attempted accounted for by the player while on the
+    floor for the season and split.
+  pct_fgm: Share of the team's field goals made accounted for by the player while on the floor, as a decimal.
+  pct_fgm_rank: League rank of the row's share of the team's field goals made accounted for by the player while on the floor
+    for the season and split.
+  pct_fta: Share of the team's free throws attempted accounted for by the player while on the floor, as a decimal.
+  pct_fta_rank: League rank of the row's share of the team's free throws attempted accounted for by the player while on the
+    floor for the season and split.
+  pct_ftm: Share of the team's free throws made accounted for by the player while on the floor, as a decimal.
+  pct_ftm_rank: League rank of the row's share of the team's free throws made accounted for by the player while on the floor
+    for the season and split.
+  pct_oreb: Share of the team's offensive rebounds accounted for by the player while on the floor, as a decimal.
+  pct_oreb_rank: League rank of the row's share of the team's offensive rebounds accounted for by the player while on the
+    floor for the season and split.
+  pct_pf: Share of the team's personal fouls committed accounted for by the player while on the floor, as a decimal.
+  pct_pf_rank: League rank of the row's share of the team's personal fouls committed accounted for by the player while on
+    the floor for the season and split.
+  pct_pfd: Share of the team's personal fouls drawn accounted for by the player while on the floor, as a decimal.
+  pct_pfd_rank: League rank of the row's share of the team's personal fouls drawn accounted for by the player while on the
+    floor for the season and split.
+  pct_pts: Share of the team's points scored accounted for by the player while on the floor, as a decimal.
+  pct_pts_2pt: Share of points scored on two-point field goals, as a decimal.
+  pct_pts_2pt_mr: Share of points scored on mid-range two-pointers, as a decimal.
+  pct_pts_2pt_mr_rank: League rank of the row's share of points scored on mid-range two-pointers for the season and split.
+  pct_pts_2pt_rank: League rank of the row's share of points scored on two-point field goals for the season and split.
+  pct_pts_3pt: Share of points scored on three-pointers, as a decimal.
+  pct_pts_3pt_rank: League rank of the row's share of points scored on three-pointers for the season and split.
+  pct_pts_fb: Share of points scored on fast breaks, as a decimal.
+  pct_pts_fb_rank: League rank of the row's share of points scored on fast breaks for the season and split.
+  pct_pts_ft: Share of points scored at the free throw line, as a decimal.
+  pct_pts_ft_rank: League rank of the row's share of points scored at the free throw line for the season and split.
+  pct_pts_off_tov: Share of points scored off opponent turnovers, as a decimal.
+  pct_pts_off_tov_rank: League rank of the row's share of points scored off opponent turnovers for the season and split.
+  pct_pts_paint: Share of points scored in the paint, as a decimal.
+  pct_pts_paint_rank: League rank of the row's share of points scored in the paint for the season and split.
+  pct_pts_rank: League rank of the row's share of the team's points scored accounted for by the player while on the floor
+    for the season and split.
+  pct_reb: Share of the team's total rebounds accounted for by the player while on the floor, as a decimal.
+  pct_reb_rank: League rank of the row's share of the team's total rebounds accounted for by the player while on the floor
+    for the season and split.
+  pct_stl: Share of the team's steals accounted for by the player while on the floor, as a decimal.
+  pct_stl_rank: League rank of the row's share of the team's steals accounted for by the player while on the floor for the
+    season and split.
+  pct_tov: Share of the team's turnovers accounted for by the player while on the floor, as a decimal.
+  pct_tov_rank: League rank of the row's share of the team's turnovers accounted for by the player while on the floor for
+    the season and split.
+  pct_uast_2pm: Percentage of made two-pointers that were unassisted, as a decimal.
+  pct_uast_2pm_rank: League rank of the row's percentage of made two-pointers that were unassisted for the season and split.
+  pct_uast_3pm: Percentage of made three-pointers that were unassisted, as a decimal.
+  pct_uast_3pm_rank: League rank of the row's percentage of made three-pointers that were unassisted for the season and split.
+  pct_uast_fgm: Percentage of made field goals that were unassisted, as a decimal.
+  pct_uast_fgm_rank: League rank of the row's percentage of made field goals that were unassisted for the season and split.
+  per_mode: NBA Stats per-mode of the row values (e.g. Totals, PerGame, Per100Possessions).
+  pf_rank: League rank of the row's personal fouls committed for the season and split.
+  pfd: Personal fouls drawn.
+  pfd_rank: League rank of the row's personal fouls drawn for the season and split.
+  pie_rank: League rank of the row's Player Impact Estimate (PIE, the NBA Stats catch-all impact metric) for the season and
+    split.
+  plus_minus_rank: League rank of the row's plus-minus point differential while on the floor for the season and split.
+  pts_2nd_chance: Second-chance points over the split.
+  pts_2nd_chance_rank: League rank of the row's second-chance points for the season and split.
+  pts_fb: Fast-break points over the split.
+  pts_fb_rank: League rank of the row's fast-break points for the season and split.
+  pts_off_tov: Points scored off opponent turnovers over the split.
+  pts_off_tov_rank: League rank of the row's points scored off opponent turnovers for the season and split.
+  pts_paint: Points in the paint over the split.
+  pts_paint_rank: League rank of the row's points in the paint for the season and split.
+  pts_rank: League rank of the row's points scored for the season and split.
+  reb_pct: Total rebound percentage over the split, as a decimal.
+  reb_pct_rank: League rank of the row's total rebound percentage for the season and split.
+  reb_rank: League rank of the row's total rebounds for the season and split.
+  sp_work_def_rating: Defensive rating carried in the stats API's SP_WORK column set (mirrors def_rating) over the split.
+  sp_work_def_rating_rank: League rank of the row's defensive rating carried in the stats API's SP_WORK column set (mirrors
+    def_rating) for the season and split.
+  sp_work_net_rating: Net rating carried in the stats API's SP_WORK column set (mirrors net_rating) over the split.
+  sp_work_net_rating_rank: League rank of the row's net rating carried in the stats API's SP_WORK column set (mirrors net_rating)
+    for the season and split.
+  sp_work_off_rating: Offensive rating carried in the stats API's SP_WORK column set (mirrors off_rating) over the split.
+  sp_work_off_rating_rank: League rank of the row's offensive rating carried in the stats API's SP_WORK column set (mirrors
+    off_rating) for the season and split.
+  sp_work_pace: Pace carried in the stats API's SP_WORK column set (mirrors pace) over the split.
+  sp_work_pace_rank: League rank of the row's pace carried in the stats API's SP_WORK column set (mirrors pace) for the season
+    and split.
+  stl_rank: League rank of the row's steals for the season and split.
+  td3: Triple-doubles recorded over the split.
+  td3_rank: League rank of the row's triple-doubles for the season and split.
+  team_count: Number of distinct teams aggregated into the split row.
+  tm_tov_pct: Team turnover percentage (turnovers per 100 possessions) over the split, as a decimal.
+  tm_tov_pct_rank: League rank of the row's team turnover percentage (turnovers per 100 possessions) for the season and split.
+  tov_rank: League rank of the row's turnovers for the season and split.
+  ts_pct_rank: League rank of the row's true shooting percentage for the season and split.
+  usg_pct: Usage percentage (share of team plays used while on the floor) over the split, as a decimal.
+  usg_pct_rank: League rank of the row's usage percentage (share of team plays used while on the floor) for the season and
+    split.
+  w_pct_rank: League rank of the row's win percentage for the season and split.
+  w_rank: League rank of the row's wins for the season and split.
+  wnba_fantasy_pts: Fantasy points under the WNBA's fantasy scoring formula.
+  wnba_fantasy_pts_rank: League rank of the row's WNBA fantasy points (league scoring formula) for the season and split.
+load_nba_stats_possessions:
+  count_as_possession: Whether the row counts as a true possession for per-possession rate stats.
+  def_player_1: NBA Stats player id of defensive on-court player 1 of 5 for the possession.
+  def_player_2: NBA Stats player id of defensive on-court player 2 of 5 for the possession.
+  def_player_3: NBA Stats player id of defensive on-court player 3 of 5 for the possession.
+  def_player_4: NBA Stats player id of defensive on-court player 4 of 5 for the possession.
+  def_player_5: NBA Stats player id of defensive on-court player 5 of 5 for the possession.
+  defense_team_id: NBA Stats team id of the defending team for the possession.
+  end_order_index: order_index of the play-by-play event that ends the possession.
+  end_seconds_remaining: Seconds remaining in the period when the possession ended.
+  fg2a: Two-point field goal attempts during the possession.
+  fg2m: Two-point field goals made during the possession.
+  is_second_chance: Whether the row is a second-chance continuation following an offensive rebound.
+  lineup_source: Provenance of the on-court lineup identification for the row (how the five-man units were resolved).
+  number_in_period: Sequential possession number for the offense within the period.
+  off_player_1: NBA Stats player id of offensive on-court player 1 of 5 for the possession.
+  off_player_2: NBA Stats player id of offensive on-court player 2 of 5 for the possession.
+  off_player_3: NBA Stats player id of offensive on-court player 3 of 5 for the possession.
+  off_player_4: NBA Stats player id of offensive on-court player 4 of 5 for the possession.
+  off_player_5: NBA Stats player id of offensive on-court player 5 of 5 for the possession.
+  possession_start_type: How the possession began (e.g. off a made shot, defensive rebound, turnover, or period start).
+  start_order_index: order_index of the play-by-play event that starts the possession.
+  start_seconds_remaining: Seconds remaining in the period when the possession started.
+load_nba_stats_possessions_v3:
+  count_as_possession: Whether the row counts as a true possession for per-possession rate stats.
+  def_player_1: NBA Stats player id of defensive on-court player 1 of 5 for the possession.
+  def_player_2: NBA Stats player id of defensive on-court player 2 of 5 for the possession.
+  def_player_3: NBA Stats player id of defensive on-court player 3 of 5 for the possession.
+  def_player_4: NBA Stats player id of defensive on-court player 4 of 5 for the possession.
+  def_player_5: NBA Stats player id of defensive on-court player 5 of 5 for the possession.
+  defense_team_id: NBA Stats team id of the defending team for the possession.
+  end_order_index: order_index of the play-by-play event that ends the possession.
+  end_seconds_remaining: Seconds remaining in the period when the possession ended.
+  fg2a: Two-point field goal attempts during the possession.
+  fg2m: Two-point field goals made during the possession.
+  is_second_chance: Whether the row is a second-chance continuation following an offensive rebound.
+  lineup_source: Provenance of the on-court lineup identification for the row (how the five-man units were resolved).
+  number_in_period: Sequential possession number for the offense within the period.
+  off_player_1: NBA Stats player id of offensive on-court player 1 of 5 for the possession.
+  off_player_2: NBA Stats player id of offensive on-court player 2 of 5 for the possession.
+  off_player_3: NBA Stats player id of offensive on-court player 3 of 5 for the possession.
+  off_player_4: NBA Stats player id of offensive on-court player 4 of 5 for the possession.
+  off_player_5: NBA Stats player id of offensive on-court player 5 of 5 for the possession.
+  possession_start_type: How the possession began (e.g. off a made shot, defensive rebound, turnover, or period start).
+  start_order_index: order_index of the play-by-play event that starts the possession.
+  start_seconds_remaining: Seconds remaining in the period when the possession started.
+load_nba_stats_rosters:
+  exp: Years of NBA playing experience entering the season ('R' = rookie).
+  how_acquired: How the team acquired the player (e.g. draft, trade, free agency).
+  num: Jersey number worn by the player.
+load_nba_stats_schedules:
+  away_pts: Final points scored by the away team.
+  away_wl: Away team's result for the game (W or L).
+  home_pts: Final points scored by the home team.
+  home_wl: Home team's result for the game (W or L).
+load_nba_stats_standings:
+  ahead_at_half: Win-loss record when leading at halftime.
+  ahead_at_third: Win-loss record when leading after three quarters.
+  apr: Win-loss record in games played in April.
+  aug: Win-loss record in games played in August.
+  behind_at_half: Win-loss record when trailing at halftime.
+  behind_at_third: Win-loss record when trailing after three quarters.
+  clinched_conference_title: Flag (1/0) for whether the team has clinched the conference title.
+  clinched_division_title: Flag (1/0) for whether the team has clinched its division.
+  clinched_play_in: Flag (1/0) for whether the team has clinched a play-in tournament spot.
+  clinched_playoff_birth: Flag (1/0) for whether the team has clinched a playoff berth.
+  clinched_post_season: Flag (1/0) for whether the team has clinched any postseason berth.
+  conference_games_back: Games behind the conference leader.
+  current_home_streak: Current home streak (positive counts wins, negative losses).
+  current_road_streak: Current road streak (positive counts wins, negative losses).
+  current_streak: Current overall streak (positive counts wins, negative losses).
+  dec: Win-loss record in games played in December.
+  diff_total_points: Season point differential (points scored minus points allowed).
+  division_games_back: Games behind the division leader.
+  division_rank: Team's rank within its division.
+  division_record: Win-loss record against division opponents.
+  eliminated_conference: Flag (1/0) for whether the team is eliminated from conference contention.
+  eliminated_division: Flag (1/0) for whether the team is eliminated from division contention.
+  feb: Win-loss record in games played in February.
+  fewer_turnovers: Win-loss record when committing fewer turnovers than the opponent.
+  jan: Win-loss record in games played in January.
+  jul: Win-loss record in games played in July.
+  jun: Win-loss record in games played in June.
+  last10_home: Win-loss record over the team's last 10 home games.
+  last10_road: Win-loss record over the team's last 10 road games.
+  lead_in_fgpct: Win-loss record when posting the higher field goal percentage.
+  lead_in_reb: Win-loss record when out-rebounding the opponent.
+  league_games_back: Games behind the overall league leader.
+  league_rank: Team's rank in the overall league standings.
+  long_home_streak: Longest home streak of the season (positive counts wins, negative losses).
+  long_loss_streak: Longest losing streak of the season, in games.
+  long_road_streak: Longest road streak of the season (positive counts wins, negative losses).
+  long_win_streak: Longest winning streak of the season, in games.
+  mar: Win-loss record in games played in March.
+  may: Win-loss record in games played in May.
+  nov: Win-loss record in games played in November.
+  oct: Win-loss record in games played in October.
+  opp_over500: Win-loss record against teams with winning (over .500) records.
+  opp_score100_pts: Win-loss record when the opponent scores 100 or more points.
+  opp_score_80_plus: Win-loss record when the opponent scores 80 or more points.
+  opp_score_below_80: Win-loss record when holding the opponent below 80 points.
+  opp_total_points: Total points allowed by the team over the season to date.
+  playoff_seeding: Team's current playoff seed.
+  score100_pts: Win-loss record when scoring 100 or more points.
+  score_80_plus: Win-loss record when scoring 80 or more points.
+  score_below_80: Win-loss record when scoring fewer than 80 points.
+  sep: Win-loss record in games played in September.
+  str_current_home_streak: Current home streak as display text (e.g. "L 2").
+  str_current_road_streak: Current road streak as display text (e.g. "W 3").
+  str_current_streak: Current overall streak as display text (e.g. "W 4").
+  str_long_home_streak: Longest home streak of the season as display text (e.g. "W 5").
+  str_long_road_streak: Longest road streak of the season as display text (e.g. "W 5").
+  ten_pts_or_more: Win-loss record in games decided by ten points or more.
+  three_pts_or_less: Win-loss record in games decided by three points or fewer.
+  tied_at_half: Win-loss record when tied at halftime.
+  tied_at_third: Win-loss record when tied after three quarters.
+  total_points: Total points scored by the team over the season to date.
+  vs_atlantic: Win-loss record against Atlantic Division opponents.
+  vs_central: Win-loss record against Central Division opponents.
+  vs_east: Win-loss record against Eastern Conference opponents.
+  vs_northwest: Win-loss record against Northwest Division opponents.
+  vs_pacific: Win-loss record against Pacific Division opponents.
+  vs_southeast: Win-loss record against Southeast Division opponents.
+  vs_southwest: Win-loss record against Southwest Division opponents.
+  vs_west: Win-loss record against Western Conference opponents.
+load_nba_stats_team_season_stats:
+  ast_pct_rank: League rank of the row's assist percentage (share of teammate field goals assisted while on the floor) for
+    the season and split.
+  ast_rank: League rank of the row's assists for the season and split.
+  ast_ratio: Assist ratio (assists per 100 possessions used) over the split.
+  ast_ratio_rank: League rank of the row's assist ratio (assists per 100 possessions used) for the season and split.
+  ast_to: Assist-to-turnover ratio over the split.
+  ast_to_rank: League rank of the row's assist-to-turnover ratio for the season and split.
+  blk_rank: League rank of the row's blocked shots for the season and split.
+  blka: Shot attempts blocked by opponents (blocks against).
+  blka_rank: League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split.
+  def_rating: Defensive rating (points allowed per 100 possessions) over the split.
+  def_rating_rank: League rank of the row's defensive rating (points allowed per 100 possessions) for the season and split.
+  dreb_pct: Defensive rebound percentage over the split, as a decimal.
+  dreb_pct_rank: League rank of the row's defensive rebound percentage for the season and split.
+  dreb_rank: League rank of the row's defensive rebounds for the season and split.
+  e_def_rating: Estimated defensive rating (NBA Stats estimated-metrics family) over the split.
+  e_net_rating: Estimated net rating (NBA Stats estimated-metrics family) over the split.
+  e_off_rating: Estimated offensive rating (NBA Stats estimated-metrics family) over the split.
+  e_pace: Estimated pace (NBA Stats estimated-metrics family) over the split.
+  efg_pct: Effective field goal percentage over the split, as a decimal.
+  efg_pct_rank: League rank of the row's effective field goal percentage for the season and split.
+  fg3_pct_rank: League rank of the row's three-point field goal percentage for the season and split.
+  fg3a_rank: League rank of the row's three-point field goals attempted for the season and split.
+  fg3m_rank: League rank of the row's three-point field goals made for the season and split.
+  fg_pct_rank: League rank of the row's field goal percentage for the season and split.
+  fga_rank: League rank of the row's field goals attempted for the season and split.
+  fgm_rank: League rank of the row's field goals made for the season and split.
+  ft_pct_rank: League rank of the row's free throw percentage for the season and split.
+  fta_rank: League rank of the row's free throws attempted for the season and split.
+  ftm_rank: League rank of the row's free throws made for the season and split.
+  gp_rank: League rank of the row's games played for the season and split.
+  l_rank: League rank of the row's losses for the season and split.
+  measure_type: NBA Stats measure type the row was pulled from (e.g. Base, Advanced, Misc, Scoring, Opponent, Usage, Defense).
+  min_rank: League rank of the row's minutes played for the season and split.
+  net_rating_rank: League rank of the row's net rating (offensive minus defensive rating) for the season and split.
+  off_rating: Offensive rating (points scored per 100 possessions) over the split.
+  off_rating_rank: League rank of the row's offensive rating (points scored per 100 possessions) for the season and split.
+  opp_ast: Opponent assists allowed over the split.
+  opp_ast_rank: League rank of the row's opponent assists for the season and split.
+  opp_blk: Opponent blocked shots allowed over the split.
+  opp_blk_rank: League rank of the row's opponent blocked shots for the season and split.
+  opp_blka: Opponent shot attempts blocked by opponents (blocks against) allowed over the split.
+  opp_blka_rank: League rank of the row's opponent shot attempts blocked by opponents (blocks against) for the season and
+    split.
+  opp_dreb: Opponent defensive rebounds allowed over the split.
+  opp_dreb_rank: League rank of the row's opponent defensive rebounds for the season and split.
+  opp_fg3_pct: Opponent three-point field goal percentage allowed over the split.
+  opp_fg3_pct_rank: League rank of the row's opponent three-point field goal percentage for the season and split.
+  opp_fg3a: Opponent three-point field goals attempted allowed over the split.
+  opp_fg3a_rank: League rank of the row's opponent three-point field goals attempted for the season and split.
+  opp_fg3m: Opponent three-point field goals made allowed over the split.
+  opp_fg3m_rank: League rank of the row's opponent three-point field goals made for the season and split.
+  opp_fg_pct: Opponent field goal percentage allowed over the split.
+  opp_fg_pct_rank: League rank of the row's opponent field goal percentage for the season and split.
+  opp_fga: Opponent field goals attempted allowed over the split.
+  opp_fga_rank: League rank of the row's opponent field goals attempted for the season and split.
+  opp_fgm: Opponent field goals made allowed over the split.
+  opp_fgm_rank: League rank of the row's opponent field goals made for the season and split.
+  opp_ft_pct: Opponent free throw percentage allowed over the split.
+  opp_ft_pct_rank: League rank of the row's opponent free throw percentage for the season and split.
+  opp_fta: Opponent free throws attempted allowed over the split.
+  opp_fta_rank: League rank of the row's opponent free throws attempted for the season and split.
+  opp_ftm: Opponent free throws made allowed over the split.
+  opp_ftm_rank: League rank of the row's opponent free throws made for the season and split.
+  opp_oreb: Opponent offensive rebounds allowed over the split.
+  opp_oreb_rank: League rank of the row's opponent offensive rebounds for the season and split.
+  opp_pf: Opponent personal fouls committed allowed over the split.
+  opp_pf_rank: League rank of the row's opponent personal fouls committed for the season and split.
+  opp_pfd: Opponent personal fouls drawn allowed over the split.
+  opp_pfd_rank: League rank of the row's opponent personal fouls drawn for the season and split.
+  opp_pts_2nd_chance: Opponent second-chance points allowed over the split.
+  opp_pts_2nd_chance_rank: League rank of the row's opponent second-chance points for the season and split.
+  opp_pts_fb: Opponent fast-break points allowed over the split.
+  opp_pts_fb_rank: League rank of the row's opponent fast-break points for the season and split.
+  opp_pts_off_tov: Opponent points scored off opponent turnovers allowed over the split.
+  opp_pts_off_tov_rank: League rank of the row's opponent points scored off opponent turnovers for the season and split.
+  opp_pts_paint: Opponent points in the paint allowed over the split.
+  opp_pts_paint_rank: League rank of the row's opponent points in the paint for the season and split.
+  opp_pts_rank: League rank of the row's opponent points scored for the season and split.
+  opp_reb: Opponent total rebounds allowed over the split.
+  opp_reb_rank: League rank of the row's opponent total rebounds for the season and split.
+  opp_stl: Opponent steals allowed over the split.
+  opp_stl_rank: League rank of the row's opponent steals for the season and split.
+  opp_tov: Opponent turnovers allowed over the split.
+  opp_tov_rank: League rank of the row's opponent turnovers for the season and split.
+  oreb_pct: Offensive rebound percentage over the split, as a decimal.
+  oreb_pct_rank: League rank of the row's offensive rebound percentage for the season and split.
+  oreb_rank: League rank of the row's offensive rebounds for the season and split.
+  pace_rank: League rank of the row's pace (possessions per 48 minutes) for the season and split.
+  pct_ast_2pm: Percentage of made two-pointers that were assisted, as a decimal.
+  pct_ast_2pm_rank: League rank of the row's percentage of made two-pointers that were assisted for the season and split.
+  pct_ast_3pm: Percentage of made three-pointers that were assisted, as a decimal.
+  pct_ast_3pm_rank: League rank of the row's percentage of made three-pointers that were assisted for the season and split.
+  pct_ast_fgm: Percentage of made field goals that were assisted, as a decimal.
+  pct_ast_fgm_rank: League rank of the row's percentage of made field goals that were assisted for the season and split.
+  pct_fga_2pt: Share of field goal attempts taken as two-pointers, as a decimal.
+  pct_fga_2pt_rank: League rank of the row's share of field goal attempts taken as two-pointers for the season and split.
+  pct_fga_3pt: Share of field goal attempts taken as three-pointers, as a decimal.
+  pct_fga_3pt_rank: League rank of the row's share of field goal attempts taken as three-pointers for the season and split.
+  pct_pts_2pt: Share of points scored on two-point field goals, as a decimal.
+  pct_pts_2pt_mr: Share of points scored on mid-range two-pointers, as a decimal.
+  pct_pts_2pt_mr_rank: League rank of the row's share of points scored on mid-range two-pointers for the season and split.
+  pct_pts_2pt_rank: League rank of the row's share of points scored on two-point field goals for the season and split.
+  pct_pts_3pt: Share of points scored on three-pointers, as a decimal.
+  pct_pts_3pt_rank: League rank of the row's share of points scored on three-pointers for the season and split.
+  pct_pts_fb: Share of points scored on fast breaks, as a decimal.
+  pct_pts_fb_rank: League rank of the row's share of points scored on fast breaks for the season and split.
+  pct_pts_ft: Share of points scored at the free throw line, as a decimal.
+  pct_pts_ft_rank: League rank of the row's share of points scored at the free throw line for the season and split.
+  pct_pts_off_tov: Share of points scored off opponent turnovers, as a decimal.
+  pct_pts_off_tov_rank: League rank of the row's share of points scored off opponent turnovers for the season and split.
+  pct_pts_paint: Share of points scored in the paint, as a decimal.
+  pct_pts_paint_rank: League rank of the row's share of points scored in the paint for the season and split.
+  pct_uast_2pm: Percentage of made two-pointers that were unassisted, as a decimal.
+  pct_uast_2pm_rank: League rank of the row's percentage of made two-pointers that were unassisted for the season and split.
+  pct_uast_3pm: Percentage of made three-pointers that were unassisted, as a decimal.
+  pct_uast_3pm_rank: League rank of the row's percentage of made three-pointers that were unassisted for the season and split.
+  pct_uast_fgm: Percentage of made field goals that were unassisted, as a decimal.
+  pct_uast_fgm_rank: League rank of the row's percentage of made field goals that were unassisted for the season and split.
+  per_mode: NBA Stats per-mode of the row values (e.g. Totals, PerGame, Per100Possessions).
+  pf_rank: League rank of the row's personal fouls committed for the season and split.
+  pfd: Personal fouls drawn.
+  pfd_rank: League rank of the row's personal fouls drawn for the season and split.
+  pie_rank: League rank of the row's Player Impact Estimate (PIE, the NBA Stats catch-all impact metric) for the season and
+    split.
+  plus_minus_rank: League rank of the row's plus-minus point differential while on the floor for the season and split.
+  pts_2nd_chance: Second-chance points over the split.
+  pts_2nd_chance_rank: League rank of the row's second-chance points for the season and split.
+  pts_fb: Fast-break points over the split.
+  pts_fb_rank: League rank of the row's fast-break points for the season and split.
+  pts_off_tov: Points scored off opponent turnovers over the split.
+  pts_off_tov_rank: League rank of the row's points scored off opponent turnovers for the season and split.
+  pts_paint: Points in the paint over the split.
+  pts_paint_rank: League rank of the row's points in the paint for the season and split.
+  pts_rank: League rank of the row's points scored for the season and split.
+  reb_pct: Total rebound percentage over the split, as a decimal.
+  reb_pct_rank: League rank of the row's total rebound percentage for the season and split.
+  reb_rank: League rank of the row's total rebounds for the season and split.
+  stl_rank: League rank of the row's steals for the season and split.
+  tm_tov_pct: Team turnover percentage (turnovers per 100 possessions) over the split, as a decimal.
+  tm_tov_pct_rank: League rank of the row's team turnover percentage (turnovers per 100 possessions) for the season and split.
+  tov_rank: League rank of the row's turnovers for the season and split.
+  ts_pct_rank: League rank of the row's true shooting percentage for the season and split.
+  w_pct_rank: League rank of the row's win percentage for the season and split.
+  w_rank: League rank of the row's wins for the season and split.
+load_nba_team_boxscore:
+  lead_percentage: Percentage of the game the team held the lead, from ESPN's team box score stats.
+load_nba_team_crosswalk:
+  nba_conference: Team's conference as listed by the NBA Stats API.
+  nba_division: Team's division as listed by the NBA Stats API.
+  nba_team_abbreviation: Team abbreviation as listed by the NBA Stats API.
+  nba_team_city: Team city as listed by the NBA Stats API.
+  nba_team_id: NBA Stats team id side of the ESPN-to-NBA team crosswalk.
+  nba_team_name: Team nickname as listed by the NBA Stats API.
+  nba_team_slug: URL-friendly slug for the team's name on NBA Stats.
+load_ncaa_mbb_lineups:
+  drb: Defensive rebounds by the lineup during the stint.
+  duration_mins: Length of the stint in minutes.
+  end_allowed: Points allowed at the moment the stint ended.
+  end_diff: Score margin (scored minus allowed) when the stint ended.
+  end_min: Game minute at which the stint ended.
+  end_scored: Team points scored at the moment the stint ended.
+  fg2a: Two-point field goals attempted by the lineup during the stint.
+  fg2m: Two-point field goals made by the lineup during the stint.
+  foul: Fouls committed by the lineup during the stint.
+  lineup_id: Sorted-name identifier of the five-player lineup, joined from the on-floor player names.
+  lineup_key: Sorted player-code key identifying the five-player unit on the floor (hoop-explorer convention).
+  location_type: Whether the lineup's team was the Home or Away side in the game.
+  mid_ast: Assisted mid-range makes by the lineup during the stint.
+  mida: Mid-range shots attempted by the lineup during the stint.
+  midm: Mid-range shots made by the lineup during the stint.
+  opp_ast: Opponent assists while the lineup was on the floor during the stint.
+  opp_blk: Opponent blocks while the lineup was on the floor during the stint.
+  opp_drb: Opponent defensive rebounds while the lineup was on the floor during the stint.
+  opp_fg2a: Opponent two-point attempts while the lineup was on the floor during the stint.
+  opp_fg2m: Opponent two-point makes while the lineup was on the floor during the stint.
+  opp_fga: Opponent field-goal attempts while the lineup was on the floor during the stint.
+  opp_fgm: Opponent field goals made while the lineup was on the floor during the stint.
+  opp_foul: Opponent fouls committed while the lineup was on the floor during the stint.
+  opp_fta: Opponent free-throw attempts while the lineup was on the floor during the stint.
+  opp_ftm: Opponent free throws made while the lineup was on the floor during the stint.
+  opp_mid_ast: Opponent assisted mid-range makes while the lineup was on the floor during the stint.
+  opp_mida: Opponent mid-range shots attempted while the lineup was on the floor during the stint.
+  opp_midm: Opponent mid-range shots made while the lineup was on the floor during the stint.
+  opp_orb: Opponent offensive rebounds while the lineup was on the floor during the stint.
+  opp_plus_minus: Opponent scoring margin while the lineup was on the floor during the stint.
+  opp_poss: Opponent possessions while the lineup was on the floor during the stint.
+  opp_rim_ast: Opponent assisted rim makes while the lineup was on the floor during the stint.
+  opp_rima: Opponent rim shots attempted while the lineup was on the floor during the stint.
+  opp_rimm: Opponent rim shots made while the lineup was on the floor during the stint.
+  opp_stl: Opponent steals while the lineup was on the floor during the stint.
+  opp_to: Opponent turnovers while the lineup was on the floor during the stint.
+  opp_tp_ast: Opponent assisted three-point makes while the lineup was on the floor during the stint.
+  opp_tpa: Opponent three-point attempts while the lineup was on the floor during the stint.
+  opp_tpm: Opponent three-point makes while the lineup was on the floor during the stint.
+  orb: Offensive rebounds by the lineup during the stint.
+  player_1: Name of the first player (in sorted order) of the five-player lineup.
+  player_2: Name of the second player (in sorted order) of the five-player lineup.
+  player_3: Name of the third player (in sorted order) of the five-player lineup.
+  player_4: Name of the fourth player (in sorted order) of the five-player lineup.
+  player_5: Name of the fifth player (in sorted order) of the five-player lineup.
+  player_count_error: Flag marking stints where the reconciled on-floor count was not exactly five players (all-null when
+    clean).
+  players_in: Delimited names of the players substituted in at the start of the stint.
+  players_out: Delimited names of the players substituted out at the end of the stint.
+  rim_ast: Assisted rim makes by the lineup during the stint.
+  rima: Rim shots (dunks, layups, hooks, tip-ins) attempted by the lineup during the stint.
+  rimm: Rim shots made by the lineup during the stint.
+  start_allowed: Points allowed at the moment the stint began.
+  start_diff: Score margin (scored minus allowed) when the stint began.
+  start_min: Game minute at which the stint began.
+  start_scored: Team points scored at the moment the stint began.
+  stint_num: Sequential on-floor stint number for the lineup within the game.
+  team_year: Season year of the team-season the lineup row belongs to.
+  tp_ast: Assisted three-point makes by the lineup during the stint.
+  tpa: Three-pointers attempted by the lineup during the stint.
+  tpm: Three-pointers made by the lineup during the stint.
+load_ncaa_mbb_matchup_stints:
+  away_1: Name of the away team's on-floor player in lineup slot 1 for the stint.
+  away_2: Name of the away team's on-floor player in lineup slot 2 for the stint.
+  away_3: Name of the away team's on-floor player in lineup slot 3 for the stint.
+  away_4: Name of the away team's on-floor player in lineup slot 4 for the stint.
+  away_5: Name of the away team's on-floor player in lineup slot 5 for the stint.
+  away_lineup: Delimited names of the away five on the floor during the stint.
+  away_lineup_key: Sorted player-code key for the away five on the floor.
+  away_pts: Points scored by the away team during the stint.
+  end_away_score: Away team score when the stint ended.
+  end_home_score: Home team score when the stint ended.
+  end_seconds: Elapsed game seconds at which the stint ended.
+  game_stint_num: Sequential stint number within the game, incremented at every substitution by either team.
+  home_1: Name of the home team's on-floor player in lineup slot 1 for the stint.
+  home_2: Name of the home team's on-floor player in lineup slot 2 for the stint.
+  home_3: Name of the home team's on-floor player in lineup slot 3 for the stint.
+  home_4: Name of the home team's on-floor player in lineup slot 4 for the stint.
+  home_5: Name of the home team's on-floor player in lineup slot 5 for the stint.
+  home_lineup: Delimited names of the home five on the floor during the stint.
+  home_lineup_key: Sorted player-code key for the home five on the floor.
+  home_pts: Points scored by the home team during the stint.
+  matchup_key: Combined home-plus-away lineup key identifying the ten-player matchup on the floor.
+  n_events: Number of play-by-play events falling within the stint.
+  n_possessions: Number of possessions falling within the stint.
+  start_away_score: Away team score when the stint began.
+  start_home_score: Home team score when the stint began.
+  start_seconds: Elapsed game seconds at which the stint began.
+load_ncaa_mbb_pbp:
+  assist_player: Name of the player credited with the assist on a made shot, when present.
+  away_1: Name of the away team's on-floor player in lineup slot 1 for the event, from the substitution walk-forward.
+  away_1_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-1 on-floor player.
+  away_1_player_id: stats.ncaa.org player identifier for the away slot-1 on-floor player.
+  away_2: Name of the away team's on-floor player in lineup slot 2 for the event, from the substitution walk-forward.
+  away_2_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-2 on-floor player.
+  away_2_player_id: stats.ncaa.org player identifier for the away slot-2 on-floor player.
+  away_3: Name of the away team's on-floor player in lineup slot 3 for the event, from the substitution walk-forward.
+  away_3_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-3 on-floor player.
+  away_3_player_id: stats.ncaa.org player identifier for the away slot-3 on-floor player.
+  away_4: Name of the away team's on-floor player in lineup slot 4 for the event, from the substitution walk-forward.
+  away_4_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-4 on-floor player.
+  away_4_player_id: stats.ncaa.org player identifier for the away slot-4 on-floor player.
+  away_5: Name of the away team's on-floor player in lineup slot 5 for the event, from the substitution walk-forward.
+  away_5_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-5 on-floor player.
+  away_5_player_id: stats.ncaa.org player identifier for the away slot-5 on-floor player.
+  away_ncaa_team_id: stats.ncaa.org team identifier for the away team.
+  challenge_outcome: Outcome of a coach's challenge or video-review event, when present.
+  event_length: Seconds elapsed between this event and the previous event in the game.
+  event_result: Outcome of the event, e.g. made or missed for shot attempts.
+  event_team_espn_team_id: ESPN team identifier of the team credited with the event, via the NCAA-to-ESPN crosswalk.
+  event_team_ncaa_team_id: stats.ncaa.org team identifier of the team credited with the event.
+  foul_class: Parsed category of the foul event (e.g. personal, offensive).
+  foul_tech_class: Parsed technical-foul class for technical foul events, when present.
+  ft_attempts: Total free throws in the trip this attempt belongs to.
+  ft_awarded: Number of free throws awarded by the foul.
+  ft_number: Which free throw of the trip this attempt is (1 of 2, 2 of 2, etc.).
+  home_1: Name of the home team's on-floor player in lineup slot 1 for the event, from the substitution walk-forward.
+  home_1_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-1 on-floor player.
+  home_1_player_id: stats.ncaa.org player identifier for the home slot-1 on-floor player.
+  home_2: Name of the home team's on-floor player in lineup slot 2 for the event, from the substitution walk-forward.
+  home_2_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-2 on-floor player.
+  home_2_player_id: stats.ncaa.org player identifier for the home slot-2 on-floor player.
+  home_3: Name of the home team's on-floor player in lineup slot 3 for the event, from the substitution walk-forward.
+  home_3_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-3 on-floor player.
+  home_3_player_id: stats.ncaa.org player identifier for the home slot-3 on-floor player.
+  home_4: Name of the home team's on-floor player in lineup slot 4 for the event, from the substitution walk-forward.
+  home_4_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-4 on-floor player.
+  home_4_player_id: stats.ncaa.org player identifier for the home slot-4 on-floor player.
+  home_5: Name of the home team's on-floor player in lineup slot 5 for the event, from the substitution walk-forward.
+  home_5_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-5 on-floor player.
+  home_5_player_id: stats.ncaa.org player identifier for the home slot-5 on-floor player.
+  home_ncaa_team_id: stats.ncaa.org team identifier for the home team.
+  is_fastbreak: Flag marking the shot as a fast-break attempt, from the stats.ncaa.org play text.
+  is_flagrant: Flag marking the foul as flagrant.
+  is_from_turnover: Flag marking an attempt generated off an opponent turnover.
+  is_garbage_time: Flag marking events in garbage time under the score-margin and clock rule of the pbp builder.
+  is_looseball_foul: Flag marking the foul as a loose-ball foul.
+  is_one_and_one: Flag marking a bonus one-and-one free-throw trip.
+  is_paint: Flag marking the shot as attempted in the paint.
+  is_second_chance: Flag marking a second-chance attempt following an offensive rebound.
+  is_shooting_foul: Flag marking the foul as a shooting foul.
+  is_team_turnover: Flag marking a turnover charged to the team rather than an individual player.
+  is_transition: Flag marking events that occurred in transition, within the opening seconds of the possession.
+  player_1: Name of the primary player credited on the event (shooter, fouler, rebounder, etc.), as scraped from stats.ncaa.org.
+  player_1_clean_name: Normalized (diacritics- and punctuation-cleaned) name for player_1.
+  player_1_id: stats.ncaa.org player identifier for player_1, resolved through the roster name matcher.
+  player_2: Name of the secondary player on the event (e.g., the assister or the player subbed for), when present.
+  player_2_clean_name: Normalized (diacritics- and punctuation-cleaned) name for player_2.
+  player_2_id: stats.ncaa.org player identifier for player_2, resolved through the roster name matcher.
+  poss_length: Duration of the enclosing possession in seconds.
+  poss_num: Sequential possession number within the game that the event belongs to.
+  poss_team: Name of the team in possession when the event occurred.
+  poss_team_espn_team_id: ESPN team identifier of the team in possession, via the NCAA-to-ESPN crosswalk.
+  poss_team_ncaa_team_id: stats.ncaa.org team identifier of the team in possession.
+  sub_deviate: Per-game count of substitution-tracking deviations found while walking lineups forward; nonzero flags imperfect
+    substitution data.
+  timeout_type: Type of timeout called (e.g. full, 30-second, media).
+  turnover_type: Parsed turnover subtype (e.g. lost ball, bad pass, travel).
+load_ncaa_mbb_player_box:
+  ast_half: Assists in halfcourt possessions.
+  ast_trans: Assists in transition possessions.
+  away_ncaa_team_id: stats.ncaa.org team identifier for the away team.
+  blk_half: Blocks in halfcourt possessions.
+  blk_mid: Blocks recorded against opponent mid-range attempts.
+  blk_rim: Blocks recorded against opponent rim attempts.
+  blk_three: Blocks recorded against opponent three-point attempts.
+  blk_trans: Blocks in transition possessions.
+  clean_name: Normalized (diacritics- and punctuation-cleaned) player name used to join across the NCAA datasets.
+  drb: Defensive rebounds.
+  drb_half: Defensive rebounds in halfcourt possessions.
+  drb_trans: Defensive rebounds in transition possessions.
+  efg_pct: Effective field-goal percentage, weighting made threes at 1.5.
+  efg_pct_half: Effective field-goal percentage in halfcourt possessions.
+  efg_pct_trans: Effective field-goal percentage in transition possessions.
+  efg_pct_unast: Effective field-goal percentage in the unassisted split (makes not credited with an assist).
+  fg_pct_half: Field-goal percentage in halfcourt possessions.
+  fg_pct_trans: Field-goal percentage in transition possessions.
+  fg_pct_unast: Field-goal percentage in the unassisted split (makes not credited with an assist).
+  fga_half: Field goals attempted in halfcourt possessions.
+  fga_trans: Field goals attempted in transition possessions.
+  fga_unast: Field goals attempted in the unassisted split (makes not credited with an assist).
+  fgm_ast: Assisted field-goal makes.
+  fgm_half: Field goals made in halfcourt possessions.
+  fgm_trans: Field goals made in transition possessions.
+  fgm_unast: Field goals made in the unassisted split (makes not credited with an assist).
+  ft_pct_half: Free-throw percentage in halfcourt possessions.
+  ft_pct_trans: Free-throw percentage in transition possessions.
+  fta_half: Free throws attempted in halfcourt possessions.
+  fta_trans: Free throws attempted in transition possessions.
+  ftm_half: Free throws made in halfcourt possessions.
+  ftm_trans: Free throws made in transition possessions.
+  home_ncaa_team_id: stats.ncaa.org team identifier for the home team.
+  mid_pct: Field-goal percentage on mid-range attempts.
+  mid_pct_half: Mid-range field-goal percentage in halfcourt possessions.
+  mid_pct_trans: Mid-range field-goal percentage in transition possessions.
+  mid_pct_unast: Mid-range field-goal percentage in the unassisted split (makes not credited with an assist).
+  mida: Mid-range (non-rim two-point) shots attempted.
+  mida_half: Mid-range shots attempted in halfcourt possessions.
+  mida_trans: Mid-range shots attempted in transition possessions.
+  mida_unast: Mid-range shots attempted in the unassisted split (makes not credited with an assist).
+  midm: Mid-range (non-rim two-point) shots made.
+  midm_ast: Assisted mid-range makes.
+  midm_half: Mid-range shots made in halfcourt possessions.
+  midm_trans: Mid-range shots made in transition possessions.
+  midm_unast: Mid-range shots made in the unassisted split (makes not credited with an assist).
+  mins: Minutes played, derived from the lineup walk-forward through the play-by-play.
+  o_poss: Offensive possessions the player was on the floor for.
+  orb: Offensive rebounds.
+  orb_half: Offensive rebounds in halfcourt possessions.
+  orb_trans: Offensive rebounds in transition possessions.
+  pback_pct: Field-goal percentage on putback attempts.
+  pbacka: Putbacks attempted — rim shots immediately following an offensive rebound.
+  pbackm: Putbacks made — rim shots immediately following an offensive rebound.
+  pct_fga_trans: Share of the player's field-goal attempts taken in transition.
+  pct_fgm_ast: Share of the player's made field goals that were assisted.
+  pct_fgm_trans: Share of the player's field-goal makes that came in transition.
+  pct_rima_trans: Share of the player's rim attempts taken in transition.
+  pct_rimm_ast: Share of the player's made rim shots that were assisted.
+  pct_rimm_trans: Share of the player's rim makes that came in transition.
+  pct_tpa_trans: Share of the player's three-point attempts taken in transition.
+  pct_tpm_ast: Share of the player's made threes that were assisted.
+  pct_tpm_trans: Share of the player's three-point makes that came in transition.
+  pts_ast: Points from the player's assisted field-goal makes.
+  pts_half: Points scored in halfcourt possessions.
+  pts_trans: Points scored in transition possessions.
+  pts_unast: Points from the player's unassisted field-goal makes.
+  rim_pct: Field-goal percentage on rim attempts.
+  rim_pct_half: Rim field-goal percentage in halfcourt possessions.
+  rim_pct_trans: Rim field-goal percentage in transition possessions.
+  rim_pct_unast: Rim field-goal percentage in the unassisted split (makes not credited with an assist).
+  rima: Rim shots (dunks, layups, hooks, tip-ins) attempted.
+  rima_half: Rim shots attempted in halfcourt possessions.
+  rima_trans: Rim shots attempted in transition possessions.
+  rima_unast: Rim shots attempted in the unassisted split (makes not credited with an assist).
+  rimm: Rim shots (dunks, layups, hooks, tip-ins) made.
+  rimm_ast: Assisted rim makes.
+  rimm_half: Rim shots made in halfcourt possessions.
+  rimm_trans: Rim shots made in transition possessions.
+  rimm_unast: Rim shots made in the unassisted split (makes not credited with an assist).
+  stl_half: Steals in halfcourt possessions.
+  stl_trans: Steals in transition possessions.
+  team_espn_team_id: ESPN team identifier of the player's team, via the NCAA-to-ESPN crosswalk.
+  team_ncaa_team_id: stats.ncaa.org team identifier of the player's team.
+  tov_half: Turnovers in halfcourt possessions.
+  tov_trans: Turnovers in transition possessions.
+  tp_pct: Three-point field-goal percentage.
+  tp_pct_half: Three-point percentage in halfcourt possessions.
+  tp_pct_trans: Three-point percentage in transition possessions.
+  tp_pct_unast: Three-point percentage in the unassisted split (makes not credited with an assist).
+  tpa: Three-point field goals attempted.
+  tpa_half: Three-pointers attempted in halfcourt possessions.
+  tpa_trans: Three-pointers attempted in transition possessions.
+  tpa_unast: Three-pointers attempted in the unassisted split (makes not credited with an assist).
+  tpm: Three-point field goals made.
+  tpm_ast: Assisted three-point makes.
+  tpm_half: Three-pointers made in halfcourt possessions.
+  tpm_trans: Three-pointers made in transition possessions.
+  tpm_unast: Three-pointers made in the unassisted split (makes not credited with an assist).
+  ts_pct_half: True-shooting percentage in halfcourt possessions.
+  ts_pct_trans: True-shooting percentage in transition possessions.
+load_ncaa_mbb_possessions:
+  away_1: Name of the away team's on-floor player in lineup slot 1 for the possession, from the substitution walk-forward.
+  away_1_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-1 on-floor player.
+  away_1_player_id: stats.ncaa.org player identifier for the away slot-1 on-floor player.
+  away_2: Name of the away team's on-floor player in lineup slot 2 for the possession, from the substitution walk-forward.
+  away_2_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-2 on-floor player.
+  away_2_player_id: stats.ncaa.org player identifier for the away slot-2 on-floor player.
+  away_3: Name of the away team's on-floor player in lineup slot 3 for the possession, from the substitution walk-forward.
+  away_3_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-3 on-floor player.
+  away_3_player_id: stats.ncaa.org player identifier for the away slot-3 on-floor player.
+  away_4: Name of the away team's on-floor player in lineup slot 4 for the possession, from the substitution walk-forward.
+  away_4_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-4 on-floor player.
+  away_4_player_id: stats.ncaa.org player identifier for the away slot-4 on-floor player.
+  away_5: Name of the away team's on-floor player in lineup slot 5 for the possession, from the substitution walk-forward.
+  away_5_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-5 on-floor player.
+  away_5_player_id: stats.ncaa.org player identifier for the away slot-5 on-floor player.
+  away_ncaa_team_id: stats.ncaa.org team identifier for the away team.
+  first_shot_time: Clock time in seconds at the possession's first shot attempt, from the possession segmentation engine.
+  first_shot_type: Shot class of the possession's first attempt (rim, mid-range, or three).
+  home_1: Name of the home team's on-floor player in lineup slot 1 for the possession, from the substitution walk-forward.
+  home_1_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-1 on-floor player.
+  home_1_player_id: stats.ncaa.org player identifier for the home slot-1 on-floor player.
+  home_2: Name of the home team's on-floor player in lineup slot 2 for the possession, from the substitution walk-forward.
+  home_2_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-2 on-floor player.
+  home_2_player_id: stats.ncaa.org player identifier for the home slot-2 on-floor player.
+  home_3: Name of the home team's on-floor player in lineup slot 3 for the possession, from the substitution walk-forward.
+  home_3_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-3 on-floor player.
+  home_3_player_id: stats.ncaa.org player identifier for the home slot-3 on-floor player.
+  home_4: Name of the home team's on-floor player in lineup slot 4 for the possession, from the substitution walk-forward.
+  home_4_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-4 on-floor player.
+  home_4_player_id: stats.ncaa.org player identifier for the home slot-4 on-floor player.
+  home_5: Name of the home team's on-floor player in lineup slot 5 for the possession, from the substitution walk-forward.
+  home_5_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-5 on-floor player.
+  home_5_player_id: stats.ncaa.org player identifier for the home slot-5 on-floor player.
+  home_ncaa_team_id: stats.ncaa.org team identifier for the home team.
+  is_assisted: 1 when the possession's made field goal was assisted, else 0.
+  is_garbage_time: 1 for possessions in garbage time under the score-margin and clock rule, else 0.
+  is_transition: 1 for transition possessions, else 0.
+  last_event_time: Clock time in seconds at the possession's final event.
+  last_event_type: Event type that ended the possession (e.g., a made shot, turnover, or defensive rebound).
+  poss_num: Sequential possession number within the game.
+  poss_team: Name of the team in possession.
+  poss_team_espn_team_id: ESPN team identifier of the team in possession, via the NCAA-to-ESPN crosswalk.
+  poss_team_ncaa_team_id: stats.ncaa.org team identifier of the team in possession.
+  start_event_type: Event type that opened the possession (e.g., a defensive rebound or a made-basket inbound).
+load_ncaa_mbb_rapm_within_team:
+  num_players: Number of players in the team's RAPM design matrix.
+  player_code: Short unique-within-team player code generated from the player's name (hoop-explorer convention).
+  rapm_def: Ridge-regressed defensive RAPM per 100 possessions relative to teammates; positive means good defense.
+  rapm_net: Net RAPM — the sum of the offensive and defensive components, per 100 possessions.
+  rapm_off: Ridge-regressed offensive RAPM per 100 possessions, estimated relative to the player's own teammates.
+  team_off_poss: Team offensive possessions underlying the within-team fit.
+load_ncaa_mbb_shots:
+  dist_ft: Shot distance from the basket in feet.
+  made: Whether the shot was made.
+  ncaa_team_id: stats.ncaa.org team identifier of the shooting team.
+  point_value: Point value of the attempt (2 or 3).
+  sec_left: Seconds remaining in the period when the shot was taken (all-null in current captures).
+  shooter_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the shooter.
+  shooter_player_id: stats.ncaa.org player identifier of the shooter.
+  shot_x: Court x-coordinate of the attempt in feet, decoded from the stats.ncaa.org shot-chart map.
+  shot_y: Court y-coordinate of the attempt in feet, decoded from the stats.ncaa.org shot-chart map.
+  shot_zone: Labeled zone of the attempt (rim, mid-range, or three-point).
+load_ncaa_mbb_team_box:
+  ast_rate: Share of the team's made field goals that were assisted.
+  away_ncaa_team_id: stats.ncaa.org team identifier for the away team.
+  blk_rate: Share of opponent two-point attempts the team blocked.
+  d_ast: Opponent assists allowed.
+  d_ast_rate: Share of opponent made field goals that were assisted.
+  d_blk: Opponent blocks (own shots blocked).
+  d_drb: Opponent defensive rebounds.
+  d_efg_pct: Opponent effective field-goal percentage.
+  d_fg_pct: Opponent field-goal percentage.
+  d_fga: Opponent field-goal attempts.
+  d_fgm: Opponent field goals made.
+  d_ft_rate: Opponent free-throw attempts relative to their field-goal attempts.
+  d_fta: Opponent free-throw attempts.
+  d_ftm: Opponent free throws made.
+  d_ftp: Opponent free-throw percentage.
+  d_mid_pct: Opponent field-goal percentage on mid-range attempts.
+  d_mid_rate: Opponent mid-range attempts as a share of their field-goal attempts.
+  d_mins: Minutes spent on tracked defensive possessions.
+  d_orb: Opponent offensive rebounds.
+  d_poss: Defensive possessions.
+  d_pts: Points allowed.
+  d_rim_pct: Opponent field-goal percentage on rim attempts.
+  d_rim_rate: Opponent rim attempts as a share of their field-goal attempts.
+  d_rima: Opponent rim shots attempted.
+  d_rimm: Opponent rim shots made.
+  d_time_per_poss: Average seconds per defensive possession.
+  d_to: Opponent turnovers forced.
+  d_to_rate: Opponent turnovers as a share of their possessions (forced-turnover rate).
+  d_tp_rate: Opponent three-point attempts as a share of their field-goal attempts.
+  d_tpa: Opponent three-point attempts.
+  d_tpm: Opponent three-pointers made.
+  d_tpp: Opponent three-point percentage.
+  d_ts_pct: Opponent true-shooting percentage.
+  drb: Defensive rebounds.
+  drtg: Defensive rating — points allowed per 100 possessions.
+  e_poss: Estimated possessions — the average of the team's and the opponent's raw possession counts.
+  efg_pct: Effective field-goal percentage, weighting made threes at 1.5.
+  ftp: Free-throw percentage.
+  home_ncaa_team_id: stats.ncaa.org team identifier for the home team.
+  mid_pct: Field-goal percentage on mid-range attempts.
+  mid_rate: Mid-range attempts as a share of field-goal attempts.
+  mins: Minutes covered by the team's tracked lineups in the game.
+  netrtg: Net rating — offensive rating minus defensive rating.
+  o_blk_rate: Share of the team's own two-point attempts blocked by the opponent.
+  o_mins: Minutes spent on tracked offensive possessions.
+  o_poss: Offensive possessions.
+  orb: Offensive rebounds.
+  ortg: Offensive rating — points scored per 100 possessions.
+  rim_pct: Field-goal percentage on rim attempts.
+  rim_rate: Rim attempts as a share of field-goal attempts.
+  rima: Rim shots (dunks, layups, hooks, tip-ins) attempted.
+  rimm: Rim shots made.
+  team_espn_team_id: ESPN team identifier of the team, via the NCAA-to-ESPN crosswalk.
+  team_ncaa_team_id: stats.ncaa.org team identifier of the team the row belongs to.
+  time_per_poss: Average seconds per offensive possession.
+  tp_rate: Three-point attempts as a share of field-goal attempts.
+  tpa: Three-point attempts.
+  tpm: Three-pointers made.
+  tpp: Three-point percentage.
+load_ncaa_mbb_team_rosters:
+  clean_name: Normalized (diacritics- and punctuation-cleaned) player name used to join across the NCAA datasets.
+  ht_inches: Player height converted to total inches from the stats.ncaa.org roster listing.
+load_ncaa_wbb_lineups:
+  drb: Defensive rebounds by the lineup during the stint.
+  duration_mins: Length of the stint in minutes.
+  end_allowed: Points allowed at the moment the stint ended.
+  end_diff: Score margin (scored minus allowed) when the stint ended.
+  end_min: Game minute at which the stint ended.
+  end_scored: Team points scored at the moment the stint ended.
+  fg2a: Two-point field goals attempted by the lineup during the stint.
+  fg2m: Two-point field goals made by the lineup during the stint.
+  foul: Fouls committed by the lineup during the stint.
+  lineup_id: Sorted-name identifier of the five-player lineup, joined from the on-floor player names.
+  lineup_key: Sorted player-code key identifying the five-player unit on the floor (hoop-explorer convention).
+  location_type: Whether the lineup's team was the Home or Away side in the game.
+  mid_ast: Assisted mid-range makes by the lineup during the stint.
+  mida: Mid-range shots attempted by the lineup during the stint.
+  midm: Mid-range shots made by the lineup during the stint.
+  opp_ast: Opponent assists while the lineup was on the floor during the stint.
+  opp_blk: Opponent blocks while the lineup was on the floor during the stint.
+  opp_drb: Opponent defensive rebounds while the lineup was on the floor during the stint.
+  opp_fg2a: Opponent two-point attempts while the lineup was on the floor during the stint.
+  opp_fg2m: Opponent two-point makes while the lineup was on the floor during the stint.
+  opp_fga: Opponent field-goal attempts while the lineup was on the floor during the stint.
+  opp_fgm: Opponent field goals made while the lineup was on the floor during the stint.
+  opp_foul: Opponent fouls committed while the lineup was on the floor during the stint.
+  opp_fta: Opponent free-throw attempts while the lineup was on the floor during the stint.
+  opp_ftm: Opponent free throws made while the lineup was on the floor during the stint.
+  opp_mid_ast: Opponent assisted mid-range makes while the lineup was on the floor during the stint.
+  opp_mida: Opponent mid-range shots attempted while the lineup was on the floor during the stint.
+  opp_midm: Opponent mid-range shots made while the lineup was on the floor during the stint.
+  opp_orb: Opponent offensive rebounds while the lineup was on the floor during the stint.
+  opp_plus_minus: Opponent scoring margin while the lineup was on the floor during the stint.
+  opp_poss: Opponent possessions while the lineup was on the floor during the stint.
+  opp_rim_ast: Opponent assisted rim makes while the lineup was on the floor during the stint.
+  opp_rima: Opponent rim shots attempted while the lineup was on the floor during the stint.
+  opp_rimm: Opponent rim shots made while the lineup was on the floor during the stint.
+  opp_stl: Opponent steals while the lineup was on the floor during the stint.
+  opp_to: Opponent turnovers while the lineup was on the floor during the stint.
+  opp_tp_ast: Opponent assisted three-point makes while the lineup was on the floor during the stint.
+  opp_tpa: Opponent three-point attempts while the lineup was on the floor during the stint.
+  opp_tpm: Opponent three-point makes while the lineup was on the floor during the stint.
+  orb: Offensive rebounds by the lineup during the stint.
+  player_1: Name of the first player (in sorted order) of the five-player lineup.
+  player_2: Name of the second player (in sorted order) of the five-player lineup.
+  player_3: Name of the third player (in sorted order) of the five-player lineup.
+  player_4: Name of the fourth player (in sorted order) of the five-player lineup.
+  player_5: Name of the fifth player (in sorted order) of the five-player lineup.
+  player_count_error: Flag marking stints where the reconciled on-floor count was not exactly five players (all-null when
+    clean).
+  players_in: Delimited names of the players substituted in at the start of the stint.
+  players_out: Delimited names of the players substituted out at the end of the stint.
+  rim_ast: Assisted rim makes by the lineup during the stint.
+  rima: Rim shots (dunks, layups, hooks, tip-ins) attempted by the lineup during the stint.
+  rimm: Rim shots made by the lineup during the stint.
+  start_allowed: Points allowed at the moment the stint began.
+  start_diff: Score margin (scored minus allowed) when the stint began.
+  start_min: Game minute at which the stint began.
+  start_scored: Team points scored at the moment the stint began.
+  stint_num: Sequential on-floor stint number for the lineup within the game.
+  team_year: Season year of the team-season the lineup row belongs to.
+  tp_ast: Assisted three-point makes by the lineup during the stint.
+  tpa: Three-pointers attempted by the lineup during the stint.
+  tpm: Three-pointers made by the lineup during the stint.
+load_ncaa_wbb_matchup_stints:
+  away_1: Name of the away team's on-floor player in lineup slot 1 for the stint.
+  away_2: Name of the away team's on-floor player in lineup slot 2 for the stint.
+  away_3: Name of the away team's on-floor player in lineup slot 3 for the stint.
+  away_4: Name of the away team's on-floor player in lineup slot 4 for the stint.
+  away_5: Name of the away team's on-floor player in lineup slot 5 for the stint.
+  away_lineup: Delimited names of the away five on the floor during the stint.
+  away_lineup_key: Sorted player-code key for the away five on the floor.
+  away_pts: Points scored by the away team during the stint.
+  end_away_score: Away team score when the stint ended.
+  end_home_score: Home team score when the stint ended.
+  end_seconds: Elapsed game seconds at which the stint ended.
+  game_stint_num: Sequential stint number within the game, incremented at every substitution by either team.
+  home_1: Name of the home team's on-floor player in lineup slot 1 for the stint.
+  home_2: Name of the home team's on-floor player in lineup slot 2 for the stint.
+  home_3: Name of the home team's on-floor player in lineup slot 3 for the stint.
+  home_4: Name of the home team's on-floor player in lineup slot 4 for the stint.
+  home_5: Name of the home team's on-floor player in lineup slot 5 for the stint.
+  home_lineup: Delimited names of the home five on the floor during the stint.
+  home_lineup_key: Sorted player-code key for the home five on the floor.
+  home_pts: Points scored by the home team during the stint.
+  matchup_key: Combined home-plus-away lineup key identifying the ten-player matchup on the floor.
+  n_events: Number of play-by-play events falling within the stint.
+  n_possessions: Number of possessions falling within the stint.
+  start_away_score: Away team score when the stint began.
+  start_home_score: Home team score when the stint began.
+  start_seconds: Elapsed game seconds at which the stint began.
+load_ncaa_wbb_pbp:
+  assist_player: Name of the player credited with the assist on a made shot, when present.
+  away_1: Name of the away team's on-floor player in lineup slot 1 for the event, from the substitution walk-forward.
+  away_1_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-1 on-floor player.
+  away_1_player_id: stats.ncaa.org player identifier for the away slot-1 on-floor player.
+  away_2: Name of the away team's on-floor player in lineup slot 2 for the event, from the substitution walk-forward.
+  away_2_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-2 on-floor player.
+  away_2_player_id: stats.ncaa.org player identifier for the away slot-2 on-floor player.
+  away_3: Name of the away team's on-floor player in lineup slot 3 for the event, from the substitution walk-forward.
+  away_3_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-3 on-floor player.
+  away_3_player_id: stats.ncaa.org player identifier for the away slot-3 on-floor player.
+  away_4: Name of the away team's on-floor player in lineup slot 4 for the event, from the substitution walk-forward.
+  away_4_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-4 on-floor player.
+  away_4_player_id: stats.ncaa.org player identifier for the away slot-4 on-floor player.
+  away_5: Name of the away team's on-floor player in lineup slot 5 for the event, from the substitution walk-forward.
+  away_5_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-5 on-floor player.
+  away_5_player_id: stats.ncaa.org player identifier for the away slot-5 on-floor player.
+  away_ncaa_team_id: stats.ncaa.org team identifier for the away team.
+  challenge_outcome: Outcome of a coach's challenge or video-review event, when present.
+  event_length: Seconds elapsed between this event and the previous event in the game.
+  event_result: Outcome of the event, e.g. made or missed for shot attempts.
+  event_team_espn_team_id: ESPN team identifier of the team credited with the event, via the NCAA-to-ESPN crosswalk.
+  event_team_ncaa_team_id: stats.ncaa.org team identifier of the team credited with the event.
+  foul_class: Parsed category of the foul event (e.g. personal, offensive).
+  foul_tech_class: Parsed technical-foul class for technical foul events, when present.
+  ft_attempts: Total free throws in the trip this attempt belongs to.
+  ft_awarded: Number of free throws awarded by the foul.
+  ft_number: Which free throw of the trip this attempt is (1 of 2, 2 of 2, etc.).
+  home_1: Name of the home team's on-floor player in lineup slot 1 for the event, from the substitution walk-forward.
+  home_1_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-1 on-floor player.
+  home_1_player_id: stats.ncaa.org player identifier for the home slot-1 on-floor player.
+  home_2: Name of the home team's on-floor player in lineup slot 2 for the event, from the substitution walk-forward.
+  home_2_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-2 on-floor player.
+  home_2_player_id: stats.ncaa.org player identifier for the home slot-2 on-floor player.
+  home_3: Name of the home team's on-floor player in lineup slot 3 for the event, from the substitution walk-forward.
+  home_3_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-3 on-floor player.
+  home_3_player_id: stats.ncaa.org player identifier for the home slot-3 on-floor player.
+  home_4: Name of the home team's on-floor player in lineup slot 4 for the event, from the substitution walk-forward.
+  home_4_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-4 on-floor player.
+  home_4_player_id: stats.ncaa.org player identifier for the home slot-4 on-floor player.
+  home_5: Name of the home team's on-floor player in lineup slot 5 for the event, from the substitution walk-forward.
+  home_5_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-5 on-floor player.
+  home_5_player_id: stats.ncaa.org player identifier for the home slot-5 on-floor player.
+  home_ncaa_team_id: stats.ncaa.org team identifier for the home team.
+  is_fastbreak: Flag marking the shot as a fast-break attempt, from the stats.ncaa.org play text.
+  is_flagrant: Flag marking the foul as flagrant.
+  is_from_turnover: Flag marking an attempt generated off an opponent turnover.
+  is_garbage_time: Flag marking events in garbage time under the score-margin and clock rule of the pbp builder.
+  is_looseball_foul: Flag marking the foul as a loose-ball foul.
+  is_one_and_one: Flag marking a bonus one-and-one free-throw trip.
+  is_paint: Flag marking the shot as attempted in the paint.
+  is_second_chance: Flag marking a second-chance attempt following an offensive rebound.
+  is_shooting_foul: Flag marking the foul as a shooting foul.
+  is_team_turnover: Flag marking a turnover charged to the team rather than an individual player.
+  is_transition: Flag marking events that occurred in transition, within the opening seconds of the possession.
+  player_1: Name of the primary player credited on the event (shooter, fouler, rebounder, etc.), as scraped from stats.ncaa.org.
+  player_1_clean_name: Normalized (diacritics- and punctuation-cleaned) name for player_1.
+  player_1_id: stats.ncaa.org player identifier for player_1, resolved through the roster name matcher.
+  player_2: Name of the secondary player on the event (e.g., the assister or the player subbed for), when present.
+  player_2_clean_name: Normalized (diacritics- and punctuation-cleaned) name for player_2.
+  player_2_id: stats.ncaa.org player identifier for player_2, resolved through the roster name matcher.
+  poss_length: Duration of the enclosing possession in seconds.
+  poss_num: Sequential possession number within the game that the event belongs to.
+  poss_team: Name of the team in possession when the event occurred.
+  poss_team_espn_team_id: ESPN team identifier of the team in possession, via the NCAA-to-ESPN crosswalk.
+  poss_team_ncaa_team_id: stats.ncaa.org team identifier of the team in possession.
+  sub_deviate: Per-game count of substitution-tracking deviations found while walking lineups forward; nonzero flags imperfect
+    substitution data.
+  timeout_type: Type of timeout called (e.g. full, 30-second, media).
+  turnover_type: Parsed turnover subtype (e.g. lost ball, bad pass, travel).
+load_ncaa_wbb_player_box:
+  ast_half: Assists in halfcourt possessions.
+  ast_trans: Assists in transition possessions.
+  away_ncaa_team_id: stats.ncaa.org team identifier for the away team.
+  blk_half: Blocks in halfcourt possessions.
+  blk_mid: Blocks recorded against opponent mid-range attempts.
+  blk_rim: Blocks recorded against opponent rim attempts.
+  blk_three: Blocks recorded against opponent three-point attempts.
+  blk_trans: Blocks in transition possessions.
+  clean_name: Normalized (diacritics- and punctuation-cleaned) player name used to join across the NCAA datasets.
+  drb: Defensive rebounds.
+  drb_half: Defensive rebounds in halfcourt possessions.
+  drb_trans: Defensive rebounds in transition possessions.
+  efg_pct: Effective field-goal percentage, weighting made threes at 1.5.
+  efg_pct_half: Effective field-goal percentage in halfcourt possessions.
+  efg_pct_trans: Effective field-goal percentage in transition possessions.
+  efg_pct_unast: Effective field-goal percentage in the unassisted split (makes not credited with an assist).
+  fg_pct_half: Field-goal percentage in halfcourt possessions.
+  fg_pct_trans: Field-goal percentage in transition possessions.
+  fg_pct_unast: Field-goal percentage in the unassisted split (makes not credited with an assist).
+  fga_half: Field goals attempted in halfcourt possessions.
+  fga_trans: Field goals attempted in transition possessions.
+  fga_unast: Field goals attempted in the unassisted split (makes not credited with an assist).
+  fgm_ast: Assisted field-goal makes.
+  fgm_half: Field goals made in halfcourt possessions.
+  fgm_trans: Field goals made in transition possessions.
+  fgm_unast: Field goals made in the unassisted split (makes not credited with an assist).
+  ft_pct_half: Free-throw percentage in halfcourt possessions.
+  ft_pct_trans: Free-throw percentage in transition possessions.
+  fta_half: Free throws attempted in halfcourt possessions.
+  fta_trans: Free throws attempted in transition possessions.
+  ftm_half: Free throws made in halfcourt possessions.
+  ftm_trans: Free throws made in transition possessions.
+  home_ncaa_team_id: stats.ncaa.org team identifier for the home team.
+  mid_pct: Field-goal percentage on mid-range attempts.
+  mid_pct_half: Mid-range field-goal percentage in halfcourt possessions.
+  mid_pct_trans: Mid-range field-goal percentage in transition possessions.
+  mid_pct_unast: Mid-range field-goal percentage in the unassisted split (makes not credited with an assist).
+  mida: Mid-range (non-rim two-point) shots attempted.
+  mida_half: Mid-range shots attempted in halfcourt possessions.
+  mida_trans: Mid-range shots attempted in transition possessions.
+  mida_unast: Mid-range shots attempted in the unassisted split (makes not credited with an assist).
+  midm: Mid-range (non-rim two-point) shots made.
+  midm_ast: Assisted mid-range makes.
+  midm_half: Mid-range shots made in halfcourt possessions.
+  midm_trans: Mid-range shots made in transition possessions.
+  midm_unast: Mid-range shots made in the unassisted split (makes not credited with an assist).
+  mins: Minutes played, derived from the lineup walk-forward through the play-by-play.
+  o_poss: Offensive possessions the player was on the floor for.
+  orb: Offensive rebounds.
+  orb_half: Offensive rebounds in halfcourt possessions.
+  orb_trans: Offensive rebounds in transition possessions.
+  pback_pct: Field-goal percentage on putback attempts.
+  pbacka: Putbacks attempted — rim shots immediately following an offensive rebound.
+  pbackm: Putbacks made — rim shots immediately following an offensive rebound.
+  pct_fga_trans: Share of the player's field-goal attempts taken in transition.
+  pct_fgm_ast: Share of the player's made field goals that were assisted.
+  pct_fgm_trans: Share of the player's field-goal makes that came in transition.
+  pct_rima_trans: Share of the player's rim attempts taken in transition.
+  pct_rimm_ast: Share of the player's made rim shots that were assisted.
+  pct_rimm_trans: Share of the player's rim makes that came in transition.
+  pct_tpa_trans: Share of the player's three-point attempts taken in transition.
+  pct_tpm_ast: Share of the player's made threes that were assisted.
+  pct_tpm_trans: Share of the player's three-point makes that came in transition.
+  pts_ast: Points from the player's assisted field-goal makes.
+  pts_half: Points scored in halfcourt possessions.
+  pts_trans: Points scored in transition possessions.
+  pts_unast: Points from the player's unassisted field-goal makes.
+  rim_pct: Field-goal percentage on rim attempts.
+  rim_pct_half: Rim field-goal percentage in halfcourt possessions.
+  rim_pct_trans: Rim field-goal percentage in transition possessions.
+  rim_pct_unast: Rim field-goal percentage in the unassisted split (makes not credited with an assist).
+  rima: Rim shots (dunks, layups, hooks, tip-ins) attempted.
+  rima_half: Rim shots attempted in halfcourt possessions.
+  rima_trans: Rim shots attempted in transition possessions.
+  rima_unast: Rim shots attempted in the unassisted split (makes not credited with an assist).
+  rimm: Rim shots (dunks, layups, hooks, tip-ins) made.
+  rimm_ast: Assisted rim makes.
+  rimm_half: Rim shots made in halfcourt possessions.
+  rimm_trans: Rim shots made in transition possessions.
+  rimm_unast: Rim shots made in the unassisted split (makes not credited with an assist).
+  stl_half: Steals in halfcourt possessions.
+  stl_trans: Steals in transition possessions.
+  team_espn_team_id: ESPN team identifier of the player's team, via the NCAA-to-ESPN crosswalk.
+  team_ncaa_team_id: stats.ncaa.org team identifier of the player's team.
+  tov_half: Turnovers in halfcourt possessions.
+  tov_trans: Turnovers in transition possessions.
+  tp_pct: Three-point field-goal percentage.
+  tp_pct_half: Three-point percentage in halfcourt possessions.
+  tp_pct_trans: Three-point percentage in transition possessions.
+  tp_pct_unast: Three-point percentage in the unassisted split (makes not credited with an assist).
+  tpa: Three-point field goals attempted.
+  tpa_half: Three-pointers attempted in halfcourt possessions.
+  tpa_trans: Three-pointers attempted in transition possessions.
+  tpa_unast: Three-pointers attempted in the unassisted split (makes not credited with an assist).
+  tpm: Three-point field goals made.
+  tpm_ast: Assisted three-point makes.
+  tpm_half: Three-pointers made in halfcourt possessions.
+  tpm_trans: Three-pointers made in transition possessions.
+  tpm_unast: Three-pointers made in the unassisted split (makes not credited with an assist).
+  ts_pct_half: True-shooting percentage in halfcourt possessions.
+  ts_pct_trans: True-shooting percentage in transition possessions.
+load_ncaa_wbb_possessions:
+  away_1: Name of the away team's on-floor player in lineup slot 1 for the possession, from the substitution walk-forward.
+  away_1_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-1 on-floor player.
+  away_1_player_id: stats.ncaa.org player identifier for the away slot-1 on-floor player.
+  away_2: Name of the away team's on-floor player in lineup slot 2 for the possession, from the substitution walk-forward.
+  away_2_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-2 on-floor player.
+  away_2_player_id: stats.ncaa.org player identifier for the away slot-2 on-floor player.
+  away_3: Name of the away team's on-floor player in lineup slot 3 for the possession, from the substitution walk-forward.
+  away_3_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-3 on-floor player.
+  away_3_player_id: stats.ncaa.org player identifier for the away slot-3 on-floor player.
+  away_4: Name of the away team's on-floor player in lineup slot 4 for the possession, from the substitution walk-forward.
+  away_4_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-4 on-floor player.
+  away_4_player_id: stats.ncaa.org player identifier for the away slot-4 on-floor player.
+  away_5: Name of the away team's on-floor player in lineup slot 5 for the possession, from the substitution walk-forward.
+  away_5_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-5 on-floor player.
+  away_5_player_id: stats.ncaa.org player identifier for the away slot-5 on-floor player.
+  away_ncaa_team_id: stats.ncaa.org team identifier for the away team.
+  first_shot_time: Clock time in seconds at the possession's first shot attempt, from the possession segmentation engine.
+  first_shot_type: Shot class of the possession's first attempt (rim, mid-range, or three).
+  home_1: Name of the home team's on-floor player in lineup slot 1 for the possession, from the substitution walk-forward.
+  home_1_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-1 on-floor player.
+  home_1_player_id: stats.ncaa.org player identifier for the home slot-1 on-floor player.
+  home_2: Name of the home team's on-floor player in lineup slot 2 for the possession, from the substitution walk-forward.
+  home_2_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-2 on-floor player.
+  home_2_player_id: stats.ncaa.org player identifier for the home slot-2 on-floor player.
+  home_3: Name of the home team's on-floor player in lineup slot 3 for the possession, from the substitution walk-forward.
+  home_3_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-3 on-floor player.
+  home_3_player_id: stats.ncaa.org player identifier for the home slot-3 on-floor player.
+  home_4: Name of the home team's on-floor player in lineup slot 4 for the possession, from the substitution walk-forward.
+  home_4_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-4 on-floor player.
+  home_4_player_id: stats.ncaa.org player identifier for the home slot-4 on-floor player.
+  home_5: Name of the home team's on-floor player in lineup slot 5 for the possession, from the substitution walk-forward.
+  home_5_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the home slot-5 on-floor player.
+  home_5_player_id: stats.ncaa.org player identifier for the home slot-5 on-floor player.
+  home_ncaa_team_id: stats.ncaa.org team identifier for the home team.
+  is_assisted: 1 when the possession's made field goal was assisted, else 0.
+  is_garbage_time: 1 for possessions in garbage time under the score-margin and clock rule, else 0.
+  is_transition: 1 for transition possessions, else 0.
+  last_event_time: Clock time in seconds at the possession's final event.
+  last_event_type: Event type that ended the possession (e.g., a made shot, turnover, or defensive rebound).
+  poss_num: Sequential possession number within the game.
+  poss_team: Name of the team in possession.
+  poss_team_espn_team_id: ESPN team identifier of the team in possession, via the NCAA-to-ESPN crosswalk.
+  poss_team_ncaa_team_id: stats.ncaa.org team identifier of the team in possession.
+  start_event_type: Event type that opened the possession (e.g., a defensive rebound or a made-basket inbound).
+load_ncaa_wbb_rapm_within_team:
+  num_players: Number of players in the team's RAPM design matrix.
+  player_code: Short unique-within-team player code generated from the player's name (hoop-explorer convention).
+  rapm_def: Ridge-regressed defensive RAPM per 100 possessions relative to teammates; positive means good defense.
+  rapm_net: Net RAPM — the sum of the offensive and defensive components, per 100 possessions.
+  rapm_off: Ridge-regressed offensive RAPM per 100 possessions, estimated relative to the player's own teammates.
+  team_off_poss: Team offensive possessions underlying the within-team fit.
+load_ncaa_wbb_shots:
+  dist_ft: Shot distance from the basket in feet.
+  made: Whether the shot was made.
+  ncaa_team_id: stats.ncaa.org team identifier of the shooting team.
+  point_value: Point value of the attempt (2 or 3).
+  sec_left: Seconds remaining in the period when the shot was taken (all-null in current captures).
+  shooter_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the shooter.
+  shooter_player_id: stats.ncaa.org player identifier of the shooter.
+  shot_x: Court x-coordinate of the attempt in feet, decoded from the stats.ncaa.org shot-chart map.
+  shot_y: Court y-coordinate of the attempt in feet, decoded from the stats.ncaa.org shot-chart map.
+  shot_zone: Labeled zone of the attempt (rim, mid-range, or three-point).
+load_ncaa_wbb_team_box:
+  ast_rate: Share of the team's made field goals that were assisted.
+  away_ncaa_team_id: stats.ncaa.org team identifier for the away team.
+  blk_rate: Share of opponent two-point attempts the team blocked.
+  d_ast: Opponent assists allowed.
+  d_ast_rate: Share of opponent made field goals that were assisted.
+  d_blk: Opponent blocks (own shots blocked).
+  d_drb: Opponent defensive rebounds.
+  d_efg_pct: Opponent effective field-goal percentage.
+  d_fg_pct: Opponent field-goal percentage.
+  d_fga: Opponent field-goal attempts.
+  d_fgm: Opponent field goals made.
+  d_ft_rate: Opponent free-throw attempts relative to their field-goal attempts.
+  d_fta: Opponent free-throw attempts.
+  d_ftm: Opponent free throws made.
+  d_ftp: Opponent free-throw percentage.
+  d_mid_pct: Opponent field-goal percentage on mid-range attempts.
+  d_mid_rate: Opponent mid-range attempts as a share of their field-goal attempts.
+  d_mins: Minutes spent on tracked defensive possessions.
+  d_orb: Opponent offensive rebounds.
+  d_poss: Defensive possessions.
+  d_pts: Points allowed.
+  d_rim_pct: Opponent field-goal percentage on rim attempts.
+  d_rim_rate: Opponent rim attempts as a share of their field-goal attempts.
+  d_rima: Opponent rim shots attempted.
+  d_rimm: Opponent rim shots made.
+  d_time_per_poss: Average seconds per defensive possession.
+  d_to: Opponent turnovers forced.
+  d_to_rate: Opponent turnovers as a share of their possessions (forced-turnover rate).
+  d_tp_rate: Opponent three-point attempts as a share of their field-goal attempts.
+  d_tpa: Opponent three-point attempts.
+  d_tpm: Opponent three-pointers made.
+  d_tpp: Opponent three-point percentage.
+  d_ts_pct: Opponent true-shooting percentage.
+  drb: Defensive rebounds.
+  drtg: Defensive rating — points allowed per 100 possessions.
+  e_poss: Estimated possessions — the average of the team's and the opponent's raw possession counts.
+  efg_pct: Effective field-goal percentage, weighting made threes at 1.5.
+  ftp: Free-throw percentage.
+  home_ncaa_team_id: stats.ncaa.org team identifier for the home team.
+  mid_pct: Field-goal percentage on mid-range attempts.
+  mid_rate: Mid-range attempts as a share of field-goal attempts.
+  mins: Minutes covered by the team's tracked lineups in the game.
+  netrtg: Net rating — offensive rating minus defensive rating.
+  o_blk_rate: Share of the team's own two-point attempts blocked by the opponent.
+  o_mins: Minutes spent on tracked offensive possessions.
+  o_poss: Offensive possessions.
+  orb: Offensive rebounds.
+  ortg: Offensive rating — points scored per 100 possessions.
+  rim_pct: Field-goal percentage on rim attempts.
+  rim_rate: Rim attempts as a share of field-goal attempts.
+  rima: Rim shots (dunks, layups, hooks, tip-ins) attempted.
+  rimm: Rim shots made.
+  team_espn_team_id: ESPN team identifier of the team, via the NCAA-to-ESPN crosswalk.
+  team_ncaa_team_id: stats.ncaa.org team identifier of the team the row belongs to.
+  time_per_poss: Average seconds per offensive possession.
+  tp_rate: Three-point attempts as a share of field-goal attempts.
+  tpa: Three-point attempts.
+  tpm: Three-pointers made.
+  tpp: Three-point percentage.
+load_ncaa_wbb_team_rosters:
+  clean_name: Normalized (diacritics- and punctuation-cleaned) player name used to join across the NCAA datasets.
+  ht_inches: Player height converted to total inches from the stats.ncaa.org roster listing.
+load_nhl_schedules:
+  linescore: Flag indicating a period-by-period linescore payload was captured for this game in the NHL raw store.
+  scratches: Flag indicating a scratches payload was captured for this game in the NHL raw store.
+  series_letter: NHL API letter code identifying the playoff series the game belongs to (null for regular-season games).
+load_nhl_scoring:
+  discreteClipFr: Numeric NHL video identifier of the French-language standalone clip of the goal, always a different asset
+    id from discreteClip.
+  firstName.cs: Alternate given name for the player under the NHL feed's Czech key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.de: Alternate given name for the player under the NHL feed's German key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.default: Given name of the goal scorer as rendered in the NHL feed's default English locale.
+  firstName.es: Alternate given name for the player under the NHL feed's Spanish key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.fi: Alternate given name for the player under the NHL feed's Finnish key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.fr: Alternate given name for the player under the NHL feed's French key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.sk: Alternate given name for the player under the NHL feed's Slovak key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.sv: Alternate given name for the player under the NHL feed's Swedish key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  goalInGame: Running goal count credited to the scorer within this game at the time of the goal.
+  highlightClipFr: NHL video id of the French-language highlight clip for the goal. Stored as Float64 even though it is a
+    whole 13-digit identifier, so cast before using it as a key.
+  highlightClipSharingUrlFr: Shareable nhl.com URL for the French-language highlight clip; its trailing numeric segment is
+    the same id carried in highlightClipFr.
+  lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.de: Alternate rendering of the player's family name under the NHL feed's German key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.default: Family name of the goal scorer as rendered in the NHL feed's default English locale.
+  lastName.es: Alternate rendering of the player's family name under the NHL feed's Spanish key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  leadingTeamAbbrev.default: Three-letter code of the team ahead on the scoreboard immediately after this goal, null exactly
+    when the goal tied the game and not always the scoring team.
+  name.cs: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.de: Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.default: Abbreviated name of the player as published in the NHL feed's default English locale.
+  name.fi: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.sk: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.sv: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  teamAbbrev.default: Three-letter code of the team that scored the goal, resolving to the home club exactly when isHome is
+    true and to the visitor otherwise.
+load_nhl_shootout:
+  discreteClipFr: Numeric NHL video identifier of the French-language clip of the shootout attempt, distinct from the id in
+    discreteClip.
+  firstName.cs: Alternate given name published under the NHL feed's Czech key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.de: Alternate given name published under the NHL feed's German key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.default: Given name of the shooter in the feed's default English locale; null on the per-game summary row.
+  firstName.es: Alternate given name published under the NHL feed's Spanish key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.fi: Alternate given name published under the NHL feed's Finnish key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.sk: Alternate given name published under the NHL feed's Slovak key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.sv: Alternate given name published under the NHL feed's Swedish key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  gameWinner: True on the single attempt per shootout credited as the game-deciding goal, false on every other attempt and
+    null on the per-game summary row.
+  highlightClipFr: NHL video identifier of the French-language highlight clip for the shootout attempt.
+  highlightClipSharingUrlFr: Shareable URL of the French-language broadcast highlight clip for the shootout attempt.
+  lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.default: Family name of the shooter in the feed's default English locale; null on the per-game summary row.
+  lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  teamAbbrev.default: Three-letter code of the shooting player's team; null on the per-game summary row that instead carries
+    the home and away shootout goal totals.
+load_pwhl_pbp:
+  skaters_away: Number of away skaters on the ice for the event, derived from HockeyTech shift data.
+  skaters_home: Number of home skaters on the ice for the event, derived from HockeyTech shift data.
+  strength_state_valid: Flag that the shift-derived strength state reconciles cleanly and can be trusted for this event.
+load_wbb_pbp:
+  athlete_name_1: Display name of the first athlete in the ESPN play participants (e.g., the shooter on a shot attempt).
+  athlete_name_2: Display name of the second athlete in the ESPN play participants (e.g., the assisting player), when present.
+  athlete_name_3: Display name of the third athlete in the ESPN play participants, when present.
+  away_timeout_called: Flag set on plays where a timeout was charged to the away team.
+  home_timeout_called: Flag set on plays where a timeout was charged to the home team.
+  points_attempted: Point value at stake on the shot attempt (3 for threes, 2 for other field goals, 1 for free throws), from
+    the ESPN play type.
+  score_value: Point value of the attempt (1 / 2 / 3), carried even on misses (a missed free throw still shows 1); use scoring_play
+    to identify points actually scored.
+  short_description: Shortened version of ESPN's play description text, without score context.
+  type_text: Play type text, passed through verbatim from ESPN. ESPN labels the free-throw play type "MadeFreeThrow" for made
+    AND missed free throws; filter makes vs. misses with scoring_play, not type_text.
+load_wbb_schedule:
+  away_current_rank: Poll ranking ESPN listed for the away team at game time (unranked teams carry a sentinel value).
+  away_linescores: Period-by-period scores for the away team as a delimited string from ESPN's schedule feed.
+  away_records: Record strings (overall and split records) for the away team from ESPN's schedule feed.
+  home_current_rank: Poll ranking ESPN listed for the home team at game time (unranked teams carry a sentinel value).
+  home_linescores: Period-by-period scores for the home team as a delimited string from ESPN's schedule feed.
+  home_records: Record strings (overall and split records) for the home team from ESPN's schedule feed.
+load_wbb_shots:
+  athlete_name_1: Display name of the shooter credited on the attempt in ESPN's play participants.
+  athlete_name_2: Display name of the second athlete tied to the attempt (typically the assister), when present.
+  team_mascot: Mascot/nickname of the shooting team from ESPN's team record.
+load_wbb_team_boxscore:
+  lead_percentage: Share of game time the team held the lead, as reported in ESPN's team boxscore.
+load_wnba_pbp:
+  athlete_name_1: Display name of the primary athlete on the play (e.g. the shooter, rebounder, or fouler), per ESPN participant
+    order.
+  athlete_name_2: Display name of the secondary athlete on the play (e.g. the assister or fouled player), when present.
+  athlete_name_3: Display name of the third athlete listed on the play, when present.
+  away_timeout_called: True when the play is a timeout charged to the away team.
+  home_timeout_called: True when the play is a timeout charged to the home team.
+  points_attempted: Point value at stake on the play's shot attempt (1, 2, or 3); 0 for non-shooting plays.
+  score_value: Point value of the attempt (1 / 2 / 3), carried even on misses (a missed free throw still shows 1); use scoring_play
+    to identify points actually scored.
+  short_description: Abbreviated ESPN text description of the play.
+  type_text: Play type text, passed through verbatim from ESPN. ESPN labels the free-throw play type "MadeFreeThrow" for made
+    AND missed free throws; filter makes vs. misses with scoring_play, not type_text.
+load_wnba_player_crosswalk:
+  wnba_jersey_num: Jersey number listed on the stats.wnba.com side of the crosswalk.
+  wnba_player_id: Player identifier on stats.wnba.com matched to the ESPN player.
+  wnba_player_name: Player display name on the stats.wnba.com side of the crosswalk.
+  wnba_position: Position listed on the stats.wnba.com side of the crosswalk.
+load_wnba_player_impact:
+  adj_rapm: Total prior-informed RAPM (offense plus defense), in points per 100 possessions.
+  d_adj_rapm: 'Defensive prior-informed RAPM: ridge shrunk toward a box-score prior, in points per 100 possessions.'
+  d_rapm: 'Defensive RAPM: ridge-regularized on/off impact on team defense, in points per 100 possessions.'
+  darko_filtered_skill: DARKO-style Kalman-filtered estimate of the player's current skill level.
+  darko_projected_rating: DARKO-style projected forward rating, including the empirical aging-curve drift.
+  darko_projected_sd: Posterior standard deviation of the DARKO-style projected rating.
+  def_poss: Defensive possessions the player was on the floor for in the RAPM sample.
+  dspm: 'Defensive statistical plus-minus: box-score features regressed onto the defensive RAPM target, per 100 possessions.'
+  o_adj_rapm: 'Offensive prior-informed RAPM: ridge shrunk toward a box-score prior, in points per 100 possessions.'
+  o_rapm: 'Offensive RAPM: ridge-regularized on/off impact on team offense, in points per 100 possessions.'
+  off_poss: Offensive possessions the player was on the floor for in the RAPM sample.
+  ospm: 'Offensive statistical plus-minus: box-score features regressed onto the offensive RAPM target, per 100 possessions.'
+  rapm: 'Total RAPM: offensive plus defensive regularized on/off impact, in points per 100 possessions.'
+  spm: 'Statistical plus-minus: offensive plus defensive box-score estimate of the RAPM target, per 100 possessions.'
+  war: Wins above replacement implied by the player's impact and playing time, calibrated from team points-per-win.
+load_wnba_schedule:
+  away_linescores: Stringified list of the away team's period-by-period scores from the ESPN schedule feed.
+  away_records: Stringified list of the away team's record summaries (overall/home/away) from the ESPN schedule feed.
+  home_linescores: Stringified list of the home team's period-by-period scores from the ESPN schedule feed.
+  home_records: Stringified list of the home team's record summaries (overall/home/away) from the ESPN schedule feed.
+load_wnba_schedule_crosswalk:
+  fox_away_team_id: Away team identifier on Fox Sports for the matched game.
+  fox_home_team_id: Home team identifier on Fox Sports for the matched game.
+  wnba_away_team_id: Away team identifier on stats.wnba.com for the matched game.
+  wnba_game_code: stats.wnba.com game code (date/matchup slug) for the matched game.
+  wnba_game_id: Game identifier on stats.wnba.com matched to the ESPN game.
+  wnba_home_team_id: Home team identifier on stats.wnba.com for the matched game.
+load_wnba_shots:
+  athlete_name_1: Display name of the shooter, per ESPN participant order.
+  athlete_name_2: Display name of the secondary athlete on the shot (typically the assister), when present.
+  team_mascot: ESPN mascot (nickname) of the shooting team.
+load_wnba_stats_game_lineups:
+  away_player_1: stats.wnba.com identifier of away on-court player 1 of 5 for the lineup stint.
+  away_player_2: stats.wnba.com identifier of away on-court player 2 of 5 for the lineup stint.
+  away_player_3: stats.wnba.com identifier of away on-court player 3 of 5 for the lineup stint.
+  away_player_4: stats.wnba.com identifier of away on-court player 4 of 5 for the lineup stint.
+  away_player_5: stats.wnba.com identifier of away on-court player 5 of 5 for the lineup stint.
+  home_player_1: stats.wnba.com identifier of home on-court player 1 of 5 for the lineup stint.
+  home_player_2: stats.wnba.com identifier of home on-court player 2 of 5 for the lineup stint.
+  home_player_3: stats.wnba.com identifier of home on-court player 3 of 5 for the lineup stint.
+  home_player_4: stats.wnba.com identifier of home on-court player 4 of 5 for the lineup stint.
+  home_player_5: stats.wnba.com identifier of home on-court player 5 of 5 for the lineup stint.
+load_wnba_stats_pbp:
+  is_foul: True when the event is a foul.
+  is_free_throw: True when the event is a free throw attempt.
+  is_jump_ball: True when the event is a jump ball.
+  is_made_shot: True when the event is a made field goal.
+  is_missed_shot: True when the event is a missed field goal.
+  is_period: True for period-start and period-end marker events.
+  is_rebound: True when the event is a rebound (player or team).
+  is_substitution: True when the event is a substitution.
+  is_timeout: True when the event is a timeout.
+  order_index: Stable ordering index of the event within the game's stats.wnba.com play-by-play.
+load_wnba_stats_player_game_logs:
+  ast: Assists credited.
+  blk: Total shots blocked.
+  dreb: Defensive rebounds collected.
+  fantasy_pts: Fantasy points.
+  fg3_pct: Three-point percentage.
+  fg3a: Three-point field goals attempted.
+  fg3m: Three-point field goals made.
+  fg_pct: Field-goal percentage.
+  fga: Field goals attempted.
+  fgm: Field goals made.
+  ft_pct: Free-throw percentage.
+  fta: Free throws attempted.
+  ftm: Free throws made.
+  measure_type: Stats API measure-type slice the row was pulled from (e.g. 'Base').
+  min: Minutes played.
+  oreb: Offensive rebounds collected.
+  pf: Personal fouls committed.
+  plus_minus: Plus-minus point differential.
+  pts: Total points scored.
+  reb: Total rebounds collected.
+  stl: Steals recorded.
+  tov: Turnovers committed.
+load_wnba_stats_possessions:
+  count_as_possession: False only for a possession starting with 2 seconds or less left in the period and no made basket before
+    the period ends.
+  def_player_1: stats.wnba.com identifier of defensive on-court player 1 of 5 for the possession (unordered slot).
+  def_player_2: stats.wnba.com identifier of defensive on-court player 2 of 5 for the possession (unordered slot).
+  def_player_3: stats.wnba.com identifier of defensive on-court player 3 of 5 for the possession (unordered slot).
+  def_player_4: stats.wnba.com identifier of defensive on-court player 4 of 5 for the possession (unordered slot).
+  def_player_5: stats.wnba.com identifier of defensive on-court player 5 of 5 for the possession (unordered slot).
+  defense_team_id: stats.wnba.com identifier of the defending team for the possession.
+  end_order_index: order_index of the last event in the possession; joins to the wnba_stats_pbp table.
+  end_seconds_remaining: Seconds remaining in the period when the possession ended.
+  fg2a: Two-point field goals attempted by the offense during the possession.
+  fg2m: Two-point field goals made by the offense during the possession.
+  is_second_chance: True when the possession continued after an offensive rebound (contains a second-chance segment).
+  number_in_period: Possession number within the period, resetting to 1 at each period start.
+  off_player_1: stats.wnba.com identifier of offensive on-court player 1 of 5 for the possession (unordered slot).
+  off_player_2: stats.wnba.com identifier of offensive on-court player 2 of 5 for the possession (unordered slot).
+  off_player_3: stats.wnba.com identifier of offensive on-court player 3 of 5 for the possession (unordered slot).
+  off_player_4: stats.wnba.com identifier of offensive on-court player 4 of 5 for the possession (unordered slot).
+  off_player_5: stats.wnba.com identifier of offensive on-court player 5 of 5 for the possession (unordered slot).
+  possession_start_type: 'How the possession began: OffDeadball, OffTimeout, OffMadeShot, OffMissedShot, or OffLiveBallTurnover.'
+  start_order_index: order_index of the first event in the possession; joins to the wnba_stats_pbp table.
+  start_seconds_remaining: Seconds remaining in the period when the possession began.
+load_wnba_stats_rosters:
+  exp: Years of WNBA playing experience entering the season ('R' = rookie).
+  how_acquired: How the team acquired the player (draft, trade, free agency).
+  num: Jersey number worn by the player.
+  supplemental_status: Numeric supplemental roster-status code from the stats.wnba.com roster feed.
+load_wnba_stats_schedules:
+  away_pts: Final points scored by the away team.
+  away_wl: Result for the away team ('W' or 'L'); null before the game is final.
+  home_pts: Final points scored by the home team.
+  home_wl: Result for the home team ('W' or 'L'); null before the game is final.
+load_wnba_team_boxscore:
+  lead_percentage: Share of game time the team spent in the lead, as reported by ESPN.
+nil_100:
+  person: Nested On3 person object for the ranked athlete (stringified).
+  valuation: Athlete's On3 NIL valuation in dollars.
+nil_100_v2:
+  person: Nested On3 person object for the ranked athlete (stringified).
+  valuation: Athlete's On3 NIL valuation in dollars.
+nil_compliances_state:
+  current_rules: Text of the state's current NIL rules, as tracked by On3.
+  governing_rule_label: Name of the governing body or rule for NIL in the state.
+  governing_rule_url: URL of the governing NIL rule or policy document.
+  key: On3 RDB key for the state NIL-compliance record.
+  monetization_allowed: Whether the state allows high-school athletes to monetize their NIL.
+  state_key: On3 key of the U.S. state the compliance record covers.
+nil_rankings:
+  person: Nested On3 person object for the ranked athlete (stringified).
+  valuation: Athlete's On3 NIL valuation in dollars.
+offense_summary:
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  franchise_id: PFF franchise (team) id (integer join key).
+  grades_hands_fumble: PFF ball-security (hands/fumble) grade, 0-100.
+  grades_offense: PFF overall offense grade (0-100).
+  grades_offense_penalty: PFF offensive penalty grade, 0-100.
+  grades_pass: PFF passing grade (0-100).
+  grades_pass_block: PFF pass-blocking grade (0-100).
+  grades_pass_route: PFF receiving/route grade (0-100).
+  grades_run: PFF rushing grade (0-100).
+  grades_run_block: PFF run-blocking grade (0-100).
+  jersey_number: Jersey number (string; zero-padded, e.g. "09").
+  player_game_count: Games with at least one qualifying snap in the requested range.
+  player_id: PFF player id (integer; matches the /players id and every player_id join key).
+  snap_counts_pass: Pass-play snaps spent as the passer, rather than blocking or running a route.
+  snap_counts_pass_block: Pass-blocking snaps played.
+  snap_counts_pass_route: Snaps spent running a pass route.
+  snap_counts_run: Run-play snaps spent as a runner, rather than run blocking.
+  snap_counts_run_block: Run-blocking snaps played.
+  snap_counts_total: Total offensive snaps played.
+  snap_counts_total_pass: Total pass-play snaps across passing, pass blocking, and route running.
+  snap_counts_total_run: Total run-play snaps across rushing and run blocking.
+  team_name: Team abbreviation the player is credited to for the range.
+organizations_draft_ranking_summary:
+  span_summary: Nested summary of the organization's draft ranking over the multi-year span (stringified).
+  year_summary: Nested summary of the organization's draft ranking for the single year (stringified).
+organizations_drafted_players:
+  college_organization: Nested On3 organization object for the college the player attended (stringified).
+  compensatory: Whether the selection was a compensatory draft pick.
+  drafted_from_organization: Nested On3 organization object for the school the player was drafted out of (stringified).
+  forfeited: Whether the pick was forfeited.
+  high_school_organization: Nested On3 organization object for the player's high school (stringified).
+  key: On3 RDB key for the draft-pick record.
+  person: Nested On3 person object for the drafted player (stringified).
+  recruitment_key: On3 RDB recruitment key linking the draft pick back to the player's recruitment record.
+  supplementary: Whether the selection came in a supplemental draft.
+  through_organization_one: First intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  through_organization_three: Third intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  through_organization_two: Second intermediate organization the pick passed through in trades before being exercised (On3
+    RDB).
+  trading_organization: Pro organization that traded the pick away, when it changed hands (On3 RDB).
+organizations_drafts_by_stars_summary:
+  draft_rank: Organization's national rank by draft production.
+  five_star_summary: Nested draft summary for the organization's five-star recruits (stringified).
+  four_star_summary: Nested draft summary for the organization's four-star recruits (stringified).
+  nat_total_drafted: National total of drafted players in the comparison set.
+  overall_star_summary: Nested draft summary across all star tiers (stringified).
+  three_star_summary: Nested draft summary for the organization's three-star recruits (stringified).
+  total_drafted: Total number of the organization's players drafted.
+organizations_roster:
+  industry_comparison: Nested comparison of the player's On3 rating against the industry-consensus rating (stringified).
+  nil_value: Player's On3 NIL valuation in dollars.
+  pso_key: On3 player-sport-organization (PSO) key for the roster entry.
+  roster_rating: Nested On3 roster rating object for the player (stringified).
+  rpm: Nested On3 Recruiting Prediction Machine (RPM) data for the player (stringified).
+organizations_roster_header:
+  average_nil_value: Average On3 NIL valuation across the roster, in dollars.
+  average_rating: Average On3 rating across the roster.
+  conference_rank: Program's roster-talent rank within its conference.
+  head_coach: Nested On3 person object for the program's head coach (stringified).
+  prev_average_rating: Average On3 roster rating in the previous cycle.
+  prev_conference_rank: Program's conference roster-talent rank in the previous cycle.
+  prev_talent_rank: Program's roster-talent rank in the previous cycle.
+  talent_rank: Program's current national roster-talent rank per On3.
+  total_nil_value: Total On3 NIL valuation across the roster, in dollars.
+pass_blocking:
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  grades_pass_block: PFF pass-blocking grade, 0-100.
+  hits_allowed: Quarterback hits allowed.
+  hurries_allowed: Quarterback hurries allowed.
+  non_spike_pass_block: Pass-blocking snaps excluding spike plays.
+  non_spike_pass_block_percentage: Share of non-spike pass-play snaps spent pass blocking.
+  pass_block_percent: Share of pass-play snaps spent pass blocking.
+  pbe: PFF Pass Blocking Efficiency rating, pressures allowed per pass-blocking snap weighted toward sacks.
+  player_game_count: Number of games the player appeared in over the covered span.
+  pressures_allowed: Total pressures allowed (sacks, hits, and hurries).
+  snap_counts_pass_block: Pass-blocking snaps played.
+  snap_counts_pass_play: Pass-play snaps.
+  true_pass_set_grades_pass_block: PFF pass-blocking grade on PFF-designated true pass sets, 0-100.
+  true_pass_set_hits_allowed: Quarterback hits allowed on PFF-designated true pass sets.
+  true_pass_set_hurries_allowed: Quarterback hurries allowed on PFF-designated true pass sets.
+  true_pass_set_non_spike_pass_block: Pass-blocking snaps excluding spike plays on PFF-designated true pass sets.
+  true_pass_set_non_spike_pass_block_percentage: Share of non-spike pass-play snaps spent pass blocking on PFF-designated
+    true pass sets.
+  true_pass_set_pass_block_percent: Share of pass-play snaps spent pass blocking on PFF-designated true pass sets.
+  true_pass_set_pbe: PFF Pass Blocking Efficiency rating, pressures allowed per pass-blocking snap weighted toward sacks on
+    PFF-designated true pass sets.
+  true_pass_set_pressures_allowed: Total pressures allowed (sacks, hits, and hurries) on PFF-designated true pass sets.
+  true_pass_set_sacks_allowed: Sacks allowed on PFF-designated true pass sets.
+  true_pass_set_snap_counts_pass_block: Pass-blocking snaps played on PFF-designated true pass sets.
+  true_pass_set_snap_counts_pass_play: Pass-play snaps on PFF-designated true pass sets.
+pass_rush_summary:
+  batted_passes: Passes batted down at the line of scrimmage.
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  grades_pass_rush_defense: PFF pass-rush grade, 0-100.
+  hurries: Quarterback hurries recorded.
+  pass_rush_opp: Pass-rush snaps PFF counts as pressure opportunities.
+  pass_rush_percent: Share of pass-play snaps spent rushing the passer.
+  pass_rush_win_rate: Percentage of pass-rush snaps with a PFF-charted pass-rush win.
+  pass_rush_wins: PFF-charted pass-rush wins.
+  player_game_count: Number of games the player appeared in over the covered span.
+  prp: PFF Pass Rush Productivity rating, pressure generated per pass-rush snap weighted toward sacks.
+  snap_counts_pass_play: Pass-play snaps.
+  snap_counts_pass_rush: Pass-rush snaps played.
+  total_pressures: Total pressures generated (sacks, hits, and hurries).
+  true_pass_set_batted_passes: Passes batted down at the line of scrimmage on PFF-designated true pass sets.
+  true_pass_set_grades_pass_rush_defense: PFF pass-rush grade on PFF-designated true pass sets, 0-100.
+  true_pass_set_hits: Quarterback hits recorded on PFF-designated true pass sets.
+  true_pass_set_hurries: Quarterback hurries recorded on PFF-designated true pass sets.
+  true_pass_set_pass_rush_opp: Pass-rush snaps PFF counts as pressure opportunities on PFF-designated true pass sets.
+  true_pass_set_pass_rush_percent: Share of pass-play snaps spent rushing the passer on PFF-designated true pass sets.
+  true_pass_set_pass_rush_win_rate: Percentage of pass-rush snaps with a PFF-charted pass-rush win on PFF-designated true
+    pass sets.
+  true_pass_set_pass_rush_wins: PFF-charted pass-rush wins on PFF-designated true pass sets.
+  true_pass_set_prp: PFF Pass Rush Productivity rating, pressure generated per pass-rush snap weighted toward sacks on PFF-designated
+    true pass sets.
+  true_pass_set_sacks: Sacks recorded on PFF-designated true pass sets.
+  true_pass_set_snap_counts_pass_play: Pass-play snaps on PFF-designated true pass sets.
+  true_pass_set_snap_counts_pass_rush: Pass-rush snaps played on PFF-designated true pass sets.
+  true_pass_set_total_pressures: Total pressures generated (sacks, hits, and hurries) on PFF-designated true pass sets.
+passing_allowed_pressure:
+  allowed_pressure_dropbacks: Number of dropbacks over which allowed pressures are attributed, from the PFF allowed-pressure
+    facet.
+  ce_percent: Share of allowed pressures attributed to center, expressed as a percentage.
+  declined_penalties: Number of declined penalties committed by the player.
+  draft_season: NFL season (year) in which the player was drafted, per PFF player metadata.
+  eligible_season: Season (year) of the player's NFL draft eligibility, per PFF player metadata.
+  hits_allowed: Number of quarterback hits allowed on the player's dropbacks, as charted by PFF.
+  hurries_allowed: Number of hurries allowed on the player's dropbacks, as charted by PFF.
+  lg_percent: Share of allowed pressures attributed to left guard, expressed as a percentage.
+  lt_percent: Share of allowed pressures attributed to left tackle, expressed as a percentage.
+  ol_te_percent: Share of allowed pressures attributed to the offensive line and tight ends combined, expressed as a percentage.
+  other_percent: Share of allowed pressures attributed to other players outside the listed blocking positions, expressed as
+    a percentage.
+  player_game_count: Number of games the player appeared in during the period covered.
+  pressures_allowed: Total pressures allowed on the quarterback's dropbacks, as attributed by PFF.
+  pressures_ce: Number of allowed pressures PFF attributes to center.
+  pressures_lg: Number of allowed pressures PFF attributes to left guard.
+  pressures_lt: Number of allowed pressures PFF attributes to left tackle.
+  pressures_off: Number of allowed pressures PFF attributes to the offense without a specific blocker charged.
+  pressures_ol_te: Number of allowed pressures PFF attributes to the offensive line and tight ends combined.
+  pressures_other: Number of allowed pressures PFF attributes to other players outside the listed blocking positions.
+  pressures_rg: Number of allowed pressures PFF attributes to right guard.
+  pressures_rt: Number of allowed pressures PFF attributes to right tackle.
+  pressures_self: Number of allowed pressures PFF attributes to the quarterback himself.
+  pressures_te: Number of allowed pressures PFF attributes to tight ends.
+  rg_percent: Share of allowed pressures attributed to right guard, expressed as a percentage.
+  rt_percent: Share of allowed pressures attributed to right tackle, expressed as a percentage.
+  self_percent: Share of allowed pressures attributed to the quarterback himself, expressed as a percentage.
+  te_percent: Share of allowed pressures attributed to tight ends, expressed as a percentage.
+passing_concept:
+  comp_pct_diff: Difference in completion percentage between play-action and non-play-action attempts (PA minus non-PA), from
+    the PFF passing-concept split.
+  declined_penalties: Number of declined penalties committed by the player.
+  draft_season: NFL season (year) in which the player was drafted, per PFF player metadata.
+  dropbacks: Number of dropbacks.
+  eligible_season: Season (year) of the player's NFL draft eligibility, per PFF player metadata.
+  no_screen_accuracy_percent: Percentage of aimed passes charted as accurate by PFF excluding screen passes.
+  no_screen_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) excluding screen passes, as charted
+    by PFF.
+  no_screen_attempts: Number of pass attempts excluding screen passes.
+  no_screen_avg_depth_of_target: Average depth of target in air yards excluding screen passes.
+  no_screen_avg_time_to_throw: Average time from snap to release in seconds excluding screen passes.
+  no_screen_bats: Number of pass attempts batted down at the line of scrimmage excluding screen passes.
+  no_screen_big_time_throws: Number of big-time throws excluding screen passes, per PFF's highest-value, highest-difficulty
+    throw designation.
+  no_screen_btt_rate: Big-time throws as a percentage of qualifying attempts excluding screen passes, per PFF charting.
+  no_screen_completion_percent: Percentage of pass attempts completed excluding screen passes.
+  no_screen_completions: Number of completed passes excluding screen passes.
+  no_screen_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks excluding screen passes, as
+    charted by PFF.
+  no_screen_drop_rate: Percentage of catchable passes dropped by receivers excluding screen passes.
+  no_screen_dropbacks: Number of dropbacks excluding screen passes.
+  no_screen_dropbacks_percent: Share of the player's total dropbacks that came excluding screen passes, expressed as a percentage.
+  no_screen_drops: Number of catchable passes dropped by receivers excluding screen passes.
+  no_screen_epa: Total expected points added (EPA) on the player's dropbacks excluding screen passes.
+  no_screen_first_downs: Number of passing first downs gained excluding screen passes.
+  no_screen_grades_coverage_defense: PFF coverage grade for the player (0-100) excluding screen passes.
+  no_screen_grades_defense: PFF overall defense grade for the player (0-100) excluding screen passes.
+  no_screen_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) excluding screen passes.
+  no_screen_grades_hands_drop: PFF hands (drop) grade for the player (0-100) excluding screen passes.
+  no_screen_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) excluding screen
+    passes.
+  no_screen_grades_offense: PFF overall offense grade for the player (0-100) excluding screen passes.
+  no_screen_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) excluding screen passes.
+  no_screen_grades_overall_tackle: PFF overall tackling grade for the player (0-100) excluding screen passes.
+  no_screen_grades_pass: PFF passing grade (0-100) excluding screen passes.
+  no_screen_grades_pass_block: PFF pass-blocking grade for the player (0-100) excluding screen passes.
+  no_screen_grades_pass_route: PFF receiving (route) grade for the player (0-100) excluding screen passes.
+  no_screen_grades_pass_rush_defense: PFF pass-rush grade for the player (0-100) excluding screen passes.
+  no_screen_grades_run: PFF rushing grade for the player (0-100) excluding screen passes.
+  no_screen_grades_run_block: PFF run-blocking grade for the player (0-100) excluding screen passes.
+  no_screen_grades_run_defense: PFF run-defense grade for the player (0-100) excluding screen passes.
+  no_screen_grades_screen_block: PFF screen-blocking grade for the player (0-100) excluding screen passes.
+  no_screen_grades_tackle: PFF tackling grade for the player (0-100) excluding screen passes.
+  no_screen_hit_as_threw: Number of attempts on which the passer was hit as he threw excluding screen passes, as charted by
+    PFF.
+  no_screen_interceptions: Number of passes intercepted excluding screen passes.
+  no_screen_passing_snaps: Number of passing snaps played excluding screen passes.
+  no_screen_positive_epa_percent: Percentage of dropbacks with positive expected points added excluding screen passes.
+  no_screen_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack excluding screen passes.
+  no_screen_qb_rating: Traditional NFL passer rating excluding screen passes.
+  no_screen_sack_percent: Percentage of dropbacks that ended in a sack excluding screen passes.
+  no_screen_sacks: Number of sacks taken excluding screen passes.
+  no_screen_scrambles: Number of scrambles excluding screen passes.
+  no_screen_spikes: Number of clock-stopping spikes excluding screen passes.
+  no_screen_thrown_aways: Number of intentional throwaways excluding screen passes.
+  no_screen_touchdowns: Number of passing touchdowns thrown excluding screen passes.
+  no_screen_turnover_worthy_plays: Number of turnover-worthy plays excluding screen passes, plays PFF charts as deserving
+    of a turnover.
+  no_screen_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts excluding screen passes, per PFF charting.
+  no_screen_yards: Passing yards gained excluding screen passes.
+  no_screen_ypa: Yards gained per pass attempt excluding screen passes.
+  npa_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on non-play-action dropbacks.
+  npa_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on non-play-action dropbacks, as charted
+    by PFF.
+  npa_attempts: Number of pass attempts on non-play-action dropbacks.
+  npa_avg_depth_of_target: Average depth of target in air yards on non-play-action dropbacks.
+  npa_avg_time_to_throw: Average time from snap to release in seconds on non-play-action dropbacks.
+  npa_bats: Number of pass attempts batted down at the line of scrimmage on non-play-action dropbacks.
+  npa_big_time_throws: Number of big-time throws on non-play-action dropbacks, per PFF's highest-value, highest-difficulty
+    throw designation.
+  npa_btt_rate: Big-time throws as a percentage of qualifying attempts on non-play-action dropbacks, per PFF charting.
+  npa_completion_percent: Percentage of pass attempts completed on non-play-action dropbacks.
+  npa_completions: Number of completed passes on non-play-action dropbacks.
+  npa_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on non-play-action dropbacks, as
+    charted by PFF.
+  npa_drop_rate: Percentage of catchable passes dropped by receivers on non-play-action dropbacks.
+  npa_dropbacks: Number of dropbacks on non-play-action dropbacks.
+  npa_dropbacks_percent: Share of the player's total dropbacks that came on non-play-action dropbacks, expressed as a percentage.
+  npa_drops: Number of catchable passes dropped by receivers on non-play-action dropbacks.
+  npa_epa: Total expected points added (EPA) on the player's dropbacks on non-play-action dropbacks.
+  npa_first_downs: Number of passing first downs gained on non-play-action dropbacks.
+  npa_grades_coverage_defense: PFF coverage grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_defense: PFF overall defense grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_hands_drop: PFF hands (drop) grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) on non-play-action dropbacks.
+  npa_grades_offense: PFF overall offense grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_overall_tackle: PFF overall tackling grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_pass: PFF passing grade (0-100) on non-play-action dropbacks.
+  npa_grades_pass_block: PFF pass-blocking grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_pass_route: PFF receiving (route) grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_pass_rush_defense: PFF pass-rush grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_run: PFF rushing grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_run_block: PFF run-blocking grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_run_defense: PFF run-defense grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_screen_block: PFF screen-blocking grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_tackle: PFF tackling grade for the player (0-100) on non-play-action dropbacks.
+  npa_hit_as_threw: Number of attempts on which the passer was hit as he threw on non-play-action dropbacks, as charted by
+    PFF.
+  npa_interceptions: Number of passes intercepted on non-play-action dropbacks.
+  npa_passing_snaps: Number of passing snaps played on non-play-action dropbacks.
+  npa_positive_epa_percent: Percentage of dropbacks with positive expected points added on non-play-action dropbacks.
+  npa_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on non-play-action dropbacks.
+  npa_qb_rating: Traditional NFL passer rating on non-play-action dropbacks.
+  npa_sack_percent: Percentage of dropbacks that ended in a sack on non-play-action dropbacks.
+  npa_sacks: Number of sacks taken on non-play-action dropbacks.
+  npa_scrambles: Number of scrambles on non-play-action dropbacks.
+  npa_spikes: Number of clock-stopping spikes on non-play-action dropbacks.
+  npa_thrown_aways: Number of intentional throwaways on non-play-action dropbacks.
+  npa_touchdowns: Number of passing touchdowns thrown on non-play-action dropbacks.
+  npa_turnover_worthy_plays: Number of turnover-worthy plays on non-play-action dropbacks, plays PFF charts as deserving of
+    a turnover.
+  npa_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on non-play-action dropbacks, per PFF charting.
+  npa_yards: Passing yards gained on non-play-action dropbacks.
+  npa_ypa: Yards gained per pass attempt on non-play-action dropbacks.
+  pa_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on play-action dropbacks.
+  pa_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on play-action dropbacks, as charted
+    by PFF.
+  pa_attempts: Number of pass attempts on play-action dropbacks.
+  pa_avg_depth_of_target: Average depth of target in air yards on play-action dropbacks.
+  pa_avg_time_to_throw: Average time from snap to release in seconds on play-action dropbacks.
+  pa_bats: Number of pass attempts batted down at the line of scrimmage on play-action dropbacks.
+  pa_big_time_throws: Number of big-time throws on play-action dropbacks, per PFF's highest-value, highest-difficulty throw
+    designation.
+  pa_btt_rate: Big-time throws as a percentage of qualifying attempts on play-action dropbacks, per PFF charting.
+  pa_completion_percent: Percentage of pass attempts completed on play-action dropbacks.
+  pa_completions: Number of completed passes on play-action dropbacks.
+  pa_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on play-action dropbacks, as charted
+    by PFF.
+  pa_drop_rate: Percentage of catchable passes dropped by receivers on play-action dropbacks.
+  pa_dropbacks: Number of dropbacks on play-action dropbacks.
+  pa_dropbacks_percent: Share of the player's total dropbacks that came on play-action dropbacks, expressed as a percentage.
+  pa_drops: Number of catchable passes dropped by receivers on play-action dropbacks.
+  pa_epa: Total expected points added (EPA) on the player's dropbacks on play-action dropbacks.
+  pa_first_downs: Number of passing first downs gained on play-action dropbacks.
+  pa_grades_coverage_defense: PFF coverage grade for the player (0-100) on play-action dropbacks.
+  pa_grades_defense: PFF overall defense grade for the player (0-100) on play-action dropbacks.
+  pa_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) on play-action dropbacks.
+  pa_grades_hands_drop: PFF hands (drop) grade for the player (0-100) on play-action dropbacks.
+  pa_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) on play-action dropbacks.
+  pa_grades_offense: PFF overall offense grade for the player (0-100) on play-action dropbacks.
+  pa_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) on play-action dropbacks.
+  pa_grades_overall_tackle: PFF overall tackling grade for the player (0-100) on play-action dropbacks.
+  pa_grades_pass: PFF passing grade (0-100) on play-action dropbacks.
+  pa_grades_pass_block: PFF pass-blocking grade for the player (0-100) on play-action dropbacks.
+  pa_grades_pass_route: PFF receiving (route) grade for the player (0-100) on play-action dropbacks.
+  pa_grades_pass_rush_defense: PFF pass-rush grade for the player (0-100) on play-action dropbacks.
+  pa_grades_run: PFF rushing grade for the player (0-100) on play-action dropbacks.
+  pa_grades_run_block: PFF run-blocking grade for the player (0-100) on play-action dropbacks.
+  pa_grades_run_defense: PFF run-defense grade for the player (0-100) on play-action dropbacks.
+  pa_grades_screen_block: PFF screen-blocking grade for the player (0-100) on play-action dropbacks.
+  pa_grades_tackle: PFF tackling grade for the player (0-100) on play-action dropbacks.
+  pa_hit_as_threw: Number of attempts on which the passer was hit as he threw on play-action dropbacks, as charted by PFF.
+  pa_interceptions: Number of passes intercepted on play-action dropbacks.
+  pa_passing_snaps: Number of passing snaps played on play-action dropbacks.
+  pa_positive_epa_percent: Percentage of dropbacks with positive expected points added on play-action dropbacks.
+  pa_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on play-action dropbacks.
+  pa_qb_rating: Traditional NFL passer rating on play-action dropbacks.
+  pa_sack_percent: Percentage of dropbacks that ended in a sack on play-action dropbacks.
+  pa_sacks: Number of sacks taken on play-action dropbacks.
+  pa_scrambles: Number of scrambles on play-action dropbacks.
+  pa_spikes: Number of clock-stopping spikes on play-action dropbacks.
+  pa_thrown_aways: Number of intentional throwaways on play-action dropbacks.
+  pa_touchdowns: Number of passing touchdowns thrown on play-action dropbacks.
+  pa_turnover_worthy_plays: Number of turnover-worthy plays on play-action dropbacks, plays PFF charts as deserving of a turnover.
+  pa_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on play-action dropbacks, per PFF charting.
+  pa_yards: Passing yards gained on play-action dropbacks.
+  pa_ypa: Yards gained per pass attempt on play-action dropbacks.
+  player_game_count: Number of games the player appeared in during the period covered.
+  screen_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on screen passes.
+  screen_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on screen passes, as charted by PFF.
+  screen_attempts: Number of pass attempts on screen passes.
+  screen_avg_depth_of_target: Average depth of target in air yards on screen passes.
+  screen_avg_time_to_throw: Average time from snap to release in seconds on screen passes.
+  screen_bats: Number of pass attempts batted down at the line of scrimmage on screen passes.
+  screen_big_time_throws: Number of big-time throws on screen passes, per PFF's highest-value, highest-difficulty throw designation.
+  screen_btt_rate: Big-time throws as a percentage of qualifying attempts on screen passes, per PFF charting.
+  screen_completion_percent: Percentage of pass attempts completed on screen passes.
+  screen_completions: Number of completed passes on screen passes.
+  screen_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on screen passes, as charted by
+    PFF.
+  screen_drop_rate: Percentage of catchable passes dropped by receivers on screen passes.
+  screen_dropbacks: Number of dropbacks on screen passes.
+  screen_dropbacks_percent: Share of the player's total dropbacks that came on screen passes, expressed as a percentage.
+  screen_drops: Number of catchable passes dropped by receivers on screen passes.
+  screen_epa: Total expected points added (EPA) on the player's dropbacks on screen passes.
+  screen_first_downs: Number of passing first downs gained on screen passes.
+  screen_grades_coverage_defense: PFF coverage grade for the player (0-100) on screen passes.
+  screen_grades_defense: PFF overall defense grade for the player (0-100) on screen passes.
+  screen_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) on screen passes.
+  screen_grades_hands_drop: PFF hands (drop) grade for the player (0-100) on screen passes.
+  screen_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) on screen passes.
+  screen_grades_offense: PFF overall offense grade for the player (0-100) on screen passes.
+  screen_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) on screen passes.
+  screen_grades_overall_tackle: PFF overall tackling grade for the player (0-100) on screen passes.
+  screen_grades_pass: PFF passing grade (0-100) on screen passes.
+  screen_grades_pass_block: PFF pass-blocking grade for the player (0-100) on screen passes.
+  screen_grades_pass_route: PFF receiving (route) grade for the player (0-100) on screen passes.
+  screen_grades_pass_rush_defense: PFF pass-rush grade for the player (0-100) on screen passes.
+  screen_grades_run: PFF rushing grade for the player (0-100) on screen passes.
+  screen_grades_run_block: PFF run-blocking grade for the player (0-100) on screen passes.
+  screen_grades_run_defense: PFF run-defense grade for the player (0-100) on screen passes.
+  screen_grades_screen_block: PFF screen-blocking grade for the player (0-100) on screen passes.
+  screen_grades_tackle: PFF tackling grade for the player (0-100) on screen passes.
+  screen_hit_as_threw: Number of attempts on which the passer was hit as he threw on screen passes, as charted by PFF.
+  screen_interceptions: Number of passes intercepted on screen passes.
+  screen_passing_snaps: Number of passing snaps played on screen passes.
+  screen_positive_epa_percent: Percentage of dropbacks with positive expected points added on screen passes.
+  screen_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on screen passes.
+  screen_qb_rating: Traditional NFL passer rating on screen passes.
+  screen_sack_percent: Percentage of dropbacks that ended in a sack on screen passes.
+  screen_sacks: Number of sacks taken on screen passes.
+  screen_scrambles: Number of scrambles on screen passes.
+  screen_spikes: Number of clock-stopping spikes on screen passes.
+  screen_thrown_aways: Number of intentional throwaways on screen passes.
+  screen_touchdowns: Number of passing touchdowns thrown on screen passes.
+  screen_turnover_worthy_plays: Number of turnover-worthy plays on screen passes, plays PFF charts as deserving of a turnover.
+  screen_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on screen passes, per PFF charting.
+  screen_yards: Passing yards gained on screen passes.
+  screen_ypa: Yards gained per pass attempt on screen passes.
+  ypa_diff: Difference in yards per attempt between play-action and non-play-action attempts (PA minus non-PA), from the PFF
+    passing-concept split.
+passing_depth:
+  base_attempts: Number of pass attempts across all splits, the baseline total for this facet.
+  base_dropbacks: Number of dropbacks across all splits, the baseline total for this facet.
+  behind_los_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage.
+  behind_los_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line of
+    scrimmage, as charted by PFF.
+  behind_los_attempts: Number of pass attempts on throws behind the line of scrimmage.
+  behind_los_attempts_percent: Share of the player's total pass attempts that came on throws behind the line of scrimmage,
+    expressed as a percentage.
+  behind_los_avg_depth_of_target: Average depth of target in air yards on throws behind the line of scrimmage.
+  behind_los_avg_time_to_throw: Average time from snap to release in seconds on throws behind the line of scrimmage.
+  behind_los_bats: Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage.
+  behind_los_big_time_throws: Number of big-time throws on throws behind the line of scrimmage, per PFF's highest-value, highest-difficulty
+    throw designation.
+  behind_los_btt_rate: Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage, per
+    PFF charting.
+  behind_los_completion_percent: Percentage of pass attempts completed on throws behind the line of scrimmage.
+  behind_los_completions: Number of completed passes on throws behind the line of scrimmage.
+  behind_los_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on throws behind the line
+    of scrimmage, as charted by PFF.
+  behind_los_drop_rate: Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage.
+  behind_los_dropbacks: Number of dropbacks on throws behind the line of scrimmage.
+  behind_los_drops: Number of catchable passes dropped by receivers on throws behind the line of scrimmage.
+  behind_los_epa: Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage.
+  behind_los_first_downs: Number of passing first downs gained on throws behind the line of scrimmage.
+  behind_los_grades_pass: PFF passing grade (0-100) on throws behind the line of scrimmage.
+  behind_los_hit_as_threw: Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage,
+    as charted by PFF.
+  behind_los_interceptions: Number of passes intercepted on throws behind the line of scrimmage.
+  behind_los_passing_snaps: Number of passing snaps played on throws behind the line of scrimmage.
+  behind_los_positive_epa_percent: Percentage of dropbacks with positive expected points added on throws behind the line of
+    scrimmage.
+  behind_los_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on throws behind the line of scrimmage.
+  behind_los_qb_rating: Traditional NFL passer rating on throws behind the line of scrimmage.
+  behind_los_sack_percent: Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage.
+  behind_los_sacks: Number of sacks taken on throws behind the line of scrimmage.
+  behind_los_scrambles: Number of scrambles on throws behind the line of scrimmage.
+  behind_los_spikes: Number of clock-stopping spikes on throws behind the line of scrimmage.
+  behind_los_thrown_aways: Number of intentional throwaways on throws behind the line of scrimmage.
+  behind_los_touchdowns: Number of passing touchdowns thrown on throws behind the line of scrimmage.
+  behind_los_turnover_worthy_plays: Number of turnover-worthy plays on throws behind the line of scrimmage, plays PFF charts
+    as deserving of a turnover.
+  behind_los_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage,
+    per PFF charting.
+  behind_los_yards: Passing yards gained on throws behind the line of scrimmage.
+  behind_los_ypa: Yards gained per pass attempt on throws behind the line of scrimmage.
+  center_behind_los_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage
+    to the center of the field.
+  center_behind_los_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line
+    of scrimmage to the center of the field, as charted by PFF.
+  center_behind_los_attempts: Number of pass attempts on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_attempts_percent: Share of the player's total pass attempts that came on throws behind the line of scrimmage
+    to the center of the field, expressed as a percentage.
+  center_behind_los_avg_depth_of_target: Average depth of target in air yards on throws behind the line of scrimmage to the
+    center of the field.
+  center_behind_los_avg_time_to_throw: Average time from snap to release in seconds on throws behind the line of scrimmage
+    to the center of the field.
+  center_behind_los_bats: Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage
+    to the center of the field.
+  center_behind_los_big_time_throws: Number of big-time throws on throws behind the line of scrimmage to the center of the
+    field, per PFF's highest-value, highest-difficulty throw designation.
+  center_behind_los_btt_rate: Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage
+    to the center of the field, per PFF charting.
+  center_behind_los_completion_percent: Percentage of pass attempts completed on throws behind the line of scrimmage to the
+    center of the field.
+  center_behind_los_completions: Number of completed passes on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on throws behind the
+    line of scrimmage to the center of the field, as charted by PFF.
+  center_behind_los_drop_rate: Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage
+    to the center of the field.
+  center_behind_los_dropbacks: Number of dropbacks on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_drops: Number of catchable passes dropped by receivers on throws behind the line of scrimmage to the center
+    of the field.
+  center_behind_los_epa: Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage
+    to the center of the field.
+  center_behind_los_first_downs: Number of passing first downs gained on throws behind the line of scrimmage to the center
+    of the field.
+  center_behind_los_grades_pass: PFF passing grade (0-100) on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_hit_as_threw: Number of attempts on which the passer was hit as he threw on throws behind the line of
+    scrimmage to the center of the field, as charted by PFF.
+  center_behind_los_interceptions: Number of passes intercepted on throws behind the line of scrimmage to the center of the
+    field.
+  center_behind_los_passing_snaps: Number of passing snaps played on throws behind the line of scrimmage to the center of
+    the field.
+  center_behind_los_positive_epa_percent: Percentage of dropbacks with positive expected points added on throws behind the
+    line of scrimmage to the center of the field.
+  center_behind_los_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on throws behind the line
+    of scrimmage to the center of the field.
+  center_behind_los_qb_rating: Traditional NFL passer rating on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_sack_percent: Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage to the
+    center of the field.
+  center_behind_los_sacks: Number of sacks taken on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_scrambles: Number of scrambles on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_spikes: Number of clock-stopping spikes on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_thrown_aways: Number of intentional throwaways on throws behind the line of scrimmage to the center of
+    the field.
+  center_behind_los_touchdowns: Number of passing touchdowns thrown on throws behind the line of scrimmage to the center of
+    the field.
+  center_behind_los_turnover_worthy_plays: Number of turnover-worthy plays on throws behind the line of scrimmage to the center
+    of the field, plays PFF charts as deserving of a turnover.
+  center_behind_los_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage
+    to the center of the field, per PFF charting.
+  center_behind_los_yards: Passing yards gained on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_ypa: Yards gained per pass attempt on throws behind the line of scrimmage to the center of the field.
+  center_deep_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws to the
+    center of the field.
+  center_deep_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws
+    to the center of the field, as charted by PFF.
+  center_deep_attempts: Number of pass attempts on deep (20+ air yards) throws to the center of the field.
+  center_deep_attempts_percent: Share of the player's total pass attempts that came on deep (20+ air yards) throws to the
+    center of the field, expressed as a percentage.
+  center_deep_avg_depth_of_target: Average depth of target in air yards on deep (20+ air yards) throws to the center of the
+    field.
+  center_deep_avg_time_to_throw: Average time from snap to release in seconds on deep (20+ air yards) throws to the center
+    of the field.
+  center_deep_bats: Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws to the center
+    of the field.
+  center_deep_big_time_throws: Number of big-time throws on deep (20+ air yards) throws to the center of the field, per PFF's
+    highest-value, highest-difficulty throw designation.
+  center_deep_btt_rate: Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws to the center
+    of the field, per PFF charting.
+  center_deep_completion_percent: Percentage of pass attempts completed on deep (20+ air yards) throws to the center of the
+    field.
+  center_deep_completions: Number of completed passes on deep (20+ air yards) throws to the center of the field.
+  center_deep_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws
+    to the center of the field, as charted by PFF.
+  center_deep_drop_rate: Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws to the center
+    of the field.
+  center_deep_dropbacks: Number of dropbacks on deep (20+ air yards) throws to the center of the field.
+  center_deep_drops: Number of catchable passes dropped by receivers on deep (20+ air yards) throws to the center of the field.
+  center_deep_epa: Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws to the center
+    of the field.
+  center_deep_first_downs: Number of passing first downs gained on deep (20+ air yards) throws to the center of the field.
+  center_deep_grades_pass: PFF passing grade (0-100) on deep (20+ air yards) throws to the center of the field.
+  center_deep_hit_as_threw: Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws to the
+    center of the field, as charted by PFF.
+  center_deep_interceptions: Number of passes intercepted on deep (20+ air yards) throws to the center of the field.
+  center_deep_passing_snaps: Number of passing snaps played on deep (20+ air yards) throws to the center of the field.
+  center_deep_positive_epa_percent: Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws
+    to the center of the field.
+  center_deep_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws
+    to the center of the field.
+  center_deep_qb_rating: Traditional NFL passer rating on deep (20+ air yards) throws to the center of the field.
+  center_deep_sack_percent: Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws to the center of the
+    field.
+  center_deep_sacks: Number of sacks taken on deep (20+ air yards) throws to the center of the field.
+  center_deep_scrambles: Number of scrambles on deep (20+ air yards) throws to the center of the field.
+  center_deep_spikes: Number of clock-stopping spikes on deep (20+ air yards) throws to the center of the field.
+  center_deep_thrown_aways: Number of intentional throwaways on deep (20+ air yards) throws to the center of the field.
+  center_deep_touchdowns: Number of passing touchdowns thrown on deep (20+ air yards) throws to the center of the field.
+  center_deep_turnover_worthy_plays: Number of turnover-worthy plays on deep (20+ air yards) throws to the center of the field,
+    plays PFF charts as deserving of a turnover.
+  center_deep_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws to the
+    center of the field, per PFF charting.
+  center_deep_yards: Passing yards gained on deep (20+ air yards) throws to the center of the field.
+  center_deep_ypa: Yards gained per pass attempt on deep (20+ air yards) throws to the center of the field.
+  center_medium_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws
+    to the center of the field.
+  center_medium_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards)
+    throws to the center of the field, as charted by PFF.
+  center_medium_attempts: Number of pass attempts on medium (10-19 air yards) throws to the center of the field.
+  center_medium_attempts_percent: Share of the player's total pass attempts that came on medium (10-19 air yards) throws to
+    the center of the field, expressed as a percentage.
+  center_medium_avg_depth_of_target: Average depth of target in air yards on medium (10-19 air yards) throws to the center
+    of the field.
+  center_medium_avg_time_to_throw: Average time from snap to release in seconds on medium (10-19 air yards) throws to the
+    center of the field.
+  center_medium_bats: Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws to the
+    center of the field.
+  center_medium_big_time_throws: Number of big-time throws on medium (10-19 air yards) throws to the center of the field,
+    per PFF's highest-value, highest-difficulty throw designation.
+  center_medium_btt_rate: Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws to the
+    center of the field, per PFF charting.
+  center_medium_completion_percent: Percentage of pass attempts completed on medium (10-19 air yards) throws to the center
+    of the field.
+  center_medium_completions: Number of completed passes on medium (10-19 air yards) throws to the center of the field.
+  center_medium_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards)
+    throws to the center of the field, as charted by PFF.
+  center_medium_drop_rate: Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws to the center
+    of the field.
+  center_medium_dropbacks: Number of dropbacks on medium (10-19 air yards) throws to the center of the field.
+  center_medium_drops: Number of catchable passes dropped by receivers on medium (10-19 air yards) throws to the center of
+    the field.
+  center_medium_epa: Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws to the
+    center of the field.
+  center_medium_first_downs: Number of passing first downs gained on medium (10-19 air yards) throws to the center of the
+    field.
+  center_medium_grades_pass: PFF passing grade (0-100) on medium (10-19 air yards) throws to the center of the field.
+  center_medium_hit_as_threw: Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws
+    to the center of the field, as charted by PFF.
+  center_medium_interceptions: Number of passes intercepted on medium (10-19 air yards) throws to the center of the field.
+  center_medium_passing_snaps: Number of passing snaps played on medium (10-19 air yards) throws to the center of the field.
+  center_medium_positive_epa_percent: Percentage of dropbacks with positive expected points added on medium (10-19 air yards)
+    throws to the center of the field.
+  center_medium_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards)
+    throws to the center of the field.
+  center_medium_qb_rating: Traditional NFL passer rating on medium (10-19 air yards) throws to the center of the field.
+  center_medium_sack_percent: Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws to the center
+    of the field.
+  center_medium_sacks: Number of sacks taken on medium (10-19 air yards) throws to the center of the field.
+  center_medium_scrambles: Number of scrambles on medium (10-19 air yards) throws to the center of the field.
+  center_medium_spikes: Number of clock-stopping spikes on medium (10-19 air yards) throws to the center of the field.
+  center_medium_thrown_aways: Number of intentional throwaways on medium (10-19 air yards) throws to the center of the field.
+  center_medium_touchdowns: Number of passing touchdowns thrown on medium (10-19 air yards) throws to the center of the field.
+  center_medium_turnover_worthy_plays: Number of turnover-worthy plays on medium (10-19 air yards) throws to the center of
+    the field, plays PFF charts as deserving of a turnover.
+  center_medium_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws
+    to the center of the field, per PFF charting.
+  center_medium_yards: Passing yards gained on medium (10-19 air yards) throws to the center of the field.
+  center_medium_ypa: Yards gained per pass attempt on medium (10-19 air yards) throws to the center of the field.
+  center_short_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws to
+    the center of the field.
+  center_short_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws
+    to the center of the field, as charted by PFF.
+  center_short_attempts: Number of pass attempts on short (0-9 air yards) throws to the center of the field.
+  center_short_attempts_percent: Share of the player's total pass attempts that came on short (0-9 air yards) throws to the
+    center of the field, expressed as a percentage.
+  center_short_avg_depth_of_target: Average depth of target in air yards on short (0-9 air yards) throws to the center of
+    the field.
+  center_short_avg_time_to_throw: Average time from snap to release in seconds on short (0-9 air yards) throws to the center
+    of the field.
+  center_short_bats: Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws to the center
+    of the field.
+  center_short_big_time_throws: Number of big-time throws on short (0-9 air yards) throws to the center of the field, per
+    PFF's highest-value, highest-difficulty throw designation.
+  center_short_btt_rate: Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws to the center
+    of the field, per PFF charting.
+  center_short_completion_percent: Percentage of pass attempts completed on short (0-9 air yards) throws to the center of
+    the field.
+  center_short_completions: Number of completed passes on short (0-9 air yards) throws to the center of the field.
+  center_short_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards)
+    throws to the center of the field, as charted by PFF.
+  center_short_drop_rate: Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws to the center
+    of the field.
+  center_short_dropbacks: Number of dropbacks on short (0-9 air yards) throws to the center of the field.
+  center_short_drops: Number of catchable passes dropped by receivers on short (0-9 air yards) throws to the center of the
+    field.
+  center_short_epa: Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws to the center
+    of the field.
+  center_short_first_downs: Number of passing first downs gained on short (0-9 air yards) throws to the center of the field.
+  center_short_grades_pass: PFF passing grade (0-100) on short (0-9 air yards) throws to the center of the field.
+  center_short_hit_as_threw: Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws to
+    the center of the field, as charted by PFF.
+  center_short_interceptions: Number of passes intercepted on short (0-9 air yards) throws to the center of the field.
+  center_short_passing_snaps: Number of passing snaps played on short (0-9 air yards) throws to the center of the field.
+  center_short_positive_epa_percent: Percentage of dropbacks with positive expected points added on short (0-9 air yards)
+    throws to the center of the field.
+  center_short_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws
+    to the center of the field.
+  center_short_qb_rating: Traditional NFL passer rating on short (0-9 air yards) throws to the center of the field.
+  center_short_sack_percent: Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws to the center of
+    the field.
+  center_short_sacks: Number of sacks taken on short (0-9 air yards) throws to the center of the field.
+  center_short_scrambles: Number of scrambles on short (0-9 air yards) throws to the center of the field.
+  center_short_spikes: Number of clock-stopping spikes on short (0-9 air yards) throws to the center of the field.
+  center_short_thrown_aways: Number of intentional throwaways on short (0-9 air yards) throws to the center of the field.
+  center_short_touchdowns: Number of passing touchdowns thrown on short (0-9 air yards) throws to the center of the field.
+  center_short_turnover_worthy_plays: Number of turnover-worthy plays on short (0-9 air yards) throws to the center of the
+    field, plays PFF charts as deserving of a turnover.
+  center_short_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws to the
+    center of the field, per PFF charting.
+  center_short_yards: Passing yards gained on short (0-9 air yards) throws to the center of the field.
+  center_short_ypa: Yards gained per pass attempt on short (0-9 air yards) throws to the center of the field.
+  declined_penalties: Number of declined penalties committed by the player.
+  deep_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws.
+  deep_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws, as
+    charted by PFF.
+  deep_attempts: Number of pass attempts on deep (20+ air yards) throws.
+  deep_attempts_percent: Share of the player's total pass attempts that came on deep (20+ air yards) throws, expressed as
+    a percentage.
+  deep_avg_depth_of_target: Average depth of target in air yards on deep (20+ air yards) throws.
+  deep_avg_time_to_throw: Average time from snap to release in seconds on deep (20+ air yards) throws.
+  deep_bats: Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws.
+  deep_big_time_throws: Number of big-time throws on deep (20+ air yards) throws, per PFF's highest-value, highest-difficulty
+    throw designation.
+  deep_btt_rate: Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws, per PFF charting.
+  deep_completion_percent: Percentage of pass attempts completed on deep (20+ air yards) throws.
+  deep_completions: Number of completed passes on deep (20+ air yards) throws.
+  deep_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws,
+    as charted by PFF.
+  deep_drop_rate: Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws.
+  deep_dropbacks: Number of dropbacks on deep (20+ air yards) throws.
+  deep_drops: Number of catchable passes dropped by receivers on deep (20+ air yards) throws.
+  deep_epa: Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws.
+  deep_first_downs: Number of passing first downs gained on deep (20+ air yards) throws.
+  deep_grades_pass: PFF passing grade (0-100) on deep (20+ air yards) throws.
+  deep_hit_as_threw: Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws, as charted
+    by PFF.
+  deep_interceptions: Number of passes intercepted on deep (20+ air yards) throws.
+  deep_passing_snaps: Number of passing snaps played on deep (20+ air yards) throws.
+  deep_positive_epa_percent: Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws.
+  deep_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws.
+  deep_qb_rating: Traditional NFL passer rating on deep (20+ air yards) throws.
+  deep_sack_percent: Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws.
+  deep_sacks: Number of sacks taken on deep (20+ air yards) throws.
+  deep_scrambles: Number of scrambles on deep (20+ air yards) throws.
+  deep_spikes: Number of clock-stopping spikes on deep (20+ air yards) throws.
+  deep_thrown_aways: Number of intentional throwaways on deep (20+ air yards) throws.
+  deep_touchdowns: Number of passing touchdowns thrown on deep (20+ air yards) throws.
+  deep_turnover_worthy_plays: Number of turnover-worthy plays on deep (20+ air yards) throws, plays PFF charts as deserving
+    of a turnover.
+  deep_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws, per PFF charting.
+  deep_yards: Passing yards gained on deep (20+ air yards) throws.
+  deep_ypa: Yards gained per pass attempt on deep (20+ air yards) throws.
+  draft_season: NFL season (year) in which the player was drafted, per PFF player metadata.
+  eligible_season: Season (year) of the player's NFL draft eligibility, per PFF player metadata.
+  left_behind_los_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage
+    to the left side of the field.
+  left_behind_los_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line
+    of scrimmage to the left side of the field, as charted by PFF.
+  left_behind_los_attempts: Number of pass attempts on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_attempts_percent: Share of the player's total pass attempts that came on throws behind the line of scrimmage
+    to the left side of the field, expressed as a percentage.
+  left_behind_los_avg_depth_of_target: Average depth of target in air yards on throws behind the line of scrimmage to the
+    left side of the field.
+  left_behind_los_avg_time_to_throw: Average time from snap to release in seconds on throws behind the line of scrimmage to
+    the left side of the field.
+  left_behind_los_bats: Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage
+    to the left side of the field.
+  left_behind_los_big_time_throws: Number of big-time throws on throws behind the line of scrimmage to the left side of the
+    field, per PFF's highest-value, highest-difficulty throw designation.
+  left_behind_los_btt_rate: Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage
+    to the left side of the field, per PFF charting.
+  left_behind_los_completion_percent: Percentage of pass attempts completed on throws behind the line of scrimmage to the
+    left side of the field.
+  left_behind_los_completions: Number of completed passes on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on throws behind the
+    line of scrimmage to the left side of the field, as charted by PFF.
+  left_behind_los_drop_rate: Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage to
+    the left side of the field.
+  left_behind_los_dropbacks: Number of dropbacks on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_drops: Number of catchable passes dropped by receivers on throws behind the line of scrimmage to the left
+    side of the field.
+  left_behind_los_epa: Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage
+    to the left side of the field.
+  left_behind_los_first_downs: Number of passing first downs gained on throws behind the line of scrimmage to the left side
+    of the field.
+  left_behind_los_grades_pass: PFF passing grade (0-100) on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_hit_as_threw: Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage
+    to the left side of the field, as charted by PFF.
+  left_behind_los_interceptions: Number of passes intercepted on throws behind the line of scrimmage to the left side of the
+    field.
+  left_behind_los_passing_snaps: Number of passing snaps played on throws behind the line of scrimmage to the left side of
+    the field.
+  left_behind_los_positive_epa_percent: Percentage of dropbacks with positive expected points added on throws behind the line
+    of scrimmage to the left side of the field.
+  left_behind_los_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on throws behind the line
+    of scrimmage to the left side of the field.
+  left_behind_los_qb_rating: Traditional NFL passer rating on throws behind the line of scrimmage to the left side of the
+    field.
+  left_behind_los_sack_percent: Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage to the
+    left side of the field.
+  left_behind_los_sacks: Number of sacks taken on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_scrambles: Number of scrambles on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_spikes: Number of clock-stopping spikes on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_thrown_aways: Number of intentional throwaways on throws behind the line of scrimmage to the left side of
+    the field.
+  left_behind_los_touchdowns: Number of passing touchdowns thrown on throws behind the line of scrimmage to the left side
+    of the field.
+  left_behind_los_turnover_worthy_plays: Number of turnover-worthy plays on throws behind the line of scrimmage to the left
+    side of the field, plays PFF charts as deserving of a turnover.
+  left_behind_los_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage
+    to the left side of the field, per PFF charting.
+  left_behind_los_yards: Passing yards gained on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_ypa: Yards gained per pass attempt on throws behind the line of scrimmage to the left side of the field.
+  left_deep_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws to the
+    left side of the field.
+  left_deep_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws
+    to the left side of the field, as charted by PFF.
+  left_deep_attempts: Number of pass attempts on deep (20+ air yards) throws to the left side of the field.
+  left_deep_attempts_percent: Share of the player's total pass attempts that came on deep (20+ air yards) throws to the left
+    side of the field, expressed as a percentage.
+  left_deep_avg_depth_of_target: Average depth of target in air yards on deep (20+ air yards) throws to the left side of the
+    field.
+  left_deep_avg_time_to_throw: Average time from snap to release in seconds on deep (20+ air yards) throws to the left side
+    of the field.
+  left_deep_bats: Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws to the left
+    side of the field.
+  left_deep_big_time_throws: Number of big-time throws on deep (20+ air yards) throws to the left side of the field, per PFF's
+    highest-value, highest-difficulty throw designation.
+  left_deep_btt_rate: Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws to the left side
+    of the field, per PFF charting.
+  left_deep_completion_percent: Percentage of pass attempts completed on deep (20+ air yards) throws to the left side of the
+    field.
+  left_deep_completions: Number of completed passes on deep (20+ air yards) throws to the left side of the field.
+  left_deep_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws
+    to the left side of the field, as charted by PFF.
+  left_deep_drop_rate: Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws to the left side
+    of the field.
+  left_deep_dropbacks: Number of dropbacks on deep (20+ air yards) throws to the left side of the field.
+  left_deep_drops: Number of catchable passes dropped by receivers on deep (20+ air yards) throws to the left side of the
+    field.
+  left_deep_epa: Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws to the left side
+    of the field.
+  left_deep_first_downs: Number of passing first downs gained on deep (20+ air yards) throws to the left side of the field.
+  left_deep_grades_pass: PFF passing grade (0-100) on deep (20+ air yards) throws to the left side of the field.
+  left_deep_hit_as_threw: Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws to the
+    left side of the field, as charted by PFF.
+  left_deep_interceptions: Number of passes intercepted on deep (20+ air yards) throws to the left side of the field.
+  left_deep_passing_snaps: Number of passing snaps played on deep (20+ air yards) throws to the left side of the field.
+  left_deep_positive_epa_percent: Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws
+    to the left side of the field.
+  left_deep_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws to
+    the left side of the field.
+  left_deep_qb_rating: Traditional NFL passer rating on deep (20+ air yards) throws to the left side of the field.
+  left_deep_sack_percent: Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws to the left side of
+    the field.
+  left_deep_sacks: Number of sacks taken on deep (20+ air yards) throws to the left side of the field.
+  left_deep_scrambles: Number of scrambles on deep (20+ air yards) throws to the left side of the field.
+  left_deep_spikes: Number of clock-stopping spikes on deep (20+ air yards) throws to the left side of the field.
+  left_deep_thrown_aways: Number of intentional throwaways on deep (20+ air yards) throws to the left side of the field.
+  left_deep_touchdowns: Number of passing touchdowns thrown on deep (20+ air yards) throws to the left side of the field.
+  left_deep_turnover_worthy_plays: Number of turnover-worthy plays on deep (20+ air yards) throws to the left side of the
+    field, plays PFF charts as deserving of a turnover.
+  left_deep_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws to the left
+    side of the field, per PFF charting.
+  left_deep_yards: Passing yards gained on deep (20+ air yards) throws to the left side of the field.
+  left_deep_ypa: Yards gained per pass attempt on deep (20+ air yards) throws to the left side of the field.
+  left_medium_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws to
+    the left side of the field.
+  left_medium_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards)
+    throws to the left side of the field, as charted by PFF.
+  left_medium_attempts: Number of pass attempts on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_attempts_percent: Share of the player's total pass attempts that came on medium (10-19 air yards) throws to
+    the left side of the field, expressed as a percentage.
+  left_medium_avg_depth_of_target: Average depth of target in air yards on medium (10-19 air yards) throws to the left side
+    of the field.
+  left_medium_avg_time_to_throw: Average time from snap to release in seconds on medium (10-19 air yards) throws to the left
+    side of the field.
+  left_medium_bats: Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws to the
+    left side of the field.
+  left_medium_big_time_throws: Number of big-time throws on medium (10-19 air yards) throws to the left side of the field,
+    per PFF's highest-value, highest-difficulty throw designation.
+  left_medium_btt_rate: Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws to the left
+    side of the field, per PFF charting.
+  left_medium_completion_percent: Percentage of pass attempts completed on medium (10-19 air yards) throws to the left side
+    of the field.
+  left_medium_completions: Number of completed passes on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards)
+    throws to the left side of the field, as charted by PFF.
+  left_medium_drop_rate: Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws to the left
+    side of the field.
+  left_medium_dropbacks: Number of dropbacks on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_drops: Number of catchable passes dropped by receivers on medium (10-19 air yards) throws to the left side of
+    the field.
+  left_medium_epa: Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws to the left
+    side of the field.
+  left_medium_first_downs: Number of passing first downs gained on medium (10-19 air yards) throws to the left side of the
+    field.
+  left_medium_grades_pass: PFF passing grade (0-100) on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_hit_as_threw: Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws
+    to the left side of the field, as charted by PFF.
+  left_medium_interceptions: Number of passes intercepted on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_passing_snaps: Number of passing snaps played on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_positive_epa_percent: Percentage of dropbacks with positive expected points added on medium (10-19 air yards)
+    throws to the left side of the field.
+  left_medium_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws
+    to the left side of the field.
+  left_medium_qb_rating: Traditional NFL passer rating on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_sack_percent: Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws to the left side
+    of the field.
+  left_medium_sacks: Number of sacks taken on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_scrambles: Number of scrambles on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_spikes: Number of clock-stopping spikes on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_thrown_aways: Number of intentional throwaways on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_touchdowns: Number of passing touchdowns thrown on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_turnover_worthy_plays: Number of turnover-worthy plays on medium (10-19 air yards) throws to the left side of
+    the field, plays PFF charts as deserving of a turnover.
+  left_medium_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws to
+    the left side of the field, per PFF charting.
+  left_medium_yards: Passing yards gained on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_ypa: Yards gained per pass attempt on medium (10-19 air yards) throws to the left side of the field.
+  left_short_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws to the
+    left side of the field.
+  left_short_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws
+    to the left side of the field, as charted by PFF.
+  left_short_attempts: Number of pass attempts on short (0-9 air yards) throws to the left side of the field.
+  left_short_attempts_percent: Share of the player's total pass attempts that came on short (0-9 air yards) throws to the
+    left side of the field, expressed as a percentage.
+  left_short_avg_depth_of_target: Average depth of target in air yards on short (0-9 air yards) throws to the left side of
+    the field.
+  left_short_avg_time_to_throw: Average time from snap to release in seconds on short (0-9 air yards) throws to the left side
+    of the field.
+  left_short_bats: Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws to the left
+    side of the field.
+  left_short_big_time_throws: Number of big-time throws on short (0-9 air yards) throws to the left side of the field, per
+    PFF's highest-value, highest-difficulty throw designation.
+  left_short_btt_rate: Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws to the left
+    side of the field, per PFF charting.
+  left_short_completion_percent: Percentage of pass attempts completed on short (0-9 air yards) throws to the left side of
+    the field.
+  left_short_completions: Number of completed passes on short (0-9 air yards) throws to the left side of the field.
+  left_short_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards) throws
+    to the left side of the field, as charted by PFF.
+  left_short_drop_rate: Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws to the left side
+    of the field.
+  left_short_dropbacks: Number of dropbacks on short (0-9 air yards) throws to the left side of the field.
+  left_short_drops: Number of catchable passes dropped by receivers on short (0-9 air yards) throws to the left side of the
+    field.
+  left_short_epa: Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws to the left
+    side of the field.
+  left_short_first_downs: Number of passing first downs gained on short (0-9 air yards) throws to the left side of the field.
+  left_short_grades_pass: PFF passing grade (0-100) on short (0-9 air yards) throws to the left side of the field.
+  left_short_hit_as_threw: Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws to the
+    left side of the field, as charted by PFF.
+  left_short_interceptions: Number of passes intercepted on short (0-9 air yards) throws to the left side of the field.
+  left_short_passing_snaps: Number of passing snaps played on short (0-9 air yards) throws to the left side of the field.
+  left_short_positive_epa_percent: Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws
+    to the left side of the field.
+  left_short_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws
+    to the left side of the field.
+  left_short_qb_rating: Traditional NFL passer rating on short (0-9 air yards) throws to the left side of the field.
+  left_short_sack_percent: Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws to the left side of
+    the field.
+  left_short_sacks: Number of sacks taken on short (0-9 air yards) throws to the left side of the field.
+  left_short_scrambles: Number of scrambles on short (0-9 air yards) throws to the left side of the field.
+  left_short_spikes: Number of clock-stopping spikes on short (0-9 air yards) throws to the left side of the field.
+  left_short_thrown_aways: Number of intentional throwaways on short (0-9 air yards) throws to the left side of the field.
+  left_short_touchdowns: Number of passing touchdowns thrown on short (0-9 air yards) throws to the left side of the field.
+  left_short_turnover_worthy_plays: Number of turnover-worthy plays on short (0-9 air yards) throws to the left side of the
+    field, plays PFF charts as deserving of a turnover.
+  left_short_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws to the
+    left side of the field, per PFF charting.
+  left_short_yards: Passing yards gained on short (0-9 air yards) throws to the left side of the field.
+  left_short_ypa: Yards gained per pass attempt on short (0-9 air yards) throws to the left side of the field.
+  medium_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws.
+  medium_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards) throws,
+    as charted by PFF.
+  medium_attempts: Number of pass attempts on medium (10-19 air yards) throws.
+  medium_attempts_percent: Share of the player's total pass attempts that came on medium (10-19 air yards) throws, expressed
+    as a percentage.
+  medium_avg_depth_of_target: Average depth of target in air yards on medium (10-19 air yards) throws.
+  medium_avg_time_to_throw: Average time from snap to release in seconds on medium (10-19 air yards) throws.
+  medium_bats: Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws.
+  medium_big_time_throws: Number of big-time throws on medium (10-19 air yards) throws, per PFF's highest-value, highest-difficulty
+    throw designation.
+  medium_btt_rate: Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws, per PFF charting.
+  medium_completion_percent: Percentage of pass attempts completed on medium (10-19 air yards) throws.
+  medium_completions: Number of completed passes on medium (10-19 air yards) throws.
+  medium_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards) throws,
+    as charted by PFF.
+  medium_drop_rate: Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws.
+  medium_dropbacks: Number of dropbacks on medium (10-19 air yards) throws.
+  medium_drops: Number of catchable passes dropped by receivers on medium (10-19 air yards) throws.
+  medium_epa: Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws.
+  medium_first_downs: Number of passing first downs gained on medium (10-19 air yards) throws.
+  medium_grades_pass: PFF passing grade (0-100) on medium (10-19 air yards) throws.
+  medium_hit_as_threw: Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws, as charted
+    by PFF.
+  medium_interceptions: Number of passes intercepted on medium (10-19 air yards) throws.
+  medium_passing_snaps: Number of passing snaps played on medium (10-19 air yards) throws.
+  medium_positive_epa_percent: Percentage of dropbacks with positive expected points added on medium (10-19 air yards) throws.
+  medium_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws.
+  medium_qb_rating: Traditional NFL passer rating on medium (10-19 air yards) throws.
+  medium_sack_percent: Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws.
+  medium_sacks: Number of sacks taken on medium (10-19 air yards) throws.
+  medium_scrambles: Number of scrambles on medium (10-19 air yards) throws.
+  medium_spikes: Number of clock-stopping spikes on medium (10-19 air yards) throws.
+  medium_thrown_aways: Number of intentional throwaways on medium (10-19 air yards) throws.
+  medium_touchdowns: Number of passing touchdowns thrown on medium (10-19 air yards) throws.
+  medium_turnover_worthy_plays: Number of turnover-worthy plays on medium (10-19 air yards) throws, plays PFF charts as deserving
+    of a turnover.
+  medium_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws, per PFF
+    charting.
+  medium_yards: Passing yards gained on medium (10-19 air yards) throws.
+  medium_ypa: Yards gained per pass attempt on medium (10-19 air yards) throws.
+  player_game_count: Number of games the player appeared in during the period covered.
+  right_behind_los_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage
+    to the right side of the field.
+  right_behind_los_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line
+    of scrimmage to the right side of the field, as charted by PFF.
+  right_behind_los_attempts: Number of pass attempts on throws behind the line of scrimmage to the right side of the field.
+  right_behind_los_attempts_percent: Share of the player's total pass attempts that came on throws behind the line of scrimmage
+    to the right side of the field, expressed as a percentage.
+  right_behind_los_avg_depth_of_target: Average depth of target in air yards on throws behind the line of scrimmage to the
+    right side of the field.
+  right_behind_los_avg_time_to_throw: Average time from snap to release in seconds on throws behind the line of scrimmage
+    to the right side of the field.
+  right_behind_los_bats: Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage
+    to the right side of the field.
+  right_behind_los_big_time_throws: Number of big-time throws on throws behind the line of scrimmage to the right side of
+    the field, per PFF's highest-value, highest-difficulty throw designation.
+  right_behind_los_btt_rate: Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage
+    to the right side of the field, per PFF charting.
+  right_behind_los_completion_percent: Percentage of pass attempts completed on throws behind the line of scrimmage to the
+    right side of the field.
+  right_behind_los_completions: Number of completed passes on throws behind the line of scrimmage to the right side of the
+    field.
+  right_behind_los_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on throws behind the
+    line of scrimmage to the right side of the field, as charted by PFF.
+  right_behind_los_drop_rate: Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage to
+    the right side of the field.
+  right_behind_los_dropbacks: Number of dropbacks on throws behind the line of scrimmage to the right side of the field.
+  right_behind_los_drops: Number of catchable passes dropped by receivers on throws behind the line of scrimmage to the right
+    side of the field.
+  right_behind_los_epa: Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage
+    to the right side of the field.
+  right_behind_los_first_downs: Number of passing first downs gained on throws behind the line of scrimmage to the right side
+    of the field.
+  right_behind_los_grades_pass: PFF passing grade (0-100) on throws behind the line of scrimmage to the right side of the
+    field.
+  right_behind_los_hit_as_threw: Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage
+    to the right side of the field, as charted by PFF.
+  right_behind_los_interceptions: Number of passes intercepted on throws behind the line of scrimmage to the right side of
+    the field.
+  right_behind_los_passing_snaps: Number of passing snaps played on throws behind the line of scrimmage to the right side
+    of the field.
+  right_behind_los_positive_epa_percent: Percentage of dropbacks with positive expected points added on throws behind the
+    line of scrimmage to the right side of the field.
+  right_behind_los_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on throws behind the line
+    of scrimmage to the right side of the field.
+  right_behind_los_qb_rating: Traditional NFL passer rating on throws behind the line of scrimmage to the right side of the
+    field.
+  right_behind_los_sack_percent: Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage to the
+    right side of the field.
+  right_behind_los_sacks: Number of sacks taken on throws behind the line of scrimmage to the right side of the field.
+  right_behind_los_scrambles: Number of scrambles on throws behind the line of scrimmage to the right side of the field.
+  right_behind_los_spikes: Number of clock-stopping spikes on throws behind the line of scrimmage to the right side of the
+    field.
+  right_behind_los_thrown_aways: Number of intentional throwaways on throws behind the line of scrimmage to the right side
+    of the field.
+  right_behind_los_touchdowns: Number of passing touchdowns thrown on throws behind the line of scrimmage to the right side
+    of the field.
+  right_behind_los_turnover_worthy_plays: Number of turnover-worthy plays on throws behind the line of scrimmage to the right
+    side of the field, plays PFF charts as deserving of a turnover.
+  right_behind_los_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage
+    to the right side of the field, per PFF charting.
+  right_behind_los_yards: Passing yards gained on throws behind the line of scrimmage to the right side of the field.
+  right_behind_los_ypa: Yards gained per pass attempt on throws behind the line of scrimmage to the right side of the field.
+  right_deep_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws to the
+    right side of the field.
+  right_deep_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws
+    to the right side of the field, as charted by PFF.
+  right_deep_attempts: Number of pass attempts on deep (20+ air yards) throws to the right side of the field.
+  right_deep_attempts_percent: Share of the player's total pass attempts that came on deep (20+ air yards) throws to the right
+    side of the field, expressed as a percentage.
+  right_deep_avg_depth_of_target: Average depth of target in air yards on deep (20+ air yards) throws to the right side of
+    the field.
+  right_deep_avg_time_to_throw: Average time from snap to release in seconds on deep (20+ air yards) throws to the right side
+    of the field.
+  right_deep_bats: Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws to the right
+    side of the field.
+  right_deep_big_time_throws: Number of big-time throws on deep (20+ air yards) throws to the right side of the field, per
+    PFF's highest-value, highest-difficulty throw designation.
+  right_deep_btt_rate: Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws to the right
+    side of the field, per PFF charting.
+  right_deep_completion_percent: Percentage of pass attempts completed on deep (20+ air yards) throws to the right side of
+    the field.
+  right_deep_completions: Number of completed passes on deep (20+ air yards) throws to the right side of the field.
+  right_deep_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws
+    to the right side of the field, as charted by PFF.
+  right_deep_drop_rate: Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws to the right side
+    of the field.
+  right_deep_dropbacks: Number of dropbacks on deep (20+ air yards) throws to the right side of the field.
+  right_deep_drops: Number of catchable passes dropped by receivers on deep (20+ air yards) throws to the right side of the
+    field.
+  right_deep_epa: Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws to the right
+    side of the field.
+  right_deep_first_downs: Number of passing first downs gained on deep (20+ air yards) throws to the right side of the field.
+  right_deep_grades_pass: PFF passing grade (0-100) on deep (20+ air yards) throws to the right side of the field.
+  right_deep_hit_as_threw: Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws to the
+    right side of the field, as charted by PFF.
+  right_deep_interceptions: Number of passes intercepted on deep (20+ air yards) throws to the right side of the field.
+  right_deep_passing_snaps: Number of passing snaps played on deep (20+ air yards) throws to the right side of the field.
+  right_deep_positive_epa_percent: Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws
+    to the right side of the field.
+  right_deep_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws
+    to the right side of the field.
+  right_deep_qb_rating: Traditional NFL passer rating on deep (20+ air yards) throws to the right side of the field.
+  right_deep_sack_percent: Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws to the right side of
+    the field.
+  right_deep_sacks: Number of sacks taken on deep (20+ air yards) throws to the right side of the field.
+  right_deep_scrambles: Number of scrambles on deep (20+ air yards) throws to the right side of the field.
+  right_deep_spikes: Number of clock-stopping spikes on deep (20+ air yards) throws to the right side of the field.
+  right_deep_thrown_aways: Number of intentional throwaways on deep (20+ air yards) throws to the right side of the field.
+  right_deep_touchdowns: Number of passing touchdowns thrown on deep (20+ air yards) throws to the right side of the field.
+  right_deep_turnover_worthy_plays: Number of turnover-worthy plays on deep (20+ air yards) throws to the right side of the
+    field, plays PFF charts as deserving of a turnover.
+  right_deep_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws to the
+    right side of the field, per PFF charting.
+  right_deep_yards: Passing yards gained on deep (20+ air yards) throws to the right side of the field.
+  right_deep_ypa: Yards gained per pass attempt on deep (20+ air yards) throws to the right side of the field.
+  right_medium_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws
+    to the right side of the field.
+  right_medium_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards)
+    throws to the right side of the field, as charted by PFF.
+  right_medium_attempts: Number of pass attempts on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_attempts_percent: Share of the player's total pass attempts that came on medium (10-19 air yards) throws to
+    the right side of the field, expressed as a percentage.
+  right_medium_avg_depth_of_target: Average depth of target in air yards on medium (10-19 air yards) throws to the right side
+    of the field.
+  right_medium_avg_time_to_throw: Average time from snap to release in seconds on medium (10-19 air yards) throws to the right
+    side of the field.
+  right_medium_bats: Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws to the
+    right side of the field.
+  right_medium_big_time_throws: Number of big-time throws on medium (10-19 air yards) throws to the right side of the field,
+    per PFF's highest-value, highest-difficulty throw designation.
+  right_medium_btt_rate: Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws to the
+    right side of the field, per PFF charting.
+  right_medium_completion_percent: Percentage of pass attempts completed on medium (10-19 air yards) throws to the right side
+    of the field.
+  right_medium_completions: Number of completed passes on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards)
+    throws to the right side of the field, as charted by PFF.
+  right_medium_drop_rate: Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws to the right
+    side of the field.
+  right_medium_dropbacks: Number of dropbacks on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_drops: Number of catchable passes dropped by receivers on medium (10-19 air yards) throws to the right side
+    of the field.
+  right_medium_epa: Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws to the
+    right side of the field.
+  right_medium_first_downs: Number of passing first downs gained on medium (10-19 air yards) throws to the right side of the
+    field.
+  right_medium_grades_pass: PFF passing grade (0-100) on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_hit_as_threw: Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws
+    to the right side of the field, as charted by PFF.
+  right_medium_interceptions: Number of passes intercepted on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_passing_snaps: Number of passing snaps played on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_positive_epa_percent: Percentage of dropbacks with positive expected points added on medium (10-19 air yards)
+    throws to the right side of the field.
+  right_medium_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws
+    to the right side of the field.
+  right_medium_qb_rating: Traditional NFL passer rating on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_sack_percent: Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws to the right
+    side of the field.
+  right_medium_sacks: Number of sacks taken on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_scrambles: Number of scrambles on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_spikes: Number of clock-stopping spikes on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_thrown_aways: Number of intentional throwaways on medium (10-19 air yards) throws to the right side of the
+    field.
+  right_medium_touchdowns: Number of passing touchdowns thrown on medium (10-19 air yards) throws to the right side of the
+    field.
+  right_medium_turnover_worthy_plays: Number of turnover-worthy plays on medium (10-19 air yards) throws to the right side
+    of the field, plays PFF charts as deserving of a turnover.
+  right_medium_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws to
+    the right side of the field, per PFF charting.
+  right_medium_yards: Passing yards gained on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_ypa: Yards gained per pass attempt on medium (10-19 air yards) throws to the right side of the field.
+  right_short_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws to the
+    right side of the field.
+  right_short_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws
+    to the right side of the field, as charted by PFF.
+  right_short_attempts: Number of pass attempts on short (0-9 air yards) throws to the right side of the field.
+  right_short_attempts_percent: Share of the player's total pass attempts that came on short (0-9 air yards) throws to the
+    right side of the field, expressed as a percentage.
+  right_short_avg_depth_of_target: Average depth of target in air yards on short (0-9 air yards) throws to the right side
+    of the field.
+  right_short_avg_time_to_throw: Average time from snap to release in seconds on short (0-9 air yards) throws to the right
+    side of the field.
+  right_short_bats: Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws to the right
+    side of the field.
+  right_short_big_time_throws: Number of big-time throws on short (0-9 air yards) throws to the right side of the field, per
+    PFF's highest-value, highest-difficulty throw designation.
+  right_short_btt_rate: Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws to the right
+    side of the field, per PFF charting.
+  right_short_completion_percent: Percentage of pass attempts completed on short (0-9 air yards) throws to the right side
+    of the field.
+  right_short_completions: Number of completed passes on short (0-9 air yards) throws to the right side of the field.
+  right_short_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards)
+    throws to the right side of the field, as charted by PFF.
+  right_short_drop_rate: Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws to the right
+    side of the field.
+  right_short_dropbacks: Number of dropbacks on short (0-9 air yards) throws to the right side of the field.
+  right_short_drops: Number of catchable passes dropped by receivers on short (0-9 air yards) throws to the right side of
+    the field.
+  right_short_epa: Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws to the right
+    side of the field.
+  right_short_first_downs: Number of passing first downs gained on short (0-9 air yards) throws to the right side of the field.
+  right_short_grades_pass: PFF passing grade (0-100) on short (0-9 air yards) throws to the right side of the field.
+  right_short_hit_as_threw: Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws to
+    the right side of the field, as charted by PFF.
+  right_short_interceptions: Number of passes intercepted on short (0-9 air yards) throws to the right side of the field.
+  right_short_passing_snaps: Number of passing snaps played on short (0-9 air yards) throws to the right side of the field.
+  right_short_positive_epa_percent: Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws
+    to the right side of the field.
+  right_short_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws
+    to the right side of the field.
+  right_short_qb_rating: Traditional NFL passer rating on short (0-9 air yards) throws to the right side of the field.
+  right_short_sack_percent: Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws to the right side
+    of the field.
+  right_short_sacks: Number of sacks taken on short (0-9 air yards) throws to the right side of the field.
+  right_short_scrambles: Number of scrambles on short (0-9 air yards) throws to the right side of the field.
+  right_short_spikes: Number of clock-stopping spikes on short (0-9 air yards) throws to the right side of the field.
+  right_short_thrown_aways: Number of intentional throwaways on short (0-9 air yards) throws to the right side of the field.
+  right_short_touchdowns: Number of passing touchdowns thrown on short (0-9 air yards) throws to the right side of the field.
+  right_short_turnover_worthy_plays: Number of turnover-worthy plays on short (0-9 air yards) throws to the right side of
+    the field, plays PFF charts as deserving of a turnover.
+  right_short_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws to the
+    right side of the field, per PFF charting.
+  right_short_yards: Passing yards gained on short (0-9 air yards) throws to the right side of the field.
+  right_short_ypa: Yards gained per pass attempt on short (0-9 air yards) throws to the right side of the field.
+  short_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws.
+  short_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws, as
+    charted by PFF.
+  short_attempts: Number of pass attempts on short (0-9 air yards) throws.
+  short_attempts_percent: Share of the player's total pass attempts that came on short (0-9 air yards) throws, expressed as
+    a percentage.
+  short_avg_depth_of_target: Average depth of target in air yards on short (0-9 air yards) throws.
+  short_avg_time_to_throw: Average time from snap to release in seconds on short (0-9 air yards) throws.
+  short_bats: Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws.
+  short_big_time_throws: Number of big-time throws on short (0-9 air yards) throws, per PFF's highest-value, highest-difficulty
+    throw designation.
+  short_btt_rate: Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws, per PFF charting.
+  short_completion_percent: Percentage of pass attempts completed on short (0-9 air yards) throws.
+  short_completions: Number of completed passes on short (0-9 air yards) throws.
+  short_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards) throws,
+    as charted by PFF.
+  short_drop_rate: Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws.
+  short_dropbacks: Number of dropbacks on short (0-9 air yards) throws.
+  short_drops: Number of catchable passes dropped by receivers on short (0-9 air yards) throws.
+  short_epa: Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws.
+  short_first_downs: Number of passing first downs gained on short (0-9 air yards) throws.
+  short_grades_pass: PFF passing grade (0-100) on short (0-9 air yards) throws.
+  short_hit_as_threw: Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws, as charted
+    by PFF.
+  short_interceptions: Number of passes intercepted on short (0-9 air yards) throws.
+  short_passing_snaps: Number of passing snaps played on short (0-9 air yards) throws.
+  short_positive_epa_percent: Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws.
+  short_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws.
+  short_qb_rating: Traditional NFL passer rating on short (0-9 air yards) throws.
+  short_sack_percent: Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws.
+  short_sacks: Number of sacks taken on short (0-9 air yards) throws.
+  short_scrambles: Number of scrambles on short (0-9 air yards) throws.
+  short_spikes: Number of clock-stopping spikes on short (0-9 air yards) throws.
+  short_thrown_aways: Number of intentional throwaways on short (0-9 air yards) throws.
+  short_touchdowns: Number of passing touchdowns thrown on short (0-9 air yards) throws.
+  short_turnover_worthy_plays: Number of turnover-worthy plays on short (0-9 air yards) throws, plays PFF charts as deserving
+    of a turnover.
+  short_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws, per PFF charting.
+  short_yards: Passing yards gained on short (0-9 air yards) throws.
+  short_ypa: Yards gained per pass attempt on short (0-9 air yards) throws.
+passing_detail_stats:
+  accuracy_percent: Percentage of aimed passes charted as accurate by PFF.
+  aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways), as charted by PFF.
+  avg_depth_of_target: Average depth of target in air yards.
+  bats: Number of pass attempts batted down at the line of scrimmage.
+  behind_los_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage.
+  behind_los_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line of
+    scrimmage, as charted by PFF.
+  behind_los_attempts: Number of pass attempts on throws behind the line of scrimmage.
+  behind_los_attempts_percent: Share of the player's total pass attempts that came on throws behind the line of scrimmage,
+    expressed as a percentage.
+  behind_los_avg_depth_of_target: Average depth of target in air yards on throws behind the line of scrimmage.
+  behind_los_avg_time_to_throw: Average time from snap to release in seconds on throws behind the line of scrimmage.
+  behind_los_bats: Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage.
+  behind_los_big_time_throws: Number of big-time throws on throws behind the line of scrimmage, per PFF's highest-value, highest-difficulty
+    throw designation.
+  behind_los_btt_rate: Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage, per
+    PFF charting.
+  behind_los_completion_percent: Percentage of pass attempts completed on throws behind the line of scrimmage.
+  behind_los_completions: Number of completed passes on throws behind the line of scrimmage.
+  behind_los_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on throws behind the line
+    of scrimmage, as charted by PFF.
+  behind_los_drop_rate: Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage.
+  behind_los_dropbacks: Number of dropbacks on throws behind the line of scrimmage.
+  behind_los_drops: Number of catchable passes dropped by receivers on throws behind the line of scrimmage.
+  behind_los_epa: Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage.
+  behind_los_first_downs: Number of passing first downs gained on throws behind the line of scrimmage.
+  behind_los_grades_pass: PFF passing grade (0-100) on throws behind the line of scrimmage.
+  behind_los_hit_as_threw: Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage,
+    as charted by PFF.
+  behind_los_interceptions: Number of passes intercepted on throws behind the line of scrimmage.
+  behind_los_passing_snaps: Number of passing snaps played on throws behind the line of scrimmage.
+  behind_los_positive_epa_percent: Percentage of dropbacks with positive expected points added on throws behind the line of
+    scrimmage.
+  behind_los_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on throws behind the line of scrimmage.
+  behind_los_qb_rating: Traditional NFL passer rating on throws behind the line of scrimmage.
+  behind_los_sack_percent: Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage.
+  behind_los_sacks: Number of sacks taken on throws behind the line of scrimmage.
+  behind_los_scrambles: Number of scrambles on throws behind the line of scrimmage.
+  behind_los_spikes: Number of clock-stopping spikes on throws behind the line of scrimmage.
+  behind_los_thrown_aways: Number of intentional throwaways on throws behind the line of scrimmage.
+  behind_los_touchdowns: Number of passing touchdowns thrown on throws behind the line of scrimmage.
+  behind_los_turnover_worthy_plays: Number of turnover-worthy plays on throws behind the line of scrimmage, plays PFF charts
+    as deserving of a turnover.
+  behind_los_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage,
+    per PFF charting.
+  behind_los_yards: Passing yards gained on throws behind the line of scrimmage.
+  behind_los_ypa: Yards gained per pass attempt on throws behind the line of scrimmage.
+  big_time_throws: Number of big-time throws, per PFF's highest-value, highest-difficulty throw designation.
+  blitz_accuracy_percent: Percentage of aimed passes charted as accurate by PFF when blitzed.
+  blitz_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) when blitzed, as charted by PFF.
+  blitz_attempts: Number of pass attempts when blitzed.
+  blitz_avg_depth_of_target: Average depth of target in air yards when blitzed.
+  blitz_avg_time_to_throw: Average time from snap to release in seconds when blitzed.
+  blitz_bats: Number of pass attempts batted down at the line of scrimmage when blitzed.
+  blitz_big_time_throws: Number of big-time throws when blitzed, per PFF's highest-value, highest-difficulty throw designation.
+  blitz_btt_rate: Big-time throws as a percentage of qualifying attempts when blitzed, per PFF charting.
+  blitz_completion_percent: Percentage of pass attempts completed when blitzed.
+  blitz_completions: Number of completed passes when blitzed.
+  blitz_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks when blitzed, as charted by PFF.
+  blitz_drop_rate: Percentage of catchable passes dropped by receivers when blitzed.
+  blitz_dropbacks: Number of dropbacks when blitzed.
+  blitz_dropbacks_percent: Share of the player's total dropbacks that came when blitzed, expressed as a percentage.
+  blitz_drops: Number of catchable passes dropped by receivers when blitzed.
+  blitz_epa: Total expected points added (EPA) on the player's dropbacks when blitzed.
+  blitz_first_downs: Number of passing first downs gained when blitzed.
+  blitz_grades_hands_drop: PFF hands (drop) grade for the player (0-100) when blitzed.
+  blitz_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) when blitzed.
+  blitz_grades_offense: PFF overall offense grade for the player (0-100) when blitzed.
+  blitz_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) when blitzed.
+  blitz_grades_pass: PFF passing grade (0-100) when blitzed.
+  blitz_grades_pass_block: PFF pass-blocking grade for the player (0-100) when blitzed.
+  blitz_grades_pass_route: PFF receiving (route) grade for the player (0-100) when blitzed.
+  blitz_grades_run: PFF rushing grade for the player (0-100) when blitzed.
+  blitz_grades_run_block: PFF run-blocking grade for the player (0-100) when blitzed.
+  blitz_grades_screen_block: PFF screen-blocking grade for the player (0-100) when blitzed.
+  blitz_hit_as_threw: Number of attempts on which the passer was hit as he threw when blitzed, as charted by PFF.
+  blitz_interceptions: Number of passes intercepted when blitzed.
+  blitz_passing_snaps: Number of passing snaps played when blitzed.
+  blitz_positive_epa_percent: Percentage of dropbacks with positive expected points added when blitzed.
+  blitz_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack when blitzed.
+  blitz_qb_rating: Traditional NFL passer rating when blitzed.
+  blitz_sack_percent: Percentage of dropbacks that ended in a sack when blitzed.
+  blitz_sacks: Number of sacks taken when blitzed.
+  blitz_scrambles: Number of scrambles when blitzed.
+  blitz_spikes: Number of clock-stopping spikes when blitzed.
+  blitz_thrown_aways: Number of intentional throwaways when blitzed.
+  blitz_touchdowns: Number of passing touchdowns thrown when blitzed.
+  blitz_turnover_worthy_plays: Number of turnover-worthy plays when blitzed, plays PFF charts as deserving of a turnover.
+  blitz_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts when blitzed, per PFF charting.
+  blitz_yards: Passing yards gained when blitzed.
+  blitz_ypa: Yards gained per pass attempt when blitzed.
+  btt_rate: Big-time throws as a percentage of qualifying attempts, per PFF charting.
+  center_behind_los_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage
+    to the center of the field.
+  center_behind_los_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line
+    of scrimmage to the center of the field, as charted by PFF.
+  center_behind_los_attempts: Number of pass attempts on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_attempts_percent: Share of the player's total pass attempts that came on throws behind the line of scrimmage
+    to the center of the field, expressed as a percentage.
+  center_behind_los_avg_depth_of_target: Average depth of target in air yards on throws behind the line of scrimmage to the
+    center of the field.
+  center_behind_los_avg_time_to_throw: Average time from snap to release in seconds on throws behind the line of scrimmage
+    to the center of the field.
+  center_behind_los_bats: Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage
+    to the center of the field.
+  center_behind_los_big_time_throws: Number of big-time throws on throws behind the line of scrimmage to the center of the
+    field, per PFF's highest-value, highest-difficulty throw designation.
+  center_behind_los_btt_rate: Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage
+    to the center of the field, per PFF charting.
+  center_behind_los_completion_percent: Percentage of pass attempts completed on throws behind the line of scrimmage to the
+    center of the field.
+  center_behind_los_completions: Number of completed passes on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on throws behind the
+    line of scrimmage to the center of the field, as charted by PFF.
+  center_behind_los_drop_rate: Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage
+    to the center of the field.
+  center_behind_los_dropbacks: Number of dropbacks on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_drops: Number of catchable passes dropped by receivers on throws behind the line of scrimmage to the center
+    of the field.
+  center_behind_los_epa: Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage
+    to the center of the field.
+  center_behind_los_first_downs: Number of passing first downs gained on throws behind the line of scrimmage to the center
+    of the field.
+  center_behind_los_grades_pass: PFF passing grade (0-100) on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_hit_as_threw: Number of attempts on which the passer was hit as he threw on throws behind the line of
+    scrimmage to the center of the field, as charted by PFF.
+  center_behind_los_interceptions: Number of passes intercepted on throws behind the line of scrimmage to the center of the
+    field.
+  center_behind_los_passing_snaps: Number of passing snaps played on throws behind the line of scrimmage to the center of
+    the field.
+  center_behind_los_positive_epa_percent: Percentage of dropbacks with positive expected points added on throws behind the
+    line of scrimmage to the center of the field.
+  center_behind_los_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on throws behind the line
+    of scrimmage to the center of the field.
+  center_behind_los_qb_rating: Traditional NFL passer rating on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_sack_percent: Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage to the
+    center of the field.
+  center_behind_los_sacks: Number of sacks taken on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_scrambles: Number of scrambles on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_spikes: Number of clock-stopping spikes on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_thrown_aways: Number of intentional throwaways on throws behind the line of scrimmage to the center of
+    the field.
+  center_behind_los_touchdowns: Number of passing touchdowns thrown on throws behind the line of scrimmage to the center of
+    the field.
+  center_behind_los_turnover_worthy_plays: Number of turnover-worthy plays on throws behind the line of scrimmage to the center
+    of the field, plays PFF charts as deserving of a turnover.
+  center_behind_los_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage
+    to the center of the field, per PFF charting.
+  center_behind_los_yards: Passing yards gained on throws behind the line of scrimmage to the center of the field.
+  center_behind_los_ypa: Yards gained per pass attempt on throws behind the line of scrimmage to the center of the field.
+  center_deep_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws to the
+    center of the field.
+  center_deep_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws
+    to the center of the field, as charted by PFF.
+  center_deep_attempts: Number of pass attempts on deep (20+ air yards) throws to the center of the field.
+  center_deep_attempts_percent: Share of the player's total pass attempts that came on deep (20+ air yards) throws to the
+    center of the field, expressed as a percentage.
+  center_deep_avg_depth_of_target: Average depth of target in air yards on deep (20+ air yards) throws to the center of the
+    field.
+  center_deep_avg_time_to_throw: Average time from snap to release in seconds on deep (20+ air yards) throws to the center
+    of the field.
+  center_deep_bats: Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws to the center
+    of the field.
+  center_deep_big_time_throws: Number of big-time throws on deep (20+ air yards) throws to the center of the field, per PFF's
+    highest-value, highest-difficulty throw designation.
+  center_deep_btt_rate: Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws to the center
+    of the field, per PFF charting.
+  center_deep_completion_percent: Percentage of pass attempts completed on deep (20+ air yards) throws to the center of the
+    field.
+  center_deep_completions: Number of completed passes on deep (20+ air yards) throws to the center of the field.
+  center_deep_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws
+    to the center of the field, as charted by PFF.
+  center_deep_drop_rate: Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws to the center
+    of the field.
+  center_deep_dropbacks: Number of dropbacks on deep (20+ air yards) throws to the center of the field.
+  center_deep_drops: Number of catchable passes dropped by receivers on deep (20+ air yards) throws to the center of the field.
+  center_deep_epa: Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws to the center
+    of the field.
+  center_deep_first_downs: Number of passing first downs gained on deep (20+ air yards) throws to the center of the field.
+  center_deep_grades_pass: PFF passing grade (0-100) on deep (20+ air yards) throws to the center of the field.
+  center_deep_hit_as_threw: Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws to the
+    center of the field, as charted by PFF.
+  center_deep_interceptions: Number of passes intercepted on deep (20+ air yards) throws to the center of the field.
+  center_deep_passing_snaps: Number of passing snaps played on deep (20+ air yards) throws to the center of the field.
+  center_deep_positive_epa_percent: Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws
+    to the center of the field.
+  center_deep_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws
+    to the center of the field.
+  center_deep_qb_rating: Traditional NFL passer rating on deep (20+ air yards) throws to the center of the field.
+  center_deep_sack_percent: Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws to the center of the
+    field.
+  center_deep_sacks: Number of sacks taken on deep (20+ air yards) throws to the center of the field.
+  center_deep_scrambles: Number of scrambles on deep (20+ air yards) throws to the center of the field.
+  center_deep_spikes: Number of clock-stopping spikes on deep (20+ air yards) throws to the center of the field.
+  center_deep_thrown_aways: Number of intentional throwaways on deep (20+ air yards) throws to the center of the field.
+  center_deep_touchdowns: Number of passing touchdowns thrown on deep (20+ air yards) throws to the center of the field.
+  center_deep_turnover_worthy_plays: Number of turnover-worthy plays on deep (20+ air yards) throws to the center of the field,
+    plays PFF charts as deserving of a turnover.
+  center_deep_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws to the
+    center of the field, per PFF charting.
+  center_deep_yards: Passing yards gained on deep (20+ air yards) throws to the center of the field.
+  center_deep_ypa: Yards gained per pass attempt on deep (20+ air yards) throws to the center of the field.
+  center_medium_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws
+    to the center of the field.
+  center_medium_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards)
+    throws to the center of the field, as charted by PFF.
+  center_medium_attempts: Number of pass attempts on medium (10-19 air yards) throws to the center of the field.
+  center_medium_attempts_percent: Share of the player's total pass attempts that came on medium (10-19 air yards) throws to
+    the center of the field, expressed as a percentage.
+  center_medium_avg_depth_of_target: Average depth of target in air yards on medium (10-19 air yards) throws to the center
+    of the field.
+  center_medium_avg_time_to_throw: Average time from snap to release in seconds on medium (10-19 air yards) throws to the
+    center of the field.
+  center_medium_bats: Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws to the
+    center of the field.
+  center_medium_big_time_throws: Number of big-time throws on medium (10-19 air yards) throws to the center of the field,
+    per PFF's highest-value, highest-difficulty throw designation.
+  center_medium_btt_rate: Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws to the
+    center of the field, per PFF charting.
+  center_medium_completion_percent: Percentage of pass attempts completed on medium (10-19 air yards) throws to the center
+    of the field.
+  center_medium_completions: Number of completed passes on medium (10-19 air yards) throws to the center of the field.
+  center_medium_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards)
+    throws to the center of the field, as charted by PFF.
+  center_medium_drop_rate: Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws to the center
+    of the field.
+  center_medium_dropbacks: Number of dropbacks on medium (10-19 air yards) throws to the center of the field.
+  center_medium_drops: Number of catchable passes dropped by receivers on medium (10-19 air yards) throws to the center of
+    the field.
+  center_medium_epa: Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws to the
+    center of the field.
+  center_medium_first_downs: Number of passing first downs gained on medium (10-19 air yards) throws to the center of the
+    field.
+  center_medium_grades_pass: PFF passing grade (0-100) on medium (10-19 air yards) throws to the center of the field.
+  center_medium_hit_as_threw: Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws
+    to the center of the field, as charted by PFF.
+  center_medium_interceptions: Number of passes intercepted on medium (10-19 air yards) throws to the center of the field.
+  center_medium_passing_snaps: Number of passing snaps played on medium (10-19 air yards) throws to the center of the field.
+  center_medium_positive_epa_percent: Percentage of dropbacks with positive expected points added on medium (10-19 air yards)
+    throws to the center of the field.
+  center_medium_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards)
+    throws to the center of the field.
+  center_medium_qb_rating: Traditional NFL passer rating on medium (10-19 air yards) throws to the center of the field.
+  center_medium_sack_percent: Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws to the center
+    of the field.
+  center_medium_sacks: Number of sacks taken on medium (10-19 air yards) throws to the center of the field.
+  center_medium_scrambles: Number of scrambles on medium (10-19 air yards) throws to the center of the field.
+  center_medium_spikes: Number of clock-stopping spikes on medium (10-19 air yards) throws to the center of the field.
+  center_medium_thrown_aways: Number of intentional throwaways on medium (10-19 air yards) throws to the center of the field.
+  center_medium_touchdowns: Number of passing touchdowns thrown on medium (10-19 air yards) throws to the center of the field.
+  center_medium_turnover_worthy_plays: Number of turnover-worthy plays on medium (10-19 air yards) throws to the center of
+    the field, plays PFF charts as deserving of a turnover.
+  center_medium_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws
+    to the center of the field, per PFF charting.
+  center_medium_yards: Passing yards gained on medium (10-19 air yards) throws to the center of the field.
+  center_medium_ypa: Yards gained per pass attempt on medium (10-19 air yards) throws to the center of the field.
+  center_short_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws to
+    the center of the field.
+  center_short_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws
+    to the center of the field, as charted by PFF.
+  center_short_attempts: Number of pass attempts on short (0-9 air yards) throws to the center of the field.
+  center_short_attempts_percent: Share of the player's total pass attempts that came on short (0-9 air yards) throws to the
+    center of the field, expressed as a percentage.
+  center_short_avg_depth_of_target: Average depth of target in air yards on short (0-9 air yards) throws to the center of
+    the field.
+  center_short_avg_time_to_throw: Average time from snap to release in seconds on short (0-9 air yards) throws to the center
+    of the field.
+  center_short_bats: Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws to the center
+    of the field.
+  center_short_big_time_throws: Number of big-time throws on short (0-9 air yards) throws to the center of the field, per
+    PFF's highest-value, highest-difficulty throw designation.
+  center_short_btt_rate: Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws to the center
+    of the field, per PFF charting.
+  center_short_completion_percent: Percentage of pass attempts completed on short (0-9 air yards) throws to the center of
+    the field.
+  center_short_completions: Number of completed passes on short (0-9 air yards) throws to the center of the field.
+  center_short_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards)
+    throws to the center of the field, as charted by PFF.
+  center_short_drop_rate: Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws to the center
+    of the field.
+  center_short_dropbacks: Number of dropbacks on short (0-9 air yards) throws to the center of the field.
+  center_short_drops: Number of catchable passes dropped by receivers on short (0-9 air yards) throws to the center of the
+    field.
+  center_short_epa: Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws to the center
+    of the field.
+  center_short_first_downs: Number of passing first downs gained on short (0-9 air yards) throws to the center of the field.
+  center_short_grades_pass: PFF passing grade (0-100) on short (0-9 air yards) throws to the center of the field.
+  center_short_hit_as_threw: Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws to
+    the center of the field, as charted by PFF.
+  center_short_interceptions: Number of passes intercepted on short (0-9 air yards) throws to the center of the field.
+  center_short_passing_snaps: Number of passing snaps played on short (0-9 air yards) throws to the center of the field.
+  center_short_positive_epa_percent: Percentage of dropbacks with positive expected points added on short (0-9 air yards)
+    throws to the center of the field.
+  center_short_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws
+    to the center of the field.
+  center_short_qb_rating: Traditional NFL passer rating on short (0-9 air yards) throws to the center of the field.
+  center_short_sack_percent: Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws to the center of
+    the field.
+  center_short_sacks: Number of sacks taken on short (0-9 air yards) throws to the center of the field.
+  center_short_scrambles: Number of scrambles on short (0-9 air yards) throws to the center of the field.
+  center_short_spikes: Number of clock-stopping spikes on short (0-9 air yards) throws to the center of the field.
+  center_short_thrown_aways: Number of intentional throwaways on short (0-9 air yards) throws to the center of the field.
+  center_short_touchdowns: Number of passing touchdowns thrown on short (0-9 air yards) throws to the center of the field.
+  center_short_turnover_worthy_plays: Number of turnover-worthy plays on short (0-9 air yards) throws to the center of the
+    field, plays PFF charts as deserving of a turnover.
+  center_short_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws to the
+    center of the field, per PFF charting.
+  center_short_yards: Passing yards gained on short (0-9 air yards) throws to the center of the field.
+  center_short_ypa: Yards gained per pass attempt on short (0-9 air yards) throws to the center of the field.
+  comp_pct_diff: Difference in completion percentage between play-action and non-play-action attempts (PA minus non-PA), from
+    the PFF passing-concept split.
+  completion_percent: Percentage of pass attempts completed.
+  deep_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws.
+  deep_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws, as
+    charted by PFF.
+  deep_attempts: Number of pass attempts on deep (20+ air yards) throws.
+  deep_attempts_percent: Share of the player's total pass attempts that came on deep (20+ air yards) throws, expressed as
+    a percentage.
+  deep_avg_depth_of_target: Average depth of target in air yards on deep (20+ air yards) throws.
+  deep_avg_time_to_throw: Average time from snap to release in seconds on deep (20+ air yards) throws.
+  deep_bats: Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws.
+  deep_big_time_throws: Number of big-time throws on deep (20+ air yards) throws, per PFF's highest-value, highest-difficulty
+    throw designation.
+  deep_btt_rate: Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws, per PFF charting.
+  deep_completion_percent: Percentage of pass attempts completed on deep (20+ air yards) throws.
+  deep_completions: Number of completed passes on deep (20+ air yards) throws.
+  deep_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws,
+    as charted by PFF.
+  deep_drop_rate: Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws.
+  deep_dropbacks: Number of dropbacks on deep (20+ air yards) throws.
+  deep_drops: Number of catchable passes dropped by receivers on deep (20+ air yards) throws.
+  deep_epa: Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws.
+  deep_first_downs: Number of passing first downs gained on deep (20+ air yards) throws.
+  deep_grades_pass: PFF passing grade (0-100) on deep (20+ air yards) throws.
+  deep_hit_as_threw: Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws, as charted
+    by PFF.
+  deep_interceptions: Number of passes intercepted on deep (20+ air yards) throws.
+  deep_passing_snaps: Number of passing snaps played on deep (20+ air yards) throws.
+  deep_positive_epa_percent: Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws.
+  deep_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws.
+  deep_qb_rating: Traditional NFL passer rating on deep (20+ air yards) throws.
+  deep_sack_percent: Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws.
+  deep_sacks: Number of sacks taken on deep (20+ air yards) throws.
+  deep_scrambles: Number of scrambles on deep (20+ air yards) throws.
+  deep_spikes: Number of clock-stopping spikes on deep (20+ air yards) throws.
+  deep_thrown_aways: Number of intentional throwaways on deep (20+ air yards) throws.
+  deep_touchdowns: Number of passing touchdowns thrown on deep (20+ air yards) throws.
+  deep_turnover_worthy_plays: Number of turnover-worthy plays on deep (20+ air yards) throws, plays PFF charts as deserving
+    of a turnover.
+  deep_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws, per PFF charting.
+  deep_yards: Passing yards gained on deep (20+ air yards) throws.
+  deep_ypa: Yards gained per pass attempt on deep (20+ air yards) throws.
+  def_gen_pressures: Number of defense-generated pressures on the player's dropbacks, as charted by PFF.
+  draft_season: NFL season (year) in which the player was drafted, per PFF player metadata.
+  drop_rate: Percentage of catchable passes dropped by receivers.
+  dropbacks: Number of dropbacks.
+  eligible_season: Season (year) of the player's NFL draft eligibility, per PFF player metadata.
+  grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100).
+  grades_offense: PFF overall offense grade for the player (0-100).
+  grades_pass: PFF passing grade (0-100).
+  grades_run: PFF rushing grade for the player (0-100).
+  hit_as_threw: Number of attempts on which the passer was hit as he threw, as charted by PFF.
+  left_behind_los_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage
+    to the left side of the field.
+  left_behind_los_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line
+    of scrimmage to the left side of the field, as charted by PFF.
+  left_behind_los_attempts: Number of pass attempts on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_attempts_percent: Share of the player's total pass attempts that came on throws behind the line of scrimmage
+    to the left side of the field, expressed as a percentage.
+  left_behind_los_avg_depth_of_target: Average depth of target in air yards on throws behind the line of scrimmage to the
+    left side of the field.
+  left_behind_los_avg_time_to_throw: Average time from snap to release in seconds on throws behind the line of scrimmage to
+    the left side of the field.
+  left_behind_los_bats: Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage
+    to the left side of the field.
+  left_behind_los_big_time_throws: Number of big-time throws on throws behind the line of scrimmage to the left side of the
+    field, per PFF's highest-value, highest-difficulty throw designation.
+  left_behind_los_btt_rate: Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage
+    to the left side of the field, per PFF charting.
+  left_behind_los_completion_percent: Percentage of pass attempts completed on throws behind the line of scrimmage to the
+    left side of the field.
+  left_behind_los_completions: Number of completed passes on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on throws behind the
+    line of scrimmage to the left side of the field, as charted by PFF.
+  left_behind_los_drop_rate: Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage to
+    the left side of the field.
+  left_behind_los_dropbacks: Number of dropbacks on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_drops: Number of catchable passes dropped by receivers on throws behind the line of scrimmage to the left
+    side of the field.
+  left_behind_los_epa: Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage
+    to the left side of the field.
+  left_behind_los_first_downs: Number of passing first downs gained on throws behind the line of scrimmage to the left side
+    of the field.
+  left_behind_los_grades_pass: PFF passing grade (0-100) on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_hit_as_threw: Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage
+    to the left side of the field, as charted by PFF.
+  left_behind_los_interceptions: Number of passes intercepted on throws behind the line of scrimmage to the left side of the
+    field.
+  left_behind_los_passing_snaps: Number of passing snaps played on throws behind the line of scrimmage to the left side of
+    the field.
+  left_behind_los_positive_epa_percent: Percentage of dropbacks with positive expected points added on throws behind the line
+    of scrimmage to the left side of the field.
+  left_behind_los_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on throws behind the line
+    of scrimmage to the left side of the field.
+  left_behind_los_qb_rating: Traditional NFL passer rating on throws behind the line of scrimmage to the left side of the
+    field.
+  left_behind_los_sack_percent: Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage to the
+    left side of the field.
+  left_behind_los_sacks: Number of sacks taken on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_scrambles: Number of scrambles on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_spikes: Number of clock-stopping spikes on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_thrown_aways: Number of intentional throwaways on throws behind the line of scrimmage to the left side of
+    the field.
+  left_behind_los_touchdowns: Number of passing touchdowns thrown on throws behind the line of scrimmage to the left side
+    of the field.
+  left_behind_los_turnover_worthy_plays: Number of turnover-worthy plays on throws behind the line of scrimmage to the left
+    side of the field, plays PFF charts as deserving of a turnover.
+  left_behind_los_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage
+    to the left side of the field, per PFF charting.
+  left_behind_los_yards: Passing yards gained on throws behind the line of scrimmage to the left side of the field.
+  left_behind_los_ypa: Yards gained per pass attempt on throws behind the line of scrimmage to the left side of the field.
+  left_deep_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws to the
+    left side of the field.
+  left_deep_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws
+    to the left side of the field, as charted by PFF.
+  left_deep_attempts: Number of pass attempts on deep (20+ air yards) throws to the left side of the field.
+  left_deep_attempts_percent: Share of the player's total pass attempts that came on deep (20+ air yards) throws to the left
+    side of the field, expressed as a percentage.
+  left_deep_avg_depth_of_target: Average depth of target in air yards on deep (20+ air yards) throws to the left side of the
+    field.
+  left_deep_avg_time_to_throw: Average time from snap to release in seconds on deep (20+ air yards) throws to the left side
+    of the field.
+  left_deep_bats: Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws to the left
+    side of the field.
+  left_deep_big_time_throws: Number of big-time throws on deep (20+ air yards) throws to the left side of the field, per PFF's
+    highest-value, highest-difficulty throw designation.
+  left_deep_btt_rate: Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws to the left side
+    of the field, per PFF charting.
+  left_deep_completion_percent: Percentage of pass attempts completed on deep (20+ air yards) throws to the left side of the
+    field.
+  left_deep_completions: Number of completed passes on deep (20+ air yards) throws to the left side of the field.
+  left_deep_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws
+    to the left side of the field, as charted by PFF.
+  left_deep_drop_rate: Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws to the left side
+    of the field.
+  left_deep_dropbacks: Number of dropbacks on deep (20+ air yards) throws to the left side of the field.
+  left_deep_drops: Number of catchable passes dropped by receivers on deep (20+ air yards) throws to the left side of the
+    field.
+  left_deep_epa: Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws to the left side
+    of the field.
+  left_deep_first_downs: Number of passing first downs gained on deep (20+ air yards) throws to the left side of the field.
+  left_deep_grades_pass: PFF passing grade (0-100) on deep (20+ air yards) throws to the left side of the field.
+  left_deep_hit_as_threw: Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws to the
+    left side of the field, as charted by PFF.
+  left_deep_interceptions: Number of passes intercepted on deep (20+ air yards) throws to the left side of the field.
+  left_deep_passing_snaps: Number of passing snaps played on deep (20+ air yards) throws to the left side of the field.
+  left_deep_positive_epa_percent: Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws
+    to the left side of the field.
+  left_deep_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws to
+    the left side of the field.
+  left_deep_qb_rating: Traditional NFL passer rating on deep (20+ air yards) throws to the left side of the field.
+  left_deep_sack_percent: Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws to the left side of
+    the field.
+  left_deep_sacks: Number of sacks taken on deep (20+ air yards) throws to the left side of the field.
+  left_deep_scrambles: Number of scrambles on deep (20+ air yards) throws to the left side of the field.
+  left_deep_spikes: Number of clock-stopping spikes on deep (20+ air yards) throws to the left side of the field.
+  left_deep_thrown_aways: Number of intentional throwaways on deep (20+ air yards) throws to the left side of the field.
+  left_deep_touchdowns: Number of passing touchdowns thrown on deep (20+ air yards) throws to the left side of the field.
+  left_deep_turnover_worthy_plays: Number of turnover-worthy plays on deep (20+ air yards) throws to the left side of the
+    field, plays PFF charts as deserving of a turnover.
+  left_deep_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws to the left
+    side of the field, per PFF charting.
+  left_deep_yards: Passing yards gained on deep (20+ air yards) throws to the left side of the field.
+  left_deep_ypa: Yards gained per pass attempt on deep (20+ air yards) throws to the left side of the field.
+  left_medium_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws to
+    the left side of the field.
+  left_medium_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards)
+    throws to the left side of the field, as charted by PFF.
+  left_medium_attempts: Number of pass attempts on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_attempts_percent: Share of the player's total pass attempts that came on medium (10-19 air yards) throws to
+    the left side of the field, expressed as a percentage.
+  left_medium_avg_depth_of_target: Average depth of target in air yards on medium (10-19 air yards) throws to the left side
+    of the field.
+  left_medium_avg_time_to_throw: Average time from snap to release in seconds on medium (10-19 air yards) throws to the left
+    side of the field.
+  left_medium_bats: Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws to the
+    left side of the field.
+  left_medium_big_time_throws: Number of big-time throws on medium (10-19 air yards) throws to the left side of the field,
+    per PFF's highest-value, highest-difficulty throw designation.
+  left_medium_btt_rate: Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws to the left
+    side of the field, per PFF charting.
+  left_medium_completion_percent: Percentage of pass attempts completed on medium (10-19 air yards) throws to the left side
+    of the field.
+  left_medium_completions: Number of completed passes on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards)
+    throws to the left side of the field, as charted by PFF.
+  left_medium_drop_rate: Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws to the left
+    side of the field.
+  left_medium_dropbacks: Number of dropbacks on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_drops: Number of catchable passes dropped by receivers on medium (10-19 air yards) throws to the left side of
+    the field.
+  left_medium_epa: Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws to the left
+    side of the field.
+  left_medium_first_downs: Number of passing first downs gained on medium (10-19 air yards) throws to the left side of the
+    field.
+  left_medium_grades_pass: PFF passing grade (0-100) on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_hit_as_threw: Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws
+    to the left side of the field, as charted by PFF.
+  left_medium_interceptions: Number of passes intercepted on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_passing_snaps: Number of passing snaps played on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_positive_epa_percent: Percentage of dropbacks with positive expected points added on medium (10-19 air yards)
+    throws to the left side of the field.
+  left_medium_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws
+    to the left side of the field.
+  left_medium_qb_rating: Traditional NFL passer rating on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_sack_percent: Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws to the left side
+    of the field.
+  left_medium_sacks: Number of sacks taken on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_scrambles: Number of scrambles on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_spikes: Number of clock-stopping spikes on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_thrown_aways: Number of intentional throwaways on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_touchdowns: Number of passing touchdowns thrown on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_turnover_worthy_plays: Number of turnover-worthy plays on medium (10-19 air yards) throws to the left side of
+    the field, plays PFF charts as deserving of a turnover.
+  left_medium_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws to
+    the left side of the field, per PFF charting.
+  left_medium_yards: Passing yards gained on medium (10-19 air yards) throws to the left side of the field.
+  left_medium_ypa: Yards gained per pass attempt on medium (10-19 air yards) throws to the left side of the field.
+  left_short_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws to the
+    left side of the field.
+  left_short_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws
+    to the left side of the field, as charted by PFF.
+  left_short_attempts: Number of pass attempts on short (0-9 air yards) throws to the left side of the field.
+  left_short_attempts_percent: Share of the player's total pass attempts that came on short (0-9 air yards) throws to the
+    left side of the field, expressed as a percentage.
+  left_short_avg_depth_of_target: Average depth of target in air yards on short (0-9 air yards) throws to the left side of
+    the field.
+  left_short_avg_time_to_throw: Average time from snap to release in seconds on short (0-9 air yards) throws to the left side
+    of the field.
+  left_short_bats: Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws to the left
+    side of the field.
+  left_short_big_time_throws: Number of big-time throws on short (0-9 air yards) throws to the left side of the field, per
+    PFF's highest-value, highest-difficulty throw designation.
+  left_short_btt_rate: Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws to the left
+    side of the field, per PFF charting.
+  left_short_completion_percent: Percentage of pass attempts completed on short (0-9 air yards) throws to the left side of
+    the field.
+  left_short_completions: Number of completed passes on short (0-9 air yards) throws to the left side of the field.
+  left_short_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards) throws
+    to the left side of the field, as charted by PFF.
+  left_short_drop_rate: Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws to the left side
+    of the field.
+  left_short_dropbacks: Number of dropbacks on short (0-9 air yards) throws to the left side of the field.
+  left_short_drops: Number of catchable passes dropped by receivers on short (0-9 air yards) throws to the left side of the
+    field.
+  left_short_epa: Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws to the left
+    side of the field.
+  left_short_first_downs: Number of passing first downs gained on short (0-9 air yards) throws to the left side of the field.
+  left_short_grades_pass: PFF passing grade (0-100) on short (0-9 air yards) throws to the left side of the field.
+  left_short_hit_as_threw: Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws to the
+    left side of the field, as charted by PFF.
+  left_short_interceptions: Number of passes intercepted on short (0-9 air yards) throws to the left side of the field.
+  left_short_passing_snaps: Number of passing snaps played on short (0-9 air yards) throws to the left side of the field.
+  left_short_positive_epa_percent: Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws
+    to the left side of the field.
+  left_short_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws
+    to the left side of the field.
+  left_short_qb_rating: Traditional NFL passer rating on short (0-9 air yards) throws to the left side of the field.
+  left_short_sack_percent: Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws to the left side of
+    the field.
+  left_short_sacks: Number of sacks taken on short (0-9 air yards) throws to the left side of the field.
+  left_short_scrambles: Number of scrambles on short (0-9 air yards) throws to the left side of the field.
+  left_short_spikes: Number of clock-stopping spikes on short (0-9 air yards) throws to the left side of the field.
+  left_short_thrown_aways: Number of intentional throwaways on short (0-9 air yards) throws to the left side of the field.
+  left_short_touchdowns: Number of passing touchdowns thrown on short (0-9 air yards) throws to the left side of the field.
+  left_short_turnover_worthy_plays: Number of turnover-worthy plays on short (0-9 air yards) throws to the left side of the
+    field, plays PFF charts as deserving of a turnover.
+  left_short_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws to the
+    left side of the field, per PFF charting.
+  left_short_yards: Passing yards gained on short (0-9 air yards) throws to the left side of the field.
+  left_short_ypa: Yards gained per pass attempt on short (0-9 air yards) throws to the left side of the field.
+  medium_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws.
+  medium_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards) throws,
+    as charted by PFF.
+  medium_attempts: Number of pass attempts on medium (10-19 air yards) throws.
+  medium_attempts_percent: Share of the player's total pass attempts that came on medium (10-19 air yards) throws, expressed
+    as a percentage.
+  medium_avg_depth_of_target: Average depth of target in air yards on medium (10-19 air yards) throws.
+  medium_avg_time_to_throw: Average time from snap to release in seconds on medium (10-19 air yards) throws.
+  medium_bats: Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws.
+  medium_big_time_throws: Number of big-time throws on medium (10-19 air yards) throws, per PFF's highest-value, highest-difficulty
+    throw designation.
+  medium_btt_rate: Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws, per PFF charting.
+  medium_completion_percent: Percentage of pass attempts completed on medium (10-19 air yards) throws.
+  medium_completions: Number of completed passes on medium (10-19 air yards) throws.
+  medium_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards) throws,
+    as charted by PFF.
+  medium_drop_rate: Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws.
+  medium_dropbacks: Number of dropbacks on medium (10-19 air yards) throws.
+  medium_drops: Number of catchable passes dropped by receivers on medium (10-19 air yards) throws.
+  medium_epa: Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws.
+  medium_first_downs: Number of passing first downs gained on medium (10-19 air yards) throws.
+  medium_grades_pass: PFF passing grade (0-100) on medium (10-19 air yards) throws.
+  medium_hit_as_threw: Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws, as charted
+    by PFF.
+  medium_interceptions: Number of passes intercepted on medium (10-19 air yards) throws.
+  medium_passing_snaps: Number of passing snaps played on medium (10-19 air yards) throws.
+  medium_positive_epa_percent: Percentage of dropbacks with positive expected points added on medium (10-19 air yards) throws.
+  medium_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws.
+  medium_qb_rating: Traditional NFL passer rating on medium (10-19 air yards) throws.
+  medium_sack_percent: Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws.
+  medium_sacks: Number of sacks taken on medium (10-19 air yards) throws.
+  medium_scrambles: Number of scrambles on medium (10-19 air yards) throws.
+  medium_spikes: Number of clock-stopping spikes on medium (10-19 air yards) throws.
+  medium_thrown_aways: Number of intentional throwaways on medium (10-19 air yards) throws.
+  medium_touchdowns: Number of passing touchdowns thrown on medium (10-19 air yards) throws.
+  medium_turnover_worthy_plays: Number of turnover-worthy plays on medium (10-19 air yards) throws, plays PFF charts as deserving
+    of a turnover.
+  medium_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws, per PFF
+    charting.
+  medium_yards: Passing yards gained on medium (10-19 air yards) throws.
+  medium_ypa: Yards gained per pass attempt on medium (10-19 air yards) throws.
+  no_blitz_accuracy_percent: Percentage of aimed passes charted as accurate by PFF when not blitzed.
+  no_blitz_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) when not blitzed, as charted by
+    PFF.
+  no_blitz_attempts: Number of pass attempts when not blitzed.
+  no_blitz_avg_depth_of_target: Average depth of target in air yards when not blitzed.
+  no_blitz_avg_time_to_throw: Average time from snap to release in seconds when not blitzed.
+  no_blitz_bats: Number of pass attempts batted down at the line of scrimmage when not blitzed.
+  no_blitz_big_time_throws: Number of big-time throws when not blitzed, per PFF's highest-value, highest-difficulty throw
+    designation.
+  no_blitz_btt_rate: Big-time throws as a percentage of qualifying attempts when not blitzed, per PFF charting.
+  no_blitz_completion_percent: Percentage of pass attempts completed when not blitzed.
+  no_blitz_completions: Number of completed passes when not blitzed.
+  no_blitz_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks when not blitzed, as charted
+    by PFF.
+  no_blitz_drop_rate: Percentage of catchable passes dropped by receivers when not blitzed.
+  no_blitz_dropbacks: Number of dropbacks when not blitzed.
+  no_blitz_dropbacks_percent: Share of the player's total dropbacks that came when not blitzed, expressed as a percentage.
+  no_blitz_drops: Number of catchable passes dropped by receivers when not blitzed.
+  no_blitz_epa: Total expected points added (EPA) on the player's dropbacks when not blitzed.
+  no_blitz_first_downs: Number of passing first downs gained when not blitzed.
+  no_blitz_grades_hands_drop: PFF hands (drop) grade for the player (0-100) when not blitzed.
+  no_blitz_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) when not blitzed.
+  no_blitz_grades_offense: PFF overall offense grade for the player (0-100) when not blitzed.
+  no_blitz_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) when not blitzed.
+  no_blitz_grades_pass: PFF passing grade (0-100) when not blitzed.
+  no_blitz_grades_pass_block: PFF pass-blocking grade for the player (0-100) when not blitzed.
+  no_blitz_grades_pass_route: PFF receiving (route) grade for the player (0-100) when not blitzed.
+  no_blitz_grades_run: PFF rushing grade for the player (0-100) when not blitzed.
+  no_blitz_grades_run_block: PFF run-blocking grade for the player (0-100) when not blitzed.
+  no_blitz_grades_screen_block: PFF screen-blocking grade for the player (0-100) when not blitzed.
+  no_blitz_hit_as_threw: Number of attempts on which the passer was hit as he threw when not blitzed, as charted by PFF.
+  no_blitz_interceptions: Number of passes intercepted when not blitzed.
+  no_blitz_passing_snaps: Number of passing snaps played when not blitzed.
+  no_blitz_positive_epa_percent: Percentage of dropbacks with positive expected points added when not blitzed.
+  no_blitz_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack when not blitzed.
+  no_blitz_qb_rating: Traditional NFL passer rating when not blitzed.
+  no_blitz_sack_percent: Percentage of dropbacks that ended in a sack when not blitzed.
+  no_blitz_sacks: Number of sacks taken when not blitzed.
+  no_blitz_scrambles: Number of scrambles when not blitzed.
+  no_blitz_spikes: Number of clock-stopping spikes when not blitzed.
+  no_blitz_thrown_aways: Number of intentional throwaways when not blitzed.
+  no_blitz_touchdowns: Number of passing touchdowns thrown when not blitzed.
+  no_blitz_turnover_worthy_plays: Number of turnover-worthy plays when not blitzed, plays PFF charts as deserving of a turnover.
+  no_blitz_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts when not blitzed, per PFF charting.
+  no_blitz_yards: Passing yards gained when not blitzed.
+  no_blitz_ypa: Yards gained per pass attempt when not blitzed.
+  no_pressure_accuracy_percent: Percentage of aimed passes charted as accurate by PFF from a clean pocket (no pressure).
+  no_pressure_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) from a clean pocket (no pressure),
+    as charted by PFF.
+  no_pressure_attempts: Number of pass attempts from a clean pocket (no pressure).
+  no_pressure_avg_depth_of_target: Average depth of target in air yards from a clean pocket (no pressure).
+  no_pressure_avg_time_to_throw: Average time from snap to release in seconds from a clean pocket (no pressure).
+  no_pressure_bats: Number of pass attempts batted down at the line of scrimmage from a clean pocket (no pressure).
+  no_pressure_big_time_throws: Number of big-time throws from a clean pocket (no pressure), per PFF's highest-value, highest-difficulty
+    throw designation.
+  no_pressure_btt_rate: Big-time throws as a percentage of qualifying attempts from a clean pocket (no pressure), per PFF
+    charting.
+  no_pressure_completion_percent: Percentage of pass attempts completed from a clean pocket (no pressure).
+  no_pressure_completions: Number of completed passes from a clean pocket (no pressure).
+  no_pressure_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks from a clean pocket (no pressure),
+    as charted by PFF.
+  no_pressure_drop_rate: Percentage of catchable passes dropped by receivers from a clean pocket (no pressure).
+  no_pressure_dropbacks: Number of dropbacks from a clean pocket (no pressure).
+  no_pressure_dropbacks_percent: Share of the player's total dropbacks that came from a clean pocket (no pressure), expressed
+    as a percentage.
+  no_pressure_drops: Number of catchable passes dropped by receivers from a clean pocket (no pressure).
+  no_pressure_epa: Total expected points added (EPA) on the player's dropbacks from a clean pocket (no pressure).
+  no_pressure_first_downs: Number of passing first downs gained from a clean pocket (no pressure).
+  no_pressure_grades_hands_drop: PFF hands (drop) grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) from a clean
+    pocket (no pressure).
+  no_pressure_grades_offense: PFF overall offense grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_pass: PFF passing grade (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_pass_block: PFF pass-blocking grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_pass_route: PFF receiving (route) grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_run: PFF rushing grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_run_block: PFF run-blocking grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_screen_block: PFF screen-blocking grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_hit_as_threw: Number of attempts on which the passer was hit as he threw from a clean pocket (no pressure),
+    as charted by PFF.
+  no_pressure_interceptions: Number of passes intercepted from a clean pocket (no pressure).
+  no_pressure_passing_snaps: Number of passing snaps played from a clean pocket (no pressure).
+  no_pressure_positive_epa_percent: Percentage of dropbacks with positive expected points added from a clean pocket (no pressure).
+  no_pressure_pressure_to_sack_rate: Pressure-to-sack rate as reported within the no-pressure split of the PFF passing-pressure
+    facet.
+  no_pressure_qb_rating: Traditional NFL passer rating from a clean pocket (no pressure).
+  no_pressure_sack_percent: Percentage of dropbacks that ended in a sack from a clean pocket (no pressure).
+  no_pressure_sacks: Number of sacks taken from a clean pocket (no pressure).
+  no_pressure_scrambles: Number of scrambles from a clean pocket (no pressure).
+  no_pressure_spikes: Number of clock-stopping spikes from a clean pocket (no pressure).
+  no_pressure_thrown_aways: Number of intentional throwaways from a clean pocket (no pressure).
+  no_pressure_touchdowns: Number of passing touchdowns thrown from a clean pocket (no pressure).
+  no_pressure_turnover_worthy_plays: Number of turnover-worthy plays from a clean pocket (no pressure), plays PFF charts as
+    deserving of a turnover.
+  no_pressure_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts from a clean pocket (no pressure), per
+    PFF charting.
+  no_pressure_yards: Passing yards gained from a clean pocket (no pressure).
+  no_pressure_ypa: Yards gained per pass attempt from a clean pocket (no pressure).
+  no_screen_accuracy_percent: Percentage of aimed passes charted as accurate by PFF excluding screen passes.
+  no_screen_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) excluding screen passes, as charted
+    by PFF.
+  no_screen_attempts: Number of pass attempts excluding screen passes.
+  no_screen_avg_depth_of_target: Average depth of target in air yards excluding screen passes.
+  no_screen_avg_time_to_throw: Average time from snap to release in seconds excluding screen passes.
+  no_screen_bats: Number of pass attempts batted down at the line of scrimmage excluding screen passes.
+  no_screen_big_time_throws: Number of big-time throws excluding screen passes, per PFF's highest-value, highest-difficulty
+    throw designation.
+  no_screen_btt_rate: Big-time throws as a percentage of qualifying attempts excluding screen passes, per PFF charting.
+  no_screen_completion_percent: Percentage of pass attempts completed excluding screen passes.
+  no_screen_completions: Number of completed passes excluding screen passes.
+  no_screen_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks excluding screen passes, as
+    charted by PFF.
+  no_screen_drop_rate: Percentage of catchable passes dropped by receivers excluding screen passes.
+  no_screen_dropbacks: Number of dropbacks excluding screen passes.
+  no_screen_dropbacks_percent: Share of the player's total dropbacks that came excluding screen passes, expressed as a percentage.
+  no_screen_drops: Number of catchable passes dropped by receivers excluding screen passes.
+  no_screen_epa: Total expected points added (EPA) on the player's dropbacks excluding screen passes.
+  no_screen_first_downs: Number of passing first downs gained excluding screen passes.
+  no_screen_grades_defense: PFF overall defense grade for the player (0-100) excluding screen passes.
+  no_screen_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) excluding screen passes.
+  no_screen_grades_hands_drop: PFF hands (drop) grade for the player (0-100) excluding screen passes.
+  no_screen_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) excluding screen
+    passes.
+  no_screen_grades_offense: PFF overall offense grade for the player (0-100) excluding screen passes.
+  no_screen_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) excluding screen passes.
+  no_screen_grades_pass: PFF passing grade (0-100) excluding screen passes.
+  no_screen_grades_pass_block: PFF pass-blocking grade for the player (0-100) excluding screen passes.
+  no_screen_grades_pass_route: PFF receiving (route) grade for the player (0-100) excluding screen passes.
+  no_screen_grades_run: PFF rushing grade for the player (0-100) excluding screen passes.
+  no_screen_grades_run_block: PFF run-blocking grade for the player (0-100) excluding screen passes.
+  no_screen_grades_run_defense: PFF run-defense grade for the player (0-100) excluding screen passes.
+  no_screen_grades_screen_block: PFF screen-blocking grade for the player (0-100) excluding screen passes.
+  no_screen_hit_as_threw: Number of attempts on which the passer was hit as he threw excluding screen passes, as charted by
+    PFF.
+  no_screen_interceptions: Number of passes intercepted excluding screen passes.
+  no_screen_passing_snaps: Number of passing snaps played excluding screen passes.
+  no_screen_positive_epa_percent: Percentage of dropbacks with positive expected points added excluding screen passes.
+  no_screen_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack excluding screen passes.
+  no_screen_qb_rating: Traditional NFL passer rating excluding screen passes.
+  no_screen_sack_percent: Percentage of dropbacks that ended in a sack excluding screen passes.
+  no_screen_sacks: Number of sacks taken excluding screen passes.
+  no_screen_scrambles: Number of scrambles excluding screen passes.
+  no_screen_spikes: Number of clock-stopping spikes excluding screen passes.
+  no_screen_thrown_aways: Number of intentional throwaways excluding screen passes.
+  no_screen_touchdowns: Number of passing touchdowns thrown excluding screen passes.
+  no_screen_turnover_worthy_plays: Number of turnover-worthy plays excluding screen passes, plays PFF charts as deserving
+    of a turnover.
+  no_screen_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts excluding screen passes, per PFF charting.
+  no_screen_yards: Passing yards gained excluding screen passes.
+  no_screen_ypa: Yards gained per pass attempt excluding screen passes.
+  npa_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on non-play-action dropbacks.
+  npa_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on non-play-action dropbacks, as charted
+    by PFF.
+  npa_attempts: Number of pass attempts on non-play-action dropbacks.
+  npa_avg_depth_of_target: Average depth of target in air yards on non-play-action dropbacks.
+  npa_avg_time_to_throw: Average time from snap to release in seconds on non-play-action dropbacks.
+  npa_bats: Number of pass attempts batted down at the line of scrimmage on non-play-action dropbacks.
+  npa_big_time_throws: Number of big-time throws on non-play-action dropbacks, per PFF's highest-value, highest-difficulty
+    throw designation.
+  npa_btt_rate: Big-time throws as a percentage of qualifying attempts on non-play-action dropbacks, per PFF charting.
+  npa_completion_percent: Percentage of pass attempts completed on non-play-action dropbacks.
+  npa_completions: Number of completed passes on non-play-action dropbacks.
+  npa_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on non-play-action dropbacks, as
+    charted by PFF.
+  npa_drop_rate: Percentage of catchable passes dropped by receivers on non-play-action dropbacks.
+  npa_dropbacks: Number of dropbacks on non-play-action dropbacks.
+  npa_dropbacks_percent: Share of the player's total dropbacks that came on non-play-action dropbacks, expressed as a percentage.
+  npa_drops: Number of catchable passes dropped by receivers on non-play-action dropbacks.
+  npa_epa: Total expected points added (EPA) on the player's dropbacks on non-play-action dropbacks.
+  npa_first_downs: Number of passing first downs gained on non-play-action dropbacks.
+  npa_grades_defense: PFF overall defense grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_hands_drop: PFF hands (drop) grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) on non-play-action dropbacks.
+  npa_grades_offense: PFF overall offense grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_pass: PFF passing grade (0-100) on non-play-action dropbacks.
+  npa_grades_pass_block: PFF pass-blocking grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_pass_route: PFF receiving (route) grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_run: PFF rushing grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_run_block: PFF run-blocking grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_run_defense: PFF run-defense grade for the player (0-100) on non-play-action dropbacks.
+  npa_grades_screen_block: PFF screen-blocking grade for the player (0-100) on non-play-action dropbacks.
+  npa_hit_as_threw: Number of attempts on which the passer was hit as he threw on non-play-action dropbacks, as charted by
+    PFF.
+  npa_interceptions: Number of passes intercepted on non-play-action dropbacks.
+  npa_passing_snaps: Number of passing snaps played on non-play-action dropbacks.
+  npa_positive_epa_percent: Percentage of dropbacks with positive expected points added on non-play-action dropbacks.
+  npa_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on non-play-action dropbacks.
+  npa_qb_rating: Traditional NFL passer rating on non-play-action dropbacks.
+  npa_sack_percent: Percentage of dropbacks that ended in a sack on non-play-action dropbacks.
+  npa_sacks: Number of sacks taken on non-play-action dropbacks.
+  npa_scrambles: Number of scrambles on non-play-action dropbacks.
+  npa_spikes: Number of clock-stopping spikes on non-play-action dropbacks.
+  npa_thrown_aways: Number of intentional throwaways on non-play-action dropbacks.
+  npa_touchdowns: Number of passing touchdowns thrown on non-play-action dropbacks.
+  npa_turnover_worthy_plays: Number of turnover-worthy plays on non-play-action dropbacks, plays PFF charts as deserving of
+    a turnover.
+  npa_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on non-play-action dropbacks, per PFF charting.
+  npa_yards: Passing yards gained on non-play-action dropbacks.
+  npa_ypa: Yards gained per pass attempt on non-play-action dropbacks.
+  pa_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on play-action dropbacks.
+  pa_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on play-action dropbacks, as charted
+    by PFF.
+  pa_attempts: Number of pass attempts on play-action dropbacks.
+  pa_avg_depth_of_target: Average depth of target in air yards on play-action dropbacks.
+  pa_avg_time_to_throw: Average time from snap to release in seconds on play-action dropbacks.
+  pa_bats: Number of pass attempts batted down at the line of scrimmage on play-action dropbacks.
+  pa_big_time_throws: Number of big-time throws on play-action dropbacks, per PFF's highest-value, highest-difficulty throw
+    designation.
+  pa_btt_rate: Big-time throws as a percentage of qualifying attempts on play-action dropbacks, per PFF charting.
+  pa_completion_percent: Percentage of pass attempts completed on play-action dropbacks.
+  pa_completions: Number of completed passes on play-action dropbacks.
+  pa_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on play-action dropbacks, as charted
+    by PFF.
+  pa_drop_rate: Percentage of catchable passes dropped by receivers on play-action dropbacks.
+  pa_dropbacks: Number of dropbacks on play-action dropbacks.
+  pa_dropbacks_percent: Share of the player's total dropbacks that came on play-action dropbacks, expressed as a percentage.
+  pa_drops: Number of catchable passes dropped by receivers on play-action dropbacks.
+  pa_epa: Total expected points added (EPA) on the player's dropbacks on play-action dropbacks.
+  pa_first_downs: Number of passing first downs gained on play-action dropbacks.
+  pa_grades_defense: PFF overall defense grade for the player (0-100) on play-action dropbacks.
+  pa_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) on play-action dropbacks.
+  pa_grades_hands_drop: PFF hands (drop) grade for the player (0-100) on play-action dropbacks.
+  pa_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) on play-action dropbacks.
+  pa_grades_offense: PFF overall offense grade for the player (0-100) on play-action dropbacks.
+  pa_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) on play-action dropbacks.
+  pa_grades_pass: PFF passing grade (0-100) on play-action dropbacks.
+  pa_grades_pass_block: PFF pass-blocking grade for the player (0-100) on play-action dropbacks.
+  pa_grades_pass_route: PFF receiving (route) grade for the player (0-100) on play-action dropbacks.
+  pa_grades_run: PFF rushing grade for the player (0-100) on play-action dropbacks.
+  pa_grades_run_block: PFF run-blocking grade for the player (0-100) on play-action dropbacks.
+  pa_grades_run_defense: PFF run-defense grade for the player (0-100) on play-action dropbacks.
+  pa_grades_screen_block: PFF screen-blocking grade for the player (0-100) on play-action dropbacks.
+  pa_hit_as_threw: Number of attempts on which the passer was hit as he threw on play-action dropbacks, as charted by PFF.
+  pa_interceptions: Number of passes intercepted on play-action dropbacks.
+  pa_passing_snaps: Number of passing snaps played on play-action dropbacks.
+  pa_positive_epa_percent: Percentage of dropbacks with positive expected points added on play-action dropbacks.
+  pa_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on play-action dropbacks.
+  pa_qb_rating: Traditional NFL passer rating on play-action dropbacks.
+  pa_sack_percent: Percentage of dropbacks that ended in a sack on play-action dropbacks.
+  pa_sacks: Number of sacks taken on play-action dropbacks.
+  pa_scrambles: Number of scrambles on play-action dropbacks.
+  pa_spikes: Number of clock-stopping spikes on play-action dropbacks.
+  pa_thrown_aways: Number of intentional throwaways on play-action dropbacks.
+  pa_touchdowns: Number of passing touchdowns thrown on play-action dropbacks.
+  pa_turnover_worthy_plays: Number of turnover-worthy plays on play-action dropbacks, plays PFF charts as deserving of a turnover.
+  pa_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on play-action dropbacks, per PFF charting.
+  pa_yards: Passing yards gained on play-action dropbacks.
+  pa_ypa: Yards gained per pass attempt on play-action dropbacks.
+  passing_snaps: Number of passing snaps played.
+  player_game_count: Number of games the player appeared in during the period covered.
+  positive_epa_percent: Percentage of dropbacks with positive expected points added.
+  pressure_accuracy_percent: Percentage of aimed passes charted as accurate by PFF when under pressure.
+  pressure_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) when under pressure, as charted
+    by PFF.
+  pressure_attempts: Number of pass attempts when under pressure.
+  pressure_avg_depth_of_target: Average depth of target in air yards when under pressure.
+  pressure_avg_time_to_throw: Average time from snap to release in seconds when under pressure.
+  pressure_bats: Number of pass attempts batted down at the line of scrimmage when under pressure.
+  pressure_big_time_throws: Number of big-time throws when under pressure, per PFF's highest-value, highest-difficulty throw
+    designation.
+  pressure_btt_rate: Big-time throws as a percentage of qualifying attempts when under pressure, per PFF charting.
+  pressure_completion_percent: Percentage of pass attempts completed when under pressure.
+  pressure_completions: Number of completed passes when under pressure.
+  pressure_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks when under pressure, as charted
+    by PFF.
+  pressure_drop_rate: Percentage of catchable passes dropped by receivers when under pressure.
+  pressure_dropbacks: Number of dropbacks when under pressure.
+  pressure_dropbacks_percent: Share of the player's total dropbacks that came when under pressure, expressed as a percentage.
+  pressure_drops: Number of catchable passes dropped by receivers when under pressure.
+  pressure_epa: Total expected points added (EPA) on the player's dropbacks when under pressure.
+  pressure_first_downs: Number of passing first downs gained when under pressure.
+  pressure_grades_hands_drop: PFF hands (drop) grade for the player (0-100) when under pressure.
+  pressure_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) when under pressure.
+  pressure_grades_offense: PFF overall offense grade for the player (0-100) when under pressure.
+  pressure_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) when under pressure.
+  pressure_grades_pass: PFF passing grade (0-100) when under pressure.
+  pressure_grades_pass_block: PFF pass-blocking grade for the player (0-100) when under pressure.
+  pressure_grades_pass_route: PFF receiving (route) grade for the player (0-100) when under pressure.
+  pressure_grades_run: PFF rushing grade for the player (0-100) when under pressure.
+  pressure_grades_run_block: PFF run-blocking grade for the player (0-100) when under pressure.
+  pressure_grades_screen_block: PFF screen-blocking grade for the player (0-100) when under pressure.
+  pressure_hit_as_threw: Number of attempts on which the passer was hit as he threw when under pressure, as charted by PFF.
+  pressure_interceptions: Number of passes intercepted when under pressure.
+  pressure_passing_snaps: Number of passing snaps played when under pressure.
+  pressure_positive_epa_percent: Percentage of dropbacks with positive expected points added when under pressure.
+  pressure_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack, reported within the pressure split.
+  pressure_qb_rating: Traditional NFL passer rating when under pressure.
+  pressure_sack_percent: Percentage of dropbacks that ended in a sack when under pressure.
+  pressure_sacks: Number of sacks taken when under pressure.
+  pressure_scrambles: Number of scrambles when under pressure.
+  pressure_spikes: Number of clock-stopping spikes when under pressure.
+  pressure_thrown_aways: Number of intentional throwaways when under pressure.
+  pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack.
+  pressure_touchdowns: Number of passing touchdowns thrown when under pressure.
+  pressure_turnover_worthy_plays: Number of turnover-worthy plays when under pressure, plays PFF charts as deserving of a
+    turnover.
+  pressure_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts when under pressure, per PFF charting.
+  pressure_yards: Passing yards gained when under pressure.
+  pressure_ypa: Yards gained per pass attempt when under pressure.
+  qb_rating: Traditional NFL passer rating.
+  right_behind_los_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on throws behind the line of scrimmage
+    to the right side of the field.
+  right_behind_los_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on throws behind the line
+    of scrimmage to the right side of the field, as charted by PFF.
+  right_behind_los_attempts: Number of pass attempts on throws behind the line of scrimmage to the right side of the field.
+  right_behind_los_attempts_percent: Share of the player's total pass attempts that came on throws behind the line of scrimmage
+    to the right side of the field, expressed as a percentage.
+  right_behind_los_avg_depth_of_target: Average depth of target in air yards on throws behind the line of scrimmage to the
+    right side of the field.
+  right_behind_los_avg_time_to_throw: Average time from snap to release in seconds on throws behind the line of scrimmage
+    to the right side of the field.
+  right_behind_los_bats: Number of pass attempts batted down at the line of scrimmage on throws behind the line of scrimmage
+    to the right side of the field.
+  right_behind_los_big_time_throws: Number of big-time throws on throws behind the line of scrimmage to the right side of
+    the field, per PFF's highest-value, highest-difficulty throw designation.
+  right_behind_los_btt_rate: Big-time throws as a percentage of qualifying attempts on throws behind the line of scrimmage
+    to the right side of the field, per PFF charting.
+  right_behind_los_completion_percent: Percentage of pass attempts completed on throws behind the line of scrimmage to the
+    right side of the field.
+  right_behind_los_completions: Number of completed passes on throws behind the line of scrimmage to the right side of the
+    field.
+  right_behind_los_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on throws behind the
+    line of scrimmage to the right side of the field, as charted by PFF.
+  right_behind_los_drop_rate: Percentage of catchable passes dropped by receivers on throws behind the line of scrimmage to
+    the right side of the field.
+  right_behind_los_dropbacks: Number of dropbacks on throws behind the line of scrimmage to the right side of the field.
+  right_behind_los_drops: Number of catchable passes dropped by receivers on throws behind the line of scrimmage to the right
+    side of the field.
+  right_behind_los_epa: Total expected points added (EPA) on the player's dropbacks on throws behind the line of scrimmage
+    to the right side of the field.
+  right_behind_los_first_downs: Number of passing first downs gained on throws behind the line of scrimmage to the right side
+    of the field.
+  right_behind_los_grades_pass: PFF passing grade (0-100) on throws behind the line of scrimmage to the right side of the
+    field.
+  right_behind_los_hit_as_threw: Number of attempts on which the passer was hit as he threw on throws behind the line of scrimmage
+    to the right side of the field, as charted by PFF.
+  right_behind_los_interceptions: Number of passes intercepted on throws behind the line of scrimmage to the right side of
+    the field.
+  right_behind_los_passing_snaps: Number of passing snaps played on throws behind the line of scrimmage to the right side
+    of the field.
+  right_behind_los_positive_epa_percent: Percentage of dropbacks with positive expected points added on throws behind the
+    line of scrimmage to the right side of the field.
+  right_behind_los_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on throws behind the line
+    of scrimmage to the right side of the field.
+  right_behind_los_qb_rating: Traditional NFL passer rating on throws behind the line of scrimmage to the right side of the
+    field.
+  right_behind_los_sack_percent: Percentage of dropbacks that ended in a sack on throws behind the line of scrimmage to the
+    right side of the field.
+  right_behind_los_sacks: Number of sacks taken on throws behind the line of scrimmage to the right side of the field.
+  right_behind_los_scrambles: Number of scrambles on throws behind the line of scrimmage to the right side of the field.
+  right_behind_los_spikes: Number of clock-stopping spikes on throws behind the line of scrimmage to the right side of the
+    field.
+  right_behind_los_thrown_aways: Number of intentional throwaways on throws behind the line of scrimmage to the right side
+    of the field.
+  right_behind_los_touchdowns: Number of passing touchdowns thrown on throws behind the line of scrimmage to the right side
+    of the field.
+  right_behind_los_turnover_worthy_plays: Number of turnover-worthy plays on throws behind the line of scrimmage to the right
+    side of the field, plays PFF charts as deserving of a turnover.
+  right_behind_los_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on throws behind the line of scrimmage
+    to the right side of the field, per PFF charting.
+  right_behind_los_yards: Passing yards gained on throws behind the line of scrimmage to the right side of the field.
+  right_behind_los_ypa: Yards gained per pass attempt on throws behind the line of scrimmage to the right side of the field.
+  right_deep_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on deep (20+ air yards) throws to the
+    right side of the field.
+  right_deep_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on deep (20+ air yards) throws
+    to the right side of the field, as charted by PFF.
+  right_deep_attempts: Number of pass attempts on deep (20+ air yards) throws to the right side of the field.
+  right_deep_attempts_percent: Share of the player's total pass attempts that came on deep (20+ air yards) throws to the right
+    side of the field, expressed as a percentage.
+  right_deep_avg_depth_of_target: Average depth of target in air yards on deep (20+ air yards) throws to the right side of
+    the field.
+  right_deep_avg_time_to_throw: Average time from snap to release in seconds on deep (20+ air yards) throws to the right side
+    of the field.
+  right_deep_bats: Number of pass attempts batted down at the line of scrimmage on deep (20+ air yards) throws to the right
+    side of the field.
+  right_deep_big_time_throws: Number of big-time throws on deep (20+ air yards) throws to the right side of the field, per
+    PFF's highest-value, highest-difficulty throw designation.
+  right_deep_btt_rate: Big-time throws as a percentage of qualifying attempts on deep (20+ air yards) throws to the right
+    side of the field, per PFF charting.
+  right_deep_completion_percent: Percentage of pass attempts completed on deep (20+ air yards) throws to the right side of
+    the field.
+  right_deep_completions: Number of completed passes on deep (20+ air yards) throws to the right side of the field.
+  right_deep_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on deep (20+ air yards) throws
+    to the right side of the field, as charted by PFF.
+  right_deep_drop_rate: Percentage of catchable passes dropped by receivers on deep (20+ air yards) throws to the right side
+    of the field.
+  right_deep_dropbacks: Number of dropbacks on deep (20+ air yards) throws to the right side of the field.
+  right_deep_drops: Number of catchable passes dropped by receivers on deep (20+ air yards) throws to the right side of the
+    field.
+  right_deep_epa: Total expected points added (EPA) on the player's dropbacks on deep (20+ air yards) throws to the right
+    side of the field.
+  right_deep_first_downs: Number of passing first downs gained on deep (20+ air yards) throws to the right side of the field.
+  right_deep_grades_pass: PFF passing grade (0-100) on deep (20+ air yards) throws to the right side of the field.
+  right_deep_hit_as_threw: Number of attempts on which the passer was hit as he threw on deep (20+ air yards) throws to the
+    right side of the field, as charted by PFF.
+  right_deep_interceptions: Number of passes intercepted on deep (20+ air yards) throws to the right side of the field.
+  right_deep_passing_snaps: Number of passing snaps played on deep (20+ air yards) throws to the right side of the field.
+  right_deep_positive_epa_percent: Percentage of dropbacks with positive expected points added on deep (20+ air yards) throws
+    to the right side of the field.
+  right_deep_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on deep (20+ air yards) throws
+    to the right side of the field.
+  right_deep_qb_rating: Traditional NFL passer rating on deep (20+ air yards) throws to the right side of the field.
+  right_deep_sack_percent: Percentage of dropbacks that ended in a sack on deep (20+ air yards) throws to the right side of
+    the field.
+  right_deep_sacks: Number of sacks taken on deep (20+ air yards) throws to the right side of the field.
+  right_deep_scrambles: Number of scrambles on deep (20+ air yards) throws to the right side of the field.
+  right_deep_spikes: Number of clock-stopping spikes on deep (20+ air yards) throws to the right side of the field.
+  right_deep_thrown_aways: Number of intentional throwaways on deep (20+ air yards) throws to the right side of the field.
+  right_deep_touchdowns: Number of passing touchdowns thrown on deep (20+ air yards) throws to the right side of the field.
+  right_deep_turnover_worthy_plays: Number of turnover-worthy plays on deep (20+ air yards) throws to the right side of the
+    field, plays PFF charts as deserving of a turnover.
+  right_deep_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on deep (20+ air yards) throws to the
+    right side of the field, per PFF charting.
+  right_deep_yards: Passing yards gained on deep (20+ air yards) throws to the right side of the field.
+  right_deep_ypa: Yards gained per pass attempt on deep (20+ air yards) throws to the right side of the field.
+  right_medium_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on medium (10-19 air yards) throws
+    to the right side of the field.
+  right_medium_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on medium (10-19 air yards)
+    throws to the right side of the field, as charted by PFF.
+  right_medium_attempts: Number of pass attempts on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_attempts_percent: Share of the player's total pass attempts that came on medium (10-19 air yards) throws to
+    the right side of the field, expressed as a percentage.
+  right_medium_avg_depth_of_target: Average depth of target in air yards on medium (10-19 air yards) throws to the right side
+    of the field.
+  right_medium_avg_time_to_throw: Average time from snap to release in seconds on medium (10-19 air yards) throws to the right
+    side of the field.
+  right_medium_bats: Number of pass attempts batted down at the line of scrimmage on medium (10-19 air yards) throws to the
+    right side of the field.
+  right_medium_big_time_throws: Number of big-time throws on medium (10-19 air yards) throws to the right side of the field,
+    per PFF's highest-value, highest-difficulty throw designation.
+  right_medium_btt_rate: Big-time throws as a percentage of qualifying attempts on medium (10-19 air yards) throws to the
+    right side of the field, per PFF charting.
+  right_medium_completion_percent: Percentage of pass attempts completed on medium (10-19 air yards) throws to the right side
+    of the field.
+  right_medium_completions: Number of completed passes on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on medium (10-19 air yards)
+    throws to the right side of the field, as charted by PFF.
+  right_medium_drop_rate: Percentage of catchable passes dropped by receivers on medium (10-19 air yards) throws to the right
+    side of the field.
+  right_medium_dropbacks: Number of dropbacks on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_drops: Number of catchable passes dropped by receivers on medium (10-19 air yards) throws to the right side
+    of the field.
+  right_medium_epa: Total expected points added (EPA) on the player's dropbacks on medium (10-19 air yards) throws to the
+    right side of the field.
+  right_medium_first_downs: Number of passing first downs gained on medium (10-19 air yards) throws to the right side of the
+    field.
+  right_medium_grades_pass: PFF passing grade (0-100) on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_hit_as_threw: Number of attempts on which the passer was hit as he threw on medium (10-19 air yards) throws
+    to the right side of the field, as charted by PFF.
+  right_medium_interceptions: Number of passes intercepted on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_passing_snaps: Number of passing snaps played on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_positive_epa_percent: Percentage of dropbacks with positive expected points added on medium (10-19 air yards)
+    throws to the right side of the field.
+  right_medium_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on medium (10-19 air yards) throws
+    to the right side of the field.
+  right_medium_qb_rating: Traditional NFL passer rating on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_sack_percent: Percentage of dropbacks that ended in a sack on medium (10-19 air yards) throws to the right
+    side of the field.
+  right_medium_sacks: Number of sacks taken on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_scrambles: Number of scrambles on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_spikes: Number of clock-stopping spikes on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_thrown_aways: Number of intentional throwaways on medium (10-19 air yards) throws to the right side of the
+    field.
+  right_medium_touchdowns: Number of passing touchdowns thrown on medium (10-19 air yards) throws to the right side of the
+    field.
+  right_medium_turnover_worthy_plays: Number of turnover-worthy plays on medium (10-19 air yards) throws to the right side
+    of the field, plays PFF charts as deserving of a turnover.
+  right_medium_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on medium (10-19 air yards) throws to
+    the right side of the field, per PFF charting.
+  right_medium_yards: Passing yards gained on medium (10-19 air yards) throws to the right side of the field.
+  right_medium_ypa: Yards gained per pass attempt on medium (10-19 air yards) throws to the right side of the field.
+  right_short_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws to the
+    right side of the field.
+  right_short_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws
+    to the right side of the field, as charted by PFF.
+  right_short_attempts: Number of pass attempts on short (0-9 air yards) throws to the right side of the field.
+  right_short_attempts_percent: Share of the player's total pass attempts that came on short (0-9 air yards) throws to the
+    right side of the field, expressed as a percentage.
+  right_short_avg_depth_of_target: Average depth of target in air yards on short (0-9 air yards) throws to the right side
+    of the field.
+  right_short_avg_time_to_throw: Average time from snap to release in seconds on short (0-9 air yards) throws to the right
+    side of the field.
+  right_short_bats: Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws to the right
+    side of the field.
+  right_short_big_time_throws: Number of big-time throws on short (0-9 air yards) throws to the right side of the field, per
+    PFF's highest-value, highest-difficulty throw designation.
+  right_short_btt_rate: Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws to the right
+    side of the field, per PFF charting.
+  right_short_completion_percent: Percentage of pass attempts completed on short (0-9 air yards) throws to the right side
+    of the field.
+  right_short_completions: Number of completed passes on short (0-9 air yards) throws to the right side of the field.
+  right_short_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards)
+    throws to the right side of the field, as charted by PFF.
+  right_short_drop_rate: Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws to the right
+    side of the field.
+  right_short_dropbacks: Number of dropbacks on short (0-9 air yards) throws to the right side of the field.
+  right_short_drops: Number of catchable passes dropped by receivers on short (0-9 air yards) throws to the right side of
+    the field.
+  right_short_epa: Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws to the right
+    side of the field.
+  right_short_first_downs: Number of passing first downs gained on short (0-9 air yards) throws to the right side of the field.
+  right_short_grades_pass: PFF passing grade (0-100) on short (0-9 air yards) throws to the right side of the field.
+  right_short_hit_as_threw: Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws to
+    the right side of the field, as charted by PFF.
+  right_short_interceptions: Number of passes intercepted on short (0-9 air yards) throws to the right side of the field.
+  right_short_passing_snaps: Number of passing snaps played on short (0-9 air yards) throws to the right side of the field.
+  right_short_positive_epa_percent: Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws
+    to the right side of the field.
+  right_short_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws
+    to the right side of the field.
+  right_short_qb_rating: Traditional NFL passer rating on short (0-9 air yards) throws to the right side of the field.
+  right_short_sack_percent: Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws to the right side
+    of the field.
+  right_short_sacks: Number of sacks taken on short (0-9 air yards) throws to the right side of the field.
+  right_short_scrambles: Number of scrambles on short (0-9 air yards) throws to the right side of the field.
+  right_short_spikes: Number of clock-stopping spikes on short (0-9 air yards) throws to the right side of the field.
+  right_short_thrown_aways: Number of intentional throwaways on short (0-9 air yards) throws to the right side of the field.
+  right_short_touchdowns: Number of passing touchdowns thrown on short (0-9 air yards) throws to the right side of the field.
+  right_short_turnover_worthy_plays: Number of turnover-worthy plays on short (0-9 air yards) throws to the right side of
+    the field, plays PFF charts as deserving of a turnover.
+  right_short_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws to the
+    right side of the field, per PFF charting.
+  right_short_yards: Passing yards gained on short (0-9 air yards) throws to the right side of the field.
+  right_short_ypa: Yards gained per pass attempt on short (0-9 air yards) throws to the right side of the field.
+  sack_percent: Percentage of dropbacks that ended in a sack.
+  scrambles: Number of scrambles.
+  screen_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on screen passes.
+  screen_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on screen passes, as charted by PFF.
+  screen_attempts: Number of pass attempts on screen passes.
+  screen_avg_depth_of_target: Average depth of target in air yards on screen passes.
+  screen_avg_time_to_throw: Average time from snap to release in seconds on screen passes.
+  screen_bats: Number of pass attempts batted down at the line of scrimmage on screen passes.
+  screen_big_time_throws: Number of big-time throws on screen passes, per PFF's highest-value, highest-difficulty throw designation.
+  screen_btt_rate: Big-time throws as a percentage of qualifying attempts on screen passes, per PFF charting.
+  screen_completion_percent: Percentage of pass attempts completed on screen passes.
+  screen_completions: Number of completed passes on screen passes.
+  screen_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on screen passes, as charted by
+    PFF.
+  screen_drop_rate: Percentage of catchable passes dropped by receivers on screen passes.
+  screen_dropbacks: Number of dropbacks on screen passes.
+  screen_dropbacks_percent: Share of the player's total dropbacks that came on screen passes, expressed as a percentage.
+  screen_drops: Number of catchable passes dropped by receivers on screen passes.
+  screen_epa: Total expected points added (EPA) on the player's dropbacks on screen passes.
+  screen_first_downs: Number of passing first downs gained on screen passes.
+  screen_grades_defense: PFF overall defense grade for the player (0-100) on screen passes.
+  screen_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) on screen passes.
+  screen_grades_hands_drop: PFF hands (drop) grade for the player (0-100) on screen passes.
+  screen_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) on screen passes.
+  screen_grades_offense: PFF overall offense grade for the player (0-100) on screen passes.
+  screen_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) on screen passes.
+  screen_grades_pass: PFF passing grade (0-100) on screen passes.
+  screen_grades_pass_block: PFF pass-blocking grade for the player (0-100) on screen passes.
+  screen_grades_pass_route: PFF receiving (route) grade for the player (0-100) on screen passes.
+  screen_grades_run: PFF rushing grade for the player (0-100) on screen passes.
+  screen_grades_run_block: PFF run-blocking grade for the player (0-100) on screen passes.
+  screen_grades_run_defense: PFF run-defense grade for the player (0-100) on screen passes.
+  screen_grades_screen_block: PFF screen-blocking grade for the player (0-100) on screen passes.
+  screen_hit_as_threw: Number of attempts on which the passer was hit as he threw on screen passes, as charted by PFF.
+  screen_interceptions: Number of passes intercepted on screen passes.
+  screen_passing_snaps: Number of passing snaps played on screen passes.
+  screen_positive_epa_percent: Percentage of dropbacks with positive expected points added on screen passes.
+  screen_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on screen passes.
+  screen_qb_rating: Traditional NFL passer rating on screen passes.
+  screen_sack_percent: Percentage of dropbacks that ended in a sack on screen passes.
+  screen_sacks: Number of sacks taken on screen passes.
+  screen_scrambles: Number of scrambles on screen passes.
+  screen_spikes: Number of clock-stopping spikes on screen passes.
+  screen_thrown_aways: Number of intentional throwaways on screen passes.
+  screen_touchdowns: Number of passing touchdowns thrown on screen passes.
+  screen_turnover_worthy_plays: Number of turnover-worthy plays on screen passes, plays PFF charts as deserving of a turnover.
+  screen_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on screen passes, per PFF charting.
+  screen_yards: Passing yards gained on screen passes.
+  screen_ypa: Yards gained per pass attempt on screen passes.
+  short_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on short (0-9 air yards) throws.
+  short_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on short (0-9 air yards) throws, as
+    charted by PFF.
+  short_attempts: Number of pass attempts on short (0-9 air yards) throws.
+  short_attempts_percent: Share of the player's total pass attempts that came on short (0-9 air yards) throws, expressed as
+    a percentage.
+  short_avg_depth_of_target: Average depth of target in air yards on short (0-9 air yards) throws.
+  short_avg_time_to_throw: Average time from snap to release in seconds on short (0-9 air yards) throws.
+  short_bats: Number of pass attempts batted down at the line of scrimmage on short (0-9 air yards) throws.
+  short_big_time_throws: Number of big-time throws on short (0-9 air yards) throws, per PFF's highest-value, highest-difficulty
+    throw designation.
+  short_btt_rate: Big-time throws as a percentage of qualifying attempts on short (0-9 air yards) throws, per PFF charting.
+  short_completion_percent: Percentage of pass attempts completed on short (0-9 air yards) throws.
+  short_completions: Number of completed passes on short (0-9 air yards) throws.
+  short_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on short (0-9 air yards) throws,
+    as charted by PFF.
+  short_drop_rate: Percentage of catchable passes dropped by receivers on short (0-9 air yards) throws.
+  short_dropbacks: Number of dropbacks on short (0-9 air yards) throws.
+  short_drops: Number of catchable passes dropped by receivers on short (0-9 air yards) throws.
+  short_epa: Total expected points added (EPA) on the player's dropbacks on short (0-9 air yards) throws.
+  short_first_downs: Number of passing first downs gained on short (0-9 air yards) throws.
+  short_grades_pass: PFF passing grade (0-100) on short (0-9 air yards) throws.
+  short_hit_as_threw: Number of attempts on which the passer was hit as he threw on short (0-9 air yards) throws, as charted
+    by PFF.
+  short_interceptions: Number of passes intercepted on short (0-9 air yards) throws.
+  short_passing_snaps: Number of passing snaps played on short (0-9 air yards) throws.
+  short_positive_epa_percent: Percentage of dropbacks with positive expected points added on short (0-9 air yards) throws.
+  short_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on short (0-9 air yards) throws.
+  short_qb_rating: Traditional NFL passer rating on short (0-9 air yards) throws.
+  short_sack_percent: Percentage of dropbacks that ended in a sack on short (0-9 air yards) throws.
+  short_sacks: Number of sacks taken on short (0-9 air yards) throws.
+  short_scrambles: Number of scrambles on short (0-9 air yards) throws.
+  short_spikes: Number of clock-stopping spikes on short (0-9 air yards) throws.
+  short_thrown_aways: Number of intentional throwaways on short (0-9 air yards) throws.
+  short_touchdowns: Number of passing touchdowns thrown on short (0-9 air yards) throws.
+  short_turnover_worthy_plays: Number of turnover-worthy plays on short (0-9 air yards) throws, plays PFF charts as deserving
+    of a turnover.
+  short_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on short (0-9 air yards) throws, per PFF charting.
+  short_yards: Passing yards gained on short (0-9 air yards) throws.
+  short_ypa: Yards gained per pass attempt on short (0-9 air yards) throws.
+  thrown_aways: Number of intentional throwaways.
+  touchdowns: Number of passing touchdowns thrown.
+  turnover_worthy_plays: Number of turnover-worthy plays, plays PFF charts as deserving of a turnover.
+  twp_rate: Turnover-worthy plays as a percentage of qualifying attempts, per PFF charting.
+  ypa: Yards gained per pass attempt.
+  ypa_diff: Difference in yards per attempt between play-action and non-play-action attempts (PA minus non-PA), from the PFF
+    passing-concept split.
+passing_pressure:
+  base_dropbacks: Number of dropbacks across all splits, the baseline total for this facet.
+  blitz_accuracy_percent: Percentage of aimed passes charted as accurate by PFF when blitzed.
+  blitz_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) when blitzed, as charted by PFF.
+  blitz_attempts: Number of pass attempts when blitzed.
+  blitz_avg_depth_of_target: Average depth of target in air yards when blitzed.
+  blitz_avg_time_to_throw: Average time from snap to release in seconds when blitzed.
+  blitz_bats: Number of pass attempts batted down at the line of scrimmage when blitzed.
+  blitz_big_time_throws: Number of big-time throws when blitzed, per PFF's highest-value, highest-difficulty throw designation.
+  blitz_btt_rate: Big-time throws as a percentage of qualifying attempts when blitzed, per PFF charting.
+  blitz_completion_percent: Percentage of pass attempts completed when blitzed.
+  blitz_completions: Number of completed passes when blitzed.
+  blitz_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks when blitzed, as charted by PFF.
+  blitz_drop_rate: Percentage of catchable passes dropped by receivers when blitzed.
+  blitz_dropbacks: Number of dropbacks when blitzed.
+  blitz_dropbacks_percent: Share of the player's total dropbacks that came when blitzed, expressed as a percentage.
+  blitz_drops: Number of catchable passes dropped by receivers when blitzed.
+  blitz_epa: Total expected points added (EPA) on the player's dropbacks when blitzed.
+  blitz_first_downs: Number of passing first downs gained when blitzed.
+  blitz_grades_coverage_defense: PFF coverage grade for the player (0-100) when blitzed.
+  blitz_grades_defense: PFF overall defense grade for the player (0-100) when blitzed.
+  blitz_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) when blitzed.
+  blitz_grades_hands_drop: PFF hands (drop) grade for the player (0-100) when blitzed.
+  blitz_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) when blitzed.
+  blitz_grades_offense: PFF overall offense grade for the player (0-100) when blitzed.
+  blitz_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) when blitzed.
+  blitz_grades_overall_tackle: PFF overall tackling grade for the player (0-100) when blitzed.
+  blitz_grades_pass: PFF passing grade (0-100) when blitzed.
+  blitz_grades_pass_block: PFF pass-blocking grade for the player (0-100) when blitzed.
+  blitz_grades_pass_route: PFF receiving (route) grade for the player (0-100) when blitzed.
+  blitz_grades_pass_rush_defense: PFF pass-rush grade for the player (0-100) when blitzed.
+  blitz_grades_run: PFF rushing grade for the player (0-100) when blitzed.
+  blitz_grades_run_block: PFF run-blocking grade for the player (0-100) when blitzed.
+  blitz_grades_screen_block: PFF screen-blocking grade for the player (0-100) when blitzed.
+  blitz_grades_tackle: PFF tackling grade for the player (0-100) when blitzed.
+  blitz_hit_as_threw: Number of attempts on which the passer was hit as he threw when blitzed, as charted by PFF.
+  blitz_interceptions: Number of passes intercepted when blitzed.
+  blitz_passing_snaps: Number of passing snaps played when blitzed.
+  blitz_positive_epa_percent: Percentage of dropbacks with positive expected points added when blitzed.
+  blitz_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack when blitzed.
+  blitz_qb_rating: Traditional NFL passer rating when blitzed.
+  blitz_sack_percent: Percentage of dropbacks that ended in a sack when blitzed.
+  blitz_sacks: Number of sacks taken when blitzed.
+  blitz_scrambles: Number of scrambles when blitzed.
+  blitz_spikes: Number of clock-stopping spikes when blitzed.
+  blitz_thrown_aways: Number of intentional throwaways when blitzed.
+  blitz_touchdowns: Number of passing touchdowns thrown when blitzed.
+  blitz_turnover_worthy_plays: Number of turnover-worthy plays when blitzed, plays PFF charts as deserving of a turnover.
+  blitz_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts when blitzed, per PFF charting.
+  blitz_yards: Passing yards gained when blitzed.
+  blitz_ypa: Yards gained per pass attempt when blitzed.
+  declined_penalties: Number of declined penalties committed by the player.
+  draft_season: NFL season (year) in which the player was drafted, per PFF player metadata.
+  eligible_season: Season (year) of the player's NFL draft eligibility, per PFF player metadata.
+  grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100).
+  grades_offense: PFF overall offense grade for the player (0-100).
+  grades_pass: PFF passing grade (0-100).
+  grades_run: PFF rushing grade for the player (0-100).
+  no_blitz_accuracy_percent: Percentage of aimed passes charted as accurate by PFF when not blitzed.
+  no_blitz_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) when not blitzed, as charted by
+    PFF.
+  no_blitz_attempts: Number of pass attempts when not blitzed.
+  no_blitz_avg_depth_of_target: Average depth of target in air yards when not blitzed.
+  no_blitz_avg_time_to_throw: Average time from snap to release in seconds when not blitzed.
+  no_blitz_bats: Number of pass attempts batted down at the line of scrimmage when not blitzed.
+  no_blitz_big_time_throws: Number of big-time throws when not blitzed, per PFF's highest-value, highest-difficulty throw
+    designation.
+  no_blitz_btt_rate: Big-time throws as a percentage of qualifying attempts when not blitzed, per PFF charting.
+  no_blitz_completion_percent: Percentage of pass attempts completed when not blitzed.
+  no_blitz_completions: Number of completed passes when not blitzed.
+  no_blitz_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks when not blitzed, as charted
+    by PFF.
+  no_blitz_drop_rate: Percentage of catchable passes dropped by receivers when not blitzed.
+  no_blitz_dropbacks: Number of dropbacks when not blitzed.
+  no_blitz_dropbacks_percent: Share of the player's total dropbacks that came when not blitzed, expressed as a percentage.
+  no_blitz_drops: Number of catchable passes dropped by receivers when not blitzed.
+  no_blitz_epa: Total expected points added (EPA) on the player's dropbacks when not blitzed.
+  no_blitz_first_downs: Number of passing first downs gained when not blitzed.
+  no_blitz_grades_coverage_defense: PFF coverage grade for the player (0-100) when not blitzed.
+  no_blitz_grades_defense: PFF overall defense grade for the player (0-100) when not blitzed.
+  no_blitz_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) when not blitzed.
+  no_blitz_grades_hands_drop: PFF hands (drop) grade for the player (0-100) when not blitzed.
+  no_blitz_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) when not blitzed.
+  no_blitz_grades_offense: PFF overall offense grade for the player (0-100) when not blitzed.
+  no_blitz_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) when not blitzed.
+  no_blitz_grades_overall_tackle: PFF overall tackling grade for the player (0-100) when not blitzed.
+  no_blitz_grades_pass: PFF passing grade (0-100) when not blitzed.
+  no_blitz_grades_pass_block: PFF pass-blocking grade for the player (0-100) when not blitzed.
+  no_blitz_grades_pass_route: PFF receiving (route) grade for the player (0-100) when not blitzed.
+  no_blitz_grades_pass_rush_defense: PFF pass-rush grade for the player (0-100) when not blitzed.
+  no_blitz_grades_run: PFF rushing grade for the player (0-100) when not blitzed.
+  no_blitz_grades_run_block: PFF run-blocking grade for the player (0-100) when not blitzed.
+  no_blitz_grades_screen_block: PFF screen-blocking grade for the player (0-100) when not blitzed.
+  no_blitz_grades_tackle: PFF tackling grade for the player (0-100) when not blitzed.
+  no_blitz_hit_as_threw: Number of attempts on which the passer was hit as he threw when not blitzed, as charted by PFF.
+  no_blitz_interceptions: Number of passes intercepted when not blitzed.
+  no_blitz_passing_snaps: Number of passing snaps played when not blitzed.
+  no_blitz_positive_epa_percent: Percentage of dropbacks with positive expected points added when not blitzed.
+  no_blitz_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack when not blitzed.
+  no_blitz_qb_rating: Traditional NFL passer rating when not blitzed.
+  no_blitz_sack_percent: Percentage of dropbacks that ended in a sack when not blitzed.
+  no_blitz_sacks: Number of sacks taken when not blitzed.
+  no_blitz_scrambles: Number of scrambles when not blitzed.
+  no_blitz_spikes: Number of clock-stopping spikes when not blitzed.
+  no_blitz_thrown_aways: Number of intentional throwaways when not blitzed.
+  no_blitz_touchdowns: Number of passing touchdowns thrown when not blitzed.
+  no_blitz_turnover_worthy_plays: Number of turnover-worthy plays when not blitzed, plays PFF charts as deserving of a turnover.
+  no_blitz_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts when not blitzed, per PFF charting.
+  no_blitz_yards: Passing yards gained when not blitzed.
+  no_blitz_ypa: Yards gained per pass attempt when not blitzed.
+  no_pressure_accuracy_percent: Percentage of aimed passes charted as accurate by PFF from a clean pocket (no pressure).
+  no_pressure_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) from a clean pocket (no pressure),
+    as charted by PFF.
+  no_pressure_attempts: Number of pass attempts from a clean pocket (no pressure).
+  no_pressure_avg_depth_of_target: Average depth of target in air yards from a clean pocket (no pressure).
+  no_pressure_avg_time_to_throw: Average time from snap to release in seconds from a clean pocket (no pressure).
+  no_pressure_bats: Number of pass attempts batted down at the line of scrimmage from a clean pocket (no pressure).
+  no_pressure_big_time_throws: Number of big-time throws from a clean pocket (no pressure), per PFF's highest-value, highest-difficulty
+    throw designation.
+  no_pressure_btt_rate: Big-time throws as a percentage of qualifying attempts from a clean pocket (no pressure), per PFF
+    charting.
+  no_pressure_completion_percent: Percentage of pass attempts completed from a clean pocket (no pressure).
+  no_pressure_completions: Number of completed passes from a clean pocket (no pressure).
+  no_pressure_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks from a clean pocket (no pressure),
+    as charted by PFF.
+  no_pressure_drop_rate: Percentage of catchable passes dropped by receivers from a clean pocket (no pressure).
+  no_pressure_dropbacks: Number of dropbacks from a clean pocket (no pressure).
+  no_pressure_dropbacks_percent: Share of the player's total dropbacks that came from a clean pocket (no pressure), expressed
+    as a percentage.
+  no_pressure_drops: Number of catchable passes dropped by receivers from a clean pocket (no pressure).
+  no_pressure_epa: Total expected points added (EPA) on the player's dropbacks from a clean pocket (no pressure).
+  no_pressure_first_downs: Number of passing first downs gained from a clean pocket (no pressure).
+  no_pressure_grades_coverage_defense: PFF coverage grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_defense: PFF overall defense grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_hands_drop: PFF hands (drop) grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) from a clean
+    pocket (no pressure).
+  no_pressure_grades_offense: PFF overall offense grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_overall_tackle: PFF overall tackling grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_pass: PFF passing grade (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_pass_block: PFF pass-blocking grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_pass_route: PFF receiving (route) grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_pass_rush_defense: PFF pass-rush grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_run: PFF rushing grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_run_block: PFF run-blocking grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_screen_block: PFF screen-blocking grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_grades_tackle: PFF tackling grade for the player (0-100) from a clean pocket (no pressure).
+  no_pressure_hit_as_threw: Number of attempts on which the passer was hit as he threw from a clean pocket (no pressure),
+    as charted by PFF.
+  no_pressure_interceptions: Number of passes intercepted from a clean pocket (no pressure).
+  no_pressure_passing_snaps: Number of passing snaps played from a clean pocket (no pressure).
+  no_pressure_positive_epa_percent: Percentage of dropbacks with positive expected points added from a clean pocket (no pressure).
+  no_pressure_pressure_to_sack_rate: Pressure-to-sack rate as reported within the no-pressure split of the PFF passing-pressure
+    facet.
+  no_pressure_qb_rating: Traditional NFL passer rating from a clean pocket (no pressure).
+  no_pressure_sack_percent: Percentage of dropbacks that ended in a sack from a clean pocket (no pressure).
+  no_pressure_sacks: Number of sacks taken from a clean pocket (no pressure).
+  no_pressure_scrambles: Number of scrambles from a clean pocket (no pressure).
+  no_pressure_spikes: Number of clock-stopping spikes from a clean pocket (no pressure).
+  no_pressure_thrown_aways: Number of intentional throwaways from a clean pocket (no pressure).
+  no_pressure_touchdowns: Number of passing touchdowns thrown from a clean pocket (no pressure).
+  no_pressure_turnover_worthy_plays: Number of turnover-worthy plays from a clean pocket (no pressure), plays PFF charts as
+    deserving of a turnover.
+  no_pressure_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts from a clean pocket (no pressure), per
+    PFF charting.
+  no_pressure_yards: Passing yards gained from a clean pocket (no pressure).
+  no_pressure_ypa: Yards gained per pass attempt from a clean pocket (no pressure).
+  player_game_count: Number of games the player appeared in during the period covered.
+  pressure_accuracy_percent: Percentage of aimed passes charted as accurate by PFF when under pressure.
+  pressure_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) when under pressure, as charted
+    by PFF.
+  pressure_attempts: Number of pass attempts when under pressure.
+  pressure_avg_depth_of_target: Average depth of target in air yards when under pressure.
+  pressure_avg_time_to_throw: Average time from snap to release in seconds when under pressure.
+  pressure_bats: Number of pass attempts batted down at the line of scrimmage when under pressure.
+  pressure_big_time_throws: Number of big-time throws when under pressure, per PFF's highest-value, highest-difficulty throw
+    designation.
+  pressure_btt_rate: Big-time throws as a percentage of qualifying attempts when under pressure, per PFF charting.
+  pressure_completion_percent: Percentage of pass attempts completed when under pressure.
+  pressure_completions: Number of completed passes when under pressure.
+  pressure_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks when under pressure, as charted
+    by PFF.
+  pressure_drop_rate: Percentage of catchable passes dropped by receivers when under pressure.
+  pressure_dropbacks: Number of dropbacks when under pressure.
+  pressure_dropbacks_percent: Share of the player's total dropbacks that came when under pressure, expressed as a percentage.
+  pressure_drops: Number of catchable passes dropped by receivers when under pressure.
+  pressure_epa: Total expected points added (EPA) on the player's dropbacks when under pressure.
+  pressure_first_downs: Number of passing first downs gained when under pressure.
+  pressure_grades_coverage_defense: PFF coverage grade for the player (0-100) when under pressure.
+  pressure_grades_defense: PFF overall defense grade for the player (0-100) when under pressure.
+  pressure_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) when under pressure.
+  pressure_grades_hands_drop: PFF hands (drop) grade for the player (0-100) when under pressure.
+  pressure_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) when under pressure.
+  pressure_grades_offense: PFF overall offense grade for the player (0-100) when under pressure.
+  pressure_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) when under pressure.
+  pressure_grades_overall_tackle: PFF overall tackling grade for the player (0-100) when under pressure.
+  pressure_grades_pass: PFF passing grade (0-100) when under pressure.
+  pressure_grades_pass_block: PFF pass-blocking grade for the player (0-100) when under pressure.
+  pressure_grades_pass_route: PFF receiving (route) grade for the player (0-100) when under pressure.
+  pressure_grades_pass_rush_defense: PFF pass-rush grade for the player (0-100) when under pressure.
+  pressure_grades_run: PFF rushing grade for the player (0-100) when under pressure.
+  pressure_grades_run_block: PFF run-blocking grade for the player (0-100) when under pressure.
+  pressure_grades_screen_block: PFF screen-blocking grade for the player (0-100) when under pressure.
+  pressure_grades_tackle: PFF tackling grade for the player (0-100) when under pressure.
+  pressure_hit_as_threw: Number of attempts on which the passer was hit as he threw when under pressure, as charted by PFF.
+  pressure_interceptions: Number of passes intercepted when under pressure.
+  pressure_passing_snaps: Number of passing snaps played when under pressure.
+  pressure_positive_epa_percent: Percentage of dropbacks with positive expected points added when under pressure.
+  pressure_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack, reported within the pressure split.
+  pressure_qb_rating: Traditional NFL passer rating when under pressure.
+  pressure_sack_percent: Percentage of dropbacks that ended in a sack when under pressure.
+  pressure_sacks: Number of sacks taken when under pressure.
+  pressure_scrambles: Number of scrambles when under pressure.
+  pressure_spikes: Number of clock-stopping spikes when under pressure.
+  pressure_thrown_aways: Number of intentional throwaways when under pressure.
+  pressure_touchdowns: Number of passing touchdowns thrown when under pressure.
+  pressure_turnover_worthy_plays: Number of turnover-worthy plays when under pressure, plays PFF charts as deserving of a
+    turnover.
+  pressure_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts when under pressure, per PFF charting.
+  pressure_yards: Passing yards gained when under pressure.
+  pressure_ypa: Yards gained per pass attempt when under pressure.
+passing_summary:
+  accuracy_percent: Charted accuracy percentage.
+  aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways), as charted by PFF.
+  attempts: Pass attempts thrown by the passer.
+  avg_depth_of_target: Average depth of target in air yards.
+  bats: Passes batted at the line.
+  big_time_throws: Number of big-time throws, per PFF's highest-value, highest-difficulty throw designation.
+  btt_rate: Big-time-throw rate.
+  completion_percent: Completion percentage.
+  completions: Completed passes by the passer.
+  declined_penalties: Declined penalties.
+  def_gen_pressures: Number of defense-generated pressures on the player's dropbacks, as charted by PFF.
+  draft_season: Draft class (year) of the player.
+  drop_rate: Receiver drop rate on the quarterback's throws.
+  dropbacks: Total quarterback dropbacks.
+  eligible_season: First eligible season for the player.
+  first_downs: Passing first downs.
+  franchise_id: PFF franchise (team) id (integer join key).
+  grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100).
+  grades_offense: PFF overall offense grade (0-100).
+  grades_pass: PFF passing grade (0-100).
+  grades_run: PFF rushing grade (0-100).
+  hit_as_threw: Plays where the quarterback was hit as he threw.
+  interceptions: Interceptions thrown.
+  jersey_number: Jersey number (string; zero-padded, e.g. "09").
+  passing_snaps: Number of passing snaps played.
+  penalties: Penalties charged.
+  player_game_count: Games with at least one qualifying dropback in the requested range.
+  player_id: PFF player id (integer; matches the /players id and every player_id join key).
+  positive_epa_percent: Percentage of dropbacks with positive expected points added.
+  pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack.
+  qb_rating: NFL passer rating.
+  sack_percent: Sack rate (sacks per dropback).
+  sacks: Times the passer was sacked.
+  scrambles: Scramble plays.
+  spikes: Clock-stopping spike plays.
+  team: Team abbreviation the player is credited to for the range.
+  team_name: Team name/abbreviation the player is credited to for the range.
+  thrown_aways: Passes intentionally thrown away.
+  touchdowns: Number of passing touchdowns thrown.
+  turnover_worthy_plays: Number of turnover-worthy plays, plays PFF charts as deserving of a turnover.
+  twp_rate: Turnover-worthy-play rate.
+  yards: Total passing yards gained.
+  ypa: Yards gained per pass attempt.
+pbes:
+  hits_allowed: Quarterback hits allowed.
+  hurries_allowed: Quarterback hurries allowed.
+  pass_snaps: Pass-play snaps.
+  pbe: PFF Pass Blocking Efficiency rating, pressures allowed per pass-blocking snap weighted toward sacks.
+  player_game_count: Number of games the player appeared in over the covered span.
+  pressures_allowed: Total pressures allowed (sacks, hits, and hurries).
+people_combine_measurements:
+  measurement_type: Measurement category (e.g. height, weight, 40-yard dash) per On3's measurement taxonomy.
+  measurement_type_key: On3 key for the measurement category.
+people_latest_valuation:
+  followers: Total social-media followers counted toward the valuation.
+  nil_status: Status of the athlete's On3 NIL valuation (e.g. active, inactive).
+  social_valuations: Per-platform breakdown of the social components of the valuation (stringified list).
+  valuation: Athlete's latest On3 NIL valuation in dollars.
+  valuation_change: Change in the NIL valuation since the previous update, in dollars.
+people_measurements:
+  age_measurement_occurred: Athlete's age when the measurement was taken.
+  date_added: Date the measurement record was added to the On3 database.
+  date_occurred: Date the measurement was actually taken.
+  delta: Change in the measured value versus the player's previous measurement of the same type.
+  draft_change_percent: Percent difference between the athlete's value and the drafted-player average.
+  drafted_average: Average value of this measurement among drafted players at the combine.
+  elite: Whether On3 flags the result as elite for this measurement type.
+  event_key: On3 key of the camp or combine event where the measurement was taken.
+  is_current: Whether this is the athlete's current (most recent) measurement of the type.
+  key: On3 RDB key for the measurement record.
+  measurement_type: Measurement category (e.g. height, weight, 40-yard dash) per On3's measurement taxonomy.
+  measurement_type_key: On3 key for the measurement category.
+  person_key: On3 person key of the measured athlete.
+  person_sport_org_key: On3 player-sport-organization (PSO) key the measurement is attached to.
+  top300_average: Average value of this measurement among On3 Top300-ranked players.
+  top_average_change_percent: Percent difference between the athlete's value and the Top300 average.
+  verified: Whether On3 verified the measurement.
+  verified_by_user_key: On3 user key of the staffer who verified the measurement.
+people_measurements_averages:
+  combine_drafted_average: Average combine value of the measurement among drafted players.
+  combine_drafted_difference: Difference between the athlete's value and the drafted-player combine average.
+  current_measurement_verified: Whether the athlete's current measurement is verified by On3.
+  current_person_measurement: Athlete's current value for the measurement.
+  measurement_key: On3 key for the measurement category being averaged.
+  measurement_name: Name of the measurement category (e.g. height, 40-yard dash).
+  measurement_record: Nested On3 record for the athlete's underlying measurement (stringified).
+  sort: Display sort order of the measurement row on the On3 profile.
+  top300_average: Average value of the measurement among On3 Top300-ranked players.
+  top300_difference: Difference between the athlete's value and the On3 Top300 average.
+people_person_connections:
+  connected_college_organization: Nested On3 organization object for the connected player's college (stringified).
+  connected_draft: Nested On3 draft record for the connected player, when drafted (stringified).
+  connected_player: Nested On3 person object for the connected player (stringified).
+  connected_rating: Nested On3 recruiting rating object for the connected player (stringified).
+  connected_roster_rating: Nested On3 roster rating object for the connected player (stringified).
+  connection: Relationship type linking the two people (e.g. sibling, parent, teammate) per On3.
+people_social:
+  handle: Athlete's account handle on the social platform.
+  handshake: On3 RDB handshake field on the social-account record (platform link/verification metadata).
+people_social_post_summary:
+  followers: Athlete's follower count on the platform.
+  social_type: Social platform the post summary covers (e.g. Twitter/X, Instagram).
+people_track_and_field_measurements:
+  age_measurement_occurred: Athlete's age when the measurement was taken.
+  date_added: Date the measurement record was added to the On3 database.
+  date_occurred: Date the measurement was actually taken.
+  delta: Change in the measured value versus the player's previous measurement of the same type.
+  draft_change_percent: Percent difference between the athlete's value and the drafted-player average.
+  drafted_average: Average value of this measurement among drafted players at the combine.
+  elite: Whether On3 flags the result as elite for this measurement type.
+  event_key: On3 key of the camp or combine event where the measurement was taken.
+  is_current: Whether this is the athlete's current (most recent) measurement of the type.
+  key: On3 RDB key for the measurement record.
+  measurement_type: Measurement category (e.g. height, weight, 40-yard dash) per On3's measurement taxonomy.
+  measurement_type_key: On3 key for the measurement category.
+  person_key: On3 person key of the measured athlete.
+  person_sport_org_key: On3 player-sport-organization (PSO) key the measurement is attached to.
+  top300_average: Average value of this measurement among On3 Top300-ranked players.
+  top_average_change_percent: Percent difference between the athlete's value and the Top300 average.
+  verified: Whether On3 verified the measurement.
+  verified_by_user_key: On3 user key of the staffer who verified the measurement.
+people_valuation_growth:
+  date_unix: Unix timestamp of the valuation snapshot.
+  nil_status: Status of the athlete's On3 NIL valuation at the snapshot (e.g. active, inactive).
+  valuation: Athlete's On3 NIL valuation in dollars at the snapshot.
+  valuation_change: Change in the NIL valuation versus the previous snapshot, in dollars.
+person_connections_connection_key:
+  connected_person_key: On3 person key of the connected person.
+  connected_person_sport: Nested athlete-sport profile of the connected person (stringified).
+  key: On3 RDB key for the person-connection record.
+  person_key: On3 person key of the profile the connection belongs to.
+  sport_key: On3 sport key the connection is scoped to.
+person_primary_recruitment_evaluation:
+  author_key: On3 user key of the evaluation's author.
+  author_name: Name of the On3 scout who wrote the evaluation.
+  author_title: Job title of the On3 scout who wrote the evaluation.
+  body: Full text of the scouting evaluation.
+  date_added: Date the evaluation was added.
+  date_updated: Date the evaluation was last updated.
+  date_updated_unix: Unix timestamp of the evaluation's last update.
+  key: On3 RDB key for the scouting evaluation.
+  primary: Whether this is the primary (featured) evaluation for the recruitment.
+  recruitment_key: On3 recruitment key the evaluation is attached to.
+person_recruitment_evaluations:
+  author_key: On3 user key of the evaluation's author.
+  author_name: Name of the On3 scout who wrote the evaluation.
+  author_title: Job title of the On3 scout who wrote the evaluation.
+  body: Full text of the scouting evaluation.
+  date_added: Date the evaluation was added.
+  date_updated: Date the evaluation was last updated.
+  date_updated_unix: Unix timestamp of the evaluation's last update.
+  key: On3 RDB key for the scouting evaluation.
+  primary: Whether this is the primary (featured) evaluation for the recruitment.
+  recruitment_key: On3 recruitment key the evaluation is attached to.
+person_sport_profile_recruit:
+  change: Rank movement since the previous ranking cycle.
+  consensus_change: Consensus rank movement since the previous cycle.
+  consensus_overall_rank: Player's national consensus rank.
+  consensus_position_rank: Player's consensus rank at their position.
+  consensus_rating: Player's industry-consensus rating (blend of the major recruiting services).
+  consensus_stars: Player's star rating under the industry consensus.
+  consensus_state_rank: Player's consensus rank within their home state.
+  five_star_plus: Whether On3 designates the player a Five-Star Plus+ prospect.
+  key: On3 RDB key for the player's ranking row.
+  ranking_key: On3 key of the ranking cycle the row belongs to.
+  state_abbr: Two-letter abbreviation of the player's home state.
+person_sport_rankings:
+  nil_value: Athlete's On3 NIL valuation in dollars.
+  person: Nested On3 person object for the ranked athlete (stringified).
+  ratings: Athlete's ratings across ranking cycles, as a stringified list.
+playbyplayv2:
+  eventmsgactiontype: Numeric sub-type code refining eventmsgtype (e.g. the specific shot, foul, or turnover variety).
+  eventmsgtype: Numeric event type code (1 = made shot, 2 = missed shot, 3 = free throw, 4 = rebound, 5 = turnover, 6 = foul,
+    ...).
+  eventnum: Sequential event number within the game's play-by-play feed.
+  homedescription: Text description of the event from the home team's perspective; empty when not a home-team action.
+  neutraldescription: Neutral text description of the event (e.g. period start/end); empty for team actions.
+  pctimestring: Game clock remaining in the period when the event occurred (MM:SS).
+  scoremargin: Score margin after the event ('TIE' when tied); empty on non-scoring events.
+  visitordescription: Text description of the event from the visiting team's perspective; empty when not a visitor action.
+  wctimestring: Wall-clock time of day when the event occurred.
+player_all_rankings:
+  change: Rank movement since the previous ranking cycle.
+  class_year: Recruiting class year the ranking covers.
+  five_star_plus: Whether On3 designates the player a Five-Star Plus+ prospect.
+  nearly_five_star_plus: On3 flag that the player narrowly missed the Five-Star Plus+ designation.
+  ranking_key: On3 key of the ranking cycle the row belongs to.
+  sport: Nested On3 sport object for the ranking row (stringified).
+  state_abbr: Two-letter abbreviation of the player's home state.
+player_database_updates:
+  date_added: Date the update entry was logged.
+  date_occurred: Date the underlying event occurred.
+  key: On3 RDB key for the database-update entry.
+  object_key: On3 key of the object the update refers to.
+  organization_key: On3 organization key involved in the update, when any.
+  person_key: On3 person key of the player the update concerns.
+  replacement_text: Rendered text of the update entry (with references substituted in).
+  sport_key: On3 sport key the update is scoped to.
+player_images:
+  alt_text: Alt text for the image.
+  asset_type: Type of the asset (e.g. image) in On3's asset system.
+  caption: Caption text for the image.
+  domain: CDN domain the image is served from.
+  domain_override: Override CDN domain for serving the image, when set.
+  file_system: Storage file system the asset lives on (On3 asset metadata).
+  key: On3 asset key for the image.
+  mime_type: MIME type of the image file (e.g. image/jpeg).
+  path: Storage path of the image file.
+  source_override: Override source attribution for the image, when set.
+  thumbnail: URL or path of the image's thumbnail rendition.
+  width: Image width in pixels.
+player_organizations:
+  draft: Nested On3 draft record for the player, when drafted (stringified).
+  organizations: Player's organization stints (high school, college, pro) as a stringified list of nested objects.
+player_organizations_org_key:
+  exp_max: Maximum years of experience listed for the player's stint with the organization (On3 RDB).
+  exp_min: Minimum years of experience listed for the player's stint with the organization (On3 RDB).
+player_person_rankings:
+  change: Rank movement since the previous ranking cycle.
+  consensus_change: Consensus rank movement since the previous cycle.
+  consensus_overall_rank: Player's national consensus rank.
+  consensus_position_rank: Player's consensus rank at their position.
+  consensus_rating: Player's industry-consensus rating (blend of the major recruiting services).
+  consensus_stars: Player's star rating under the industry consensus.
+  consensus_state_rank: Player's consensus rank within their home state.
+  five_star_plus: Whether On3 designates the player a Five-Star Plus+ prospect.
+  key: On3 RDB key for the player's ranking row.
+  ranking_key: On3 key of the ranking cycle the row belongs to.
+  state_abbr: Two-letter abbreviation of the player's home state.
+player_profile:
+  athlete_verified: Whether the athlete has verified their own On3 profile.
+  badge: Profile badge assigned by On3, when any.
+  bio_college_recruit: Bio text framing the player as a college recruit (On3 RDB).
+  bio_pro_prospect: Bio text framing the player as a pro prospect (On3 RDB).
+  class_rank: Player's rank within their recruiting class.
+  class_year: Player's recruiting class year.
+  class_year_recruitment_key: On3 recruitment key for the player's recruiting-class cycle.
+  college_org_key: On3 organization key of the player's college.
+  default_asset: Nested On3 asset object for the player's headshot (stringified).
+  default_sport: Nested On3 object for the player's primary sport (stringified).
+  degree: Degree the player earned or is pursuing, when listed.
+  high_school_org_key: On3 organization key of the player's high school.
+  hometown_name: Player's hometown, as listed by On3.
+  is_athlete: Whether the person record is an athlete.
+  is_coach: Whether the person record is a coach.
+  junior_college_org_key: On3 organization key of the player's junior college, when attended.
+  key: On3 RDB key for the player profile.
+  managed_by_user: On3 user account that manages the player's profile, when claimed.
+  ncaa_id: Player's NCAA identifier, when known to On3.
+  nil_value: Player's On3 NIL valuation in dollars.
+  oracle_key: On3's internal oracle identifier for the player record.
+  organization_level: Level of the player's current organization (e.g. high school, college, professional).
+  person_can_manage_recruitment: Whether the athlete can self-manage the recruitment on On3.
+  person_sport_key: On3 key of the athlete-sport profile (person x sport).
+  player_status: Player's current status per On3 (e.g. active, transfer portal).
+  prep_school_org_key: On3 organization key of the player's prep school, when attended.
+  primary_position: Nested On3 object for the player's primary position (stringified).
+  prospect_verified: Whether On3 has verified the prospect's profile information.
+  ranking_key: On3 key of the ranking cycle the profile's rating belongs to.
+  recruitment_key: On3 key of the player's active recruitment record.
+  review_status: Editorial review status of the profile in the On3 database.
+  sports: Sports the player is profiled in, as a stringified list.
+  tier: On3 profile tier classification for the player.
+  visibility: Profile visibility setting on On3.
+player_team_targets:
+  class_rank: Recruit's rank within their recruiting class.
+  coaches: Recruiting coaches at the target school tied to the recruitment (stringified list).
+  committed_date: Date the recruit committed to the school, when applicable.
+  draft_position_count: Number of players at the recruit's position the school has had drafted.
+  draft_total: Total number of players the school has had drafted.
+  interest: Recruit's interest level in the target school, per On3.
+  official_visit_count: Number of official visits the recruit has taken to the school.
+  position_key: On3 key of the recruit's position.
+  sport: Nested On3 sport object for the target entry (stringified).
+  un_official_visit_count: Number of unofficial visits the recruit has taken to the school.
+player_verified:
+  athlete_verified: Whether the athlete has verified their own On3 profile.
+  badge: Profile badge assigned by On3, when any.
+  bio_college_recruit: Bio text framing the player as a college recruit (On3 RDB).
+  bio_pro_prospect: Bio text framing the player as a pro prospect (On3 RDB).
+  class_rank: Player's rank within their recruiting class.
+  class_year: Player's recruiting class year.
+  class_year_recruitment_key: On3 recruitment key for the player's recruiting-class cycle.
+  college_org_key: On3 organization key of the player's college.
+  default_asset: Nested On3 asset object for the player's headshot (stringified).
+  default_sport: Nested On3 object for the player's primary sport (stringified).
+  degree: Degree the player earned or is pursuing, when listed.
+  high_school_org_key: On3 organization key of the player's high school.
+  hometown_name: Player's hometown, as listed by On3.
+  is_athlete: Whether the person record is an athlete.
+  is_coach: Whether the person record is a coach.
+  junior_college_org_key: On3 organization key of the player's junior college, when attended.
+  key: On3 RDB key for the player profile.
+  managed_by_user: On3 user account that manages the player's profile, when claimed.
+  ncaa_id: Player's NCAA identifier, when known to On3.
+  nil_value: Player's On3 NIL valuation in dollars.
+  oracle_key: On3's internal oracle identifier for the player record.
+  organization_level: Level of the player's current organization (e.g. high school, college, professional).
+  person_can_manage_recruitment: Whether the athlete can self-manage the recruitment on On3.
+  person_sport_key: On3 key of the athlete-sport profile (person x sport).
+  player_status: Player's current status per On3 (e.g. active, transfer portal).
+  prep_school_org_key: On3 organization key of the player's prep school, when attended.
+  primary_position: Nested On3 object for the player's primary position (stringified).
+  prospect_verified: Whether On3 has verified the prospect's profile information.
+  ranking_key: On3 key of the ranking cycle the profile's rating belongs to.
+  recruitment_key: On3 key of the player's active recruitment record.
+  review_status: Editorial review status of the profile in the On3 database.
+  sports: Sports the player is profiled in, as a stringified list.
+  tier: On3 profile tier classification for the player.
+  visibility: Profile visibility setting on On3.
+player_videos:
+  is_featured: Whether the video is featured on the player's On3 profile.
+  key: On3 RDB key for the video record.
+  person_key: On3 person key of the featured athlete.
+  person_sport: Nested athlete-sport profile the video is attached to (stringified).
+  source_url: Source URL of the hosted video.
+  thumbnail: URL of the video's thumbnail image.
+player_visit_center:
+  sport: Nested On3 sport object for the visit-center entry (stringified).
+  total_visits: Total number of school visits logged for the recruit.
+  visits: The recruit's school visits with dates and types, as a stringified list.
+playercareerbycollegerollup:
+  seed: Region seed slot of the college in the stats API's career-by-college rollup grid.
+playercompare:
+  blka: Shot attempts blocked by opponents (blocks against).
+  group_set: Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month).
+  pfd: Personal fouls drawn.
+playerdashboardbyopponent:
+  ast_rank: League rank of the row's assists for the season and split.
+  blk_rank: League rank of the row's blocked shots for the season and split.
+  blka: Shot attempts blocked by opponents (blocks against).
+  blka_rank: League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split.
+  dd2: Double-doubles recorded over the split.
+  dd2_rank: League rank of the row's double-doubles for the season and split.
+  dreb_rank: League rank of the row's defensive rebounds for the season and split.
+  fg3_pct_rank: League rank of the row's three-point field goal percentage for the season and split.
+  fg3a_rank: League rank of the row's three-point field goals attempted for the season and split.
+  fg3m_rank: League rank of the row's three-point field goals made for the season and split.
+  fg_pct_rank: League rank of the row's field goal percentage for the season and split.
+  fga_rank: League rank of the row's field goals attempted for the season and split.
+  fgm_rank: League rank of the row's field goals made for the season and split.
+  ft_pct_rank: League rank of the row's free throw percentage for the season and split.
+  fta_rank: League rank of the row's free throws attempted for the season and split.
+  ftm_rank: League rank of the row's free throws made for the season and split.
+  gp_rank: League rank of the row's games played for the season and split.
+  group_set: Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month).
+  group_value: Value of the split within the group (e.g. a specific opponent, month, or result).
+  l_rank: League rank of the row's losses for the season and split.
+  min_rank: League rank of the row's minutes played for the season and split.
+  nba_fantasy_pts: Fantasy points under the NBA's fantasy scoring formula.
+  nba_fantasy_pts_rank: League rank of the row's NBA fantasy points (league scoring formula) for the season and split.
+  oreb_rank: League rank of the row's offensive rebounds for the season and split.
+  pf_rank: League rank of the row's personal fouls committed for the season and split.
+  pfd: Personal fouls drawn.
+  pfd_rank: League rank of the row's personal fouls drawn for the season and split.
+  plus_minus_rank: League rank of the row's plus-minus point differential while on the floor for the season and split.
+  pts_rank: League rank of the row's points scored for the season and split.
+  reb_rank: League rank of the row's total rebounds for the season and split.
+  stl_rank: League rank of the row's steals for the season and split.
+  td3: Triple-doubles recorded over the split.
+  td3_rank: League rank of the row's triple-doubles for the season and split.
+  team_count: Number of distinct teams aggregated into the split row.
+  tov_rank: League rank of the row's turnovers for the season and split.
+  w_pct_rank: League rank of the row's win percentage for the season and split.
+  w_rank: League rank of the row's wins for the season and split.
+  wnba_fantasy_pts: Fantasy points under the WNBA's fantasy scoring formula.
+  wnba_fantasy_pts_rank: League rank of the row's WNBA fantasy points (league scoring formula) for the season and split.
+playerfantasyprofile:
+  blka: Shot attempts blocked by opponents (blocks against).
+  dd2: Double-doubles recorded over the split.
+  fan_duel_pts: Fantasy points under FanDuel's scoring formula.
+  group_set: Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month).
+  group_value: Value of the split within the group (e.g. a specific opponent, month, or result).
+  nba_fantasy_pts: Fantasy points under the NBA's fantasy scoring formula.
+  pfd: Personal fouls drawn.
+  td3: Triple-doubles recorded over the split.
+playernextngames:
+  home_wl: Home team's win-loss record entering the upcoming game.
+  visitor_team_abbreviation: Abbreviation of the visiting team in the upcoming game.
+  visitor_team_name: Full name of the visiting team in the upcoming game.
+  visitor_team_nickname: Nickname of the visiting team in the upcoming game.
+  visitor_wl: Visiting team's win-loss record entering the upcoming game.
+players:
+  current_class: Player's current college class designation (e.g., Freshman, Senior), per PFF.
+  current_eligible_year: Year the player is or was first draft-eligible, per PFF.
+  draft: Nested draft-selection details for the player (year, round, pick, and franchise) as returned by the source API.
+players_industry_comparision_list:
+  nil_value: Player's On3 NIL valuation in dollars.
+  person: Nested On3 person object for the compared player (stringified).
+  ratings: Player's ratings across the industry services, as a stringified list.
+playervsplayer:
+  blka: Shot attempts blocked by opponents (blocks against).
+  court_status: Whether the split covers minutes with the vs. player on or off the court.
+  group_set: Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month).
+  nba_fantasy_pts: Fantasy points under the NBA's fantasy scoring formula.
+  pfd: Personal fouls drawn.
+  vs_player_id: Stats API player id of the comparison (vs.) player.
+  vs_player_name: Name of the comparison (vs.) player.
+playoffpicture:
+  clinched_conference: Flag (1/0) for whether the team has clinched the conference title.
+  clinched_division: Flag (1/0) for whether the team has clinched its division.
+  clinched_playoffs: Flag (1/0) for whether the team has clinched a playoff berth.
+  div: Abbreviation of the team's division.
+  eliminated_playoffs: Flag (1/0) for whether the team has been eliminated from playoff contention.
+  gr_over_500: Remaining games against teams with winning (over .500) records.
+  gr_over_500_away: Remaining road games against teams with winning records.
+  gr_over_500_home: Remaining home games against teams with winning records.
+  gr_under_500: Remaining games against teams with losing (under .500) records.
+  gr_under_500_away: Remaining road games against teams with losing records.
+  gr_under_500_home: Remaining home games against teams with losing records.
+  ranking_criteria: Code for the ranking or tiebreak criteria applied to the team in the playoff picture.
+  sosa_remaining: Strength of schedule of the team's remaining opponents (combined opponent winning percentage).
+prps:
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  hurries: Quarterback hurries recorded.
+  lhs_assists: Assisted tackles when rushing from the left side.
+  lhs_hits: Quarterback hits recorded when rushing from the left side.
+  lhs_hurries: Quarterback hurries recorded when rushing from the left side.
+  lhs_misses: Missed tackles when rushing from the left side.
+  lhs_pass_rush_percent: Share of pass-play snaps spent rushing the passer when rushing from the left side.
+  lhs_pass_rush_snaps: Pass-rush snaps played when rushing from the left side.
+  lhs_pressures: Total pressures generated (sacks, hits, and hurries) when rushing from the left side.
+  lhs_prp: PFF Pass Rush Productivity rating, pressure generated per pass-rush snap weighted toward sacks when rushing from
+    the left side.
+  lhs_sacks: Sacks recorded when rushing from the left side.
+  lhs_stops: Stops, PFF's tackles that constitute a failed play for the offense when rushing from the left side.
+  lhs_tackles: Tackles made when rushing from the left side.
+  misses: Missed tackles.
+  pass_rush_percent: Share of pass-play snaps spent rushing the passer.
+  pass_rush_snaps: Pass-rush snaps played.
+  pass_snaps: Pass-play snaps.
+  player_game_count: Number of games the player appeared in over the covered span.
+  pressures: Total pressures generated (sacks, hits, and hurries).
+  prp: PFF Pass Rush Productivity rating, pressure generated per pass-rush snap weighted toward sacks.
+  rhs_assists: Assisted tackles when rushing from the right side.
+  rhs_hits: Quarterback hits recorded when rushing from the right side.
+  rhs_hurries: Quarterback hurries recorded when rushing from the right side.
+  rhs_misses: Missed tackles when rushing from the right side.
+  rhs_pass_rush_percent: Share of pass-play snaps spent rushing the passer when rushing from the right side.
+  rhs_pass_rush_snaps: Pass-rush snaps played when rushing from the right side.
+  rhs_pressures: Total pressures generated (sacks, hits, and hurries) when rushing from the right side.
+  rhs_prp: PFF Pass Rush Productivity rating, pressure generated per pass-rush snap weighted toward sacks when rushing from
+    the right side.
+  rhs_sacks: Sacks recorded when rushing from the right side.
+  rhs_stops: Stops, PFF's tackles that constitute a failed play for the offense when rushing from the right side.
+  rhs_tackles: Tackles made when rushing from the right side.
+  stops: Stops, PFF's tackles that constitute a failed play for the offense.
+punting_summary:
+  attempts_with_hangtime: Punts with a PFF-recorded hangtime.
+  average_hangtime: Average punt hangtime in seconds.
+  average_net_yards: Average net punting yards per attempt.
+  average_yards_per_attempt: Average gross punting yards per attempt.
+  average_yards_per_return: Average return yards allowed per punt returned.
+  declined_penalties: Penalties committed by the player that were declined.
+  downeds: Punts downed by the coverage unit.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  fair_catches: Punts fair-caught by the return team.
+  grades_punter: PFF punting grade, 0-100.
+  inside_twenties: Punts downed inside the opponent 20-yard line.
+  long: Longest punt in yards.
+  percent_returned: Percentage of the player's punts that were returned.
+  player_game_count: Number of games the player appeared in over the covered span.
+  returns: Punts returned by the opponent.
+  snaps: Punting snaps played.
+  total_hangtime: Total punt hangtime in seconds.
+  total_net_yards: Total net punting yards.
+  touchbacks: Punts resulting in touchbacks.
+quotes:
+  body: Full text of the quote.
+  date_added: Date the quote was added to the On3 database.
+  date_updated: Date the quote was last updated.
+  key: On3 RDB key for the quote record.
+  person: Nested On3 person object for the quote's subject (stringified).
+  person_key: On3 person key of the person quoted or quoted about.
+quotes_key:
+  body: Full text of the quote.
+  date_added: Date the quote was added to the On3 database.
+  date_updated: Date the quote was last updated.
+  key: On3 RDB key for the quote record.
+  person: Nested On3 person object for the quote's subject (stringified).
+  person_key: On3 person key of the person quoted or quoted about.
+receiving_concept:
+  base_targets: Total targets from the facet's unsplit base row, across all concepts.
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  player_game_count: Number of games the player appeared in over the covered span.
+  screen_avg_depth_of_target: Average depth of target in yards downfield on screen concepts.
+  screen_avoided_tackles: Tackles avoided after the catch on screen concepts.
+  screen_caught_percent: Percentage of targets caught on screen concepts.
+  screen_contested_catch_rate: Percentage of PFF-charted contested targets caught on screen concepts.
+  screen_contested_receptions: Catches made on PFF-charted contested targets on screen concepts.
+  screen_contested_targets: PFF-charted contested targets on screen concepts.
+  screen_drop_rate: Share of catchable targets the player dropped on screen concepts.
+  screen_drops: PFF-charted drops on screen concepts.
+  screen_epa: Total expected points added on targets to the player on screen concepts.
+  screen_first_downs: Receptions that converted a first down on screen concepts.
+  screen_fumbles: Fumbles by the player after the catch on screen concepts.
+  screen_grades_hands_drop: PFF hands/drop grade on screen concepts, 0-100.
+  screen_grades_pass_route: PFF route-running (receiving) grade on screen concepts, 0-100.
+  screen_interceptions: Interceptions thrown on passes targeting the player on screen concepts.
+  screen_longest: Longest reception in yards on screen concepts.
+  screen_pass_block_rate: Share of pass-play snaps spent pass blocking on screen concepts.
+  screen_pass_blocks: Pass-play snaps spent pass blocking on screen concepts.
+  screen_pass_plays: Pass-play snaps on screen concepts.
+  screen_positive_epa_percent: Percentage of the player's targets producing positive expected points added on screen concepts.
+  screen_receptions: Receptions made on screen concepts.
+  screen_route_rate: Share of pass-play snaps on which the player ran a route on screen concepts.
+  screen_routes: Pass routes run by the player on screen concepts.
+  screen_targeted_qb_rating: NFL passer rating on throws targeting the player on screen concepts.
+  screen_targets: Pass targets to the player on screen concepts.
+  screen_targets_percent: Share of the team's targets thrown to the player on screen concepts.
+  screen_touchdowns: Receiving touchdowns scored on screen concepts.
+  screen_yards: Receiving yards gained on screen concepts.
+  screen_yards_after_catch: Yards gained after the catch on screen concepts.
+  screen_yards_after_catch_per_reception: Average yards after the catch per reception on screen concepts.
+  screen_yards_per_reception: Average yards per reception on screen concepts.
+  screen_yprr: Yards per route run on screen concepts.
+  slot_avg_depth_of_target: Average depth of target in yards downfield when aligned in the slot.
+  slot_avoided_tackles: Tackles avoided after the catch when aligned in the slot.
+  slot_caught_percent: Percentage of targets caught when aligned in the slot.
+  slot_contested_catch_rate: Percentage of PFF-charted contested targets caught when aligned in the slot.
+  slot_contested_receptions: Catches made on PFF-charted contested targets when aligned in the slot.
+  slot_contested_targets: PFF-charted contested targets when aligned in the slot.
+  slot_drop_rate: Share of catchable targets the player dropped when aligned in the slot.
+  slot_drops: PFF-charted drops when aligned in the slot.
+  slot_epa: Total expected points added on targets to the player when aligned in the slot.
+  slot_first_downs: Receptions that converted a first down when aligned in the slot.
+  slot_fumbles: Fumbles by the player after the catch when aligned in the slot.
+  slot_grades_hands_drop: PFF hands/drop grade when aligned in the slot, 0-100.
+  slot_grades_pass_route: PFF route-running (receiving) grade when aligned in the slot, 0-100.
+  slot_interceptions: Interceptions thrown on passes targeting the player when aligned in the slot.
+  slot_longest: Longest reception in yards when aligned in the slot.
+  slot_pass_block_rate: Share of pass-play snaps spent pass blocking when aligned in the slot.
+  slot_pass_blocks: Pass-play snaps spent pass blocking when aligned in the slot.
+  slot_pass_plays: Pass-play snaps when aligned in the slot.
+  slot_positive_epa_percent: Percentage of the player's targets producing positive expected points added when aligned in the
+    slot.
+  slot_receptions: Receptions made when aligned in the slot.
+  slot_route_rate: Share of pass-play snaps on which the player ran a route when aligned in the slot.
+  slot_routes: Pass routes run by the player when aligned in the slot.
+  slot_targeted_qb_rating: NFL passer rating on throws targeting the player when aligned in the slot.
+  slot_targets: Pass targets to the player when aligned in the slot.
+  slot_targets_percent: Share of the team's targets thrown to the player when aligned in the slot.
+  slot_touchdowns: Receiving touchdowns scored when aligned in the slot.
+  slot_yards: Receiving yards gained when aligned in the slot.
+  slot_yards_after_catch: Yards gained after the catch when aligned in the slot.
+  slot_yards_after_catch_per_reception: Average yards after the catch per reception when aligned in the slot.
+  slot_yards_per_reception: Average yards per reception when aligned in the slot.
+  slot_yprr: Yards per route run when aligned in the slot.
+receiving_depth:
+  base_targets: Total targets from the facet's unsplit base row, across all depths and directions.
+  behind_los_avg_depth_of_target: Average depth of target in yards downfield on passes thrown behind the line of scrimmage.
+  behind_los_avoided_tackles: Tackles avoided after the catch on passes thrown behind the line of scrimmage.
+  behind_los_caught_percent: Percentage of targets caught on passes thrown behind the line of scrimmage.
+  behind_los_contested_catch_rate: Percentage of PFF-charted contested targets caught on passes thrown behind the line of
+    scrimmage.
+  behind_los_contested_receptions: Catches made on PFF-charted contested targets on passes thrown behind the line of scrimmage.
+  behind_los_contested_targets: PFF-charted contested targets on passes thrown behind the line of scrimmage.
+  behind_los_drop_rate: Share of catchable targets the player dropped on passes thrown behind the line of scrimmage.
+  behind_los_drops: PFF-charted drops on passes thrown behind the line of scrimmage.
+  behind_los_epa: Total expected points added on targets to the player on passes thrown behind the line of scrimmage.
+  behind_los_first_downs: Receptions that converted a first down on passes thrown behind the line of scrimmage.
+  behind_los_fumbles: Fumbles by the player after the catch on passes thrown behind the line of scrimmage.
+  behind_los_grades_hands_drop: PFF hands/drop grade on passes thrown behind the line of scrimmage, 0-100.
+  behind_los_grades_pass_route: PFF route-running (receiving) grade on passes thrown behind the line of scrimmage, 0-100.
+  behind_los_interceptions: Interceptions thrown on passes targeting the player on passes thrown behind the line of scrimmage.
+  behind_los_longest: Longest reception in yards on passes thrown behind the line of scrimmage.
+  behind_los_pass_block_rate: Share of pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage.
+  behind_los_pass_blocks: Pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage.
+  behind_los_pass_plays: Pass-play snaps on passes thrown behind the line of scrimmage.
+  behind_los_positive_epa_percent: Percentage of the player's targets producing positive expected points added on passes thrown
+    behind the line of scrimmage.
+  behind_los_receptions: Receptions made on passes thrown behind the line of scrimmage.
+  behind_los_route_rate: Share of pass-play snaps on which the player ran a route on passes thrown behind the line of scrimmage.
+  behind_los_routes: Pass routes run by the player on passes thrown behind the line of scrimmage.
+  behind_los_targeted_qb_rating: NFL passer rating on throws targeting the player on passes thrown behind the line of scrimmage.
+  behind_los_targets: Pass targets to the player on passes thrown behind the line of scrimmage.
+  behind_los_targets_percent: Share of the team's targets thrown to the player on passes thrown behind the line of scrimmage.
+  behind_los_touchdowns: Receiving touchdowns scored on passes thrown behind the line of scrimmage.
+  behind_los_yards: Receiving yards gained on passes thrown behind the line of scrimmage.
+  behind_los_yards_after_catch: Yards gained after the catch on passes thrown behind the line of scrimmage.
+  behind_los_yards_after_catch_per_reception: Average yards after the catch per reception on passes thrown behind the line
+    of scrimmage.
+  behind_los_yards_per_reception: Average yards per reception on passes thrown behind the line of scrimmage.
+  behind_los_yprr: Yards per route run on passes thrown behind the line of scrimmage.
+  center_behind_los_avg_depth_of_target: Average depth of target in yards downfield on passes thrown behind the line of scrimmage
+    to the middle of the field.
+  center_behind_los_avoided_tackles: Tackles avoided after the catch on passes thrown behind the line of scrimmage to the
+    middle of the field.
+  center_behind_los_caught_percent: Percentage of targets caught on passes thrown behind the line of scrimmage to the middle
+    of the field.
+  center_behind_los_contested_catch_rate: Percentage of PFF-charted contested targets caught on passes thrown behind the line
+    of scrimmage to the middle of the field.
+  center_behind_los_contested_receptions: Catches made on PFF-charted contested targets on passes thrown behind the line of
+    scrimmage to the middle of the field.
+  center_behind_los_contested_targets: PFF-charted contested targets on passes thrown behind the line of scrimmage to the
+    middle of the field.
+  center_behind_los_drop_rate: Share of catchable targets the player dropped on passes thrown behind the line of scrimmage
+    to the middle of the field.
+  center_behind_los_drops: PFF-charted drops on passes thrown behind the line of scrimmage to the middle of the field.
+  center_behind_los_epa: Total expected points added on targets to the player on passes thrown behind the line of scrimmage
+    to the middle of the field.
+  center_behind_los_first_downs: Receptions that converted a first down on passes thrown behind the line of scrimmage to the
+    middle of the field.
+  center_behind_los_fumbles: Fumbles by the player after the catch on passes thrown behind the line of scrimmage to the middle
+    of the field.
+  center_behind_los_grades_hands_drop: PFF hands/drop grade on passes thrown behind the line of scrimmage to the middle of
+    the field, 0-100.
+  center_behind_los_grades_pass_route: PFF route-running (receiving) grade on passes thrown behind the line of scrimmage to
+    the middle of the field, 0-100.
+  center_behind_los_interceptions: Interceptions thrown on passes targeting the player on passes thrown behind the line of
+    scrimmage to the middle of the field.
+  center_behind_los_longest: Longest reception in yards on passes thrown behind the line of scrimmage to the middle of the
+    field.
+  center_behind_los_pass_block_rate: Share of pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage
+    to the middle of the field.
+  center_behind_los_pass_blocks: Pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage to the
+    middle of the field.
+  center_behind_los_pass_plays: Pass-play snaps on passes thrown behind the line of scrimmage to the middle of the field.
+  center_behind_los_positive_epa_percent: Percentage of the player's targets producing positive expected points added on passes
+    thrown behind the line of scrimmage to the middle of the field.
+  center_behind_los_receptions: Receptions made on passes thrown behind the line of scrimmage to the middle of the field.
+  center_behind_los_route_rate: Share of pass-play snaps on which the player ran a route on passes thrown behind the line
+    of scrimmage to the middle of the field.
+  center_behind_los_routes: Pass routes run by the player on passes thrown behind the line of scrimmage to the middle of the
+    field.
+  center_behind_los_targeted_qb_rating: NFL passer rating on throws targeting the player on passes thrown behind the line
+    of scrimmage to the middle of the field.
+  center_behind_los_targets: Pass targets to the player on passes thrown behind the line of scrimmage to the middle of the
+    field.
+  center_behind_los_targets_percent: Share of the team's targets thrown to the player on passes thrown behind the line of
+    scrimmage to the middle of the field.
+  center_behind_los_touchdowns: Receiving touchdowns scored on passes thrown behind the line of scrimmage to the middle of
+    the field.
+  center_behind_los_yards: Receiving yards gained on passes thrown behind the line of scrimmage to the middle of the field.
+  center_behind_los_yards_after_catch: Yards gained after the catch on passes thrown behind the line of scrimmage to the middle
+    of the field.
+  center_behind_los_yards_after_catch_per_reception: Average yards after the catch per reception on passes thrown behind the
+    line of scrimmage to the middle of the field.
+  center_behind_los_yards_per_reception: Average yards per reception on passes thrown behind the line of scrimmage to the
+    middle of the field.
+  center_behind_los_yprr: Yards per route run on passes thrown behind the line of scrimmage to the middle of the field.
+  center_deep_avg_depth_of_target: Average depth of target in yards downfield on deep passes (20 or more yards downfield)
+    to the middle of the field.
+  center_deep_avoided_tackles: Tackles avoided after the catch on deep passes (20 or more yards downfield) to the middle of
+    the field.
+  center_deep_caught_percent: Percentage of targets caught on deep passes (20 or more yards downfield) to the middle of the
+    field.
+  center_deep_contested_catch_rate: Percentage of PFF-charted contested targets caught on deep passes (20 or more yards downfield)
+    to the middle of the field.
+  center_deep_contested_receptions: Catches made on PFF-charted contested targets on deep passes (20 or more yards downfield)
+    to the middle of the field.
+  center_deep_contested_targets: PFF-charted contested targets on deep passes (20 or more yards downfield) to the middle of
+    the field.
+  center_deep_drop_rate: Share of catchable targets the player dropped on deep passes (20 or more yards downfield) to the
+    middle of the field.
+  center_deep_drops: PFF-charted drops on deep passes (20 or more yards downfield) to the middle of the field.
+  center_deep_epa: Total expected points added on targets to the player on deep passes (20 or more yards downfield) to the
+    middle of the field.
+  center_deep_first_downs: Receptions that converted a first down on deep passes (20 or more yards downfield) to the middle
+    of the field.
+  center_deep_fumbles: Fumbles by the player after the catch on deep passes (20 or more yards downfield) to the middle of
+    the field.
+  center_deep_grades_hands_drop: PFF hands/drop grade on deep passes (20 or more yards downfield) to the middle of the field,
+    0-100.
+  center_deep_grades_pass_route: PFF route-running (receiving) grade on deep passes (20 or more yards downfield) to the middle
+    of the field, 0-100.
+  center_deep_interceptions: Interceptions thrown on passes targeting the player on deep passes (20 or more yards downfield)
+    to the middle of the field.
+  center_deep_longest: Longest reception in yards on deep passes (20 or more yards downfield) to the middle of the field.
+  center_deep_pass_block_rate: Share of pass-play snaps spent pass blocking on deep passes (20 or more yards downfield) to
+    the middle of the field.
+  center_deep_pass_blocks: Pass-play snaps spent pass blocking on deep passes (20 or more yards downfield) to the middle of
+    the field.
+  center_deep_pass_plays: Pass-play snaps on deep passes (20 or more yards downfield) to the middle of the field.
+  center_deep_positive_epa_percent: Percentage of the player's targets producing positive expected points added on deep passes
+    (20 or more yards downfield) to the middle of the field.
+  center_deep_receptions: Receptions made on deep passes (20 or more yards downfield) to the middle of the field.
+  center_deep_route_rate: Share of pass-play snaps on which the player ran a route on deep passes (20 or more yards downfield)
+    to the middle of the field.
+  center_deep_routes: Pass routes run by the player on deep passes (20 or more yards downfield) to the middle of the field.
+  center_deep_targeted_qb_rating: NFL passer rating on throws targeting the player on deep passes (20 or more yards downfield)
+    to the middle of the field.
+  center_deep_targets: Pass targets to the player on deep passes (20 or more yards downfield) to the middle of the field.
+  center_deep_targets_percent: Share of the team's targets thrown to the player on deep passes (20 or more yards downfield)
+    to the middle of the field.
+  center_deep_touchdowns: Receiving touchdowns scored on deep passes (20 or more yards downfield) to the middle of the field.
+  center_deep_yards: Receiving yards gained on deep passes (20 or more yards downfield) to the middle of the field.
+  center_deep_yards_after_catch: Yards gained after the catch on deep passes (20 or more yards downfield) to the middle of
+    the field.
+  center_deep_yards_after_catch_per_reception: Average yards after the catch per reception on deep passes (20 or more yards
+    downfield) to the middle of the field.
+  center_deep_yards_per_reception: Average yards per reception on deep passes (20 or more yards downfield) to the middle of
+    the field.
+  center_deep_yprr: Yards per route run on deep passes (20 or more yards downfield) to the middle of the field.
+  center_medium_avg_depth_of_target: Average depth of target in yards downfield on medium passes (10-19 yards downfield) to
+    the middle of the field.
+  center_medium_avoided_tackles: Tackles avoided after the catch on medium passes (10-19 yards downfield) to the middle of
+    the field.
+  center_medium_caught_percent: Percentage of targets caught on medium passes (10-19 yards downfield) to the middle of the
+    field.
+  center_medium_contested_catch_rate: Percentage of PFF-charted contested targets caught on medium passes (10-19 yards downfield)
+    to the middle of the field.
+  center_medium_contested_receptions: Catches made on PFF-charted contested targets on medium passes (10-19 yards downfield)
+    to the middle of the field.
+  center_medium_contested_targets: PFF-charted contested targets on medium passes (10-19 yards downfield) to the middle of
+    the field.
+  center_medium_drop_rate: Share of catchable targets the player dropped on medium passes (10-19 yards downfield) to the middle
+    of the field.
+  center_medium_drops: PFF-charted drops on medium passes (10-19 yards downfield) to the middle of the field.
+  center_medium_epa: Total expected points added on targets to the player on medium passes (10-19 yards downfield) to the
+    middle of the field.
+  center_medium_first_downs: Receptions that converted a first down on medium passes (10-19 yards downfield) to the middle
+    of the field.
+  center_medium_fumbles: Fumbles by the player after the catch on medium passes (10-19 yards downfield) to the middle of the
+    field.
+  center_medium_grades_hands_drop: PFF hands/drop grade on medium passes (10-19 yards downfield) to the middle of the field,
+    0-100.
+  center_medium_grades_pass_route: PFF route-running (receiving) grade on medium passes (10-19 yards downfield) to the middle
+    of the field, 0-100.
+  center_medium_interceptions: Interceptions thrown on passes targeting the player on medium passes (10-19 yards downfield)
+    to the middle of the field.
+  center_medium_longest: Longest reception in yards on medium passes (10-19 yards downfield) to the middle of the field.
+  center_medium_pass_block_rate: Share of pass-play snaps spent pass blocking on medium passes (10-19 yards downfield) to
+    the middle of the field.
+  center_medium_pass_blocks: Pass-play snaps spent pass blocking on medium passes (10-19 yards downfield) to the middle of
+    the field.
+  center_medium_pass_plays: Pass-play snaps on medium passes (10-19 yards downfield) to the middle of the field.
+  center_medium_positive_epa_percent: Percentage of the player's targets producing positive expected points added on medium
+    passes (10-19 yards downfield) to the middle of the field.
+  center_medium_receptions: Receptions made on medium passes (10-19 yards downfield) to the middle of the field.
+  center_medium_route_rate: Share of pass-play snaps on which the player ran a route on medium passes (10-19 yards downfield)
+    to the middle of the field.
+  center_medium_routes: Pass routes run by the player on medium passes (10-19 yards downfield) to the middle of the field.
+  center_medium_targeted_qb_rating: NFL passer rating on throws targeting the player on medium passes (10-19 yards downfield)
+    to the middle of the field.
+  center_medium_targets: Pass targets to the player on medium passes (10-19 yards downfield) to the middle of the field.
+  center_medium_targets_percent: Share of the team's targets thrown to the player on medium passes (10-19 yards downfield)
+    to the middle of the field.
+  center_medium_touchdowns: Receiving touchdowns scored on medium passes (10-19 yards downfield) to the middle of the field.
+  center_medium_yards: Receiving yards gained on medium passes (10-19 yards downfield) to the middle of the field.
+  center_medium_yards_after_catch: Yards gained after the catch on medium passes (10-19 yards downfield) to the middle of
+    the field.
+  center_medium_yards_after_catch_per_reception: Average yards after the catch per reception on medium passes (10-19 yards
+    downfield) to the middle of the field.
+  center_medium_yards_per_reception: Average yards per reception on medium passes (10-19 yards downfield) to the middle of
+    the field.
+  center_medium_yprr: Yards per route run on medium passes (10-19 yards downfield) to the middle of the field.
+  center_short_avg_depth_of_target: Average depth of target in yards downfield on short passes (0-9 yards downfield) to the
+    middle of the field.
+  center_short_avoided_tackles: Tackles avoided after the catch on short passes (0-9 yards downfield) to the middle of the
+    field.
+  center_short_caught_percent: Percentage of targets caught on short passes (0-9 yards downfield) to the middle of the field.
+  center_short_contested_catch_rate: Percentage of PFF-charted contested targets caught on short passes (0-9 yards downfield)
+    to the middle of the field.
+  center_short_contested_receptions: Catches made on PFF-charted contested targets on short passes (0-9 yards downfield) to
+    the middle of the field.
+  center_short_contested_targets: PFF-charted contested targets on short passes (0-9 yards downfield) to the middle of the
+    field.
+  center_short_drop_rate: Share of catchable targets the player dropped on short passes (0-9 yards downfield) to the middle
+    of the field.
+  center_short_drops: PFF-charted drops on short passes (0-9 yards downfield) to the middle of the field.
+  center_short_epa: Total expected points added on targets to the player on short passes (0-9 yards downfield) to the middle
+    of the field.
+  center_short_first_downs: Receptions that converted a first down on short passes (0-9 yards downfield) to the middle of
+    the field.
+  center_short_fumbles: Fumbles by the player after the catch on short passes (0-9 yards downfield) to the middle of the field.
+  center_short_grades_hands_drop: PFF hands/drop grade on short passes (0-9 yards downfield) to the middle of the field, 0-100.
+  center_short_grades_pass_route: PFF route-running (receiving) grade on short passes (0-9 yards downfield) to the middle
+    of the field, 0-100.
+  center_short_interceptions: Interceptions thrown on passes targeting the player on short passes (0-9 yards downfield) to
+    the middle of the field.
+  center_short_longest: Longest reception in yards on short passes (0-9 yards downfield) to the middle of the field.
+  center_short_pass_block_rate: Share of pass-play snaps spent pass blocking on short passes (0-9 yards downfield) to the
+    middle of the field.
+  center_short_pass_blocks: Pass-play snaps spent pass blocking on short passes (0-9 yards downfield) to the middle of the
+    field.
+  center_short_pass_plays: Pass-play snaps on short passes (0-9 yards downfield) to the middle of the field.
+  center_short_positive_epa_percent: Percentage of the player's targets producing positive expected points added on short
+    passes (0-9 yards downfield) to the middle of the field.
+  center_short_receptions: Receptions made on short passes (0-9 yards downfield) to the middle of the field.
+  center_short_route_rate: Share of pass-play snaps on which the player ran a route on short passes (0-9 yards downfield)
+    to the middle of the field.
+  center_short_routes: Pass routes run by the player on short passes (0-9 yards downfield) to the middle of the field.
+  center_short_targeted_qb_rating: NFL passer rating on throws targeting the player on short passes (0-9 yards downfield)
+    to the middle of the field.
+  center_short_targets: Pass targets to the player on short passes (0-9 yards downfield) to the middle of the field.
+  center_short_targets_percent: Share of the team's targets thrown to the player on short passes (0-9 yards downfield) to
+    the middle of the field.
+  center_short_touchdowns: Receiving touchdowns scored on short passes (0-9 yards downfield) to the middle of the field.
+  center_short_yards: Receiving yards gained on short passes (0-9 yards downfield) to the middle of the field.
+  center_short_yards_after_catch: Yards gained after the catch on short passes (0-9 yards downfield) to the middle of the
+    field.
+  center_short_yards_after_catch_per_reception: Average yards after the catch per reception on short passes (0-9 yards downfield)
+    to the middle of the field.
+  center_short_yards_per_reception: Average yards per reception on short passes (0-9 yards downfield) to the middle of the
+    field.
+  center_short_yprr: Yards per route run on short passes (0-9 yards downfield) to the middle of the field.
+  declined_penalties: Penalties committed by the player that were declined.
+  deep_avg_depth_of_target: Average depth of target in yards downfield on deep passes (20 or more yards downfield).
+  deep_avoided_tackles: Tackles avoided after the catch on deep passes (20 or more yards downfield).
+  deep_caught_percent: Percentage of targets caught on deep passes (20 or more yards downfield).
+  deep_contested_catch_rate: Percentage of PFF-charted contested targets caught on deep passes (20 or more yards downfield).
+  deep_contested_receptions: Catches made on PFF-charted contested targets on deep passes (20 or more yards downfield).
+  deep_contested_targets: PFF-charted contested targets on deep passes (20 or more yards downfield).
+  deep_drop_rate: Share of catchable targets the player dropped on deep passes (20 or more yards downfield).
+  deep_drops: PFF-charted drops on deep passes (20 or more yards downfield).
+  deep_epa: Total expected points added on targets to the player on deep passes (20 or more yards downfield).
+  deep_first_downs: Receptions that converted a first down on deep passes (20 or more yards downfield).
+  deep_fumbles: Fumbles by the player after the catch on deep passes (20 or more yards downfield).
+  deep_grades_hands_drop: PFF hands/drop grade on deep passes (20 or more yards downfield), 0-100.
+  deep_grades_pass_route: PFF route-running (receiving) grade on deep passes (20 or more yards downfield), 0-100.
+  deep_interceptions: Interceptions thrown on passes targeting the player on deep passes (20 or more yards downfield).
+  deep_longest: Longest reception in yards on deep passes (20 or more yards downfield).
+  deep_pass_block_rate: Share of pass-play snaps spent pass blocking on deep passes (20 or more yards downfield).
+  deep_pass_blocks: Pass-play snaps spent pass blocking on deep passes (20 or more yards downfield).
+  deep_pass_plays: Pass-play snaps on deep passes (20 or more yards downfield).
+  deep_positive_epa_percent: Percentage of the player's targets producing positive expected points added on deep passes (20
+    or more yards downfield).
+  deep_receptions: Receptions made on deep passes (20 or more yards downfield).
+  deep_route_rate: Share of pass-play snaps on which the player ran a route on deep passes (20 or more yards downfield).
+  deep_routes: Pass routes run by the player on deep passes (20 or more yards downfield).
+  deep_targeted_qb_rating: NFL passer rating on throws targeting the player on deep passes (20 or more yards downfield).
+  deep_targets: Pass targets to the player on deep passes (20 or more yards downfield).
+  deep_targets_percent: Share of the team's targets thrown to the player on deep passes (20 or more yards downfield).
+  deep_touchdowns: Receiving touchdowns scored on deep passes (20 or more yards downfield).
+  deep_yards: Receiving yards gained on deep passes (20 or more yards downfield).
+  deep_yards_after_catch: Yards gained after the catch on deep passes (20 or more yards downfield).
+  deep_yards_after_catch_per_reception: Average yards after the catch per reception on deep passes (20 or more yards downfield).
+  deep_yards_per_reception: Average yards per reception on deep passes (20 or more yards downfield).
+  deep_yprr: Yards per route run on deep passes (20 or more yards downfield).
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  left_behind_los_avg_depth_of_target: Average depth of target in yards downfield on passes thrown behind the line of scrimmage
+    to the left third of the field.
+  left_behind_los_avoided_tackles: Tackles avoided after the catch on passes thrown behind the line of scrimmage to the left
+    third of the field.
+  left_behind_los_caught_percent: Percentage of targets caught on passes thrown behind the line of scrimmage to the left third
+    of the field.
+  left_behind_los_contested_catch_rate: Percentage of PFF-charted contested targets caught on passes thrown behind the line
+    of scrimmage to the left third of the field.
+  left_behind_los_contested_receptions: Catches made on PFF-charted contested targets on passes thrown behind the line of
+    scrimmage to the left third of the field.
+  left_behind_los_contested_targets: PFF-charted contested targets on passes thrown behind the line of scrimmage to the left
+    third of the field.
+  left_behind_los_drop_rate: Share of catchable targets the player dropped on passes thrown behind the line of scrimmage to
+    the left third of the field.
+  left_behind_los_drops: PFF-charted drops on passes thrown behind the line of scrimmage to the left third of the field.
+  left_behind_los_epa: Total expected points added on targets to the player on passes thrown behind the line of scrimmage
+    to the left third of the field.
+  left_behind_los_first_downs: Receptions that converted a first down on passes thrown behind the line of scrimmage to the
+    left third of the field.
+  left_behind_los_fumbles: Fumbles by the player after the catch on passes thrown behind the line of scrimmage to the left
+    third of the field.
+  left_behind_los_grades_hands_drop: PFF hands/drop grade on passes thrown behind the line of scrimmage to the left third
+    of the field, 0-100.
+  left_behind_los_grades_pass_route: PFF route-running (receiving) grade on passes thrown behind the line of scrimmage to
+    the left third of the field, 0-100.
+  left_behind_los_interceptions: Interceptions thrown on passes targeting the player on passes thrown behind the line of scrimmage
+    to the left third of the field.
+  left_behind_los_longest: Longest reception in yards on passes thrown behind the line of scrimmage to the left third of the
+    field.
+  left_behind_los_pass_block_rate: Share of pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage
+    to the left third of the field.
+  left_behind_los_pass_blocks: Pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage to the left
+    third of the field.
+  left_behind_los_pass_plays: Pass-play snaps on passes thrown behind the line of scrimmage to the left third of the field.
+  left_behind_los_positive_epa_percent: Percentage of the player's targets producing positive expected points added on passes
+    thrown behind the line of scrimmage to the left third of the field.
+  left_behind_los_receptions: Receptions made on passes thrown behind the line of scrimmage to the left third of the field.
+  left_behind_los_route_rate: Share of pass-play snaps on which the player ran a route on passes thrown behind the line of
+    scrimmage to the left third of the field.
+  left_behind_los_routes: Pass routes run by the player on passes thrown behind the line of scrimmage to the left third of
+    the field.
+  left_behind_los_targeted_qb_rating: NFL passer rating on throws targeting the player on passes thrown behind the line of
+    scrimmage to the left third of the field.
+  left_behind_los_targets: Pass targets to the player on passes thrown behind the line of scrimmage to the left third of the
+    field.
+  left_behind_los_targets_percent: Share of the team's targets thrown to the player on passes thrown behind the line of scrimmage
+    to the left third of the field.
+  left_behind_los_touchdowns: Receiving touchdowns scored on passes thrown behind the line of scrimmage to the left third
+    of the field.
+  left_behind_los_yards: Receiving yards gained on passes thrown behind the line of scrimmage to the left third of the field.
+  left_behind_los_yards_after_catch: Yards gained after the catch on passes thrown behind the line of scrimmage to the left
+    third of the field.
+  left_behind_los_yards_after_catch_per_reception: Average yards after the catch per reception on passes thrown behind the
+    line of scrimmage to the left third of the field.
+  left_behind_los_yards_per_reception: Average yards per reception on passes thrown behind the line of scrimmage to the left
+    third of the field.
+  left_behind_los_yprr: Yards per route run on passes thrown behind the line of scrimmage to the left third of the field.
+  left_deep_avg_depth_of_target: Average depth of target in yards downfield on deep passes (20 or more yards downfield) to
+    the left third of the field.
+  left_deep_avoided_tackles: Tackles avoided after the catch on deep passes (20 or more yards downfield) to the left third
+    of the field.
+  left_deep_caught_percent: Percentage of targets caught on deep passes (20 or more yards downfield) to the left third of
+    the field.
+  left_deep_contested_catch_rate: Percentage of PFF-charted contested targets caught on deep passes (20 or more yards downfield)
+    to the left third of the field.
+  left_deep_contested_receptions: Catches made on PFF-charted contested targets on deep passes (20 or more yards downfield)
+    to the left third of the field.
+  left_deep_contested_targets: PFF-charted contested targets on deep passes (20 or more yards downfield) to the left third
+    of the field.
+  left_deep_drop_rate: Share of catchable targets the player dropped on deep passes (20 or more yards downfield) to the left
+    third of the field.
+  left_deep_drops: PFF-charted drops on deep passes (20 or more yards downfield) to the left third of the field.
+  left_deep_epa: Total expected points added on targets to the player on deep passes (20 or more yards downfield) to the left
+    third of the field.
+  left_deep_first_downs: Receptions that converted a first down on deep passes (20 or more yards downfield) to the left third
+    of the field.
+  left_deep_fumbles: Fumbles by the player after the catch on deep passes (20 or more yards downfield) to the left third of
+    the field.
+  left_deep_grades_hands_drop: PFF hands/drop grade on deep passes (20 or more yards downfield) to the left third of the field,
+    0-100.
+  left_deep_grades_pass_route: PFF route-running (receiving) grade on deep passes (20 or more yards downfield) to the left
+    third of the field, 0-100.
+  left_deep_interceptions: Interceptions thrown on passes targeting the player on deep passes (20 or more yards downfield)
+    to the left third of the field.
+  left_deep_longest: Longest reception in yards on deep passes (20 or more yards downfield) to the left third of the field.
+  left_deep_pass_block_rate: Share of pass-play snaps spent pass blocking on deep passes (20 or more yards downfield) to the
+    left third of the field.
+  left_deep_pass_blocks: Pass-play snaps spent pass blocking on deep passes (20 or more yards downfield) to the left third
+    of the field.
+  left_deep_pass_plays: Pass-play snaps on deep passes (20 or more yards downfield) to the left third of the field.
+  left_deep_positive_epa_percent: Percentage of the player's targets producing positive expected points added on deep passes
+    (20 or more yards downfield) to the left third of the field.
+  left_deep_receptions: Receptions made on deep passes (20 or more yards downfield) to the left third of the field.
+  left_deep_route_rate: Share of pass-play snaps on which the player ran a route on deep passes (20 or more yards downfield)
+    to the left third of the field.
+  left_deep_routes: Pass routes run by the player on deep passes (20 or more yards downfield) to the left third of the field.
+  left_deep_targeted_qb_rating: NFL passer rating on throws targeting the player on deep passes (20 or more yards downfield)
+    to the left third of the field.
+  left_deep_targets: Pass targets to the player on deep passes (20 or more yards downfield) to the left third of the field.
+  left_deep_targets_percent: Share of the team's targets thrown to the player on deep passes (20 or more yards downfield)
+    to the left third of the field.
+  left_deep_touchdowns: Receiving touchdowns scored on deep passes (20 or more yards downfield) to the left third of the field.
+  left_deep_yards: Receiving yards gained on deep passes (20 or more yards downfield) to the left third of the field.
+  left_deep_yards_after_catch: Yards gained after the catch on deep passes (20 or more yards downfield) to the left third
+    of the field.
+  left_deep_yards_after_catch_per_reception: Average yards after the catch per reception on deep passes (20 or more yards
+    downfield) to the left third of the field.
+  left_deep_yards_per_reception: Average yards per reception on deep passes (20 or more yards downfield) to the left third
+    of the field.
+  left_deep_yprr: Yards per route run on deep passes (20 or more yards downfield) to the left third of the field.
+  left_medium_avg_depth_of_target: Average depth of target in yards downfield on medium passes (10-19 yards downfield) to
+    the left third of the field.
+  left_medium_avoided_tackles: Tackles avoided after the catch on medium passes (10-19 yards downfield) to the left third
+    of the field.
+  left_medium_caught_percent: Percentage of targets caught on medium passes (10-19 yards downfield) to the left third of the
+    field.
+  left_medium_contested_catch_rate: Percentage of PFF-charted contested targets caught on medium passes (10-19 yards downfield)
+    to the left third of the field.
+  left_medium_contested_receptions: Catches made on PFF-charted contested targets on medium passes (10-19 yards downfield)
+    to the left third of the field.
+  left_medium_contested_targets: PFF-charted contested targets on medium passes (10-19 yards downfield) to the left third
+    of the field.
+  left_medium_drop_rate: Share of catchable targets the player dropped on medium passes (10-19 yards downfield) to the left
+    third of the field.
+  left_medium_drops: PFF-charted drops on medium passes (10-19 yards downfield) to the left third of the field.
+  left_medium_epa: Total expected points added on targets to the player on medium passes (10-19 yards downfield) to the left
+    third of the field.
+  left_medium_first_downs: Receptions that converted a first down on medium passes (10-19 yards downfield) to the left third
+    of the field.
+  left_medium_fumbles: Fumbles by the player after the catch on medium passes (10-19 yards downfield) to the left third of
+    the field.
+  left_medium_grades_hands_drop: PFF hands/drop grade on medium passes (10-19 yards downfield) to the left third of the field,
+    0-100.
+  left_medium_grades_pass_route: PFF route-running (receiving) grade on medium passes (10-19 yards downfield) to the left
+    third of the field, 0-100.
+  left_medium_interceptions: Interceptions thrown on passes targeting the player on medium passes (10-19 yards downfield)
+    to the left third of the field.
+  left_medium_longest: Longest reception in yards on medium passes (10-19 yards downfield) to the left third of the field.
+  left_medium_pass_block_rate: Share of pass-play snaps spent pass blocking on medium passes (10-19 yards downfield) to the
+    left third of the field.
+  left_medium_pass_blocks: Pass-play snaps spent pass blocking on medium passes (10-19 yards downfield) to the left third
+    of the field.
+  left_medium_pass_plays: Pass-play snaps on medium passes (10-19 yards downfield) to the left third of the field.
+  left_medium_positive_epa_percent: Percentage of the player's targets producing positive expected points added on medium
+    passes (10-19 yards downfield) to the left third of the field.
+  left_medium_receptions: Receptions made on medium passes (10-19 yards downfield) to the left third of the field.
+  left_medium_route_rate: Share of pass-play snaps on which the player ran a route on medium passes (10-19 yards downfield)
+    to the left third of the field.
+  left_medium_routes: Pass routes run by the player on medium passes (10-19 yards downfield) to the left third of the field.
+  left_medium_targeted_qb_rating: NFL passer rating on throws targeting the player on medium passes (10-19 yards downfield)
+    to the left third of the field.
+  left_medium_targets: Pass targets to the player on medium passes (10-19 yards downfield) to the left third of the field.
+  left_medium_targets_percent: Share of the team's targets thrown to the player on medium passes (10-19 yards downfield) to
+    the left third of the field.
+  left_medium_touchdowns: Receiving touchdowns scored on medium passes (10-19 yards downfield) to the left third of the field.
+  left_medium_yards: Receiving yards gained on medium passes (10-19 yards downfield) to the left third of the field.
+  left_medium_yards_after_catch: Yards gained after the catch on medium passes (10-19 yards downfield) to the left third of
+    the field.
+  left_medium_yards_after_catch_per_reception: Average yards after the catch per reception on medium passes (10-19 yards downfield)
+    to the left third of the field.
+  left_medium_yards_per_reception: Average yards per reception on medium passes (10-19 yards downfield) to the left third
+    of the field.
+  left_medium_yprr: Yards per route run on medium passes (10-19 yards downfield) to the left third of the field.
+  left_short_avg_depth_of_target: Average depth of target in yards downfield on short passes (0-9 yards downfield) to the
+    left third of the field.
+  left_short_avoided_tackles: Tackles avoided after the catch on short passes (0-9 yards downfield) to the left third of the
+    field.
+  left_short_caught_percent: Percentage of targets caught on short passes (0-9 yards downfield) to the left third of the field.
+  left_short_contested_catch_rate: Percentage of PFF-charted contested targets caught on short passes (0-9 yards downfield)
+    to the left third of the field.
+  left_short_contested_receptions: Catches made on PFF-charted contested targets on short passes (0-9 yards downfield) to
+    the left third of the field.
+  left_short_contested_targets: PFF-charted contested targets on short passes (0-9 yards downfield) to the left third of the
+    field.
+  left_short_drop_rate: Share of catchable targets the player dropped on short passes (0-9 yards downfield) to the left third
+    of the field.
+  left_short_drops: PFF-charted drops on short passes (0-9 yards downfield) to the left third of the field.
+  left_short_epa: Total expected points added on targets to the player on short passes (0-9 yards downfield) to the left third
+    of the field.
+  left_short_first_downs: Receptions that converted a first down on short passes (0-9 yards downfield) to the left third of
+    the field.
+  left_short_fumbles: Fumbles by the player after the catch on short passes (0-9 yards downfield) to the left third of the
+    field.
+  left_short_grades_hands_drop: PFF hands/drop grade on short passes (0-9 yards downfield) to the left third of the field,
+    0-100.
+  left_short_grades_pass_route: PFF route-running (receiving) grade on short passes (0-9 yards downfield) to the left third
+    of the field, 0-100.
+  left_short_interceptions: Interceptions thrown on passes targeting the player on short passes (0-9 yards downfield) to the
+    left third of the field.
+  left_short_longest: Longest reception in yards on short passes (0-9 yards downfield) to the left third of the field.
+  left_short_pass_block_rate: Share of pass-play snaps spent pass blocking on short passes (0-9 yards downfield) to the left
+    third of the field.
+  left_short_pass_blocks: Pass-play snaps spent pass blocking on short passes (0-9 yards downfield) to the left third of the
+    field.
+  left_short_pass_plays: Pass-play snaps on short passes (0-9 yards downfield) to the left third of the field.
+  left_short_positive_epa_percent: Percentage of the player's targets producing positive expected points added on short passes
+    (0-9 yards downfield) to the left third of the field.
+  left_short_receptions: Receptions made on short passes (0-9 yards downfield) to the left third of the field.
+  left_short_route_rate: Share of pass-play snaps on which the player ran a route on short passes (0-9 yards downfield) to
+    the left third of the field.
+  left_short_routes: Pass routes run by the player on short passes (0-9 yards downfield) to the left third of the field.
+  left_short_targeted_qb_rating: NFL passer rating on throws targeting the player on short passes (0-9 yards downfield) to
+    the left third of the field.
+  left_short_targets: Pass targets to the player on short passes (0-9 yards downfield) to the left third of the field.
+  left_short_targets_percent: Share of the team's targets thrown to the player on short passes (0-9 yards downfield) to the
+    left third of the field.
+  left_short_touchdowns: Receiving touchdowns scored on short passes (0-9 yards downfield) to the left third of the field.
+  left_short_yards: Receiving yards gained on short passes (0-9 yards downfield) to the left third of the field.
+  left_short_yards_after_catch: Yards gained after the catch on short passes (0-9 yards downfield) to the left third of the
+    field.
+  left_short_yards_after_catch_per_reception: Average yards after the catch per reception on short passes (0-9 yards downfield)
+    to the left third of the field.
+  left_short_yards_per_reception: Average yards per reception on short passes (0-9 yards downfield) to the left third of the
+    field.
+  left_short_yprr: Yards per route run on short passes (0-9 yards downfield) to the left third of the field.
+  medium_avg_depth_of_target: Average depth of target in yards downfield on medium passes (10-19 yards downfield).
+  medium_avoided_tackles: Tackles avoided after the catch on medium passes (10-19 yards downfield).
+  medium_caught_percent: Percentage of targets caught on medium passes (10-19 yards downfield).
+  medium_contested_catch_rate: Percentage of PFF-charted contested targets caught on medium passes (10-19 yards downfield).
+  medium_contested_receptions: Catches made on PFF-charted contested targets on medium passes (10-19 yards downfield).
+  medium_contested_targets: PFF-charted contested targets on medium passes (10-19 yards downfield).
+  medium_drop_rate: Share of catchable targets the player dropped on medium passes (10-19 yards downfield).
+  medium_drops: PFF-charted drops on medium passes (10-19 yards downfield).
+  medium_epa: Total expected points added on targets to the player on medium passes (10-19 yards downfield).
+  medium_first_downs: Receptions that converted a first down on medium passes (10-19 yards downfield).
+  medium_fumbles: Fumbles by the player after the catch on medium passes (10-19 yards downfield).
+  medium_grades_hands_drop: PFF hands/drop grade on medium passes (10-19 yards downfield), 0-100.
+  medium_grades_pass_route: PFF route-running (receiving) grade on medium passes (10-19 yards downfield), 0-100.
+  medium_interceptions: Interceptions thrown on passes targeting the player on medium passes (10-19 yards downfield).
+  medium_longest: Longest reception in yards on medium passes (10-19 yards downfield).
+  medium_pass_block_rate: Share of pass-play snaps spent pass blocking on medium passes (10-19 yards downfield).
+  medium_pass_blocks: Pass-play snaps spent pass blocking on medium passes (10-19 yards downfield).
+  medium_pass_plays: Pass-play snaps on medium passes (10-19 yards downfield).
+  medium_positive_epa_percent: Percentage of the player's targets producing positive expected points added on medium passes
+    (10-19 yards downfield).
+  medium_receptions: Receptions made on medium passes (10-19 yards downfield).
+  medium_route_rate: Share of pass-play snaps on which the player ran a route on medium passes (10-19 yards downfield).
+  medium_routes: Pass routes run by the player on medium passes (10-19 yards downfield).
+  medium_targeted_qb_rating: NFL passer rating on throws targeting the player on medium passes (10-19 yards downfield).
+  medium_targets: Pass targets to the player on medium passes (10-19 yards downfield).
+  medium_targets_percent: Share of the team's targets thrown to the player on medium passes (10-19 yards downfield).
+  medium_touchdowns: Receiving touchdowns scored on medium passes (10-19 yards downfield).
+  medium_yards: Receiving yards gained on medium passes (10-19 yards downfield).
+  medium_yards_after_catch: Yards gained after the catch on medium passes (10-19 yards downfield).
+  medium_yards_after_catch_per_reception: Average yards after the catch per reception on medium passes (10-19 yards downfield).
+  medium_yards_per_reception: Average yards per reception on medium passes (10-19 yards downfield).
+  medium_yprr: Yards per route run on medium passes (10-19 yards downfield).
+  player_game_count: Number of games the player appeared in over the covered span.
+  right_behind_los_avg_depth_of_target: Average depth of target in yards downfield on passes thrown behind the line of scrimmage
+    to the right third of the field.
+  right_behind_los_avoided_tackles: Tackles avoided after the catch on passes thrown behind the line of scrimmage to the right
+    third of the field.
+  right_behind_los_caught_percent: Percentage of targets caught on passes thrown behind the line of scrimmage to the right
+    third of the field.
+  right_behind_los_contested_catch_rate: Percentage of PFF-charted contested targets caught on passes thrown behind the line
+    of scrimmage to the right third of the field.
+  right_behind_los_contested_receptions: Catches made on PFF-charted contested targets on passes thrown behind the line of
+    scrimmage to the right third of the field.
+  right_behind_los_contested_targets: PFF-charted contested targets on passes thrown behind the line of scrimmage to the right
+    third of the field.
+  right_behind_los_drop_rate: Share of catchable targets the player dropped on passes thrown behind the line of scrimmage
+    to the right third of the field.
+  right_behind_los_drops: PFF-charted drops on passes thrown behind the line of scrimmage to the right third of the field.
+  right_behind_los_epa: Total expected points added on targets to the player on passes thrown behind the line of scrimmage
+    to the right third of the field.
+  right_behind_los_first_downs: Receptions that converted a first down on passes thrown behind the line of scrimmage to the
+    right third of the field.
+  right_behind_los_fumbles: Fumbles by the player after the catch on passes thrown behind the line of scrimmage to the right
+    third of the field.
+  right_behind_los_grades_hands_drop: PFF hands/drop grade on passes thrown behind the line of scrimmage to the right third
+    of the field, 0-100.
+  right_behind_los_grades_pass_route: PFF route-running (receiving) grade on passes thrown behind the line of scrimmage to
+    the right third of the field, 0-100.
+  right_behind_los_interceptions: Interceptions thrown on passes targeting the player on passes thrown behind the line of
+    scrimmage to the right third of the field.
+  right_behind_los_longest: Longest reception in yards on passes thrown behind the line of scrimmage to the right third of
+    the field.
+  right_behind_los_pass_block_rate: Share of pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage
+    to the right third of the field.
+  right_behind_los_pass_blocks: Pass-play snaps spent pass blocking on passes thrown behind the line of scrimmage to the right
+    third of the field.
+  right_behind_los_pass_plays: Pass-play snaps on passes thrown behind the line of scrimmage to the right third of the field.
+  right_behind_los_positive_epa_percent: Percentage of the player's targets producing positive expected points added on passes
+    thrown behind the line of scrimmage to the right third of the field.
+  right_behind_los_receptions: Receptions made on passes thrown behind the line of scrimmage to the right third of the field.
+  right_behind_los_route_rate: Share of pass-play snaps on which the player ran a route on passes thrown behind the line of
+    scrimmage to the right third of the field.
+  right_behind_los_routes: Pass routes run by the player on passes thrown behind the line of scrimmage to the right third
+    of the field.
+  right_behind_los_targeted_qb_rating: NFL passer rating on throws targeting the player on passes thrown behind the line of
+    scrimmage to the right third of the field.
+  right_behind_los_targets: Pass targets to the player on passes thrown behind the line of scrimmage to the right third of
+    the field.
+  right_behind_los_targets_percent: Share of the team's targets thrown to the player on passes thrown behind the line of scrimmage
+    to the right third of the field.
+  right_behind_los_touchdowns: Receiving touchdowns scored on passes thrown behind the line of scrimmage to the right third
+    of the field.
+  right_behind_los_yards: Receiving yards gained on passes thrown behind the line of scrimmage to the right third of the field.
+  right_behind_los_yards_after_catch: Yards gained after the catch on passes thrown behind the line of scrimmage to the right
+    third of the field.
+  right_behind_los_yards_after_catch_per_reception: Average yards after the catch per reception on passes thrown behind the
+    line of scrimmage to the right third of the field.
+  right_behind_los_yards_per_reception: Average yards per reception on passes thrown behind the line of scrimmage to the right
+    third of the field.
+  right_behind_los_yprr: Yards per route run on passes thrown behind the line of scrimmage to the right third of the field.
+  right_deep_avg_depth_of_target: Average depth of target in yards downfield on deep passes (20 or more yards downfield) to
+    the right third of the field.
+  right_deep_avoided_tackles: Tackles avoided after the catch on deep passes (20 or more yards downfield) to the right third
+    of the field.
+  right_deep_caught_percent: Percentage of targets caught on deep passes (20 or more yards downfield) to the right third of
+    the field.
+  right_deep_contested_catch_rate: Percentage of PFF-charted contested targets caught on deep passes (20 or more yards downfield)
+    to the right third of the field.
+  right_deep_contested_receptions: Catches made on PFF-charted contested targets on deep passes (20 or more yards downfield)
+    to the right third of the field.
+  right_deep_contested_targets: PFF-charted contested targets on deep passes (20 or more yards downfield) to the right third
+    of the field.
+  right_deep_drop_rate: Share of catchable targets the player dropped on deep passes (20 or more yards downfield) to the right
+    third of the field.
+  right_deep_drops: PFF-charted drops on deep passes (20 or more yards downfield) to the right third of the field.
+  right_deep_epa: Total expected points added on targets to the player on deep passes (20 or more yards downfield) to the
+    right third of the field.
+  right_deep_first_downs: Receptions that converted a first down on deep passes (20 or more yards downfield) to the right
+    third of the field.
+  right_deep_fumbles: Fumbles by the player after the catch on deep passes (20 or more yards downfield) to the right third
+    of the field.
+  right_deep_grades_hands_drop: PFF hands/drop grade on deep passes (20 or more yards downfield) to the right third of the
+    field, 0-100.
+  right_deep_grades_pass_route: PFF route-running (receiving) grade on deep passes (20 or more yards downfield) to the right
+    third of the field, 0-100.
+  right_deep_interceptions: Interceptions thrown on passes targeting the player on deep passes (20 or more yards downfield)
+    to the right third of the field.
+  right_deep_longest: Longest reception in yards on deep passes (20 or more yards downfield) to the right third of the field.
+  right_deep_pass_block_rate: Share of pass-play snaps spent pass blocking on deep passes (20 or more yards downfield) to
+    the right third of the field.
+  right_deep_pass_blocks: Pass-play snaps spent pass blocking on deep passes (20 or more yards downfield) to the right third
+    of the field.
+  right_deep_pass_plays: Pass-play snaps on deep passes (20 or more yards downfield) to the right third of the field.
+  right_deep_positive_epa_percent: Percentage of the player's targets producing positive expected points added on deep passes
+    (20 or more yards downfield) to the right third of the field.
+  right_deep_receptions: Receptions made on deep passes (20 or more yards downfield) to the right third of the field.
+  right_deep_route_rate: Share of pass-play snaps on which the player ran a route on deep passes (20 or more yards downfield)
+    to the right third of the field.
+  right_deep_routes: Pass routes run by the player on deep passes (20 or more yards downfield) to the right third of the field.
+  right_deep_targeted_qb_rating: NFL passer rating on throws targeting the player on deep passes (20 or more yards downfield)
+    to the right third of the field.
+  right_deep_targets: Pass targets to the player on deep passes (20 or more yards downfield) to the right third of the field.
+  right_deep_targets_percent: Share of the team's targets thrown to the player on deep passes (20 or more yards downfield)
+    to the right third of the field.
+  right_deep_touchdowns: Receiving touchdowns scored on deep passes (20 or more yards downfield) to the right third of the
+    field.
+  right_deep_yards: Receiving yards gained on deep passes (20 or more yards downfield) to the right third of the field.
+  right_deep_yards_after_catch: Yards gained after the catch on deep passes (20 or more yards downfield) to the right third
+    of the field.
+  right_deep_yards_after_catch_per_reception: Average yards after the catch per reception on deep passes (20 or more yards
+    downfield) to the right third of the field.
+  right_deep_yards_per_reception: Average yards per reception on deep passes (20 or more yards downfield) to the right third
+    of the field.
+  right_deep_yprr: Yards per route run on deep passes (20 or more yards downfield) to the right third of the field.
+  right_medium_avg_depth_of_target: Average depth of target in yards downfield on medium passes (10-19 yards downfield) to
+    the right third of the field.
+  right_medium_avoided_tackles: Tackles avoided after the catch on medium passes (10-19 yards downfield) to the right third
+    of the field.
+  right_medium_caught_percent: Percentage of targets caught on medium passes (10-19 yards downfield) to the right third of
+    the field.
+  right_medium_contested_catch_rate: Percentage of PFF-charted contested targets caught on medium passes (10-19 yards downfield)
+    to the right third of the field.
+  right_medium_contested_receptions: Catches made on PFF-charted contested targets on medium passes (10-19 yards downfield)
+    to the right third of the field.
+  right_medium_contested_targets: PFF-charted contested targets on medium passes (10-19 yards downfield) to the right third
+    of the field.
+  right_medium_drop_rate: Share of catchable targets the player dropped on medium passes (10-19 yards downfield) to the right
+    third of the field.
+  right_medium_drops: PFF-charted drops on medium passes (10-19 yards downfield) to the right third of the field.
+  right_medium_epa: Total expected points added on targets to the player on medium passes (10-19 yards downfield) to the right
+    third of the field.
+  right_medium_first_downs: Receptions that converted a first down on medium passes (10-19 yards downfield) to the right third
+    of the field.
+  right_medium_fumbles: Fumbles by the player after the catch on medium passes (10-19 yards downfield) to the right third
+    of the field.
+  right_medium_grades_hands_drop: PFF hands/drop grade on medium passes (10-19 yards downfield) to the right third of the
+    field, 0-100.
+  right_medium_grades_pass_route: PFF route-running (receiving) grade on medium passes (10-19 yards downfield) to the right
+    third of the field, 0-100.
+  right_medium_interceptions: Interceptions thrown on passes targeting the player on medium passes (10-19 yards downfield)
+    to the right third of the field.
+  right_medium_longest: Longest reception in yards on medium passes (10-19 yards downfield) to the right third of the field.
+  right_medium_pass_block_rate: Share of pass-play snaps spent pass blocking on medium passes (10-19 yards downfield) to the
+    right third of the field.
+  right_medium_pass_blocks: Pass-play snaps spent pass blocking on medium passes (10-19 yards downfield) to the right third
+    of the field.
+  right_medium_pass_plays: Pass-play snaps on medium passes (10-19 yards downfield) to the right third of the field.
+  right_medium_positive_epa_percent: Percentage of the player's targets producing positive expected points added on medium
+    passes (10-19 yards downfield) to the right third of the field.
+  right_medium_receptions: Receptions made on medium passes (10-19 yards downfield) to the right third of the field.
+  right_medium_route_rate: Share of pass-play snaps on which the player ran a route on medium passes (10-19 yards downfield)
+    to the right third of the field.
+  right_medium_routes: Pass routes run by the player on medium passes (10-19 yards downfield) to the right third of the field.
+  right_medium_targeted_qb_rating: NFL passer rating on throws targeting the player on medium passes (10-19 yards downfield)
+    to the right third of the field.
+  right_medium_targets: Pass targets to the player on medium passes (10-19 yards downfield) to the right third of the field.
+  right_medium_targets_percent: Share of the team's targets thrown to the player on medium passes (10-19 yards downfield)
+    to the right third of the field.
+  right_medium_touchdowns: Receiving touchdowns scored on medium passes (10-19 yards downfield) to the right third of the
+    field.
+  right_medium_yards: Receiving yards gained on medium passes (10-19 yards downfield) to the right third of the field.
+  right_medium_yards_after_catch: Yards gained after the catch on medium passes (10-19 yards downfield) to the right third
+    of the field.
+  right_medium_yards_after_catch_per_reception: Average yards after the catch per reception on medium passes (10-19 yards
+    downfield) to the right third of the field.
+  right_medium_yards_per_reception: Average yards per reception on medium passes (10-19 yards downfield) to the right third
+    of the field.
+  right_medium_yprr: Yards per route run on medium passes (10-19 yards downfield) to the right third of the field.
+  right_short_avg_depth_of_target: Average depth of target in yards downfield on short passes (0-9 yards downfield) to the
+    right third of the field.
+  right_short_avoided_tackles: Tackles avoided after the catch on short passes (0-9 yards downfield) to the right third of
+    the field.
+  right_short_caught_percent: Percentage of targets caught on short passes (0-9 yards downfield) to the right third of the
+    field.
+  right_short_contested_catch_rate: Percentage of PFF-charted contested targets caught on short passes (0-9 yards downfield)
+    to the right third of the field.
+  right_short_contested_receptions: Catches made on PFF-charted contested targets on short passes (0-9 yards downfield) to
+    the right third of the field.
+  right_short_contested_targets: PFF-charted contested targets on short passes (0-9 yards downfield) to the right third of
+    the field.
+  right_short_drop_rate: Share of catchable targets the player dropped on short passes (0-9 yards downfield) to the right
+    third of the field.
+  right_short_drops: PFF-charted drops on short passes (0-9 yards downfield) to the right third of the field.
+  right_short_epa: Total expected points added on targets to the player on short passes (0-9 yards downfield) to the right
+    third of the field.
+  right_short_first_downs: Receptions that converted a first down on short passes (0-9 yards downfield) to the right third
+    of the field.
+  right_short_fumbles: Fumbles by the player after the catch on short passes (0-9 yards downfield) to the right third of the
+    field.
+  right_short_grades_hands_drop: PFF hands/drop grade on short passes (0-9 yards downfield) to the right third of the field,
+    0-100.
+  right_short_grades_pass_route: PFF route-running (receiving) grade on short passes (0-9 yards downfield) to the right third
+    of the field, 0-100.
+  right_short_interceptions: Interceptions thrown on passes targeting the player on short passes (0-9 yards downfield) to
+    the right third of the field.
+  right_short_longest: Longest reception in yards on short passes (0-9 yards downfield) to the right third of the field.
+  right_short_pass_block_rate: Share of pass-play snaps spent pass blocking on short passes (0-9 yards downfield) to the right
+    third of the field.
+  right_short_pass_blocks: Pass-play snaps spent pass blocking on short passes (0-9 yards downfield) to the right third of
+    the field.
+  right_short_pass_plays: Pass-play snaps on short passes (0-9 yards downfield) to the right third of the field.
+  right_short_positive_epa_percent: Percentage of the player's targets producing positive expected points added on short passes
+    (0-9 yards downfield) to the right third of the field.
+  right_short_receptions: Receptions made on short passes (0-9 yards downfield) to the right third of the field.
+  right_short_route_rate: Share of pass-play snaps on which the player ran a route on short passes (0-9 yards downfield) to
+    the right third of the field.
+  right_short_routes: Pass routes run by the player on short passes (0-9 yards downfield) to the right third of the field.
+  right_short_targeted_qb_rating: NFL passer rating on throws targeting the player on short passes (0-9 yards downfield) to
+    the right third of the field.
+  right_short_targets: Pass targets to the player on short passes (0-9 yards downfield) to the right third of the field.
+  right_short_targets_percent: Share of the team's targets thrown to the player on short passes (0-9 yards downfield) to the
+    right third of the field.
+  right_short_touchdowns: Receiving touchdowns scored on short passes (0-9 yards downfield) to the right third of the field.
+  right_short_yards: Receiving yards gained on short passes (0-9 yards downfield) to the right third of the field.
+  right_short_yards_after_catch: Yards gained after the catch on short passes (0-9 yards downfield) to the right third of
+    the field.
+  right_short_yards_after_catch_per_reception: Average yards after the catch per reception on short passes (0-9 yards downfield)
+    to the right third of the field.
+  right_short_yards_per_reception: Average yards per reception on short passes (0-9 yards downfield) to the right third of
+    the field.
+  right_short_yprr: Yards per route run on short passes (0-9 yards downfield) to the right third of the field.
+  short_avg_depth_of_target: Average depth of target in yards downfield on short passes (0-9 yards downfield).
+  short_avoided_tackles: Tackles avoided after the catch on short passes (0-9 yards downfield).
+  short_caught_percent: Percentage of targets caught on short passes (0-9 yards downfield).
+  short_contested_catch_rate: Percentage of PFF-charted contested targets caught on short passes (0-9 yards downfield).
+  short_contested_receptions: Catches made on PFF-charted contested targets on short passes (0-9 yards downfield).
+  short_contested_targets: PFF-charted contested targets on short passes (0-9 yards downfield).
+  short_drop_rate: Share of catchable targets the player dropped on short passes (0-9 yards downfield).
+  short_drops: PFF-charted drops on short passes (0-9 yards downfield).
+  short_epa: Total expected points added on targets to the player on short passes (0-9 yards downfield).
+  short_first_downs: Receptions that converted a first down on short passes (0-9 yards downfield).
+  short_fumbles: Fumbles by the player after the catch on short passes (0-9 yards downfield).
+  short_grades_hands_drop: PFF hands/drop grade on short passes (0-9 yards downfield), 0-100.
+  short_grades_pass_route: PFF route-running (receiving) grade on short passes (0-9 yards downfield), 0-100.
+  short_interceptions: Interceptions thrown on passes targeting the player on short passes (0-9 yards downfield).
+  short_longest: Longest reception in yards on short passes (0-9 yards downfield).
+  short_pass_block_rate: Share of pass-play snaps spent pass blocking on short passes (0-9 yards downfield).
+  short_pass_blocks: Pass-play snaps spent pass blocking on short passes (0-9 yards downfield).
+  short_pass_plays: Pass-play snaps on short passes (0-9 yards downfield).
+  short_positive_epa_percent: Percentage of the player's targets producing positive expected points added on short passes
+    (0-9 yards downfield).
+  short_receptions: Receptions made on short passes (0-9 yards downfield).
+  short_route_rate: Share of pass-play snaps on which the player ran a route on short passes (0-9 yards downfield).
+  short_routes: Pass routes run by the player on short passes (0-9 yards downfield).
+  short_targeted_qb_rating: NFL passer rating on throws targeting the player on short passes (0-9 yards downfield).
+  short_targets: Pass targets to the player on short passes (0-9 yards downfield).
+  short_targets_percent: Share of the team's targets thrown to the player on short passes (0-9 yards downfield).
+  short_touchdowns: Receiving touchdowns scored on short passes (0-9 yards downfield).
+  short_yards: Receiving yards gained on short passes (0-9 yards downfield).
+  short_yards_after_catch: Yards gained after the catch on short passes (0-9 yards downfield).
+  short_yards_after_catch_per_reception: Average yards after the catch per reception on short passes (0-9 yards downfield).
+  short_yards_per_reception: Average yards per reception on short passes (0-9 yards downfield).
+  short_yprr: Yards per route run on short passes (0-9 yards downfield).
+receiving_scheme:
+  base_targets: Total targets from the facet's unsplit base row, across all coverage schemes.
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  man_avg_depth_of_target: Average depth of target in yards downfield against man coverage.
+  man_avoided_tackles: Tackles avoided after the catch against man coverage.
+  man_caught_percent: Percentage of targets caught against man coverage.
+  man_contested_catch_rate: Percentage of PFF-charted contested targets caught against man coverage.
+  man_contested_receptions: Catches made on PFF-charted contested targets against man coverage.
+  man_contested_targets: PFF-charted contested targets against man coverage.
+  man_drop_rate: Share of catchable targets the player dropped against man coverage.
+  man_drops: PFF-charted drops against man coverage.
+  man_epa: Total expected points added on targets to the player against man coverage.
+  man_first_downs: Receptions that converted a first down against man coverage.
+  man_fumbles: Fumbles by the player after the catch against man coverage.
+  man_grades_hands_drop: PFF hands/drop grade against man coverage, 0-100.
+  man_grades_pass_route: PFF route-running (receiving) grade against man coverage, 0-100.
+  man_interceptions: Interceptions thrown on passes targeting the player against man coverage.
+  man_longest: Longest reception in yards against man coverage.
+  man_pass_block_rate: Share of pass-play snaps spent pass blocking against man coverage.
+  man_pass_blocks: Pass-play snaps spent pass blocking against man coverage.
+  man_pass_plays: Pass-play snaps against man coverage.
+  man_positive_epa_percent: Percentage of the player's targets producing positive expected points added against man coverage.
+  man_receptions: Receptions made against man coverage.
+  man_route_rate: Share of pass-play snaps on which the player ran a route against man coverage.
+  man_routes: Pass routes run by the player against man coverage.
+  man_targeted_qb_rating: NFL passer rating on throws targeting the player against man coverage.
+  man_targets: Pass targets to the player against man coverage.
+  man_targets_percent: Share of the team's targets thrown to the player against man coverage.
+  man_touchdowns: Receiving touchdowns scored against man coverage.
+  man_yards: Receiving yards gained against man coverage.
+  man_yards_after_catch: Yards gained after the catch against man coverage.
+  man_yards_after_catch_per_reception: Average yards after the catch per reception against man coverage.
+  man_yards_per_reception: Average yards per reception against man coverage.
+  man_yprr: Yards per route run against man coverage.
+  player_game_count: Number of games the player appeared in over the covered span.
+  zone_avg_depth_of_target: Average depth of target in yards downfield against zone coverage.
+  zone_avoided_tackles: Tackles avoided after the catch against zone coverage.
+  zone_caught_percent: Percentage of targets caught against zone coverage.
+  zone_contested_catch_rate: Percentage of PFF-charted contested targets caught against zone coverage.
+  zone_contested_receptions: Catches made on PFF-charted contested targets against zone coverage.
+  zone_contested_targets: PFF-charted contested targets against zone coverage.
+  zone_drop_rate: Share of catchable targets the player dropped against zone coverage.
+  zone_drops: PFF-charted drops against zone coverage.
+  zone_epa: Total expected points added on targets to the player against zone coverage.
+  zone_first_downs: Receptions that converted a first down against zone coverage.
+  zone_fumbles: Fumbles by the player after the catch against zone coverage.
+  zone_grades_hands_drop: PFF hands/drop grade against zone coverage, 0-100.
+  zone_grades_pass_route: PFF route-running (receiving) grade against zone coverage, 0-100.
+  zone_interceptions: Interceptions thrown on passes targeting the player against zone coverage.
+  zone_longest: Longest reception in yards against zone coverage.
+  zone_pass_block_rate: Share of pass-play snaps spent pass blocking against zone coverage.
+  zone_pass_blocks: Pass-play snaps spent pass blocking against zone coverage.
+  zone_pass_plays: Pass-play snaps against zone coverage.
+  zone_positive_epa_percent: Percentage of the player's targets producing positive expected points added against zone coverage.
+  zone_receptions: Receptions made against zone coverage.
+  zone_route_rate: Share of pass-play snaps on which the player ran a route against zone coverage.
+  zone_routes: Pass routes run by the player against zone coverage.
+  zone_targeted_qb_rating: NFL passer rating on throws targeting the player against zone coverage.
+  zone_targets: Pass targets to the player against zone coverage.
+  zone_targets_percent: Share of the team's targets thrown to the player against zone coverage.
+  zone_touchdowns: Receiving touchdowns scored against zone coverage.
+  zone_yards: Receiving yards gained against zone coverage.
+  zone_yards_after_catch: Yards gained after the catch against zone coverage.
+  zone_yards_after_catch_per_reception: Average yards after the catch per reception against zone coverage.
+  zone_yards_per_reception: Average yards per reception against zone coverage.
+  zone_yprr: Yards per route run against zone coverage.
+receiving_summary:
+  avg_depth_of_target: Average depth of target in yards downfield.
+  avoided_tackles: Tackles avoided after the catch.
+  caught_percent: Percentage of targets caught.
+  contested_catch_rate: Percentage of PFF-charted contested targets caught.
+  contested_receptions: Contested catches made.
+  contested_targets: Contested targets.
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  drop_rate: Share of catchable targets the player dropped.
+  drops: Dropped passes.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  franchise_id: PFF franchise (team) id (integer join key).
+  fumbles: Fumbles by the player after the catch.
+  grades_hands_drop: PFF hands/drop grade (0-100).
+  grades_hands_fumble: PFF ball-security (hands/fumble) grade, 0-100.
+  grades_offense: PFF overall offense grade (0-100).
+  grades_pass_block: PFF pass-blocking grade, 0-100.
+  grades_pass_route: PFF receiving/route grade (0-100).
+  inline_rate: Share of receiving snaps aligned inline, tight to the formation.
+  inline_snaps: Receiving snaps aligned inline, tight to the formation.
+  jersey_number: Jersey number (string; zero-padded, e.g. "09").
+  longest: Longest reception in yards.
+  pass_block_rate: Share of pass-play snaps spent pass blocking.
+  pass_blocks: Pass-play snaps spent pass blocking.
+  pass_plays: Pass-play snaps.
+  player_game_count: Games with at least one qualifying snap in the requested range.
+  player_id: PFF player id (integer; matches the /players id and every player_id join key).
+  positive_epa_percent: Percentage of the player's targets producing positive expected points added.
+  receptions: Passes caught by the receiver.
+  route_rate: Share of pass-play snaps on which the player ran a route.
+  routes: Pass routes run by the receiver.
+  slot_rate: Share of receiving snaps aligned in the slot.
+  slot_snaps: Receiving snaps aligned in the slot.
+  targeted_qb_rating: NFL passer rating on throws targeting the player.
+  targets: Times targeted.
+  team_name: Team abbreviation the player is credited to for the range.
+  touchdowns: Receiving touchdowns.
+  wide_rate: Share of receiving snaps aligned out wide.
+  wide_snaps: Receiving snaps aligned out wide.
+  yards: Receiving yards.
+  yards_after_catch: Yards after the catch.
+  yards_after_catch_per_reception: Average yards after the catch per reception.
+  yards_per_reception: Average yards per reception.
+  yprr: Yards per route run.
+recruitment_primary_recruitment_evaluation:
+  author_key: On3 user key of the evaluation's author.
+  author_name: Name of the On3 scout who wrote the evaluation.
+  author_title: Job title of the On3 scout who wrote the evaluation.
+  body: Full text of the scouting evaluation.
+  date_added: Date the evaluation was added.
+  date_updated: Date the evaluation was last updated.
+  date_updated_unix: Unix timestamp of the evaluation's last update.
+  key: On3 RDB key for the scouting evaluation.
+  primary: Whether this is the primary (featured) evaluation for the recruitment.
+  recruitment_key: On3 recruitment key the evaluation is attached to.
+recruitment_recruitment_evaluations:
+  author_key: On3 user key of the evaluation's author.
+  author_name: Name of the On3 scout who wrote the evaluation.
+  author_title: Job title of the On3 scout who wrote the evaluation.
+  body: Full text of the scouting evaluation.
+  date_added: Date the evaluation was added.
+  date_updated: Date the evaluation was last updated.
+  date_updated_unix: Unix timestamp of the evaluation's last update.
+  key: On3 RDB key for the scouting evaluation.
+  primary: Whether this is the primary (featured) evaluation for the recruitment.
+  recruitment_key: On3 recruitment key the evaluation is attached to.
+recruitments_profile:
+  class_year: Recruiting class year of the recruitment.
+  committed_status: Nested commitment status of the recruitment (stringified).
+  high_school_org: Nested On3 organization object for the recruit's high school (stringified).
+recruitments_rpm_picks:
+  article_link: Link to the On3 article accompanying the pick, when any.
+  confidence: Expert's confidence level in the prediction.
+  correct: Whether the pick proved correct.
+  date_added: Date the expert logged the RPM pick.
+  days_correct: Number of days the pick stood as correct.
+  expert: Nested On3 record for the expert who logged the pick (stringified).
+  flipped_from_organization: Organization the expert's pick flipped from, when the prediction changed (stringified).
+  key: On3 RDB key for the RPM pick.
+  previous_confidence: Expert's confidence level on their previous pick for this recruitment.
+  previous_date_added: Date the expert's previous pick was logged.
+  top_teams: Teams currently leading for the recruit per the pick, as a stringified list.
+recruitments_rpm_summary:
+  locked: Whether the RPM prediction for the recruitment is locked (no longer updating).
+  predictions: Per-team RPM prediction percentages for the recruitment, as a stringified list.
+return_summary:
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  grades_kick_return: PFF kickoff-return grade, 0-100.
+  grades_punt_return: PFF punt-return grade, 0-100.
+  grades_return: PFF overall return grade, 0-100.
+  kickoff_attempts: Kickoff returns attempted.
+  kickoff_fair_catches: Kickoffs fair-caught by the player.
+  kickoff_long: Longest kickoff return in yards.
+  kickoff_muffed_returns: Kickoff returns the player muffed.
+  kickoff_touchdowns: Kickoff returns scoring a touchdown.
+  kickoff_yards: Total kickoff-return yards.
+  kickoff_ypa: Average yards per kickoff return.
+  player_game_count: Number of games the player appeared in over the covered span.
+  punt_attempts: Punt returns attempted.
+  punt_fair_catches: Punts fair-caught by the player.
+  punt_long: Longest punt return in yards.
+  punt_muffed_returns: Punt returns the player muffed.
+  punt_touchdowns: Punt returns scoring a touchdown.
+  punt_yards: Total punt-return yards.
+  punt_ypa: Average yards per punt return.
+  total_attempts: Total return attempts, kickoffs and punts combined.
+run_blocking:
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  gap_grades_run_block: PFF run-blocking grade on gap-scheme runs, 0-100.
+  gap_run_block_percent: Share of run-play snaps spent run blocking on gap-scheme runs.
+  gap_snap_counts_run_block: Run-blocking snaps played on gap-scheme runs.
+  gap_snap_counts_run_block_percent: Share of the player's run-blocking snaps on gap-scheme runs.
+  gap_snap_counts_run_play: Run-play snaps on gap-scheme runs.
+  grades_run_block: PFF run-blocking grade, 0-100.
+  player_game_count: Number of games the player appeared in over the covered span.
+  run_block_percent: Share of run-play snaps spent run blocking.
+  snap_counts_run_block: Run-blocking snaps played.
+  snap_counts_run_play: Run-play snaps.
+  zone_grades_run_block: PFF run-blocking grade on zone-scheme runs, 0-100.
+  zone_run_block_percent: Share of run-play snaps spent run blocking on zone-scheme runs.
+  zone_snap_counts_run_block: Run-blocking snaps played on zone-scheme runs.
+  zone_snap_counts_run_block_percent: Share of the player's run-blocking snaps on zone-scheme runs.
+  zone_snap_counts_run_play: Run-play snaps on zone-scheme runs.
+run_defense_summary:
+  avg_depth_of_tackle: Average depth downfield, in yards, at which the player made his tackles on run plays.
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  forced_fumbles: Fumbles forced by the player.
+  grades_coverage_defense: PFF coverage grade, 0-100.
+  grades_defense: PFF overall defense grade, 0-100.
+  grades_defense_penalty: PFF defensive penalty grade, 0-100.
+  grades_pass_rush_defense: PFF pass-rush grade, 0-100.
+  grades_run_defense: PFF run-defense grade, 0-100.
+  grades_tackle: PFF tackling grade, 0-100.
+  missed_tackle_rate: Share of tackle attempts the player missed.
+  missed_tackles: Missed tackles.
+  player_game_count: Number of games the player appeared in over the covered span.
+  run_stop_opp: Run-defense snaps PFF counts as run-stop opportunities.
+  snap_counts_run: Run-defense snaps played.
+  stop_percent: Percentage of run-stop opportunities converted into stops.
+  stops: Stops, PFF's tackles that constitute a failed play for the offense.
+rushing_direction_stats:
+  directions: Nested per-direction rushing splits (attempts and results by run direction) as returned by the PFF API.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  total_attempts: Total rushing attempts across all run directions.
+rushing_summary:
+  attempts: Rushing attempts (carries) by the runner.
+  avoided_tackles: Missed tackles forced.
+  breakaway_attempts: Runs of 15 or more yards, PFF's breakaway designation.
+  breakaway_percent: Share of rushing yards gained on breakaway runs of 15 or more yards.
+  breakaway_yards: Breakaway (long-run) yards.
+  declined_penalties: Penalties committed by the player that were declined.
+  designed_yards: Rushing yards gained on designed runs, excluding scrambles.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  elu_recv_mtf: Missed tackles forced as a receiver, an input to PFF's elusive rating.
+  elu_rush_mtf: Missed tackles forced as a rusher, an input to PFF's elusive rating.
+  elu_yco: Yards-after-contact component used in PFF's elusive rating.
+  elusive_rating: PFF elusive rating.
+  explosive: Runs PFF designates as explosive.
+  first_downs: Rushing first downs.
+  franchise_id: PFF franchise (team) id (integer join key).
+  fumbles: Fumbles by the ball carrier.
+  gap_attempts: Rushing attempts on gap-scheme runs.
+  grades_hands_fumble: PFF ball-security (hands/fumble) grade, 0-100.
+  grades_offense: PFF overall offense grade (0-100).
+  grades_offense_penalty: PFF offensive penalty grade, 0-100.
+  grades_pass: PFF passing grade, 0-100.
+  grades_pass_block: PFF pass-blocking grade, 0-100.
+  grades_pass_route: PFF route-running (receiving) grade, 0-100.
+  grades_run: PFF rushing grade (0-100).
+  grades_run_block: PFF run-blocking grade, 0-100.
+  jersey_number: Jersey number (string; zero-padded, e.g. "09").
+  longest: Longest run in yards.
+  player_game_count: Games with at least one qualifying snap in the requested range.
+  player_id: PFF player id (integer; matches the /players id and every player_id join key).
+  routes: Pass routes run by the player.
+  run_plays: Run-play snaps.
+  scramble_yards: Rushing yards gained on scrambles.
+  scrambles: Quarterback scrambles.
+  team_name: Team abbreviation the player is credited to for the range.
+  total_touches: Combined carries and receptions.
+  touchdowns: Rushing touchdowns.
+  yards: Total rushing yards gained.
+  yards_after_contact: Yards after contact.
+  yco_attempt: Average yards after contact per rushing attempt.
+  ypa: Average yards per rushing attempt.
+  yprr: Yards per route run.
+  zone_attempts: Rushing attempts on zone-scheme runs.
+scoreboardv2:
+  pts_ot10: Points scored by the team in overtime period 10.
+  pts_ot2: Points scored by the team in overtime period 2.
+  pts_ot3: Points scored by the team in overtime period 3.
+  pts_ot4: Points scored by the team in overtime period 4.
+  pts_ot5: Points scored by the team in overtime period 5.
+  pts_ot6: Points scored by the team in overtime period 6.
+  pts_ot7: Points scored by the team in overtime period 7.
+  pts_ot8: Points scored by the team in overtime period 8.
+  pts_ot9: Points scored by the team in overtime period 9.
+scoreboardv3:
+  awayteam_inbonus: Whether the away team is currently in the bonus (penalty) foul situation.
+  awayteam_losses: Away team's loss total entering the game.
+  awayteam_score: Current or final points scored by the away team.
+  awayteam_seed: Playoff seed of the away team, populated for postseason games.
+  awayteam_teamcity: City name of the away team.
+  awayteam_teamid: Team identifier of the away team from the league's stats API.
+  awayteam_teamname: Nickname of the away team.
+  awayteam_teamslug: URL-friendly slug for the away team's name.
+  awayteam_teamtricode: Three-letter abbreviation of the away team.
+  awayteam_timeoutsremaining: Timeouts the away team has remaining.
+  awayteam_wins: Away team's win total entering the game.
+  gameclock: Current game clock display for a live game.
+  gameet: Scheduled game start time in US Eastern time.
+  gameid: Unique 10-character game identifier from the league's stats API.
+  gamelabel: Display label for the game (e.g. a playoff series or event name).
+  gameleaders_awayleaders_assists: Assist total of the away team's in-game statistical leader.
+  gameleaders_awayleaders_jerseynum: Jersey number of the away team's in-game statistical leader.
+  gameleaders_awayleaders_name: Name of the away team's in-game statistical leader.
+  gameleaders_awayleaders_personid: Stats API player id of the away team's in-game statistical leader.
+  gameleaders_awayleaders_playerslug: URL name slug of the away team's in-game statistical leader.
+  gameleaders_awayleaders_points: Point total of the away team's in-game statistical leader.
+  gameleaders_awayleaders_position: Position of the away team's in-game statistical leader.
+  gameleaders_awayleaders_rebounds: Rebound total of the away team's in-game statistical leader.
+  gameleaders_awayleaders_teamtricode: Team tricode of the away team's in-game statistical leader.
+  gameleaders_homeleaders_assists: Assist total of the home team's in-game statistical leader.
+  gameleaders_homeleaders_jerseynum: Jersey number of the home team's in-game statistical leader.
+  gameleaders_homeleaders_name: Name of the home team's in-game statistical leader.
+  gameleaders_homeleaders_personid: Stats API player id of the home team's in-game statistical leader.
+  gameleaders_homeleaders_playerslug: URL name slug of the home team's in-game statistical leader.
+  gameleaders_homeleaders_points: Point total of the home team's in-game statistical leader.
+  gameleaders_homeleaders_position: Position of the home team's in-game statistical leader.
+  gameleaders_homeleaders_rebounds: Rebound total of the home team's in-game statistical leader.
+  gameleaders_homeleaders_teamtricode: Team tricode of the home team's in-game statistical leader.
+  gamestatus: Numeric game status code (1 = scheduled, 2 = in progress, 3 = final).
+  gamestatustext: Human-readable game status (e.g. "Final", "7:00 pm ET").
+  gamesublabel: Secondary display label for the game (e.g. game number within a series).
+  gamesubtype: Subtype code for the game as reported by the stats API (e.g. in-season tournament flags).
+  gametimeutc: Scheduled game start time in UTC.
+  hometeam_inbonus: Whether the home team is currently in the bonus (penalty) foul situation.
+  hometeam_losses: Home team's loss total entering the game.
+  hometeam_score: Current or final points scored by the home team.
+  hometeam_seed: Playoff seed of the home team, populated for postseason games.
+  hometeam_teamcity: City name of the home team.
+  hometeam_teamid: Team identifier of the home team from the league's stats API.
+  hometeam_teamname: Nickname of the home team.
+  hometeam_teamslug: URL-friendly slug for the home team's name.
+  hometeam_teamtricode: Three-letter abbreviation of the home team.
+  hometeam_timeoutsremaining: Timeouts the home team has remaining.
+  hometeam_wins: Home team's win total entering the game.
+  ifnecessary: Whether the game is an if-necessary playoff series game.
+  isneutral: Whether the game is played at a neutral site.
+  leagueid: League identifier from the stats API ("00" = NBA, "10" = WNBA).
+  leaguename: Display name of the league.
+  porounddesc: Playoff round description (e.g. Conference Finals).
+  regulationperiods: Number of regulation periods for the game (4).
+  seriesconference: Conference of the playoff series the game belongs to.
+  seriesgamenumber: Game number within the playoff series.
+  seriestext: Display text summarizing the series state (e.g. "BOS leads 2-1").
+  teamleaders_awayleaders_assists: Assist total of the away team's season statistical leader.
+  teamleaders_awayleaders_jerseynum: Jersey number of the away team's season statistical leader.
+  teamleaders_awayleaders_name: Name of the away team's season statistical leader.
+  teamleaders_awayleaders_personid: Stats API player id of the away team's season statistical leader.
+  teamleaders_awayleaders_playerslug: URL name slug of the away team's season statistical leader.
+  teamleaders_awayleaders_points: Point total of the away team's season statistical leader.
+  teamleaders_awayleaders_position: Position of the away team's season statistical leader.
+  teamleaders_awayleaders_rebounds: Rebound total of the away team's season statistical leader.
+  teamleaders_awayleaders_teamtricode: Team tricode of the away team's season statistical leader.
+  teamleaders_homeleaders_assists: Assist total of the home team's season statistical leader.
+  teamleaders_homeleaders_jerseynum: Jersey number of the home team's season statistical leader.
+  teamleaders_homeleaders_name: Name of the home team's season statistical leader.
+  teamleaders_homeleaders_personid: Stats API player id of the home team's season statistical leader.
+  teamleaders_homeleaders_playerslug: URL name slug of the home team's season statistical leader.
+  teamleaders_homeleaders_points: Point total of the home team's season statistical leader.
+  teamleaders_homeleaders_position: Position of the home team's season statistical leader.
+  teamleaders_homeleaders_rebounds: Rebound total of the home team's season statistical leader.
+  teamleaders_homeleaders_teamtricode: Team tricode of the home team's season statistical leader.
+  teamleaders_seasonleadersflag: Flag indicating the team-leaders block carries season-long leaders rather than in-game leaders.
+shotchartdetail:
+  grid_type: Shot chart grid type label returned by the stats API (e.g. "Shot Chart Detail").
+  htm: Home team abbreviation for the game.
+  vtm: Visiting team abbreviation for the game.
+shotchartlineupdetail:
+  grid_type: Shot chart grid type label returned by the stats API (e.g. "Shot Chart Detail").
+  htm: Home team abbreviation for the game.
+  vtm: Visiting team abbreviation for the game.
+slot_coverages:
+  coverage_snaps: Coverage snaps played while covering the slot.
+  coverage_snaps_per_reception: Coverage snaps played per reception allowed while covering the slot.
+  coverage_snaps_per_target: Coverage snaps played per target into the player's coverage while covering the slot.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  player_game_count: Number of games the player appeared in over the covered span.
+  qb_rating_against: NFL passer rating allowed on targets into the player's coverage while covering the slot.
+  touchdowns: Touchdowns allowed into the player's coverage while covering the slot.
+  yards_per_coverage_snap: Receiving yards allowed per coverage snap while covering the slot.
+special_teams_summary:
+  declined_penalties: Penalties committed by the player that were declined.
+  draft_season: Season of the player's NFL draft class, per PFF.
+  eligible_season: Season of the player's NFL draft eligibility, per PFF.
+  grades_fgep_defense: PFF grade on field-goal and extra-point defense, 0-100.
+  grades_fgep_kicker: PFF field-goal and extra-point kicking grade, 0-100.
+  grades_fgep_offense: PFF grade on the field-goal and extra-point protection unit, 0-100.
+  grades_kick_return: PFF kickoff-return grade, 0-100.
+  grades_kickoff_kicker: PFF kickoff kicking grade, 0-100.
+  grades_long_snap: PFF long-snapping grade, 0-100.
+  grades_misc_st: PFF miscellaneous special-teams grade, 0-100.
+  grades_punt_return: PFF punt-return grade, 0-100.
+  grades_punter: PFF punting grade, 0-100.
+  grades_special_teams_penalty: PFF special-teams penalty grade, 0-100.
+  missed_tackles: Missed tackles on special-teams plays.
+  player_game_count: Number of games the player appeared in over the covered span.
+  snap_counts_field_goal: Snaps on the field-goal and extra-point unit.
+  snap_counts_field_goal_blocking: Snaps on the field-goal and extra-point block unit.
+  snap_counts_kickoff: Snaps on the kickoff coverage unit.
+  snap_counts_kickoff_return: Snaps on the kickoff return unit.
+  snap_counts_punt_coverage: Snaps on the punt coverage unit.
+  snap_counts_punt_return: Snaps on the punt return unit.
+sports247_site_pages_coach:
+  alma_mater: School the coach graduated from, per 247Sports.
+  cbs_key: CBS Sports identifier for the coach (247Sports is a CBS Sports property).
+  default_asset: Nested 247Sports image asset for the coach's headshot (stringified).
+  default_name: Server-rendered display label for the entity.
+  hero_asset: Nested 247Sports hero (banner) image asset for the coach page (stringified).
+  key: Primary key of this entity (the id used in its `.json` route).
+  predictions_locked: 247Sports flag that Crystal Ball prediction entries tied to the coach are locked.
+  primary_coach_job: Nested 247Sports record for the coach's current job (stringified).
+  quote_asset: Nested 247Sports image asset used alongside the coach's quote block (stringified).
+  twitter_contact: Coach's Twitter/X handle on the 247Sports profile.
+sports247_site_pages_draft_pick:
+  college_team_name: Name of the college the player was drafted out of.
+  default_name: Server-rendered display label for the entity.
+  key: Primary key of this entity (the id used in its `.json` route).
+  mock: Whether this is a mock-draft projection vs an actual pick.
+  overall_pick: Overall selection number in the draft.
+  pick: Pick number within the round.
+  pick_type: Type of the selection (e.g. regular, compensatory, supplemental).
+  position_abbreviation: Player's position at draft.
+  pro_team: Nested 247Sports record for the professional team that made the pick (stringified).
+  pro_team_name: Name of the professional team that made the pick.
+  round: Draft round number (1-based) the pick belongs to.
+  traded_from_team: Team the pick was traded from, when it changed hands.
+sports247_site_pages_event:
+  default_asset: Nested 247Sports image asset for the event (stringified).
+  default_name: Server-rendered display label for the entity.
+  event_group: Grouping or series the event belongs to (e.g. a camp circuit) on 247Sports.
+  key: Primary key of this entity (the id used in its `.json` route).
+sports247_site_pages_feed:
+  main_text: Body text of the feed item.
+  redirection_url: URL the feed item links out to.
+  title_text: Headline text of the feed item.
+  update_date: Date the feed item was published or updated.
+sports247_site_pages_institution:
+  address: Institution's street address.
+  alternate_asset: Nested 247Sports image asset for the institution's alternate logo (stringified).
+  default_asset: Nested 247Sports image asset for the institution's primary logo (stringified).
+  default_name: Server-rendered display label for the entity.
+  group: Institution group (division/level) bitmask code.
+  is_foreign: Whether the institution is located outside the United States.
+  key: Primary key of this entity (the id used in its `.json` route).
+  light_asset: Nested 247Sports image asset for the light-background logo variant (stringified).
+  location: FK -> Location (`/Institution/{Location}/Location.json`).
+  rankable: Whether the institution participates in class rankings.
+  site: FK -> team Site (network site key).
+  state: FK -> State entity.
+  telephone: Institution's telephone number.
+  type: Institution type code (college / pro / high school).
+sports247_site_pages_location:
+  city_tax_rate: City income-tax rate for the location, carried on the 247Sports location record.
+  county_tax_rate: County income-tax rate for the location, carried on the 247Sports location record.
+  default_name: Server-rendered display label for the entity.
+  key: Primary key of this entity (the id used in its `.json` route).
+  region_name: Name of the region (state/province) for the location.
+  special_tax_rate: Special-district tax rate for the location, carried on the 247Sports location record.
+sports247_site_pages_player:
+  bio: Player biography text authored on 247Sports.
+  bio_or_default: Player bio text, falling back to a default blurb when none is authored.
+  cbs_key: Cross-reference key into the CBS Sports id space.
+  college_stat_player: Reference tying the profile to a college stats player record (247Sports field).
+  current_player_institution: FK -> PlayerInstitution (current school).
+  default_asset: Nested 247Sports image asset for the player's headshot (stringified).
+  default_asset_url: URL of the player's headshot image.
+  default_name: Server-rendered display label for the entity.
+  hero_asset: Nested 247Sports hero (banner) image asset for the player page (stringified).
+  key: Primary key of this entity (the id used in its `.json` route).
+  last_recruitment_player_institution: Nested player-institution record from the player's most recent recruitment (stringified).
+  mobile_phone_contact: Player's mobile phone contact field on the 247Sports record.
+  modified_date: Date the player record was last modified.
+  modified_user: 247Sports user who last modified the player record.
+  national_rank: Overall national rank in the recruit's class.
+  player_high_school_name: Name of the player's high school.
+  position_rank: Rank within position for the class.
+  primary_player_position_abbreviation: Abbreviation of the player's primary position.
+  primary_player_sport: FK -> PlayerSport (`/PlayerSport/{id}.json`).
+  primary_recruitment: Nested 247Sports record for the player's primary recruitment (stringified).
+  pro_stat_player: Reference tying the profile to a professional stats player record (247Sports field).
+  quote_asset: Nested 247Sports image asset used alongside the player's quote block (stringified).
+  rating: 247Sports numeric rating (0-1 scale) for the primary sport.
+  scout_evaluation: 247Sports scouting evaluation text for the player.
+  star_rating: Star tier (2-5) derived from the rating.
+  state_rank: Rank within home state for the class.
+  twitter_contact: Player's Twitter/X handle on the 247Sports profile.
+  user: 247Sports user account linked to the player profile (nested, stringified).
+sports247_site_pages_player_institution:
+  created_date: Date the player-institution record was created.
+  default_asset: Nested 247Sports image asset for the stint (stringified).
+  default_name: Server-rendered display label for the entity.
+  early_enrollee: Whether the player enrolled early at the institution.
+  early_signee: Whether the player signed in the early signing period.
+  end_year_or_current: Stint's end year, or the current year for an active stint.
+  end_year_or_expected: Stint's end year, or the expected end year for an active stint.
+  hero_asset: Nested 247Sports hero (banner) image asset for the stint (stringified).
+  institution: Nested 247Sports institution for the stint (stringified).
+  key: Primary key of this entity (the id used in its `.json` route).
+  lead_expert: 247Sports expert assigned as the lead on the recruitment (nested, stringified).
+  modified_date: Date the player-institution record was last modified.
+  next_institution_group: Grouping (e.g. conference/division) of the player's next institution, per 247Sports.
+  next_institution_type: Level of the player's next institution (e.g. college, professional), per 247Sports.
+  player_institution_evaluation: Nested 247Sports evaluation attached to this player-institution stint (stringified).
+  primary_player_sport: Nested 247Sports player-sport profile the stint belongs to (stringified).
+  primary_recruitment: Nested 247Sports record for the recruitment behind the stint (stringified).
+  start_year_or_expected: Stint's start year, or the expected start year for a future stint.
+  transfer_eligibility: Player's eligibility status for the transfer, per 247Sports.
+  transfer_institution: Nested institution involved in the player's transfer, for transfer-portal stints (stringified).
+  transfer_season: Season of the player's transfer, when applicable.
+sports247_site_pages_player_institution_evaluation:
+  comparison_player: Established player the evaluator compares the prospect to.
+  default_name: Server-rendered display label for the entity.
+  evaluated_date: Date the evaluation was written.
+  key: Primary key of this entity (the id used in its `.json` route).
+  player_institution: Nested player-institution stint the evaluation is attached to (stringified).
+  primary: Whether this is the primary (featured) evaluation for the stint.
+  projection: Evaluator's projection for the player (e.g. draft round or college level).
+  scout_evaluation: Full text of the 247Sports scouting evaluation.
+  user: 247Sports user account of the evaluator (nested, stringified).
+sports247_site_pages_player_institution_prediction:
+  confidence: Expert confidence 1-10.
+  days_correct: Number of days the prediction has stood as correct.
+  default_name: Server-rendered display label for the entity.
+  institution: FK -> predicted destination Institution.
+  is_zero_zone: Whether the prediction fell in 247Sports' zero zone (logged too close to the announcement to earn accuracy
+    credit).
+  key: Primary key of this entity (the id used in its `.json` route).
+  parent: Parent prediction record this entry updates (247Sports field).
+  player_institution: Nested player-institution stint the Crystal Ball prediction targets (stringified).
+  prediction_status: Crystal-ball prediction status code.
+  score: Expert accuracy score at time of prediction.
+  updated_on: Date the prediction was last updated.
+  user: 247Sports user account of the predictor (nested, stringified).
+sports247_site_pages_player_sport:
+  average_rank: Player's average rank across the tracked industry services.
+  class_year: Recruiting class year.
+  class_year_override: Override of the player's recruiting class year, when 247Sports reassigns it.
+  composite_rating: 247Sports Composite rating (industry blend).
+  composite_rating_or_default: 247Sports Composite rating, falling back to a default value when unrated.
+  composite_strength: Composite strength points (team-ranking weight).
+  current_player_sport_ranking: Nested current published ranking row for the player (stringified).
+  current_player_sport_year: Current ranking-cycle year for the player-sport profile.
+  default_name: Server-rendered display label for the entity.
+  espn_grade: ESPN source grade (industry composite input).
+  espn_index: ESPN index value for the player, as tracked by 247Sports.
+  espn_rank: Player's rank in the ESPN industry ranking, as tracked by 247Sports.
+  key: Primary key of this entity (the id used in its `.json` route).
+  local_index: 247Sports' own industry-index value for the player, alongside the Rivals and ESPN indexes.
+  player_institution: Nested player-institution stint the player-sport profile points to (stringified).
+  previous_recruitment: Nested record for the player's previous recruitment (stringified).
+  primary: Whether this is the player's primary sport.
+  primary_institution_prediction: Nested leading Crystal Ball institution prediction for the player (stringified).
+  primary_institution_prediction_percentage: Share of Crystal Ball predictions favoring the leading institution.
+  primary_player_position: Nested 247Sports record for the player's primary position (stringified).
+  primary_position: Player's primary position on the 247Sports profile.
+  primary_position_group: Position group the player's primary position belongs to.
+  rating: 247Sports rating string (0-1).
+  rating_or_default: 247Sports in-house rating, falling back to a default value when unrated.
+  recruitment: FK -> Recruitment aggregate for this player-sport.
+  rivals_grade: Rivals source grade (industry composite input).
+  rivals_index: Rivals index value for the player, as tracked by 247Sports.
+  rivals_rank: Player's rank in the Rivals industry ranking, as tracked by 247Sports.
+  secondary_institution_prediction: Nested second-place Crystal Ball institution prediction (stringified).
+  secondary_institution_prediction_percentage: Share of Crystal Ball predictions favoring the second-place institution.
+  show_unranked_rating: 247Sports display flag to show the rating even while the player is unranked.
+  sport: Nested 247Sports sport for the profile (stringified).
+  star_rating: Star tier (2-5).
+  unpublished_player_sport_ranking: Nested not-yet-published ranking row for the player (stringified).
+sports247_site_pages_player_sport_ranking:
+  committed_institution: FK -> committed Institution (null if uncommitted).
+  composite_group_rank: Player's rank within their position group by Composite rating.
+  composite_overall_rank: Player's national rank by 247Sports Composite rating.
+  composite_position_rank: Player's rank at their position by Composite rating.
+  composite_rating: Player's 247Sports Composite rating, blending the major services' ratings.
+  composite_state_rank: Player's rank within their home state by Composite rating.
+  composite_strength: 247Sports field describing the strength of the industry inputs behind the Composite rating.
+  default_name: Server-rendered display label for the entity.
+  institution: Nested institution the player was committed or signed to at ranking time (stringified).
+  institution_group: Grouping (e.g. conference/division) of the player's institution, per 247Sports.
+  key: Primary key of this entity (the id used in its `.json` route).
+  overall_rank: Overall national rank in the snapshot.
+  platoon: 247Sports platoon (side-of-ball grouping) identifier on the ranking row.
+  player_sport: Nested player-sport profile the ranking row belongs to (stringified).
+  position_group_rank: Player's rank within their position group in the 247Sports ranking.
+  position_rank: Rank within position.
+  previous_player_sport_ranking: Nested prior-cycle ranking row for the player (stringified).
+  ranking: FK -> Ranking snapshot.
+  sport: Nested 247Sports sport the ranking row covers (stringified).
+  state_rank: Rank within home state.
+sports247_site_pages_recruit:
+  announcement_date: Date the recruit announced their decision.
+  commited_institution_team_image: Team image asset for the committed institution (the 'commited' spelling is 247Sports' own
+    field name).
+  committed_institution: FK -> committed Institution.
+  committed_recruit_interest: Nested interest record for the school the recruit committed to (stringified).
+  composite_strength: Composite strength points contributed to team ranking.
+  default_name: Server-rendered display label for the entity.
+  final_choice: Whether this entry represents the recruit's final school choice.
+  highest_recruit_interest: Nested interest record carrying the recruit's highest interest signal (stringified).
+  highest_recruit_interest_event: Nested highest-signal event on the recruit's interest timeline (stringified).
+  highest_recruit_interest_event_type: Type of the highest-signal event on the recruit's interest timeline (e.g. commit, signing).
+  institution: Nested institution the recruit row is scoped to (stringified).
+  key: Primary key of this entity (the id used in its `.json` route).
+  player_bio: Player biography text authored on 247Sports.
+  player_bio_or_default: Player bio text, falling back to a default blurb when none is authored.
+  player_birthdate: Player's date of birth, per 247Sports.
+  player_cbs_key: Cross-reference key into the CBS Sports id space.
+  player_college_stat_player: Reference tying the profile to a college stats player record (247Sports field).
+  player_current_player_institution: FK -> PlayerInstitution (current school).
+  player_default_asset: Nested 247Sports image asset for the player's headshot (stringified).
+  player_default_asset_url: URL of the player's headshot image.
+  player_default_name: Server-rendered display label for the entity.
+  player_hero_asset: Nested 247Sports hero (banner) image asset for the player page (stringified).
+  player_hometown_city: City of the player's hometown.
+  player_hometown_state: State of the player's hometown.
+  player_institution: Nested player-institution stint behind the recruit row (stringified).
+  player_key: Primary key of this entity (the id used in its `.json` route).
+  player_last_recruitment_player_institution: Nested player-institution record from the player's most recent recruitment (stringified).
+  player_mobile_phone_contact: Player's mobile phone contact field on the 247Sports record.
+  player_modified_date: Date the player record was last modified.
+  player_modified_user: 247Sports user who last modified the player record.
+  player_national_rank: Overall national rank in the recruit's class.
+  player_player_high_school_name: Name of the player's high school.
+  player_position_rank: Rank within position for the class.
+  player_primary_player_position_abbreviation: Abbreviation of the player's primary position.
+  player_primary_player_sport: FK -> PlayerSport (`/PlayerSport/{id}.json`).
+  player_primary_recruitment: Nested 247Sports record for the player's primary recruitment (stringified).
+  player_pro_stat_player: Reference tying the profile to a professional stats player record (247Sports field).
+  player_quote_asset: Nested 247Sports image asset used alongside the player's quote block (stringified).
+  player_rating: 247Sports numeric rating (0-1 scale) for the primary sport.
+  player_scout_evaluation: 247Sports scouting evaluation text for the player.
+  player_sport: Nested player-sport profile for the recruit (stringified).
+  player_star_rating: Star tier (2-5) derived from the rating.
+  player_state_rank: Rank within home state for the class.
+  player_twitter_contact: Player's Twitter/X handle on the 247Sports profile.
+  player_user: 247Sports user account linked to the player profile (nested, stringified).
+  primary_player_position: Nested 247Sports record for the recruit's primary position (stringified).
+  primary_position: Recruit's primary position on the 247Sports profile.
+  recruit_interest_count: Number of tracked school interests.
+  recruit_interests_url: Site URL to the recruit's interest timeline.
+  signed_institution: Nested institution the recruit signed with (stringified).
+sports247_site_pages_recruit_interest:
+  commit_status: Commitment status label (e.g. Committed, Signed).
+  decommit: Date the recruit decommitted from the school, when applicable.
+  default_name: Server-rendered display label for the entity.
+  enrollment_date: Date the recruit enrolled at the school.
+  gray_shirt: Whether the offer or commitment is a grayshirt (delayed enrollment) arrangement.
+  hard_commit: FK -> the RecruitInterestEvent marking a hard commit.
+  highest_recruit_interest_event: Nested highest-signal event on the interest timeline (e.g. commitment) (stringified).
+  institution: FK -> the interested/interesting Institution.
+  institutions_interest: School's interest level in the recruit, per 247Sports.
+  keeper_coach: Coach designated as the keeper contact for the recruitment (247Sports field).
+  key: Primary key of this entity (the id used in its `.json` route).
+  lock_prediction: Crystal Ball lock-prediction value for the school on this recruitment (247Sports field).
+  offer: Whether the school has extended a scholarship offer to the recruit.
+  offered: Whether the school has extended an offer.
+  official_visit: Date of the recruit's official visit to the school.
+  platoon: 247Sports platoon (side-of-ball grouping) identifier on the interest entry.
+  player_sport: Nested player-sport profile the interest entry belongs to (stringified).
+  primary_coach: Lead recruiting coach at the school for this recruit.
+  recruit_state: 247Sports status of the recruit's interest entry for the school (e.g. committed, signed, decommitted).
+  recruitment: FK -> parent Recruitment.
+  recruits_interest: Recruit's stated interest level in the school, per 247Sports.
+  second_official_visit: Date of the recruit's second official visit to the school.
+  secondary_coach: Secondary recruiting coach at the school for this recruit.
+  signing_date: Date the recruit signed with the school.
+  soft_commit: Whether 247Sports marks the commitment as a soft commit.
+  walk_on: Whether the recruit would join the program as a walk-on.
+sports247_site_pages_recruit_interest_event:
+  default_name: Server-rendered display label for the entity.
+  institution: Nested 247Sports institution the interest event involves (stringified).
+  key: Primary key of this entity (the id used in its `.json` route).
+  recruit_interest: Nested recruit-interest record the event belongs to (stringified).
+  recruitment: Nested 247Sports recruitment the event belongs to (stringified).
+sports247_site_pages_timeline_event:
+  author_affiliation: Outlet or site the author writes for, per 247Sports.
+  author_first_name: First name of the entry's author.
+  author_last_name: Last name of the entry's author.
+  body: Text body of the timeline entry.
+synergyplaytypes:
+  efg_pct: Effective field goal percentage on the play type, as a decimal.
+  fgmx: Field goals missed on the play type.
+  ft_poss_pct: Share of play-type possessions ending in free throws, as a decimal.
+  percentile: League percentile of the row's points per possession for the play type, as a decimal.
+  plusone_poss_pct: Share of play-type possessions producing an and-one, as a decimal.
+  ppp: Points scored per possession on the play type (Synergy play-type tracking).
+  score_poss_pct: Share of play-type possessions on which points were scored, as a decimal.
+  sf_poss_pct: Share of play-type possessions on which a shooting foul was drawn, as a decimal.
+  tov_poss_pct: Share of play-type possessions ending in a turnover, as a decimal.
+  type_grouping: Whether the play-type row measures the offensive or defensive side.
+team_overview:
+  abbreviation: Team abbreviation.
+  franchise_id: PFF franchise (team) id (integer join key).
+  grades_coverage_defense: PFF team coverage grade (0-100).
+  grades_defense: PFF team defense grade (0-100).
+  grades_misc_st: Team-level PFF miscellaneous special-teams grade, 0-100.
+  grades_offense: PFF team offense grade (0-100).
+  grades_overall: Team-level PFF overall grade, 0-100.
+  grades_pass: Team-level PFF passing grade, 0-100.
+  grades_pass_block: Team-level PFF pass-blocking grade, 0-100.
+  grades_pass_route: Team-level PFF receiving (route-running) grade, 0-100.
+  grades_pass_rush_defense: Team-level PFF pass-rush grade, 0-100.
+  grades_run: Team-level PFF rushing grade, 0-100.
+  grades_run_block: Team-level PFF run-blocking grade, 0-100.
+  grades_run_defense: Team-level PFF run-defense grade, 0-100.
+  grades_tackle: Team-level PFF tackling grade, 0-100.
+  points_scored: Total points scored by the team over the covered span.
+team_ranking_bluechips_team_rankings:
+  average_distance: Average distance from the commits' hometowns to campus, in miles.
+  blue_chips: Number of blue-chip (four- or five-star) commits in the class.
+  conference_rank: Team's blue-chip class rank within its conference.
+  in_state_count: Number of commits from the school's home state.
+  social_nil_values: Nested aggregate of the class's social/NIL values (stringified).
+  total_commits: Total number of commits in the class.
+team_ranking_organizations_summary:
+  average_nil_value: Average On3 NIL valuation across the class's commits, in dollars.
+  blue_chips: Number of blue-chip (four- or five-star) commits in the class.
+  class_rating_change: Change in the class rating versus the previous cycle.
+  class_rating_current: Team's current On3 class rating.
+  class_rating_previous: Team's class rating in the previous cycle.
+  conference_consensus_rank_change: Change in conference consensus class rank versus the previous cycle.
+  conference_consensus_rank_current: Team's current conference class rank by consensus score.
+  conference_consensus_rank_previous: Team's conference consensus class rank in the previous cycle.
+  conference_rank_change: Change in conference class rank versus the previous cycle.
+  conference_rank_current: Team's current class rank within its conference.
+  conference_rank_previous: Team's conference class rank in the previous cycle.
+  director_personnel: Nested On3 person object for the program's director of player personnel (stringified).
+  head_coach: Nested On3 person object for the program's head coach (stringified).
+  in_state: Number of commits from the school's home state.
+  national_rank_change: Change in national class rank versus the previous cycle.
+  national_rank_current: Team's current national class rank.
+  national_rank_previous: Team's national class rank in the previous cycle.
+  total_commits: Total number of commits in the class.
+teamdashboardbyclutch:
+  ast_rank: League rank of the row's assists for the season and split.
+  blk_rank: League rank of the row's blocked shots for the season and split.
+  blka: Shot attempts blocked by opponents (blocks against).
+  blka_rank: League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split.
+  dreb_rank: League rank of the row's defensive rebounds for the season and split.
+  fg3_pct_rank: League rank of the row's three-point field goal percentage for the season and split.
+  fg3a_rank: League rank of the row's three-point field goals attempted for the season and split.
+  fg3m_rank: League rank of the row's three-point field goals made for the season and split.
+  fg_pct_rank: League rank of the row's field goal percentage for the season and split.
+  fga_rank: League rank of the row's field goals attempted for the season and split.
+  fgm_rank: League rank of the row's field goals made for the season and split.
+  ft_pct_rank: League rank of the row's free throw percentage for the season and split.
+  fta_rank: League rank of the row's free throws attempted for the season and split.
+  ftm_rank: League rank of the row's free throws made for the season and split.
+  gp_rank: League rank of the row's games played for the season and split.
+  group_set: Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month).
+  group_value: Value of the split within the group (e.g. a specific opponent, month, or result).
+  l_rank: League rank of the row's losses for the season and split.
+  min_rank: League rank of the row's minutes played for the season and split.
+  oreb_rank: League rank of the row's offensive rebounds for the season and split.
+  pf_rank: League rank of the row's personal fouls committed for the season and split.
+  pfd: Personal fouls drawn.
+  pfd_rank: League rank of the row's personal fouls drawn for the season and split.
+  plus_minus_rank: League rank of the row's plus-minus point differential while on the floor for the season and split.
+  pts_rank: League rank of the row's points scored for the season and split.
+  reb_rank: League rank of the row's total rebounds for the season and split.
+  stl_rank: League rank of the row's steals for the season and split.
+  tov_rank: League rank of the row's turnovers for the season and split.
+  w_pct_rank: League rank of the row's win percentage for the season and split.
+  w_rank: League rank of the row's wins for the season and split.
+teamdashboardbygamesplits:
+  ast_rank: League rank of the row's assists for the season and split.
+  blk_rank: League rank of the row's blocked shots for the season and split.
+  blka: Shot attempts blocked by opponents (blocks against).
+  blka_rank: League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split.
+  dreb_rank: League rank of the row's defensive rebounds for the season and split.
+  fg3_pct_rank: League rank of the row's three-point field goal percentage for the season and split.
+  fg3a_rank: League rank of the row's three-point field goals attempted for the season and split.
+  fg3m_rank: League rank of the row's three-point field goals made for the season and split.
+  fg_pct_rank: League rank of the row's field goal percentage for the season and split.
+  fga_rank: League rank of the row's field goals attempted for the season and split.
+  fgm_rank: League rank of the row's field goals made for the season and split.
+  ft_pct_rank: League rank of the row's free throw percentage for the season and split.
+  fta_rank: League rank of the row's free throws attempted for the season and split.
+  ftm_rank: League rank of the row's free throws made for the season and split.
+  gp_rank: League rank of the row's games played for the season and split.
+  group_set: Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month).
+  group_value: Value of the split within the group (e.g. a specific opponent, month, or result).
+  l_rank: League rank of the row's losses for the season and split.
+  min_rank: League rank of the row's minutes played for the season and split.
+  oreb_rank: League rank of the row's offensive rebounds for the season and split.
+  pf_rank: League rank of the row's personal fouls committed for the season and split.
+  pfd: Personal fouls drawn.
+  pfd_rank: League rank of the row's personal fouls drawn for the season and split.
+  plus_minus_rank: League rank of the row's plus-minus point differential while on the floor for the season and split.
+  pts_rank: League rank of the row's points scored for the season and split.
+  reb_rank: League rank of the row's total rebounds for the season and split.
+  stl_rank: League rank of the row's steals for the season and split.
+  tov_rank: League rank of the row's turnovers for the season and split.
+  w_pct_rank: League rank of the row's win percentage for the season and split.
+  w_rank: League rank of the row's wins for the season and split.
+teamdashboardbylastngames:
+  ast_rank: League rank of the row's assists for the season and split.
+  blk_rank: League rank of the row's blocked shots for the season and split.
+  blka: Shot attempts blocked by opponents (blocks against).
+  blka_rank: League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split.
+  dreb_rank: League rank of the row's defensive rebounds for the season and split.
+  fg3_pct_rank: League rank of the row's three-point field goal percentage for the season and split.
+  fg3a_rank: League rank of the row's three-point field goals attempted for the season and split.
+  fg3m_rank: League rank of the row's three-point field goals made for the season and split.
+  fg_pct_rank: League rank of the row's field goal percentage for the season and split.
+  fga_rank: League rank of the row's field goals attempted for the season and split.
+  fgm_rank: League rank of the row's field goals made for the season and split.
+  ft_pct_rank: League rank of the row's free throw percentage for the season and split.
+  fta_rank: League rank of the row's free throws attempted for the season and split.
+  ftm_rank: League rank of the row's free throws made for the season and split.
+  gp_rank: League rank of the row's games played for the season and split.
+  group_set: Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month).
+  group_value: Value of the split within the group (e.g. a specific opponent, month, or result).
+  l_rank: League rank of the row's losses for the season and split.
+  min_rank: League rank of the row's minutes played for the season and split.
+  oreb_rank: League rank of the row's offensive rebounds for the season and split.
+  pf_rank: League rank of the row's personal fouls committed for the season and split.
+  pfd: Personal fouls drawn.
+  pfd_rank: League rank of the row's personal fouls drawn for the season and split.
+  plus_minus_rank: League rank of the row's plus-minus point differential while on the floor for the season and split.
+  pts_rank: League rank of the row's points scored for the season and split.
+  reb_rank: League rank of the row's total rebounds for the season and split.
+  stl_rank: League rank of the row's steals for the season and split.
+  tov_rank: League rank of the row's turnovers for the season and split.
+  w_pct_rank: League rank of the row's win percentage for the season and split.
+  w_rank: League rank of the row's wins for the season and split.
+teamdashboardbyopponent:
+  ast_rank: League rank of the row's assists for the season and split.
+  blk_rank: League rank of the row's blocked shots for the season and split.
+  blka: Shot attempts blocked by opponents (blocks against).
+  blka_rank: League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split.
+  dreb_rank: League rank of the row's defensive rebounds for the season and split.
+  fg3_pct_rank: League rank of the row's three-point field goal percentage for the season and split.
+  fg3a_rank: League rank of the row's three-point field goals attempted for the season and split.
+  fg3m_rank: League rank of the row's three-point field goals made for the season and split.
+  fg_pct_rank: League rank of the row's field goal percentage for the season and split.
+  fga_rank: League rank of the row's field goals attempted for the season and split.
+  fgm_rank: League rank of the row's field goals made for the season and split.
+  ft_pct_rank: League rank of the row's free throw percentage for the season and split.
+  fta_rank: League rank of the row's free throws attempted for the season and split.
+  ftm_rank: League rank of the row's free throws made for the season and split.
+  gp_rank: League rank of the row's games played for the season and split.
+  group_set: Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month).
+  group_value: Value of the split within the group (e.g. a specific opponent, month, or result).
+  l_rank: League rank of the row's losses for the season and split.
+  min_rank: League rank of the row's minutes played for the season and split.
+  oreb_rank: League rank of the row's offensive rebounds for the season and split.
+  pf_rank: League rank of the row's personal fouls committed for the season and split.
+  pfd: Personal fouls drawn.
+  pfd_rank: League rank of the row's personal fouls drawn for the season and split.
+  plus_minus_rank: League rank of the row's plus-minus point differential while on the floor for the season and split.
+  pts_rank: League rank of the row's points scored for the season and split.
+  reb_rank: League rank of the row's total rebounds for the season and split.
+  stl_rank: League rank of the row's steals for the season and split.
+  tov_rank: League rank of the row's turnovers for the season and split.
+  w_pct_rank: League rank of the row's win percentage for the season and split.
+  w_rank: League rank of the row's wins for the season and split.
+teamdashboardbyteamperformance:
+  ast_rank: League rank of the row's assists for the season and split.
+  blk_rank: League rank of the row's blocked shots for the season and split.
+  blka: Shot attempts blocked by opponents (blocks against).
+  blka_rank: League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split.
+  dreb_rank: League rank of the row's defensive rebounds for the season and split.
+  fg3_pct_rank: League rank of the row's three-point field goal percentage for the season and split.
+  fg3a_rank: League rank of the row's three-point field goals attempted for the season and split.
+  fg3m_rank: League rank of the row's three-point field goals made for the season and split.
+  fg_pct_rank: League rank of the row's field goal percentage for the season and split.
+  fga_rank: League rank of the row's field goals attempted for the season and split.
+  fgm_rank: League rank of the row's field goals made for the season and split.
+  ft_pct_rank: League rank of the row's free throw percentage for the season and split.
+  fta_rank: League rank of the row's free throws attempted for the season and split.
+  ftm_rank: League rank of the row's free throws made for the season and split.
+  gp_rank: League rank of the row's games played for the season and split.
+  group_set: Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month).
+  group_value: Value of the split within the group (e.g. a specific opponent, month, or result).
+  group_value_2: Secondary split value for the row when the group uses two dimensions.
+  group_value_order: Sort order of the split value within its group.
+  l_rank: League rank of the row's losses for the season and split.
+  min_rank: League rank of the row's minutes played for the season and split.
+  oreb_rank: League rank of the row's offensive rebounds for the season and split.
+  pf_rank: League rank of the row's personal fouls committed for the season and split.
+  pfd: Personal fouls drawn.
+  pfd_rank: League rank of the row's personal fouls drawn for the season and split.
+  plus_minus_rank: League rank of the row's plus-minus point differential while on the floor for the season and split.
+  pts_rank: League rank of the row's points scored for the season and split.
+  reb_rank: League rank of the row's total rebounds for the season and split.
+  stl_rank: League rank of the row's steals for the season and split.
+  tov_rank: League rank of the row's turnovers for the season and split.
+  w_pct_rank: League rank of the row's win percentage for the season and split.
+  w_rank: League rank of the row's wins for the season and split.
+teamdashboardbyyearoveryear:
+  ast_rank: League rank of the row's assists for the season and split.
+  blk_rank: League rank of the row's blocked shots for the season and split.
+  blka: Shot attempts blocked by opponents (blocks against).
+  blka_rank: League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split.
+  dreb_rank: League rank of the row's defensive rebounds for the season and split.
+  fg3_pct_rank: League rank of the row's three-point field goal percentage for the season and split.
+  fg3a_rank: League rank of the row's three-point field goals attempted for the season and split.
+  fg3m_rank: League rank of the row's three-point field goals made for the season and split.
+  fg_pct_rank: League rank of the row's field goal percentage for the season and split.
+  fga_rank: League rank of the row's field goals attempted for the season and split.
+  fgm_rank: League rank of the row's field goals made for the season and split.
+  ft_pct_rank: League rank of the row's free throw percentage for the season and split.
+  fta_rank: League rank of the row's free throws attempted for the season and split.
+  ftm_rank: League rank of the row's free throws made for the season and split.
+  gp_rank: League rank of the row's games played for the season and split.
+  group_set: Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month).
+  group_value: Value of the split within the group (e.g. a specific opponent, month, or result).
+  l_rank: League rank of the row's losses for the season and split.
+  min_rank: League rank of the row's minutes played for the season and split.
+  oreb_rank: League rank of the row's offensive rebounds for the season and split.
+  pf_rank: League rank of the row's personal fouls committed for the season and split.
+  pfd: Personal fouls drawn.
+  pfd_rank: League rank of the row's personal fouls drawn for the season and split.
+  plus_minus_rank: League rank of the row's plus-minus point differential while on the floor for the season and split.
+  pts_rank: League rank of the row's points scored for the season and split.
+  reb_rank: League rank of the row's total rebounds for the season and split.
+  stl_rank: League rank of the row's steals for the season and split.
+  tov_rank: League rank of the row's turnovers for the season and split.
+  w_pct_rank: League rank of the row's win percentage for the season and split.
+  w_rank: League rank of the row's wins for the season and split.
+teamdetails:
+  arenacapacity: Seating capacity of the team's home arena.
+  dleagueaffiliation: Name of the team's G League (formerly D-League) affiliate.
+  generalmanager: Name of the team's general manager.
+  headcoach: Name of the team's head coach.
+  owner: Name of the team's owner or ownership group.
+  yearfounded: Year the franchise was founded.
+teaminfocommon:
+  conf_rank: Team's current rank within its conference.
+  div_rank: Team's current rank within its division.
+  team_conference: Conference the team belongs to.
+  team_division: Division the team belongs to.
+teamvsplayer:
+  ast_rank: League rank of the row's assists for the season and split.
+  blk_rank: League rank of the row's blocked shots for the season and split.
+  blka: Shot attempts blocked by opponents (blocks against).
+  blka_rank: League rank of the row's shot attempts blocked by opponents (blocks against) for the season and split.
+  dd2: Double-doubles recorded over the split.
+  dd2_rank: League rank of the row's double-doubles for the season and split.
+  dreb_rank: League rank of the row's defensive rebounds for the season and split.
+  fg3_pct_rank: League rank of the row's three-point field goal percentage for the season and split.
+  fg3a_rank: League rank of the row's three-point field goals attempted for the season and split.
+  fg3m_rank: League rank of the row's three-point field goals made for the season and split.
+  fg_pct_rank: League rank of the row's field goal percentage for the season and split.
+  fga_rank: League rank of the row's field goals attempted for the season and split.
+  fgm_rank: League rank of the row's field goals made for the season and split.
+  ft_pct_rank: League rank of the row's free throw percentage for the season and split.
+  fta_rank: League rank of the row's free throws attempted for the season and split.
+  ftm_rank: League rank of the row's free throws made for the season and split.
+  gp_rank: League rank of the row's games played for the season and split.
+  group_set: Name of the split group the row belongs to (e.g. Overall, By Opponent, By Month).
+  group_value: Value of the split within the group (e.g. a specific opponent, month, or result).
+  l_rank: League rank of the row's losses for the season and split.
+  min_rank: League rank of the row's minutes played for the season and split.
+  nba_fantasy_pts: Fantasy points under the NBA's fantasy scoring formula.
+  nba_fantasy_pts_rank: League rank of the row's NBA fantasy points (league scoring formula) for the season and split.
+  oreb_rank: League rank of the row's offensive rebounds for the season and split.
+  pf_rank: League rank of the row's personal fouls committed for the season and split.
+  pfd: Personal fouls drawn.
+  pfd_rank: League rank of the row's personal fouls drawn for the season and split.
+  plus_minus_rank: League rank of the row's plus-minus point differential while on the floor for the season and split.
+  pts_rank: League rank of the row's points scored for the season and split.
+  reb_rank: League rank of the row's total rebounds for the season and split.
+  stl_rank: League rank of the row's steals for the season and split.
+  td3: Triple-doubles recorded over the split.
+  td3_rank: League rank of the row's triple-doubles for the season and split.
+  team_count: Number of distinct teams aggregated into the split row.
+  tov_rank: League rank of the row's turnovers for the season and split.
+  w_pct_rank: League rank of the row's win percentage for the season and split.
+  w_rank: League rank of the row's wins for the season and split.
+  wnba_fantasy_pts: Fantasy points under the WNBA's fantasy scoring formula.
+  wnba_fantasy_pts_rank: League rank of the row's WNBA fantasy points (league scoring formula) for the season and split.
+teamyearbyyearstats:
+  conf_count: Number of teams in the team's conference that season.
+  conf_rank: Team's final rank within its conference for the season.
+  div_count: Number of teams in the team's division that season.
+  div_rank: Team's final rank within its division for the season.
+  nba_finals_appearance: Whether the team reached the league finals that season (e.g. "FINALS APPEARANCE" or "N/A").
+  po_losses: Playoff losses recorded by the team that season.
+  po_wins: Playoff wins recorded by the team that season.
+  pts_rank: League rank of the team's points scored for the season.
+time_in_pockets:
+  avg_ttt_attempts: Average time from snap to release in seconds on dropbacks ending in a pass attempt.
+  avg_ttt_sacks: Average time from snap to sack in seconds on dropbacks ending in a sack.
+  avg_ttt_scrambles: Average time in the pocket in seconds on dropbacks ending in a scramble.
+  draft_season: NFL season (year) in which the player was drafted, per PFF player metadata.
+  dropbacks: Number of dropbacks.
+  eligible_season: Season (year) of the player's NFL draft eligibility, per PFF player metadata.
+  less_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on dropbacks with time in pocket under 2.5
+    seconds.
+  less_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on dropbacks with time in pocket under
+    2.5 seconds, as charted by PFF.
+  less_attempts: Number of pass attempts on dropbacks with time in pocket under 2.5 seconds.
+  less_avg_depth_of_target: Average depth of target in air yards on dropbacks with time in pocket under 2.5 seconds.
+  less_avg_time_to_throw: Average time from snap to release in seconds on dropbacks with time in pocket under 2.5 seconds.
+  less_bats: Number of pass attempts batted down at the line of scrimmage on dropbacks with time in pocket under 2.5 seconds.
+  less_big_time_throws: Number of big-time throws on dropbacks with time in pocket under 2.5 seconds, per PFF's highest-value,
+    highest-difficulty throw designation.
+  less_btt_rate: Big-time throws as a percentage of qualifying attempts on dropbacks with time in pocket under 2.5 seconds,
+    per PFF charting.
+  less_completion_percent: Percentage of pass attempts completed on dropbacks with time in pocket under 2.5 seconds.
+  less_completions: Number of completed passes on dropbacks with time in pocket under 2.5 seconds.
+  less_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on dropbacks with time in pocket
+    under 2.5 seconds, as charted by PFF.
+  less_drop_rate: Percentage of catchable passes dropped by receivers on dropbacks with time in pocket under 2.5 seconds.
+  less_dropbacks: Number of dropbacks on dropbacks with time in pocket under 2.5 seconds.
+  less_dropbacks_percent: Share of the player's total dropbacks that came on dropbacks with time in pocket under 2.5 seconds,
+    expressed as a percentage.
+  less_drops: Number of catchable passes dropped by receivers on dropbacks with time in pocket under 2.5 seconds.
+  less_epa: Total expected points added (EPA) on the player's dropbacks on dropbacks with time in pocket under 2.5 seconds.
+  less_first_downs: Number of passing first downs gained on dropbacks with time in pocket under 2.5 seconds.
+  less_grades_coverage_defense: PFF coverage grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds.
+  less_grades_defense: PFF overall defense grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds.
+  less_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) on dropbacks with time in pocket under 2.5
+    seconds.
+  less_grades_hands_drop: PFF hands (drop) grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds.
+  less_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) on dropbacks with time
+    in pocket under 2.5 seconds.
+  less_grades_offense: PFF overall offense grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds.
+  less_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) on dropbacks with time in pocket under 2.5
+    seconds.
+  less_grades_overall_tackle: PFF overall tackling grade for the player (0-100) on dropbacks with time in pocket under 2.5
+    seconds.
+  less_grades_pass: PFF passing grade (0-100) on dropbacks with time in pocket under 2.5 seconds.
+  less_grades_pass_block: PFF pass-blocking grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds.
+  less_grades_pass_route: PFF receiving (route) grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds.
+  less_grades_pass_rush_defense: PFF pass-rush grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds.
+  less_grades_run: PFF rushing grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds.
+  less_grades_run_block: PFF run-blocking grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds.
+  less_grades_run_defense: PFF run-defense grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds.
+  less_grades_screen_block: PFF screen-blocking grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds.
+  less_grades_tackle: PFF tackling grade for the player (0-100) on dropbacks with time in pocket under 2.5 seconds.
+  less_hit_as_threw: Number of attempts on which the passer was hit as he threw on dropbacks with time in pocket under 2.5
+    seconds, as charted by PFF.
+  less_interceptions: Number of passes intercepted on dropbacks with time in pocket under 2.5 seconds.
+  less_passing_snaps: Number of passing snaps played on dropbacks with time in pocket under 2.5 seconds.
+  less_positive_epa_percent: Percentage of dropbacks with positive expected points added on dropbacks with time in pocket
+    under 2.5 seconds.
+  less_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on dropbacks with time in pocket under
+    2.5 seconds.
+  less_qb_rating: Traditional NFL passer rating on dropbacks with time in pocket under 2.5 seconds.
+  less_sack_percent: Percentage of dropbacks that ended in a sack on dropbacks with time in pocket under 2.5 seconds.
+  less_sacks: Number of sacks taken on dropbacks with time in pocket under 2.5 seconds.
+  less_scrambles: Number of scrambles on dropbacks with time in pocket under 2.5 seconds.
+  less_spikes: Number of clock-stopping spikes on dropbacks with time in pocket under 2.5 seconds.
+  less_thrown_aways: Number of intentional throwaways on dropbacks with time in pocket under 2.5 seconds.
+  less_touchdowns: Number of passing touchdowns thrown on dropbacks with time in pocket under 2.5 seconds.
+  less_turnover_worthy_plays: Number of turnover-worthy plays on dropbacks with time in pocket under 2.5 seconds, plays PFF
+    charts as deserving of a turnover.
+  less_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on dropbacks with time in pocket under 2.5 seconds,
+    per PFF charting.
+  less_yards: Passing yards gained on dropbacks with time in pocket under 2.5 seconds.
+  less_ypa: Yards gained per pass attempt on dropbacks with time in pocket under 2.5 seconds.
+  more_accuracy_percent: Percentage of aimed passes charted as accurate by PFF on dropbacks with time in pocket of 2.5 seconds
+    or more.
+  more_aimed_passes: Number of aimed passes (attempts excluding spikes and throwaways) on dropbacks with time in pocket of
+    2.5 seconds or more, as charted by PFF.
+  more_attempts: Number of pass attempts on dropbacks with time in pocket of 2.5 seconds or more.
+  more_avg_depth_of_target: Average depth of target in air yards on dropbacks with time in pocket of 2.5 seconds or more.
+  more_avg_time_to_throw: Average time from snap to release in seconds on dropbacks with time in pocket of 2.5 seconds or
+    more.
+  more_bats: Number of pass attempts batted down at the line of scrimmage on dropbacks with time in pocket of 2.5 seconds
+    or more.
+  more_big_time_throws: Number of big-time throws on dropbacks with time in pocket of 2.5 seconds or more, per PFF's highest-value,
+    highest-difficulty throw designation.
+  more_btt_rate: Big-time throws as a percentage of qualifying attempts on dropbacks with time in pocket of 2.5 seconds or
+    more, per PFF charting.
+  more_completion_percent: Percentage of pass attempts completed on dropbacks with time in pocket of 2.5 seconds or more.
+  more_completions: Number of completed passes on dropbacks with time in pocket of 2.5 seconds or more.
+  more_def_gen_pressures: Number of defense-generated pressures on the player's dropbacks on dropbacks with time in pocket
+    of 2.5 seconds or more, as charted by PFF.
+  more_drop_rate: Percentage of catchable passes dropped by receivers on dropbacks with time in pocket of 2.5 seconds or more.
+  more_dropbacks: Number of dropbacks on dropbacks with time in pocket of 2.5 seconds or more.
+  more_dropbacks_percent: Share of the player's total dropbacks that came on dropbacks with time in pocket of 2.5 seconds
+    or more, expressed as a percentage.
+  more_drops: Number of catchable passes dropped by receivers on dropbacks with time in pocket of 2.5 seconds or more.
+  more_epa: Total expected points added (EPA) on the player's dropbacks on dropbacks with time in pocket of 2.5 seconds or
+    more.
+  more_first_downs: Number of passing first downs gained on dropbacks with time in pocket of 2.5 seconds or more.
+  more_grades_coverage_defense: PFF coverage grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds
+    or more.
+  more_grades_defense: PFF overall defense grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or
+    more.
+  more_grades_defense_penalty: PFF defensive penalty grade for the player (0-100) on dropbacks with time in pocket of 2.5
+    seconds or more.
+  more_grades_hands_drop: PFF hands (drop) grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or
+    more.
+  more_grades_hands_fumble: PFF hands (fumble) grade for the player, reflecting ball security (0-100) on dropbacks with time
+    in pocket of 2.5 seconds or more.
+  more_grades_offense: PFF overall offense grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or
+    more.
+  more_grades_offense_penalty: PFF offensive penalty grade for the player (0-100) on dropbacks with time in pocket of 2.5
+    seconds or more.
+  more_grades_overall_tackle: PFF overall tackling grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds
+    or more.
+  more_grades_pass: PFF passing grade (0-100) on dropbacks with time in pocket of 2.5 seconds or more.
+  more_grades_pass_block: PFF pass-blocking grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or
+    more.
+  more_grades_pass_route: PFF receiving (route) grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds
+    or more.
+  more_grades_pass_rush_defense: PFF pass-rush grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds
+    or more.
+  more_grades_run: PFF rushing grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more.
+  more_grades_run_block: PFF run-blocking grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or
+    more.
+  more_grades_run_defense: PFF run-defense grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or
+    more.
+  more_grades_screen_block: PFF screen-blocking grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds
+    or more.
+  more_grades_tackle: PFF tackling grade for the player (0-100) on dropbacks with time in pocket of 2.5 seconds or more.
+  more_hit_as_threw: Number of attempts on which the passer was hit as he threw on dropbacks with time in pocket of 2.5 seconds
+    or more, as charted by PFF.
+  more_interceptions: Number of passes intercepted on dropbacks with time in pocket of 2.5 seconds or more.
+  more_passing_snaps: Number of passing snaps played on dropbacks with time in pocket of 2.5 seconds or more.
+  more_positive_epa_percent: Percentage of dropbacks with positive expected points added on dropbacks with time in pocket
+    of 2.5 seconds or more.
+  more_pressure_to_sack_rate: Percentage of pressured dropbacks that ended in a sack on dropbacks with time in pocket of 2.5
+    seconds or more.
+  more_qb_rating: Traditional NFL passer rating on dropbacks with time in pocket of 2.5 seconds or more.
+  more_sack_percent: Percentage of dropbacks that ended in a sack on dropbacks with time in pocket of 2.5 seconds or more.
+  more_sacks: Number of sacks taken on dropbacks with time in pocket of 2.5 seconds or more.
+  more_scrambles: Number of scrambles on dropbacks with time in pocket of 2.5 seconds or more.
+  more_spikes: Number of clock-stopping spikes on dropbacks with time in pocket of 2.5 seconds or more.
+  more_thrown_aways: Number of intentional throwaways on dropbacks with time in pocket of 2.5 seconds or more.
+  more_touchdowns: Number of passing touchdowns thrown on dropbacks with time in pocket of 2.5 seconds or more.
+  more_turnover_worthy_plays: Number of turnover-worthy plays on dropbacks with time in pocket of 2.5 seconds or more, plays
+    PFF charts as deserving of a turnover.
+  more_twp_rate: Turnover-worthy plays as a percentage of qualifying attempts on dropbacks with time in pocket of 2.5 seconds
+    or more, per PFF charting.
+  more_yards: Passing yards gained on dropbacks with time in pocket of 2.5 seconds or more.
+  more_ypa: Yards gained per pass attempt on dropbacks with time in pocket of 2.5 seconds or more.
+  player_game_count: Number of games the player appeared in during the period covered.
+transfers_best_available:
+  athlete_verified: Whether the athlete has verified their own On3 profile.
+  class_year: Player's original recruiting class year.
+  commit_status: Nested commitment status of the transfer recruitment (stringified).
+  committed_article: On3 article link covering the player's transfer commitment (stringified).
+  default_asset: Nested On3 asset object for the player's headshot (stringified).
+  default_asset_url: URL of the player's headshot image.
+  early_enrollee: Whether the player is an early enrollee.
+  early_signee: Whether the player signed in the early signing period.
+  entered_article: On3 article link covering the player entering the transfer portal (stringified).
+  exited_article: On3 article link covering the player exiting the portal (stringified).
+  home_town_name: Player's hometown, as listed by On3.
+  key: On3 RDB key for the transfer entry.
+  last_team: Nested On3 record for the team the player is transferring from (stringified).
+  nil_status: Status of the player's On3 NIL valuation (e.g. active, inactive).
+  nil_value: Player's On3 NIL valuation in dollars.
+  predictions: RPM prediction entries for the transfer destination, as a stringified list.
+  prospect_verified: Whether On3 has verified the prospect's profile information.
+  recruitment_key: On3 recruitment key of the player's transfer recruitment.
+  roster_rating: Nested On3 roster rating object for the player (stringified).
+  sport: Nested On3 sport object for the transfer entry (stringified).
+transfers_latest:
+  athlete_verified: Whether the athlete has verified their own On3 profile.
+  class_year: Player's original recruiting class year.
+  commit_status: Nested commitment status of the transfer recruitment (stringified).
+  committed_article: On3 article link covering the player's transfer commitment (stringified).
+  default_asset: Nested On3 asset object for the player's headshot (stringified).
+  default_asset_url: URL of the player's headshot image.
+  early_enrollee: Whether the player is an early enrollee.
+  early_signee: Whether the player signed in the early signing period.
+  entered_article: On3 article link covering the player entering the transfer portal (stringified).
+  exited_article: On3 article link covering the player exiting the portal (stringified).
+  home_town_name: Player's hometown, as listed by On3.
+  key: On3 RDB key for the transfer entry.
+  last_team: Nested On3 record for the team the player is transferring from (stringified).
+  nil_status: Status of the player's On3 NIL valuation (e.g. active, inactive).
+  nil_value: Player's On3 NIL valuation in dollars.
+  predictions: RPM prediction entries for the transfer destination, as a stringified list.
+  prospect_verified: Whether On3 has verified the prospect's profile information.
+  recruitment_key: On3 recruitment key of the player's transfer recruitment.
+  roster_rating: Nested On3 roster rating object for the player (stringified).
+  sport: Nested On3 sport object for the transfer entry (stringified).
+videos_video_key:
+  is_featured: Whether the video is featured on the player's On3 profile.
+  key: On3 RDB key for the video record.
+  person_key: On3 person key of the featured athlete.
+  person_sport: Nested athlete-sport profile the video is attached to (stringified).
+  source_url: Source URL of the hosted video.
+  thumbnail: URL of the video's thumbnail image.
+videostatus:
+  is_available: Flag indicating whether game video is available in the league's stats video system.
+  visitor_team_abbreviation: Abbreviation of the visiting team.
+  visitor_team_city: City name of the visiting team.
+  visitor_team_name: Nickname of the visiting team.
+leaguedashplayershotlocations:
+  10-14_ft_fg_pct: Field goal percentage on shots from 10-14-f feet, as a decimal.
+  10-14_ft_fga: Field goals attempted from 10-14 feet.
+  10-14_ft_fgm: Field goals made from 10-14 feet.
+  15-19_ft_fg_pct: Field goal percentage on shots from 15-19-f feet, as a decimal.
+  15-19_ft_fga: Field goals attempted from 15-19 feet.
+  15-19_ft_fgm: Field goals made from 15-19 feet.
+  20-24_ft_fg_pct: Field goal percentage on shots from 20-24-f feet, as a decimal.
+  20-24_ft_fga: Field goals attempted from 20-24 feet.
+  20-24_ft_fgm: Field goals made from 20-24 feet.
+  25-29_ft_fg_pct: Field goal percentage on shots from 25-29-f feet, as a decimal.
+  25-29_ft_fga: Field goals attempted from 25-29 feet.
+  25-29_ft_fgm: Field goals made from 25-29 feet.
+  30-34_ft_fg_pct: Field goal percentage on shots from 30-34-f feet, as a decimal.
+  30-34_ft_fga: Field goals attempted from 30-34 feet.
+  30-34_ft_fgm: Field goals made from 30-34 feet.
+  35-39_ft_fg_pct: Field goal percentage on shots from 35-39-f feet, as a decimal.
+  35-39_ft_fga: Field goals attempted from 35-39 feet.
+  35-39_ft_fgm: Field goals made from 35-39 feet.
+  40+_ft_fg_pct: Field-goal percentage on attempts from 40 feet and beyond, as a decimal.
+  40+_ft_fga: Field goals attempted from 40 feet and beyond, per the stats API's shot-location distance bands.
+  40+_ft_fgm: Field goals made from 40 feet and beyond, per the stats API's shot-location distance bands.
+  5-9_ft_fg_pct: Field goal percentage on shots from 5-9-f feet, as a decimal.
+  5-9_ft_fga: Field goals attempted from 5-9 feet.
+  5-9_ft_fgm: Field goals made from 5-9 feet.
+  less_than_5_ft_fg_pct: Field goal percentage on shots from less than 5 feet, as a decimal.
+  less_than_5_ft_fga: Field goals attempted from less than 5 feet.
+  less_than_5_ft_fgm: Field goals made from less than 5 feet.
+leaguedashteamshotlocations:
+  10-14_ft_fg_pct: Field goal percentage on shots from 10-14-f feet, as a decimal.
+  10-14_ft_fga: Field goals attempted from 10-14 feet.
+  10-14_ft_fgm: Field goals made from 10-14 feet.
+  15-19_ft_fg_pct: Field goal percentage on shots from 15-19-f feet, as a decimal.
+  15-19_ft_fga: Field goals attempted from 15-19 feet.
+  15-19_ft_fgm: Field goals made from 15-19 feet.
+  20-24_ft_fg_pct: Field goal percentage on shots from 20-24-f feet, as a decimal.
+  20-24_ft_fga: Field goals attempted from 20-24 feet.
+  20-24_ft_fgm: Field goals made from 20-24 feet.
+  25-29_ft_fg_pct: Field goal percentage on shots from 25-29-f feet, as a decimal.
+  25-29_ft_fga: Field goals attempted from 25-29 feet.
+  25-29_ft_fgm: Field goals made from 25-29 feet.
+  30-34_ft_fg_pct: Field goal percentage on shots from 30-34-f feet, as a decimal.
+  30-34_ft_fga: Field goals attempted from 30-34 feet.
+  30-34_ft_fgm: Field goals made from 30-34 feet.
+  35-39_ft_fg_pct: Field goal percentage on shots from 35-39-f feet, as a decimal.
+  35-39_ft_fga: Field goals attempted from 35-39 feet.
+  35-39_ft_fgm: Field goals made from 35-39 feet.
+  40+_ft_fg_pct: Team field-goal percentage on attempts from 40 feet and beyond, as a decimal.
+  40+_ft_fga: Team field goals attempted from 40 feet and beyond, per the stats API's shot-location distance bands.
+  40+_ft_fgm: Team field goals made from 40 feet and beyond, per the stats API's shot-location distance bands.
+  5-9_ft_fg_pct: Field goal percentage on shots from 5-9-f feet, as a decimal.
+  5-9_ft_fga: Field goals attempted from 5-9 feet.
+  5-9_ft_fgm: Field goals made from 5-9 feet.
+  less_than_5_ft_fg_pct: Field goal percentage on shots from less than 5 feet, as a decimal.
+  less_than_5_ft_fga: Field goals attempted from less than 5 feet.
+  less_than_5_ft_fgm: Field goals made from less than 5 feet.
+commits_organizations_latest_commits:
+  commits: Number of commitments in the organization's latest recruiting class.
+commits_organizations_org_key:
+  commits: Number of commitments in the organization's recruiting class for the season.
+draft_organization_rank:
+  draft_rate: Organization's draft-production rate used in On3's draft ranking.
+  five_stars: Number of five-star recruits the organization signed over the ranking window.
+  four_stars: Number of four-star recruits the organization signed over the ranking window.
+  percent_drafted: Share of the organization's recruits who went on to be drafted.
+  three_stars: Number of three-star recruits the organization signed over the ranking window.
+drafts_by_stars:
+  blue_chip_percent: Percent of the drafted group who were blue-chip (four- or five-star) recruits.
+  five_stars: Number of drafted players who were five-star recruits.
+  four_stars: Number of drafted players who were four-star recruits.
+  population_percent: Percent of the overall recruit population holding this star rating.
+  talent_ratio: Ratio of the star tier's draft share to its population share (On3's talent ratio).
+  three_stars: Number of drafted players who were three-star recruits.
+  zero_stars: Number of drafted players who were unrated (zero-star) recruits.
+drafts_by_stars_summary:
+  five_stars: Number of drafted players who were five-star recruits.
+  four_stars: Number of drafted players who were four-star recruits.
+  three_stars: Number of drafted players who were three-star recruits.
+  total_drafted: Total number of players drafted in the summarized group.
+  total_recruited: Total number of recruits in the summarized group.
+  zero_stars: Number of drafted players who were unrated (zero-star) recruits.
+organizations_draft_count_by_stars:
+  five_stars: Number of the organization's drafted players who were five-star recruits.
+  four_stars: Number of the organization's drafted players who were four-star recruits.
+  three_stars: Number of the organization's drafted players who were three-star recruits.
+  zero_stars: Number of the organization's drafted players who were unrated (zero-star) recruits.
+organizations_draft_count_by_year:
+  blue_chip_percent: Percent of the year's drafted players who were blue-chip (four- or five-star) recruits.
+  five_stars: Number of the organization's players drafted that year who were five-star recruits.
+  four_stars: Number of the organization's players drafted that year who were four-star recruits.
+  talent_ratio: Ratio of the group's draft share to its recruit-population share for the year (On3's talent ratio).
+  three_stars: Number of the organization's players drafted that year who were three-star recruits.
+  zero_stars: Number of the organization's players drafted that year who were unrated (zero-star) recruits.
+sports247_site_pages_coach_ranking:
+  average_rating: Average rating across the coach's credited commits.
+  average_scout_rating: Average 247Sports in-house (scout) rating across the credited commits.
+  commits: Number of commits credited to the coach in the ranking.
+  composite_average_rating: Average 247Sports Composite rating across the credited commits.
+  composite_conference_rank: Coach's conference recruiter rank by Composite points.
+  composite_division_rank: Coach's division recruiter rank by Composite points.
+  composite_five_stars: Number of five-star commits by the 247Sports Composite rating.
+  composite_four_stars: Number of four-star commits by the 247Sports Composite rating.
+  composite_overall_rank: Coach's national recruiter rank by Composite points.
+  composite_rating: Composite class rating for the coach's haul.
+  composite_three_stars: Number of three-star commits by the 247Sports Composite rating.
+  composite_total: Total 247Sports Composite rating points credited to the coach's commits.
+  composite_two_stars: Number of two-star commits by the 247Sports Composite rating.
+  conference_rank: Rank within conference.
+  default_name: Server-rendered display label for the entity.
+  division_rank: Coach's recruiter rank within the division.
+  five_stars: Number of five-star commits credited to the coach.
+  four_stars: Number of four-star commits credited to the coach.
+  institution: Nested 247Sports institution the coach recruited for during the ranking cycle (stringified).
+  key: Primary key of this entity (the id used in its `.json` route).
+  overall_rank: Overall national coach-recruiting rank.
+  previous_coach_ranking: Nested prior-cycle recruiter-ranking row for the coach (stringified).
+  ranking: FK -> the Ranking snapshot this row belongs to.
+  recruitment: Nested 247Sports recruitment record credited to the coach on this row (stringified).
+  scout_conference_rank: Coach's conference recruiter rank by 247Sports' own (scout) points.
+  scout_division_rank: Coach's division recruiter rank by 247Sports' own (scout) points.
+  scout_five_stars: Number of five-star commits by 247Sports' own (scout) rating.
+  scout_four_stars: Number of four-star commits by 247Sports' own (scout) rating.
+  scout_overall_rank: Coach's national recruiter rank by 247Sports' own (scout) points.
+  scout_rating: Total 247Sports in-house (scout) rating points credited to the coach's commits.
+  scout_three_stars: Number of three-star commits by 247Sports' own (scout) rating.
+  scout_two_stars: Number of two-star commits by 247Sports' own (scout) rating.
+  sport: Nested 247Sports sport the ranking covers (stringified).
+  three_stars: Number of three-star commits credited to the coach.
+  two_stars: Number of two-star commits credited to the coach.
+team_ranking:
+  applied_average_consensus_rating: Average industry-consensus rating across the counted commits.
+  applied_average_rating: Average On3 rating across the counted commits.
+  applied_commits: Number of commits counted toward the class score.
+  applied_total_consensus_rating: Sum of counted commits' industry-consensus ratings applied to the class score.
+  applied_total_rating: Sum of counted commits' On3 ratings applied to the class score.
+  average_nil_value: Average On3 NIL valuation across the class's commits, in dollars.
+  commits: Number of commits in the team's recruiting class.
+  conference_consensus_rank: Team's class rank within its conference by consensus score.
+  conference_rank: Team's class rank within its conference by On3 score.
+  consensus_five_stars: Number of five-star commits by industry-consensus rating.
+  consensus_four_stars: Number of four-star commits by industry-consensus rating.
+  consensus_three_stars: Number of three-star commits by industry-consensus rating.
+  deductions: Points deducted from the team's class score (On3 ranking formula).
+  deductions_description: Explanation of the deductions applied to the class score.
+  dispay_consensus_score: Display-formatted consensus class score (the 'dispay' spelling is On3's own field name).
+  dispay_on3_score: Display-formatted On3 class score (the 'dispay' spelling is On3's own field name).
+  five_stars: Number of five-star commits by On3's own rating.
+  four_stars: Number of four-star commits by On3's own rating.
+  key: On3 RDB key for the team's class-ranking row.
+  overall_consensus_rank: Team's national class rank by industry-consensus score.
+  three_stars: Number of three-star commits by On3's own rating.
+team_ranking_consensus_team_rankings:
+  applied_average_consensus_rating: Average industry-consensus rating across the counted commits.
+  applied_average_rating: Average On3 rating across the counted commits.
+  applied_commits: Number of commits counted toward the class score.
+  applied_total_consensus_rating: Sum of counted commits' industry-consensus ratings applied to the class score.
+  applied_total_rating: Sum of counted commits' On3 ratings applied to the class score.
+  average_nil_value: Average On3 NIL valuation across the class's commits, in dollars.
+  commits: Number of commits in the team's recruiting class.
+  conference_consensus_rank: Team's class rank within its conference by consensus score.
+  conference_rank: Team's class rank within its conference by On3 score.
+  consensus_five_stars: Number of five-star commits by industry-consensus rating.
+  consensus_four_stars: Number of four-star commits by industry-consensus rating.
+  consensus_three_stars: Number of three-star commits by industry-consensus rating.
+  deductions: Points deducted from the team's class score (On3 ranking formula).
+  deductions_description: Explanation of the deductions applied to the class score.
+  dispay_consensus_score: Display-formatted consensus class score (the 'dispay' spelling is On3's own field name).
+  dispay_on3_score: Display-formatted On3 class score (the 'dispay' spelling is On3's own field name).
+  five_stars: Number of five-star commits by On3's own rating.
+  four_stars: Number of four-star commits by On3's own rating.
+  key: On3 RDB key for the team's class-ranking row.
+  overall_consensus_rank: Team's national class rank by industry-consensus score.
+  three_stars: Number of three-star commits by the On3 consensus rating.
 load_contracts:
   cols: Placeholder column retained in the contracts loader output schema; contains no meaningful data in this context.
 load_depth_charts:
@@ -5826,9 +14110,6 @@ load_nfl_depth_charts:
   depth_team: Depth rank of the player at their position, stored as a string ('1' = starter, '2' = backup, etc.).
   elias_id: Elias Sports Bureau player identifier used for official NFL record-keeping and statistics attribution.
   formation: Offensive or defensive formation label (e.g., 'Base 3-4', 'Nickel') associated with this depth chart grouping.
-load_nba_stats_rosters:
-  num: Jersey number worn by the player.
-  exp: Years of NBA playing experience entering the season ('R' = rookie).
 load_nfl_espn_qbr:
   epa_total: Total expected points added across the quarterback's plays (ESPN QBR EPA component).
   exp_sack: QBR points contribution adjustment from expected sacks.
@@ -11339,214 +19620,6 @@ load_draft_outcomes:
   pick: Overall pick number.
   position: Position drafted at (PFR abbreviation).
 
-sports247_site_pages_coach:
-  default_name: Server-rendered display label for the entity.
-  key: Primary key of this entity (the id used in its `.json` route).
-sports247_site_pages_coach_ranking:
-  composite_rating: Composite class rating for the coach's haul.
-  conference_rank: Rank within conference.
-  default_name: Server-rendered display label for the entity.
-  key: Primary key of this entity (the id used in its `.json` route).
-  overall_rank: Overall national coach-recruiting rank.
-  ranking: FK -> the Ranking snapshot this row belongs to.
-sports247_site_pages_draft_pick:
-  default_name: Server-rendered display label for the entity.
-  key: Primary key of this entity (the id used in its `.json` route).
-  mock: Whether this is a mock-draft projection vs an actual pick.
-  overall_pick: Overall selection number in the draft.
-  pick: Pick number within the round.
-  position_abbreviation: Player's position at draft.
-  round: Draft round number (1-based) the pick belongs to.
-sports247_site_pages_event:
-  default_name: Server-rendered display label for the entity.
-  key: Primary key of this entity (the id used in its `.json` route).
-sports247_site_pages_institution:
-  default_name: Server-rendered display label for the entity.
-  group: Institution group (division/level) bitmask code.
-  key: Primary key of this entity (the id used in its `.json` route).
-  location: FK -> Location (`/Institution/{Location}/Location.json`).
-  rankable: Whether the institution participates in class rankings.
-  site: FK -> team Site (network site key).
-  state: FK -> State entity.
-  type: Institution type code (college / pro / high school).
-sports247_site_pages_location:
-  default_name: Server-rendered display label for the entity.
-  key: Primary key of this entity (the id used in its `.json` route).
-sports247_site_pages_player:
-  cbs_key: Cross-reference key into the CBS Sports id space.
-  current_player_institution: FK -> PlayerInstitution (current school).
-  default_name: Server-rendered display label for the entity.
-  key: Primary key of this entity (the id used in its `.json` route).
-  national_rank: Overall national rank in the recruit's class.
-  position_rank: Rank within position for the class.
-  primary_player_sport: FK -> PlayerSport (`/PlayerSport/{id}.json`).
-  rating: 247Sports numeric rating (0-1 scale) for the primary sport.
-  star_rating: Star tier (2-5) derived from the rating.
-  state_rank: Rank within home state for the class.
-sports247_site_pages_player_institution:
-  default_name: Server-rendered display label for the entity.
-  key: Primary key of this entity (the id used in its `.json` route).
-sports247_site_pages_player_institution_evaluation:
-  default_name: Server-rendered display label for the entity.
-  key: Primary key of this entity (the id used in its `.json` route).
-sports247_site_pages_player_institution_prediction:
-  confidence: Expert confidence 1-10.
-  default_name: Server-rendered display label for the entity.
-  institution: FK -> predicted destination Institution.
-  key: Primary key of this entity (the id used in its `.json` route).
-  prediction_status: Crystal-ball prediction status code.
-  score: Expert accuracy score at time of prediction.
-sports247_site_pages_player_sport:
-  class_year: Recruiting class year.
-  composite_rating: 247Sports Composite rating (industry blend).
-  composite_strength: Composite strength points (team-ranking weight).
-  default_name: Server-rendered display label for the entity.
-  espn_grade: ESPN source grade (industry composite input).
-  key: Primary key of this entity (the id used in its `.json` route).
-  rating: 247Sports rating string (0-1).
-  recruitment: FK -> Recruitment aggregate for this player-sport.
-  rivals_grade: Rivals source grade (industry composite input).
-  star_rating: Star tier (2-5).
-sports247_site_pages_player_sport_ranking:
-  committed_institution: FK -> committed Institution (null if uncommitted).
-  default_name: Server-rendered display label for the entity.
-  key: Primary key of this entity (the id used in its `.json` route).
-  overall_rank: Overall national rank in the snapshot.
-  position_rank: Rank within position.
-  ranking: FK -> Ranking snapshot.
-  state_rank: Rank within home state.
-sports247_site_pages_recruit:
-  committed_institution: FK -> committed Institution.
-  composite_strength: Composite strength points contributed to team ranking.
-  default_name: Server-rendered display label for the entity.
-  key: Primary key of this entity (the id used in its `.json` route).
-  player_cbs_key: Cross-reference key into the CBS Sports id space.
-  player_current_player_institution: FK -> PlayerInstitution (current school).
-  player_default_name: Server-rendered display label for the entity.
-  player_key: Primary key of this entity (the id used in its `.json` route).
-  player_national_rank: Overall national rank in the recruit's class.
-  player_position_rank: Rank within position for the class.
-  player_primary_player_sport: FK -> PlayerSport (`/PlayerSport/{id}.json`).
-  player_rating: 247Sports numeric rating (0-1 scale) for the primary sport.
-  player_star_rating: Star tier (2-5) derived from the rating.
-  player_state_rank: Rank within home state for the class.
-  recruit_interest_count: Number of tracked school interests.
-  recruit_interests_url: Site URL to the recruit's interest timeline.
-sports247_site_pages_recruit_interest:
-  commit_status: Commitment status label (e.g. Committed, Signed).
-  default_name: Server-rendered display label for the entity.
-  hard_commit: FK -> the RecruitInterestEvent marking a hard commit.
-  institution: FK -> the interested/interesting Institution.
-  key: Primary key of this entity (the id used in its `.json` route).
-  offered: Whether the school has extended an offer.
-  recruitment: FK -> parent Recruitment.
-sports247_site_pages_recruit_interest_event:
-  default_name: Server-rendered display label for the entity.
-  key: Primary key of this entity (the id used in its `.json` route).
-passing_summary:
-  player_id: PFF player id (integer; matches the /players id and every player_id join key).
-  franchise_id: PFF franchise (team) id (integer join key).
-  jersey_number: Jersey number (string; zero-padded, e.g. "09").
-  team: Team abbreviation the player is credited to for the range.
-  team_name: Team name/abbreviation the player is credited to for the range.
-  player_game_count: Games with at least one qualifying dropback in the requested range.
-  grades_offense: PFF overall offense grade (0-100).
-  grades_pass: PFF passing grade (0-100).
-  grades_run: PFF rushing grade (0-100).
-  dropbacks: Total quarterback dropbacks.
-  attempts: Pass attempts thrown by the passer.
-  completions: Completed passes by the passer.
-  completion_percent: Completion percentage.
-  yards: Total passing yards gained.
-  qb_rating: NFL passer rating.
-  sacks: Times the passer was sacked.
-  sack_percent: Sack rate (sacks per dropback).
-  twp_rate: Turnover-worthy-play rate.
-  btt_rate: Big-time-throw rate.
-  accuracy_percent: Charted accuracy percentage.
-  drop_rate: Receiver drop rate on the quarterback's throws.
-  first_downs: Passing first downs.
-  scrambles: Scramble plays.
-  thrown_aways: Passes intentionally thrown away.
-  spikes: Clock-stopping spike plays.
-  bats: Passes batted at the line.
-  hit_as_threw: Plays where the quarterback was hit as he threw.
-  interceptions: Interceptions thrown.
-  penalties: Penalties charged.
-  declined_penalties: Declined penalties.
-  draft_season: Draft class (year) of the player.
-  eligible_season: First eligible season for the player.
-defense_summary:
-  player_id: PFF player id (integer; matches the /players id and every player_id join key).
-  franchise_id: PFF franchise (team) id (integer join key).
-  jersey_number: Jersey number (string; zero-padded, e.g. "09").
-  team_name: Team abbreviation the player is credited to for the range.
-  player_game_count: Games with at least one qualifying snap in the requested range.
-  grades_defense: PFF overall defense grade (0-100).
-  grades_run_defense: PFF run-defense grade (0-100).
-  grades_coverage_defense: PFF coverage grade (0-100).
-  tackles: Total tackles made by the defender.
-  assists: Assisted tackles.
-  stops: Tackles that constitute an offensive failure ("stops").
-  sacks: Sacks credited.
-  total_pressures: Total quarterback pressures (sacks + hits + hurries).
-  interceptions: Interceptions made in coverage.
-  forced_fumbles: Forced fumbles.
-  interception_touchdowns: Touchdowns scored on interception returns.
-offense_summary:
-  player_id: PFF player id (integer; matches the /players id and every player_id join key).
-  franchise_id: PFF franchise (team) id (integer join key).
-  jersey_number: Jersey number (string; zero-padded, e.g. "09").
-  team_name: Team abbreviation the player is credited to for the range.
-  player_game_count: Games with at least one qualifying snap in the requested range.
-  grades_offense: PFF overall offense grade (0-100).
-  grades_pass: PFF passing grade (0-100).
-  grades_run: PFF rushing grade (0-100).
-  grades_pass_block: PFF pass-blocking grade (0-100).
-  grades_run_block: PFF run-blocking grade (0-100).
-  grades_pass_route: PFF receiving/route grade (0-100).
-receiving_summary:
-  player_id: PFF player id (integer; matches the /players id and every player_id join key).
-  franchise_id: PFF franchise (team) id (integer join key).
-  jersey_number: Jersey number (string; zero-padded, e.g. "09").
-  team_name: Team abbreviation the player is credited to for the range.
-  player_game_count: Games with at least one qualifying snap in the requested range.
-  grades_offense: PFF overall offense grade (0-100).
-  grades_pass_route: PFF receiving/route grade (0-100).
-  grades_hands_drop: PFF hands/drop grade (0-100).
-  targets: Times targeted.
-  receptions: Passes caught by the receiver.
-  yards: Receiving yards.
-  touchdowns: Receiving touchdowns.
-  drops: Dropped passes.
-  yards_after_catch: Yards after the catch.
-  yprr: Yards per route run.
-  routes: Pass routes run by the receiver.
-  contested_receptions: Contested catches made.
-  contested_targets: Contested targets.
-rushing_summary:
-  player_id: PFF player id (integer; matches the /players id and every player_id join key).
-  franchise_id: PFF franchise (team) id (integer join key).
-  jersey_number: Jersey number (string; zero-padded, e.g. "09").
-  team_name: Team abbreviation the player is credited to for the range.
-  player_game_count: Games with at least one qualifying snap in the requested range.
-  grades_offense: PFF overall offense grade (0-100).
-  grades_run: PFF rushing grade (0-100).
-  attempts: Rushing attempts (carries) by the runner.
-  yards: Total rushing yards gained.
-  touchdowns: Rushing touchdowns.
-  yards_after_contact: Yards after contact.
-  avoided_tackles: Missed tackles forced.
-  elusive_rating: PFF elusive rating.
-  breakaway_yards: Breakaway (long-run) yards.
-  first_downs: Rushing first downs.
-  fumbles: Fumbles by the ball carrier.
-team_overview:
-  franchise_id: PFF franchise (team) id (integer join key).
-  abbreviation: Team abbreviation.
-  grades_offense: PFF team offense grade (0-100).
-  grades_defense: PFF team defense grade (0-100).
-  grades_coverage_defense: PFF team coverage grade (0-100).
 games:
   id: PFF game id (integer join key).
   season: Season (starting year) of the game.


### PR DESCRIPTION
## Before / after

| Family | Empty description cells before | After |
|---|---|---|
| nfl | 3,155 / 8,081 | **0** |
| nba | 1,697 / 6,509 | **0** |
| cfb | 1,182 / 5,864 | **0** |
| wnba | 1,056 / 5,369 | **0** |
| wbb / mbb | 393 / 391 | **0** |
| nhl / pwhl | 6 / 3 | **0** |
| **Total** | **7,883 / 49,584 (15.9 %)** | **0 / 49,584** |

## How
Every empty cell in the rendered docs was traced to its `manual_column_descriptions.yaml` key (loader `fn` or schema internal name — 294 targets, validated against `_table_cell_desc`'s own resolution), then filled: **7,601 unique descriptions** authored per family, grounded in the producing modules where they exist (`nba_spm`/`nba_darko`/`nba_possessions`, `mbb_ncaa_*`, `cfb_pbp`/`cfb_fourth_down`/`cfb_two_point`, loader docstrings) and in the vendors' public definitions for PFF/NBA-Stats/On3/247 metrics — provenance-named, no invented formulas. League-neutral wording on schema keys shared across leagues/sources. Merged with `tools/codegen/merge_column_descriptions.py` (additive; all 8,918 pre-existing entries verified byte-identical).

Also fixes 13 **pre-existing** wrong fills leaking from the mined-R fallback (fastRhockey's "Whether three stars data is available" on On3/247 star-count columns; "Number of commits in the position group" on class-total tables) and one "Total total rebounds" wart.

## Verified
- Full `generate.py` regeneration ×3 during the work; final `--check` clean.
- Rendered docs: **0** empty description cells (was 7,883); wrong-text greps now 0.
- `sdv-docs-reviewer` audit: approve — spot-verified claims against source (`fg/go/punt_wp_diff` vs `cfb_fourth_down.py`, SPM regression target, transition definition), league-neutrality on shared keys, schema tree untouched (`schemas/**.yaml` unmodified), no lazy duplicate fills.
- Descriptions live only in `manual_column_descriptions.yaml`, per the re-capture-clobber rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded reference documentation for CFB, MBB, NHL, PWHL, WBB, and WNBA loaders.
  * Added clear descriptions for existing play-by-play, roster, player, team, scoring, lineup, shooting, and advanced-statistics fields.
  * Clarified field sources, derivations, meanings, validation rules, and language-specific details.
  * Expanded 247Sports site-page endpoint return-table descriptions.
  * Corrected terminology for conversion attempts, turnovers, assists, lineup duration, and player-credited statistics.
  * No APIs, schemas, endpoints, columns, or loader behavior were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->