### PR TITLE
fix(mlb): PA-ender discipline in expected stats — pa/ab counted raw pitches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [Unreleased](#unreleased)
+  - [Fixed — MLB expected stats counted raw pitches as plate appearances](#fixed--mlb-expected-stats-counted-raw-pitches-as-plate-appearances)
 - [0.1.4 Release: September 1, 2026](#014-release-september-1-2026)
   - [Fixed — CFB EP/WP inputs: mirrored end yardlines, the wrong `wp_after` perspective, and a flipped WP (#408, #411, #413)](#fixed--cfb-epwp-inputs-mirrored-end-yardlines-the-wrong-wp_after-perspective-and-a-flipped-wp-408-411-413)
   - [Added — the penalty's own side, net yardage and EPA, plus first-down provenance (#408)](#added--the-penaltys-own-side-net-yardage-and-epa-plus-first-down-provenance-408)
@@ -277,6 +279,25 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+## Unreleased
+
+### Fixed — MLB expected stats counted raw pitches as plate appearances
+
+`mlb_expected_stats` counted every non-batted-ball *pitch* row toward `pa`
+and `ab` — published batter-seasons carried `pa` up to ~3,400, deflating
+`xba`/`xslg` to ~.05 — and trusted each cache vintage's
+`woba_value`/`woba_denom` semantics, which corrupted the xwOBA scale per
+season (qualified league means of .34–.72 shipped past the rank-based
+gates, which are scale-blind by construction). `pa`/`ab` and the wOBA
+denominator now count only plate-appearance-ending rows (`events`
+non-null), the denominator is derived from events (PA enders minus
+intentional walks, sac bunts and catcher interference) rather than read
+from `woba_denom`, PA-ending events with a null `woba_value` get fixed
+fallback weights (walk .69, HBP .72), and `intent_walk` no longer counts
+as an at-bat. Downstream, `baseballr-data` now enforces an absolute
+league-mean scale gate at publish; the full-history republish of
+`mlb_hitting_models` is the tracked follow-up.
+
 ## 0.1.4 Release: September 1, 2026
 
 ### Fixed — CFB EP/WP inputs: mirrored end yardlines, the wrong `wp_after` perspective, and a flipped WP (#408, #411, #413)
@@ -374,7 +395,7 @@ ESPN prefixes play text with the formation:
 No Huddle-Shotgun #1 C.Parker pass complete short right to #9 J.Triplett...
 ```
 
-The player-name captures are windowed -- `(.{0,30} )pass ` -- and read the raw
+The player-name captures are windowed -- `(.{0,30} )pass` (with a trailing space) -- and read the raw
 `text`. `No Huddle-Shotgun #1 C.Parker` is 29 characters, so it fits inside the
 window and is swallowed whole; a longer prefix is captured *truncated*, starting
 mid-token (`dle-Shotgun #5 R.Marshall`). A `cleaned_text` column already stripped

--- a/docs/docs/mlb/reference/additional.md
+++ b/docs/docs/mlb/reference/additional.md
@@ -1141,9 +1141,17 @@ contact `woba`/`ba`/`slg` per batted ball with the launch-angle-
 marginal fallback, then aggregates:
 
 * `xwoba = (sum(predicted_woba over balls in play) + sum(woba_value over
-  non-batted-ball PA outcomes)) / sum(woba_denom)`
-* `xba = sum(predicted_ba over balls in play) / ab`
-* `xslg = sum(predicted_tb over balls in play) / ab`
+  non-batted-ball PA-ENDING outcomes)) / derived_woba_denom` -- the
+  denominator is DERIVED from `events` (PA enders minus intentional
+  walks / sac bunts / catcher interference), never trusted from a cache
+  vintage's `woba_denom` column.
+* `xba = sum(predicted_ba over at-bat balls in play) / ab`
+* `xslg = sum(predicted_tb over at-bat balls in play) / ab`
+
+`pa` counts PLATE-APPEARANCE-ENDING rows only (`events` non-null),
+never raw pitches -- a Statcast search pull carries every pitch, and
+counting them (the pre-fix behavior) inflated `pa`/`ab` by ~4x and
+corrupted `xba`/`xslg` scales.
 
 **Parameters**
 

--- a/docs/docs/mlb/reference/additional.md
+++ b/docs/docs/mlb/reference/additional.md
@@ -1144,7 +1144,9 @@ marginal fallback, then aggregates:
   non-batted-ball PA-ENDING outcomes)) / derived_woba_denom` -- the
   denominator is DERIVED from `events` (PA enders minus intentional
   walks / sac bunts / catcher interference), never trusted from a cache
-  vintage's `woba_denom` column.
+  vintage's `woba_denom` column. The numerator excludes those same
+  zero-denominator events, and a PA-ending walk/HBP whose `woba_value`
+  is null in a given vintage is filled with the fixed weights .69 / .72.
 * `xba = sum(predicted_ba over at-bat balls in play) / ab`
 * `xslg = sum(predicted_tb over at-bat balls in play) / ab`
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -2,6 +2,8 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [Unreleased](#unreleased)
+  - [Fixed — MLB expected stats counted raw pitches as plate appearances](#fixed--mlb-expected-stats-counted-raw-pitches-as-plate-appearances)
 - [0.1.4 Release: September 1, 2026](#014-release-september-1-2026)
   - [Fixed — CFB EP/WP inputs: mirrored end yardlines, the wrong `wp_after` perspective, and a flipped WP (#408, #411, #413)](#fixed--cfb-epwp-inputs-mirrored-end-yardlines-the-wrong-wp_after-perspective-and-a-flipped-wp-408-411-413)
   - [Added — the penalty's own side, net yardage and EPA, plus first-down provenance (#408)](#added--the-penaltys-own-side-net-yardage-and-epa-plus-first-down-provenance-408)
@@ -277,6 +279,25 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+## Unreleased
+
+### Fixed — MLB expected stats counted raw pitches as plate appearances
+
+`mlb_expected_stats` counted every non-batted-ball *pitch* row toward `pa`
+and `ab` — published batter-seasons carried `pa` up to ~3,400, deflating
+`xba`/`xslg` to ~.05 — and trusted each cache vintage's
+`woba_value`/`woba_denom` semantics, which corrupted the xwOBA scale per
+season (qualified league means of .34–.72 shipped past the rank-based
+gates, which are scale-blind by construction). `pa`/`ab` and the wOBA
+denominator now count only plate-appearance-ending rows (`events`
+non-null), the denominator is derived from events (PA enders minus
+intentional walks, sac bunts and catcher interference) rather than read
+from `woba_denom`, PA-ending events with a null `woba_value` get fixed
+fallback weights (walk .69, HBP .72), and `intent_walk` no longer counts
+as an at-bat. Downstream, `baseballr-data` now enforces an absolute
+league-mean scale gate at publish; the full-history republish of
+`mlb_hitting_models` is the tracked follow-up.
+
 ## 0.1.4 Release: September 1, 2026
 
 ### Fixed — CFB EP/WP inputs: mirrored end yardlines, the wrong `wp_after` perspective, and a flipped WP (#408, #411, #413)
@@ -374,7 +395,7 @@ ESPN prefixes play text with the formation:
 No Huddle-Shotgun #1 C.Parker pass complete short right to #9 J.Triplett...
 ```
 
-The player-name captures are windowed -- `(.{0,30} )pass ` -- and read the raw
+The player-name captures are windowed -- `(.{0,30} )pass` (with a trailing space) -- and read the raw
 `text`. `No Huddle-Shotgun #1 C.Parker` is 29 characters, so it fits inside the
 window and is swallowed whole; a longer prefix is captured *truncated*, starting
 mid-token (`dle-Shotgun #5 R.Marshall`). A `cleaned_text` column already stripped

--- a/sportsdataverse/mlb/mlb_expected_stats.py
+++ b/sportsdataverse/mlb/mlb_expected_stats.py
@@ -233,7 +233,9 @@ def mlb_expected_stats(
       non-batted-ball PA-ENDING outcomes)) / derived_woba_denom`` -- the
       denominator is DERIVED from ``events`` (PA enders minus intentional
       walks / sac bunts / catcher interference), never trusted from a cache
-      vintage's ``woba_denom`` column.
+      vintage's ``woba_denom`` column. The numerator excludes those same
+      zero-denominator events, and a PA-ending walk/HBP whose ``woba_value``
+      is null in a given vintage is filled with the fixed weights .69 / .72.
     * ``xba = sum(predicted_ba over at-bat balls in play) / ab``
     * ``xslg = sum(predicted_tb over at-bat balls in play) / ab``
 

--- a/sportsdataverse/mlb/mlb_expected_stats.py
+++ b/sportsdataverse/mlb/mlb_expected_stats.py
@@ -289,7 +289,9 @@ def mlb_expected_stats(
     pitches = pitches.with_columns(season_expr.alias("season"))
 
     pitches = _add_value_columns(pitches)
-    grid = build_outcome_grid(pitches)
+    # The outcome grid's cell means likewise use only PA-ending batted balls —
+    # an events-less "batted ball" row carries no realized outcome to average.
+    grid = build_outcome_grid(pitches.filter(pl.col("events").is_not_null() & (pl.col("events") != "")))
 
     bip_mask = (pl.col("type") == "X") & pl.col("launch_speed").is_not_null() & pl.col("launch_angle").is_not_null()
     # PA-ender discipline: pa / ab / the wOBA denominator count only rows that
@@ -303,7 +305,11 @@ def mlb_expected_stats(
     zero_denom = pl.col("events").is_in(list(_WOBA_DENOM_ZERO_EVENTS))
     non_ab = pl.col("events").is_in(list(_NON_AB_EVENTS))
 
-    bip = pitches.filter(bip_mask)
+    # A batted-ball row must ALSO be a PA ender: a type=="X" row with launch
+    # data but a null/empty ``events`` is a feed artifact, and without this
+    # gate it would count toward pa while the events-derived masks exclude it
+    # from every denominator (the inconsistency this fix exists to remove).
+    bip = pitches.filter(bip_mask & pa_end_mask)
     non_bip_pa = pitches.filter(~bip_mask & pa_end_mask)
 
     if bip.height > 0:

--- a/sportsdataverse/mlb/mlb_expected_stats.py
+++ b/sportsdataverse/mlb/mlb_expected_stats.py
@@ -50,12 +50,34 @@ _NON_BATTED_EVENTS = {
 #: Events that do NOT count toward at-bats (for the AB denominator).
 _NON_AB_EVENTS = {
     "walk",
+    "intent_walk",
     "hit_by_pitch",
     "sac_fly",
     "sac_fly_double_play",
     "sac_bunt",
     "sac_bunt_double_play",
     "catcher_interf",
+}
+
+#: PA-ending events that carry a ZERO wOBA denominator (standard wOBA denom =
+#: AB + uBB + SF + HBP -- intentional walks, sac bunts and catcher
+#: interference are excluded).
+_WOBA_DENOM_ZERO_EVENTS = {
+    "intent_walk",
+    "sac_bunt",
+    "sac_bunt_double_play",
+    "catcher_interf",
+}
+
+#: Fixed fallback wOBA weights for PA-ending events whose ``woba_value`` is
+#: null in a given cache vintage (older Savant extracts). These are
+#: FanGraphs-scale constants (true seasonal weights drift by ~±0.01) used only
+#: as a null-fill -- a documented approximation that is orders of magnitude
+#: smaller than the corruption of dropping the event entirely. Events not in
+#: this map fall back to 0.0.
+_WOBA_VALUE_FALLBACK = {
+    "walk": 0.69,
+    "hit_by_pitch": 0.72,
 }
 
 
@@ -208,9 +230,17 @@ def mlb_expected_stats(
     marginal fallback, then aggregates:
 
     * ``xwoba = (sum(predicted_woba over balls in play) + sum(woba_value over
-      non-batted-ball PA outcomes)) / sum(woba_denom)``
-    * ``xba = sum(predicted_ba over balls in play) / ab``
-    * ``xslg = sum(predicted_tb over balls in play) / ab``
+      non-batted-ball PA-ENDING outcomes)) / derived_woba_denom`` -- the
+      denominator is DERIVED from ``events`` (PA enders minus intentional
+      walks / sac bunts / catcher interference), never trusted from a cache
+      vintage's ``woba_denom`` column.
+    * ``xba = sum(predicted_ba over at-bat balls in play) / ab``
+    * ``xslg = sum(predicted_tb over at-bat balls in play) / ab``
+
+    ``pa`` counts PLATE-APPEARANCE-ENDING rows only (``events`` non-null),
+    never raw pitches -- a Statcast search pull carries every pitch, and
+    counting them (the pre-fix behavior) inflated ``pa``/``ab`` by ~4x and
+    corrupted ``xba``/``xslg`` scales.
 
     Args:
         start_dt: Pull start date, ``YYYY-MM-DD``.
@@ -262,8 +292,19 @@ def mlb_expected_stats(
     grid = build_outcome_grid(pitches)
 
     bip_mask = (pl.col("type") == "X") & pl.col("launch_speed").is_not_null() & pl.col("launch_angle").is_not_null()
+    # PA-ender discipline: pa / ab / the wOBA denominator count only rows that
+    # END a plate appearance (``events`` non-null and non-empty). A Statcast
+    # search pull carries EVERY PITCH; counting raw non-BIP pitch rows (the
+    # pre-fix behavior) inflated pa/ab by the pitch count and, on cache
+    # vintages with degenerate ``woba_value``/``woba_denom`` semantics,
+    # corrupted the xwOBA scale itself. Denominators are DERIVED from events
+    # (vintage-proof) rather than trusted from ``woba_denom``.
+    pa_end_mask = pl.col("events").is_not_null() & (pl.col("events") != "")
+    zero_denom = pl.col("events").is_in(list(_WOBA_DENOM_ZERO_EVENTS))
+    non_ab = pl.col("events").is_in(list(_NON_AB_EVENTS))
+
     bip = pitches.filter(bip_mask)
-    non_bip = pitches.filter(~bip_mask)
+    non_bip_pa = pitches.filter(~bip_mask & pa_end_mask)
 
     if bip.height > 0:
         bip = bip.with_columns(
@@ -279,35 +320,34 @@ def mlb_expected_stats(
         )
 
     bip_agg = bip.group_by("batter", "season").agg(
-        pl.col("_pred_woba").sum().alias("_bip_woba_sum"),
-        pl.col("_pred_ba").sum().alias("_bip_ba_sum"),
-        pl.col("_pred_slg").sum().alias("_bip_slg_sum"),
-        pl.len().alias("_ab_from_bip"),
+        pl.col("_pred_woba").filter(~zero_denom).sum().alias("_bip_woba_sum"),
+        pl.col("_pred_ba").filter(~non_ab).sum().alias("_bip_ba_sum"),
+        pl.col("_pred_slg").filter(~non_ab).sum().alias("_bip_slg_sum"),
+        (~zero_denom).sum().cast(pl.Float64).alias("_bip_denom"),
+        (~non_ab).sum().alias("_ab_from_bip"),
+        pl.len().alias("_pa_from_bip"),
     )
 
-    woba_denom_col = "woba_denom" if "woba_denom" in non_bip.columns else None
-    non_bip_agg = non_bip.group_by("batter", "season").agg(
-        pl.col("woba_value").fill_null(0.0).sum().alias("_non_bip_woba_sum"),
-        (pl.col(woba_denom_col).fill_null(0.0).sum() if woba_denom_col else pl.lit(0.0)).alias("_non_bip_denom"),
-        pl.col("events").is_in(list(_NON_AB_EVENTS)).sum().alias("_non_ab_events"),
+    non_bip_agg = non_bip_pa.group_by("batter", "season").agg(
+        pl.coalesce(
+            pl.col("woba_value"),
+            pl.col("events").replace_strict(_WOBA_VALUE_FALLBACK, default=0.0, return_dtype=pl.Float64),
+        )
+        .filter(~zero_denom)
+        .sum()
+        .alias("_non_bip_woba_sum"),
+        (~zero_denom).sum().cast(pl.Float64).alias("_non_bip_denom"),
+        (~non_ab).sum().alias("_ab_from_non_bip"),
         pl.len().alias("_pa_from_non_bip"),
     )
 
-    bip_denom_agg = bip.group_by("batter", "season").agg(
-        (pl.col(woba_denom_col).fill_null(1.0).sum() if woba_denom_col else pl.len().cast(pl.Float64)).alias(
-            "_bip_denom"
-        )
-    )
-
-    merged = bip_agg.join(non_bip_agg, on=["batter", "season"], how="full", coalesce=True).join(
-        bip_denom_agg, on=["batter", "season"], how="full", coalesce=True
-    )
+    merged = bip_agg.join(non_bip_agg, on=["batter", "season"], how="full", coalesce=True)
     merged = merged.fill_null(0)
 
     result = (
         merged.with_columns(
-            (pl.col("_ab_from_bip") + pl.col("_pa_from_non_bip")).alias("pa"),
-            (pl.col("_ab_from_bip") + pl.col("_pa_from_non_bip") - pl.col("_non_ab_events")).alias("ab"),
+            (pl.col("_pa_from_bip") + pl.col("_pa_from_non_bip")).alias("pa"),
+            (pl.col("_ab_from_bip") + pl.col("_ab_from_non_bip")).alias("ab"),
             (pl.col("_bip_denom") + pl.col("_non_bip_denom")).alias("_woba_denom"),
         )
         .with_columns(

--- a/tests/mlb/test_mlb_expected_stats.py
+++ b/tests/mlb/test_mlb_expected_stats.py
@@ -125,3 +125,69 @@ def test_mlb_expected_stats_empty_pull_returns_documented_schema() -> None:
     out = mlb_expected_stats("2024-06-01", "2024-06-21", puller=_empty_puller)
     assert out.height == 0
     assert out.columns == ["batter", "season", "pa", "ab", "xwoba", "xba", "xslg"]
+
+
+def _pitchy_puller_factory(rows: dict):
+    def _puller(start_dt: str, end_dt: str, *, player_type: str = "batter") -> pl.DataFrame:
+        return pl.DataFrame(rows)
+
+    return _puller
+
+
+def test_pa_counts_plate_appearance_enders_not_pitches() -> None:
+    """Regression (2026-09 incident): raw ball/strike pitch rows must not
+    inflate pa/ab — a Statcast search pull carries EVERY pitch."""
+    rows = {
+        "batter": [1] * 10,
+        "game_date": ["2024-06-01"] * 10,
+        "type": ["B", "S", "X", "B", "S", "B", "S", "S", "B", "S"],
+        "events": [None, None, "single", None, "strikeout", None, "walk", None, None, None],
+        "launch_speed": [None, None, 95.0, None, None, None, None, None, None, None],
+        "launch_angle": [None, None, 10.0, None, None, None, None, None, None, None],
+        "woba_value": [None, None, 0.9, None, 0.0, None, 0.7, None, None, None],
+        "woba_denom": [None, None, 1.0, None, 1.0, None, 1.0, None, None, None],
+    }
+    out = mlb_expected_stats("2024-06-01", "2024-06-21", puller=_pitchy_puller_factory(rows))
+    row = out.row(0, named=True)
+    assert row["pa"] == 3  # single, strikeout, walk — NOT 10 pitches
+    assert row["ab"] == 2  # walk is not an at-bat
+    # numerator: predicted woba on the lone BIP (grid mean = 0.9) + K 0.0 + walk 0.7
+    assert abs(row["xwoba"] - (0.9 + 0.0 + 0.7) / 3) < 1e-9
+    assert abs(row["xba"] - 1.0 / 2) < 1e-9  # predicted ba on the BIP = cell/global mean 1.0
+
+
+def test_vintage_missing_woba_denom_and_null_walk_value_stays_on_scale() -> None:
+    """Regression (2026-09 incident): a cache vintage with NO woba_denom
+    column and null woba_value on the walk must not corrupt the scale — the
+    denominator is derived from events and the walk gets the fixed fallback."""
+    rows = {
+        "batter": [1, 1, 1],
+        "game_date": ["2024-06-01"] * 3,
+        "type": ["X", "S", "B"],
+        "events": ["single", "strikeout", "walk"],
+        "launch_speed": [95.0, None, None],
+        "launch_angle": [10.0, None, None],
+        "woba_value": [0.9, 0.0, None],  # walk value missing in this vintage
+    }
+    out = mlb_expected_stats("2024-06-01", "2024-06-21", puller=_pitchy_puller_factory(rows))
+    row = out.row(0, named=True)
+    assert row["pa"] == 3
+    assert abs(row["xwoba"] - (0.9 + 0.0 + 0.69) / 3) < 1e-9  # 0.69 = fixed walk fallback
+
+
+def test_intent_walk_excluded_from_woba_denom_and_ab() -> None:
+    rows = {
+        "batter": [1, 1],
+        "game_date": ["2024-06-01"] * 2,
+        "type": ["X", "B"],
+        "events": ["single", "intent_walk"],
+        "launch_speed": [95.0, None],
+        "launch_angle": [10.0, None],
+        "woba_value": [0.9, 0.0],
+        "woba_denom": [1.0, 0.0],
+    }
+    out = mlb_expected_stats("2024-06-01", "2024-06-21", puller=_pitchy_puller_factory(rows))
+    row = out.row(0, named=True)
+    assert row["pa"] == 2
+    assert row["ab"] == 1
+    assert abs(row["xwoba"] - 0.9 / 1) < 1e-9  # IBB contributes neither numerator nor denominator

--- a/tests/mlb/test_mlb_expected_stats.py
+++ b/tests/mlb/test_mlb_expected_stats.py
@@ -191,3 +191,24 @@ def test_intent_walk_excluded_from_woba_denom_and_ab() -> None:
     assert row["pa"] == 2
     assert row["ab"] == 1
     assert abs(row["xwoba"] - 0.9 / 1) < 1e-9  # IBB contributes neither numerator nor denominator
+
+
+def test_batted_ball_row_without_events_is_ignored_everywhere() -> None:
+    """Sourcery review of #421: a type=='X' row with launch data but a
+    null/empty events value must not count toward pa (nor the grid) — it is a
+    feed artifact, not a plate appearance."""
+    rows = {
+        "batter": [1, 1, 1],
+        "game_date": ["2024-06-01"] * 3,
+        "type": ["X", "X", "S"],
+        "events": ["single", None, "strikeout"],
+        "launch_speed": [95.0, 96.0, None],
+        "launch_angle": [10.0, 11.0, None],
+        "woba_value": [0.9, None, 0.0],
+        "woba_denom": [1.0, None, 1.0],
+    }
+    out = mlb_expected_stats("2024-06-01", "2024-06-21", puller=_pitchy_puller_factory(rows))
+    row = out.row(0, named=True)
+    assert row["pa"] == 2  # the events-less batted ball is not a PA
+    assert row["ab"] == 2  # single + strikeout
+    assert abs(row["xwoba"] - (0.9 + 0.0) / 2) < 1e-9

--- a/uv.lock
+++ b/uv.lock
@@ -7220,7 +7220,7 @@ wheels = [
 
 [[package]]
 name = "sportsdataverse"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## The bug (found by the reproducible model-writeups campaign)

The published `mlb_hitting_models` assets carried `max_pa` ≈ 3,400 per batter-season and league-mean xBA of ~.05: `mlb_expected_stats` counted **every non-batted-ball pitch row** toward `pa`/`ab`, and trusted each cache vintage's `woba_value`/`woba_denom` semantics — corrupting the xwOBA scale per season (qualified league means .34–.72 shipped past the Spearman gates, which are rank-based and therefore scale-blind).

## The fix

- `pa`/`ab` and the wOBA denominator count only **plate-appearance-ending** rows (`events` non-null/non-empty) — never raw pitches
- the wOBA denominator is **derived from events** (PA enders minus intentional walks / sac bunts / catcher interference) instead of trusting `woba_denom` (vintage-proof)
- PA-ending events with a null `woba_value` in a given vintage get fixed fallback weights (walk .69, HBP .72 — documented approximation)
- `intent_walk` no longer counts as an at-bat

## Evidence

- 3 regression tests (pitch rows don't inflate pa/ab; a no-`woba_denom`/null-walk vintage stays on scale; IBB excluded from denom+AB)
- oracle gates unchanged and green; full suite **5,799 passed**; ruff + mypy clean; codegen drift gate green
- companion publisher-side absolute scale gate landed in baseballr-data (75d29ddbc5); the full-history republish of `mlb_hitting_models` is the tracked follow-up (ledger 2026-09-01)

Also syncs `uv.lock`'s package version with the 0.1.4 release (it was never re-locked, so every `uv run` rewrote it and failed the pre-push hook).

## Summary by Sourcery

Correct MLB expected-stat aggregation to use plate-appearance-ending events and vintage-independent wOBA denominators.

Bug Fixes:
- Ensure MLB expected hitting statistics count only plate-appearance-ending events, preventing raw pitches and feed artifacts from inflating PA/AB and distorting expected-stat scales.
- Derive the wOBA denominator from event types, exclude intentional walks, sacrifice bunts, and catcher interference appropriately, and apply fallback weights for missing walk or hit-by-pitch values.

Enhancements:
- Update MLB expected-stat documentation and changelog to describe the corrected PA, AB, and wOBA aggregation semantics.

Build:
- Synchronize the locked package version with the 0.1.4 release.

Documentation:
- Document the corrected event-based aggregation and expected-stat denominator behavior.

Tests:
- Add regression coverage for raw-pitch inflation, missing vintage wOBA metadata, intentional walks, and events-less batted-ball rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected MLB expected-stat calculations so plate appearances and at-bats count completed outcomes rather than individual pitches.
  * Improved xwOBA, xBA, and xSLG scaling by deriving denominators from event results.
  * Correctly handles intentional walks, zero-denominator events, and missing historical values.

* **Documentation**
  * Updated expected-stat reference documentation and changelog details.
  * Clarified formation-tag regex documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->