### PR TITLE
feat(mbb): per-player standard errors from the league RAPM ridge posterior

### DIFF
--- a/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
+++ b/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
@@ -291,8 +291,10 @@ def solve_rapm_league(
             exactly equivalent to a per-possession ridge with that penalty.
         compute_se: Also return the posterior standard errors (module
             docstring, "Uncertainty"). Costs one dense Cholesky inverse of the
-            ``(2P+1)``-square penalised Gram matrix: ~0.8 GB and a few seconds
-            for a D-I season (P ~ 5,000). Switch off for pooled designs past
+            ``(2P+1)``-square penalised Gram matrix. One such matrix is
+            ~0.8 GB for a D-I season (P ~ 5,000, dim ~ 10,001); the
+            symmetrise step holds two of them at once, so the peak is
+            ~1.6 GB and a few seconds. Switch off for pooled designs past
             ~20k columns.
         return_as_pandas: Return the players frame as pandas.
 
@@ -467,8 +469,10 @@ def _posterior_se(
     from scipy.linalg import lapack
 
     dim = x.shape[1]
-    # ponytail: dense Cholesky inverse, O(dim^3) -- ~10k dims (0.8 GB, seconds) for a D-I
-    # season. A pooled multi-season design past ~20k dims needs a sparse (CHOLMOD) factor.
+    # ponytail: dense Cholesky inverse, O(dim^3) -- ~10k dims for a D-I season, 0.8 GB per
+    # dense array. `low + low.T` below holds two of them live, so peak is ~1.6 GB; blocked
+    # in-place symmetrisation would halve it if that ever binds. A pooled multi-season
+    # design past ~20k dims needs a sparse (CHOLMOD) factor.
     a = (x.T @ x).toarray(order="F")
     a[np.diag_indices(dim)] += ridge_lambda
     c, info_f = lapack.dpotrf(a, lower=1, clean=1, overwrite_a=1)

--- a/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
+++ b/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
@@ -37,12 +37,32 @@ under the shared penalty is negligible because every possession loads it.
 A null slot id (an unresolved player, or the ``TEAM`` pseudo-slot) marks the
 possession unusable and it is DROPPED -- "not a rated player" must never be
 imputed. Callers should report the usable fraction.
+
+**Uncertainty.** :func:`solve_rapm_league` also reports per-player standard
+errors from the ridge POSTERIOR: with the Gaussian prior
+``beta ~ N(0, sigma^2 / lambda)`` that the penalty encodes and
+possession-weighted Gaussian errors, the posterior covariance is
+``sigma^2 (X'WX + lambda I)^-1``, where ``sigma^2`` is the weighted residual
+variance on ``n_stints - df_eff`` degrees of freedom (``df_eff`` = trace of
+the ridge hat matrix). This is the Bayesian (credible-interval) SE and is
+what the ``*_se`` columns carry: an interval for the TRUE impact under the
+prior, which widens exactly where the prior is doing the work (a
+low-possession player sits at ~0 +/- the prior SD ``sigma/sqrt(lambda)``).
+The frequentist sandwich ``sigma^2 M X'WX M = sigma^2 (M - lambda M^2)``,
+``M = (X'WX + lambda I)^-1``, is the repeatability of the SHRUNK estimate
+and is exposed as ``*_se_sampling``; it is NOT an interval for the truth
+(it collapses to ~0 for a player the ridge pins at zero) but it is the
+quantity a refit can check. On real MBB 2024 the posterior SE is ~2.3x the
+sampling SE even at 4,000 possessions (lambda = 1000 is prior-dominated), so
+a split-half test covers ~100% under the posterior SE and ~95% under the
+sampling SE -- :func:`split_half_se_check` reports both, and the producer
+gates both. The intercept is treated as fixed (its SE is ~0.14 pts/100 on
+~740k usable possessions, negligible beside player SEs of 3-5).
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import polars as pl
@@ -50,14 +70,13 @@ import polars as pl
 if TYPE_CHECKING:
     import pandas as pd
 
-if TYPE_CHECKING:
-    pass
-
 __all__ = [
     "DEFAULT_RIDGE_LAMBDA",
     "STINT_SCHEMA",
     "aggregate_stints",
+    "possession_deciles",
     "solve_rapm_league",
+    "split_half_se_check",
     "team_aggregate",
 ]
 
@@ -91,7 +110,16 @@ _PLAYERS_SCHEMA: dict[str, pl.DataType] = {
     "rapm_net": pl.Float64,
     "off_poss": pl.Int64,
     "def_poss": pl.Int64,
+    "orapm_se": pl.Float64,
+    "drapm_se": pl.Float64,
+    "rapm_net_se": pl.Float64,
+    "orapm_se_sampling": pl.Float64,
+    "drapm_se_sampling": pl.Float64,
+    "rapm_net_se_sampling": pl.Float64,
 }
+
+#: SE columns of :func:`solve_rapm_league`, posterior first, sampling (sandwich) second.
+_SE_COLS = tuple(c for c in _PLAYERS_SCHEMA if c.endswith("_se") or c.endswith("_se_sampling"))
 
 
 def aggregate_stints(resolved: pl.DataFrame) -> pl.DataFrame:
@@ -251,6 +279,7 @@ def solve_rapm_league(
     stints: pl.DataFrame,
     *,
     ridge_lambda: float = DEFAULT_RIDGE_LAMBDA,
+    compute_se: bool = True,
     return_as_pandas: bool = False,
 ) -> "tuple[pl.DataFrame | pd.DataFrame, dict[str, float]]":
     """Weighted sparse joint O/D ridge over matchup stints.
@@ -260,15 +289,35 @@ def solve_rapm_league(
         ridge_lambda: L2 penalty on the possession-weighted normal equations.
             Because rows are weighted by possessions, the same ``lambda`` is
             exactly equivalent to a per-possession ridge with that penalty.
+        compute_se: Also return the posterior standard errors (module
+            docstring, "Uncertainty"). Costs one dense Cholesky inverse of the
+            ``(2P+1)``-square penalised Gram matrix: ~0.8 GB and a few seconds
+            for a D-I season (P ~ 5,000). Switch off for pooled designs past
+            ~20k columns.
         return_as_pandas: Return the players frame as pandas.
 
     Returns:
         ``(players, info)``. ``players`` has one row per rated player:
         ``player_id``, ``orapm``, ``drapm`` (positive = good defense),
         ``rapm_net = orapm + drapm`` (all per 100 possessions), ``off_poss``,
-        ``def_poss``. ``info`` carries ``intercept`` (possession-weighted
-        league mean pts/100), ``hca`` (half the home-minus-away offensive
-        gap), ``ridge_lambda``, ``n_stints``, ``n_poss``.
+        ``def_poss``, the posterior standard errors ``orapm_se``,
+        ``drapm_se``, ``rapm_net_se`` and the sampling (sandwich) standard
+        errors ``*_se_sampling`` (both net SEs include the O/D covariance; all
+        six are null when ``compute_se=False``; see the module docstring for
+        which to publish). ``info``
+        carries ``intercept`` (possession-weighted league mean pts/100),
+        ``hca`` (half the home-minus-away offensive gap), ``ridge_lambda``,
+        ``n_stints``, ``n_poss``, the lsqr diagnostics and, with SEs,
+        ``sigma2`` (weighted residual variance on the per-100 scale = ``1e4 x``
+        the per-possession points variance, ~1.3e4 in D-I), ``df_eff`` (trace
+        of the ridge hat matrix), ``hca_se`` and ``solve_max_abs_dev`` (max
+        |lsqr - exact| coefficient deviation -- the exact solve comes free
+        with the factorisation and doubles as the solver-tolerance check).
+
+    Raises:
+        RuntimeError: lsqr stopped without converging, or the penalised Gram
+            matrix is not positive definite (``ridge_lambda`` must be > 0 for
+            the SEs).
 
     Example:
         Solve a season::
@@ -279,6 +328,13 @@ def solve_rapm_league(
 
             players, info = solve_rapm_league(aggregate_stints(resolved))
             players.sort("rapm_net", descending=True).head()
+
+        A 95% interval per player::
+
+            players.with_columns(
+                (pl.col("rapm_net") - 2 * pl.col("rapm_net_se")).alias("lo95"),
+                (pl.col("rapm_net") + 2 * pl.col("rapm_net_se")).alias("hi95"),
+            )
 
     See Also:
         * `hoopR <https://hoopR.sportsdataverse.org>`_ -- men's college
@@ -337,6 +393,12 @@ def solve_rapm_league(
     drapm = beta[n_players : 2 * n_players]
     hca = float(beta[2 * n_players])
 
+    se_info: dict[str, float] = {}
+    if compute_se:
+        se, se_info = _posterior_se(x, (y - mu) * sw, beta, n_players, float(ridge_lambda))
+    else:
+        se = {c: np.full(n_players, np.nan) for c in _SE_COLS}  # -> null below, never NaN
+
     exposure = (
         pl.concat(
             [
@@ -357,6 +419,7 @@ def solve_rapm_league(
                 "player_id": pl.Series(players, dtype=pl.Utf8),
                 "orapm": orapm.astype(np.float64),
                 "drapm": drapm.astype(np.float64),
+                **{c: pl.Series(se[c], dtype=pl.Float64).fill_nan(None) for c in _SE_COLS},
             }
         )
         .with_columns((pl.col("orapm") + pl.col("drapm")).alias("rapm_net"))
@@ -376,5 +439,220 @@ def solve_rapm_league(
         "n_poss": int(w.sum()),
         "lsqr_istop": int(istop),
         "lsqr_itn": int(itn),
+        **se_info,
     }
     return (out.to_pandas() if return_as_pandas else out), info
+
+
+def _posterior_se(
+    x: Any, yw: np.ndarray, beta: np.ndarray, n_players: int, ridge_lambda: float
+) -> "tuple[dict[str, np.ndarray], dict[str, float]]":
+    """Posterior and sampling SEs of the ridge coefficients from ONE dense Cholesky inverse.
+
+    ``x`` is the sqrt-weight-scaled sparse design, so ``X'X`` IS the
+    possession-weighted Gram matrix ``G = X_raw' W X_raw`` and ``yw`` the
+    scaled centred target. With ``M = (G + lambda I)^-1``:
+
+    * posterior covariance ``sigma2 * M`` -> ``*_se`` (interval for the truth);
+    * sampling covariance ``sigma2 * M G M = sigma2 * (M - lambda M^2)`` ->
+      ``*_se_sampling`` (repeatability of the shrunk estimate; what
+      :func:`split_half_se_check` can verify). Both are O(dim^2) once ``M``
+      is dense, since ``diag(M^2)`` is the squared row norms.
+
+    The net SEs fold in the O/D covariance ``M[i, P+i]`` (resp.
+    ``(M - lambda M^2)[i, P+i]``). Also returns ``sigma2`` (weighted residual
+    variance on ``n - df_eff`` dof), ``df_eff``, ``hca_se`` and the max
+    |lsqr - exact| coefficient deviation.
+    """
+    from scipy.linalg import lapack
+
+    dim = x.shape[1]
+    # ponytail: dense Cholesky inverse, O(dim^3) -- ~10k dims (0.8 GB, seconds) for a D-I
+    # season. A pooled multi-season design past ~20k dims needs a sparse (CHOLMOD) factor.
+    a = (x.T @ x).toarray(order="F")
+    a[np.diag_indices(dim)] += ridge_lambda
+    c, info_f = lapack.dpotrf(a, lower=1, clean=1, overwrite_a=1)
+    if info_f != 0:
+        raise RuntimeError(
+            f"penalised Gram matrix is not positive definite (dpotrf info={info_f}); ridge_lambda must be > 0"
+        )
+    low, info_i = lapack.dpotri(c, lower=1, overwrite_c=1)
+    if info_i != 0:
+        raise RuntimeError(f"Cholesky inverse failed (dpotri info={info_i})")
+    # dpotri fills only the lower triangle (clean=1 zeroed the upper): symmetrise.
+    diag = np.diagonal(low).copy()
+    m = low + low.T
+    m[np.diag_indices(dim)] = diag
+    del a, c, low
+    beta_exact = m @ (x.T @ yw)
+    resid = yw - x @ beta
+    df_eff = float(dim - ridge_lambda * diag.sum())
+    sigma2 = float(resid @ resid) / max(x.shape[0] - df_eff, 1.0)
+    p = np.arange(n_players)
+    o, d = slice(0, n_players), slice(n_players, 2 * n_players)
+    m2_diag = np.einsum("ij,ij->i", m, m)  # diag(M^2)
+    m2_od = np.einsum("ij,ij->i", m[o], m[d])  # (M^2)[i, P+i]
+    post_o, post_d, post_od = diag[o], diag[d], m[p, n_players + p]
+    samp_o = post_o - ridge_lambda * m2_diag[o]
+    samp_d = post_d - ridge_lambda * m2_diag[d]
+    samp_od = post_od - ridge_lambda * m2_od
+
+    def _se(var: np.ndarray) -> np.ndarray:
+        return np.sqrt(np.maximum(sigma2 * var, 0.0))
+
+    se = {
+        "orapm_se": _se(post_o),
+        "drapm_se": _se(post_d),
+        "rapm_net_se": _se(post_o + post_d + 2.0 * post_od),
+        "orapm_se_sampling": _se(samp_o),
+        "drapm_se_sampling": _se(samp_d),
+        "rapm_net_se_sampling": _se(samp_o + samp_d + 2.0 * samp_od),
+    }
+    info = {
+        "sigma2": sigma2,
+        "df_eff": df_eff,
+        "hca_se": float(np.sqrt(sigma2 * diag[2 * n_players])),
+        "solve_max_abs_dev": float(np.max(np.abs(beta - beta_exact))),
+    }
+    return se, info
+
+
+def split_half_se_check(
+    resolved: pl.DataFrame,
+    *,
+    ridge_lambda: float = DEFAULT_RIDGE_LAMBDA,
+) -> "tuple[pl.DataFrame, dict[str, float]]":
+    """Odd-vs-even-game refit: are the standard errors on the right scale?
+
+    Splits ``resolved`` by the parity of ``contest_id`` (deterministic and
+    roster-neutral -- the halves differ by sampling noise, not by the
+    mid-season development or transfer drift a date split would add), fits
+    :func:`solve_rapm_league` on each half, and asks per player rated in both
+    whether the two estimates agree to within ``2 * sqrt(se_A^2 + se_B^2)``.
+
+    Two readings, both reported. Under the SAMPLING SE this is the textbook
+    calibration test -- ~95% coverage means ``sigma2`` and the inverse are
+    right. Under the POSTERIOR SE (the published one) coverage is expected
+    ABOVE nominal (~100% on real seasons): a credible interval for the truth
+    is wider than the estimator's repeatability, so its coverage here is a
+    one-sided guard (a bug that shrinks the SEs drops it), not a two-sided
+    calibration.
+
+    Args:
+        resolved: Output of ``resolve_possessions`` WITH its ``contest_id``
+            column (integer-like).
+        ridge_lambda: Passed to both half fits.
+
+    Returns:
+        ``(per_player, summary)``. ``per_player`` has one row per player
+        rated in both halves: ``player_id``, ``poss`` (both halves' exposure)
+        and, for each of ``orapm`` / ``drapm`` / ``rapm_net``, ``<c>_a``,
+        ``<c>_b``, ``<c>_z`` / ``<c>_covered`` (posterior SE units, |z| <= 2)
+        and ``<c>_z_sampling`` / ``<c>_covered_sampling`` (sampling SE units).
+        ``summary`` carries ``n_players``, ``n_games_a``, ``n_games_b`` and,
+        per ``<c>``, ``coverage_<c>``, ``coverage_sampling_<c>``, ``z_sd_<c>``
+        (a posterior/sampling ratio proxy) and ``z_sd_sampling_<c>`` (~1 when
+        calibrated). Feed ``per_player`` to :func:`possession_deciles` for
+        the coverage by playing time.
+
+    Raises:
+        ValueError: ``contest_id`` is missing or not integer-like.
+
+    Example:
+        Season check::
+
+            per_player, summary = split_half_se_check(resolved)
+            print(summary["coverage_sampling_rapm_net"])   # ~0.95
+            possession_deciles(per_player)
+    """
+    if "contest_id" not in resolved.columns:
+        raise ValueError("split_half_se_check: resolved needs its contest_id column")
+    cid = resolved.get_column("contest_id").cast(pl.Int64, strict=False)
+    if cid.null_count():
+        raise ValueError("split_half_se_check: contest_id must be integer-like")
+    halves = resolved.with_columns((cid % 2).alias("_half"))
+    fits = []
+    for h in (0, 1):
+        part = halves.filter(pl.col("_half") == h)
+        players, _ = solve_rapm_league(aggregate_stints(part), ridge_lambda=ridge_lambda)
+        fits.append((players, part.get_column("contest_id").n_unique()))
+    (pa, n_a), (pb, n_b) = fits
+    assert isinstance(pa, pl.DataFrame) and isinstance(pb, pl.DataFrame)
+    j = pa.join(pb, on="player_id", how="inner", suffix="_b")
+    cols = ("orapm", "drapm", "rapm_net")
+    exprs = [pl.col(f"{c}_b") for c in cols]
+    for c in cols:
+        exprs.append(pl.col(c).alias(f"{c}_a"))
+        for kind, sfx in (("", ""), ("_sampling", "_sampling")):
+            se_a, se_b = pl.col(f"{c}_se{kind}"), pl.col(f"{c}_se{kind}_b")
+            z = (pl.col(c) - pl.col(f"{c}_b")) / (se_a**2 + se_b**2).sqrt()
+            exprs += [
+                z.alias(f"{c}_z{sfx}"),
+                (z.abs() <= 2.0).alias(f"{c}_covered{sfx}"),
+            ]
+    per_player = j.select(
+        "player_id",
+        (pl.col("off_poss") + pl.col("def_poss") + pl.col("off_poss_b") + pl.col("def_poss_b")).alias("poss"),
+        *exprs,
+    ).sort("player_id")
+    summary: dict[str, float] = {
+        "n_players": per_player.height,
+        "n_games_a": n_a,
+        "n_games_b": n_b,
+    }
+    for c in cols:
+        for sfx in ("", "_sampling"):
+            key = sfx.lstrip("_") + "_" if sfx else ""
+            cov = per_player[f"{c}_covered{sfx}"]
+            summary[f"coverage_{key}{c}"] = float(cov.mean()) if per_player.height else float("nan")
+            z_sd = per_player[f"{c}_z{sfx}"].std()
+            summary[f"z_sd_{key}{c}"] = float(z_sd) if z_sd is not None else float("nan")
+    return per_player, summary
+
+
+def possession_deciles(players: pl.DataFrame, *, n_bins: int = 10) -> pl.DataFrame:
+    """Equal-count possession bins: median of every SE column, mean of every coverage flag.
+
+    One table serves both SE validations: on :func:`solve_rapm_league`
+    output the median posterior SE must fall with playing time (Spearman
+    strongly negative; the top deciles flatten at a collinearity floor --
+    heavy-minute starters share the floor with the same four teammates); on
+    :func:`split_half_se_check` output the sampling coverage should sit
+    near 0.95 in every bin. Uses ``poss`` when present, else
+    ``off_poss + def_poss``. Bins are rank-based (always ``n_bins``
+    equal-count bins), so heavy ties at low possessions cannot collapse a
+    decile.
+
+    Args:
+        players: Output of :func:`solve_rapm_league` or the ``per_player``
+            frame of :func:`split_half_se_check`.
+        n_bins: Number of equal-count bins (10 = deciles).
+
+    Returns:
+        One row per bin, sorted: ``decile`` (0 = fewest possessions), ``n``,
+        ``poss_min``, ``poss_max``, ``median_<se col>`` ... and
+        ``coverage_<c>[_sampling]`` ... (only for the columns present).
+
+    Example:
+        Shrinkage check::
+
+            d = possession_deciles(players)
+            assert d["median_rapm_net_se"][0] > d["median_rapm_net_se"][-1]
+    """
+    poss = pl.col("poss") if "poss" in players.columns else (pl.col("off_poss") + pl.col("def_poss"))
+    se_cols = [c for c in players.columns if c.endswith("_se") or c.endswith("_se_sampling")]
+    cov_cols = [c for c in players.columns if "_covered" in c]
+    binned = players.with_columns(poss.alias("_poss")).with_columns(
+        ((pl.col("_poss").rank(method="ordinal") - 1) * n_bins // pl.len()).cast(pl.Int32).alias("decile")
+    )
+    return (
+        binned.group_by("decile")
+        .agg(
+            pl.len().alias("n"),
+            pl.col("_poss").min().alias("poss_min"),
+            pl.col("_poss").max().alias("poss_max"),
+            *[pl.col(c).median().alias(f"median_{c}") for c in se_cols],
+            *[pl.col(c).mean().alias(f"coverage_{c.replace('_covered', '')}") for c in cov_cols],
+        )
+        .sort("decile")
+    )

--- a/tests/mbb/test_mbb_ncaa_rapm_league.py
+++ b/tests/mbb/test_mbb_ncaa_rapm_league.py
@@ -12,13 +12,16 @@ lineup is pinned by the data. The external correctness contract (Torvik
 team-aggregate Spearman) runs on real seasons in the gate phase, not here.
 """
 
+import numpy as np
 import polars as pl
 import pytest
 
 from sportsdataverse.mbb.mbb_ncaa_rapm_league import (
     STINT_SCHEMA,
     aggregate_stints,
+    possession_deciles,
     solve_rapm_league,
+    split_half_se_check,
     team_aggregate,
 )
 
@@ -235,6 +238,12 @@ class TestSolveRapmLeague:
             "rapm_net",
             "off_poss",
             "def_poss",
+            "orapm_se",
+            "drapm_se",
+            "rapm_net_se",
+            "orapm_se_sampling",
+            "drapm_se_sampling",
+            "rapm_net_se_sampling",
         }
         assert info["n_stints"] == 0
 
@@ -359,3 +368,195 @@ class TestTeamAggregate:
             "off_poss",
             "def_poss",
         }
+
+
+# ---------------------------------------------------------------------------
+# Posterior + sampling standard errors, and the two SE validations
+# ---------------------------------------------------------------------------
+
+
+_EXPOSURE = np.array([1.0, 1.0, 0.9, 0.9, 0.8, 0.5, 0.2])  # h1..h7 / a1..a7 selection weights
+
+
+def _noisy_resolved(n_poss=4000, n_games=20, seed=0, h7_boost=0.25):
+    """Id-resolved possessions with a ``contest_id`` and Poisson scoring noise.
+
+    Duke (home) vs Iowa (away), each side fielding a random five of seven
+    drawn with graded exposure weights (h1 ~ every possession, h7 rarely), so
+    NO two players are perfectly collinear -- the always-together five of the
+    deterministic fixtures above would pin the starters' SEs at the prior and
+    invert every "more minutes, smaller SE" comparison. Duke's h7 lifts the
+    offence by ``h7_boost`` ppp, so the design carries signal AND noise (the
+    deterministic fixtures have near-zero residuals, where a residual-variance
+    SE is degenerate).
+    """
+    rng = np.random.default_rng(seed)
+    p = _EXPOSURE / _EXPOSURE.sum()
+    hs, as_ = [f"h{i}" for i in range(1, 8)], [f"a{i}" for i in range(1, 8)]
+    rows, contest = [], []
+    for k in range(n_poss):
+        duke = sorted(hs[i] for i in rng.choice(7, 5, replace=False, p=p))
+        iowa = sorted(as_[i] for i in rng.choice(7, 5, replace=False, p=p))
+        poss_team = "Duke" if k % 2 == 0 else "Iowa"
+        ppp = 1.0 + (h7_boost if (poss_team == "Duke" and "h7" in duke) else 0.0)
+        rows.append(("Duke", "Iowa", poss_team, int(min(rng.poisson(ppp), 3)), duke, iowa))
+        contest.append(str(1000 + k % n_games))
+    return _poss(rows).with_columns(pl.Series("contest_id", contest, dtype=pl.Utf8))
+
+
+def _dense_system(s, lam):
+    """Hand-built dense normal equations for a stint frame -- the formula the engine must match."""
+    players = sorted(set(s["off_ids"].explode().to_list()) | set(s["def_ids"].explode().to_list()))
+    idx = {p: i for i, p in enumerate(players)}
+    n_p = len(players)
+    x = np.zeros((s.height, 2 * n_p + 1))
+    rows = zip(s["off_ids"].to_list(), s["def_ids"].to_list(), s["is_home_offense"].to_list())
+    for r, (off, dfn, home) in enumerate(rows):
+        for p in off:
+            x[r, idx[p]] = 1.0
+        for p in dfn:
+            x[r, n_p + idx[p]] = -1.0
+        x[r, 2 * n_p] = 1.0 if home else -1.0
+    w = s["n_poss"].to_numpy().astype(float)
+    y = 100.0 * s["pts"].to_numpy() / w
+    yc = y - np.average(y, weights=w)
+    gram = x.T @ (w[:, None] * x)
+    m = np.linalg.inv(gram + lam * np.eye(2 * n_p + 1))
+    return players, n_p, x, w, yc, gram, m
+
+
+_SE6 = (
+    "orapm_se",
+    "drapm_se",
+    "rapm_net_se",
+    "orapm_se_sampling",
+    "drapm_se_sampling",
+    "rapm_net_se_sampling",
+)
+
+
+class TestPosteriorSe:
+    def test_matches_the_dense_formulas(self):
+        """posterior = sigma2*M, sampling = sigma2*(M - lam*M^2) = sigma2*M G M; sigma2 on n - df_eff dof."""
+        s = aggregate_stints(_noisy_resolved(n_poss=2000, seed=1))
+        lam = 50.0
+        players, info = solve_rapm_league(s, ridge_lambda=lam)
+        ids, n_p, x, w, yc, gram, m = _dense_system(s, lam)
+        assert players["player_id"].to_list() == ids
+        beta_exact = m @ (x.T @ (w * yc))
+        assert np.abs(players["orapm"].to_numpy() - beta_exact[:n_p]).max() < 1e-3
+        assert np.abs(players["drapm"].to_numpy() - beta_exact[n_p : 2 * n_p]).max() < 1e-3
+        assert info["solve_max_abs_dev"] < 1e-3
+        beta = np.concatenate([players["orapm"].to_numpy(), players["drapm"].to_numpy(), [info["hca"]]])
+        resid = yc - x @ beta
+        df_eff = np.trace(m @ gram)
+        sigma2 = float(w @ resid**2) / (s.height - df_eff)
+        assert abs(info["df_eff"] - df_eff) < 1e-8
+        assert abs(info["sigma2"] / sigma2 - 1.0) < 1e-10
+        i = np.arange(n_p)
+        sandwich = m @ gram @ m
+        assert np.allclose(sandwich, m - lam * m @ m)  # the identity the engine relies on
+        for cov, sfx in ((m, ""), (sandwich, "_sampling")):
+            d = np.diag(cov)
+            assert np.allclose(players[f"orapm_se{sfx}"].to_numpy() ** 2, sigma2 * d[:n_p], rtol=1e-9)
+            assert np.allclose(
+                players[f"drapm_se{sfx}"].to_numpy() ** 2,
+                sigma2 * d[n_p : 2 * n_p],
+                rtol=1e-9,
+            )
+            net_var = sigma2 * (d[i] + d[n_p + i] + 2.0 * cov[i, n_p + i])
+            assert np.allclose(players[f"rapm_net_se{sfx}"].to_numpy() ** 2, net_var, rtol=1e-9)
+        assert abs(info["hca_se"] ** 2 - sigma2 * m[2 * n_p, 2 * n_p]) < 1e-9
+
+    def test_sampling_se_never_exceeds_posterior_se(self):
+        """M G M <= M in the PSD order, so the shrunk estimate's repeatability is at most the posterior SD."""
+        players, _ = solve_rapm_league(aggregate_stints(_noisy_resolved(n_poss=1500, seed=5)), ridge_lambda=50.0)
+        for c in ("orapm", "drapm", "rapm_net"):
+            assert (players[f"{c}_se_sampling"] <= players[f"{c}_se"] + 1e-12).all()
+            assert (players[f"{c}_se"] > 0).all()
+
+    def test_more_possessions_tighter_posterior_se(self):
+        small, _ = solve_rapm_league(aggregate_stints(_noisy_resolved(n_poss=500, seed=2)), ridge_lambda=50.0)
+        big, _ = solve_rapm_league(aggregate_stints(_noisy_resolved(n_poss=8000, seed=2)), ridge_lambda=50.0)
+        j = small.join(big, on="player_id", suffix="_big")
+        assert j.height == 14
+        assert (j["rapm_net_se_big"] < j["rapm_net_se"]).all()
+
+    def test_possession_deciles_bins_and_columns(self):
+        """Rank-based equal-count bins over off+def possessions; medians of every SE column.
+
+        Whether the SE actually FALLS with playing time is a data property (a
+        player who never sits is confounded with his team's total under the
+        fixed-five constraint, so the top deciles flatten) -- the producer
+        gates it on real seasons; here only the table contract is tested.
+        """
+        s = aggregate_stints(_noisy_resolved(n_poss=3000, seed=3))
+        players, _ = solve_rapm_league(s, ridge_lambda=50.0)
+        d = possession_deciles(players, n_bins=2)
+        assert d["decile"].to_list() == [0, 1]
+        assert d["n"].to_list() == [7, 7]
+        assert d["poss_max"][0] <= d["poss_min"][1]
+        assert {f"median_{c}" for c in _SE6} <= set(d.columns)
+        assert (d["median_rapm_net_se"] > 0).all()
+
+    def test_tighter_prior_tighter_posterior(self):
+        s = aggregate_stints(_noisy_resolved(n_poss=1500, seed=4))
+        loose, _ = solve_rapm_league(s, ridge_lambda=1.0)
+        tight, _ = solve_rapm_league(s, ridge_lambda=1e5)
+        assert tight["rapm_net_se"].max() < loose["rapm_net_se"].min()
+
+    def test_net_se_within_triangle_bounds(self):
+        players, _ = solve_rapm_league(aggregate_stints(_noisy_resolved(n_poss=1500, seed=5)), ridge_lambda=50.0)
+        for sfx in ("", "_sampling"):
+            o, d, n = (players[f"{c}{sfx}"].to_numpy() for c in ("orapm_se", "drapm_se", "rapm_net_se"))
+            assert np.all(np.isfinite(n))
+            assert np.all(n <= o + d + 1e-12) and np.all(n >= np.abs(o - d) - 1e-12)
+
+    def test_compute_se_false_gives_nulls_not_nans(self):
+        players, info = solve_rapm_league(
+            aggregate_stints(_noisy_resolved(n_poss=300, seed=6)),
+            ridge_lambda=50.0,
+            compute_se=False,
+        )
+        for c in _SE6:
+            assert players[c].dtype == pl.Float64
+            assert players[c].null_count() == players.height
+        assert "sigma2" not in info and "solve_max_abs_dev" not in info
+
+
+class TestSplitHalfSeCheck:
+    def test_shapes_summary_and_deciles(self):
+        resolved = _noisy_resolved(n_poss=3000, n_games=10, seed=7)
+        per_player, summary = split_half_se_check(resolved, ridge_lambda=50.0)
+        assert (summary["n_games_a"], summary["n_games_b"]) == (5, 5)
+        assert summary["n_players"] == per_player.height == 14
+        for c in ("orapm", "drapm", "rapm_net"):
+            want = {
+                f"{c}_a",
+                f"{c}_b",
+                f"{c}_z",
+                f"{c}_covered",
+                f"{c}_z_sampling",
+                f"{c}_covered_sampling",
+            }
+            assert want <= set(per_player.columns)
+            assert 0.0 <= summary[f"coverage_{c}"] <= 1.0
+            assert 0.0 <= summary[f"coverage_sampling_{c}"] <= 1.0
+            assert per_player[f"{c}_z_sampling"].is_finite().all()
+            # posterior SE >= sampling SE -> posterior |z| <= sampling |z| -> coverage no lower
+            assert summary[f"coverage_{c}"] >= summary[f"coverage_sampling_{c}"]
+            assert summary[f"z_sd_{c}"] <= summary[f"z_sd_sampling_{c}"]
+        d = possession_deciles(per_player, n_bins=2)
+        assert d["n"].to_list() == [7, 7]
+        assert d["poss_max"][0] <= d["poss_min"][1]
+        assert {"coverage_rapm_net", "coverage_rapm_net_sampling"} <= set(d.columns)
+
+    def test_requires_integer_like_contest_id(self):
+        resolved = _noisy_resolved(n_poss=200, seed=8)
+        with pytest.raises(ValueError, match="contest_id"):
+            split_half_se_check(resolved.drop("contest_id"), ridge_lambda=50.0)
+        with pytest.raises(ValueError, match="integer-like"):
+            split_half_se_check(
+                resolved.with_columns(pl.lit("g-1").alias("contest_id")),
+                ridge_lambda=50.0,
+            )


### PR DESCRIPTION
Closes the "exact standard errors" avenue on the NCAA league-wide RAPM writeups (`ncaa-mbb-hoops-data` / `ncaa-wbb-hoops-data` `docs/models/rapm.qmd`): the ridge posterior gives per-player SEs almost for free, and publishing them turns point estimates into honest intervals. This PR is the engine half; the producer PRs that publish the columns and gate them are stacked on top.

## What

`solve_rapm_league` returns uncertainty alongside the coefficients, from **one** dense Cholesky inverse of the `(2P+1)`-square penalised Gram matrix (~10k dims, seconds, ~0.8 GB for a D-I season):

| columns | formula | what it is |
|---|---|---|
| `orapm_se` / `drapm_se` / `rapm_net_se` | `sqrt(σ̂²·diag((XᵀWX + λI)⁻¹))`, net incl. the O/D covariance | **posterior** — a credible interval for the TRUE impact under the prior the penalty encodes; widens exactly where the prior is doing the work |
| `*_se_sampling` | `σ̂²·M(XᵀWX)M = σ̂²(M − λM²)` | **sampling (sandwich)** — repeatability of the shrunk estimate; not an interval for the truth (it collapses to ~0 for a player the ridge pins at zero) but it is what a refit can verify |

`info` gains `sigma2` (weighted residual variance on `n − df_eff` dof), `df_eff`, `hca_se` and `solve_max_abs_dev` (`|lsqr − exact|`, free with the factorisation).

Two helpers make the validation runnable by the producers:

- **`split_half_se_check`** — refits odd- vs even-`contest_id` halves (deterministic and roster-neutral: the halves differ by sampling noise, not by the development/transfer drift a date split adds) and reports per player rated in both whether the halves agree within `2·sqrt(se_A² + se_B²)`, under each SE.
- **`possession_deciles`** — equal-count playing-time bins with the median of every SE column and the mean of every coverage flag; serves both validations.

## Why the posterior is the one to publish

The item asked for the ridge posterior and for honest intervals. The sandwich describes the sampling spread of a *shrunk* estimator around its *shrunk* mean, so it understates the error against the truth exactly for the low-possession players the prior is carrying. The posterior widens there instead. The sandwich is still computed — it is the only one of the two a split-half refit can calibrate.

## Real-data validation (2011–2026, 16 seasons × 2 leagues)

| | MBB | WBB |
|---|---|---|
| `sigma2` | 12,562–13,332 | 11,634–12,408 |
| Spearman(possessions, `rapm_net_se`) | −0.965 … −0.898 | −0.950 … −0.872 |
| top-decile ÷ bottom-decile median SE | 0.788–0.807 | 0.794–0.819 |
| split-half coverage, **sampling** SE (O/D/net) | 0.9465–0.9601 | 0.9397–0.9563 |
| split-half z-sd, sampling | 0.980–1.028 | 1.012–1.057 |
| split-half coverage, **posterior** SE | 1.0 | 0.9995–1.0 |

The sampling-SE coverage sits at the 0.954 nominal in every season — σ̂², the inverse and the O/D covariance are right. The posterior SE covers ~1.0 with z-sd ≈ 0.38, i.e. **it is conservative by ≈2.5×** relative to how far the estimate actually moves between two halves of a season. That is the honest reading of a prior-dominated fit at λ=1000, not nominal calibration, and it is stated that way in the docstrings (and in the producers' writeups) so a consumer does not read `±2·SE` as the number's repeatability.

The SE falls with playing time but **not** strictly by decile — the top deciles flatten at a collinearity floor (a starter who never sits is confounded with his team's total). The gates the producers derive from these observations are written to that shape, not to a strict monotonicity that the data does not show.

## Safety

- `compute_se=False` emits **nulls**, never zeros or NaNs, so a disabled SE cannot masquerade as a tiny one.
- A non-positive-definite Gram matrix raises instead of returning garbage (`λ` must be > 0 for the SEs).
- Tests assert the SEs against a hand-built dense normal-equations system — including the `M G M = M − λM²` identity the implementation relies on — rather than asserting that the code ran.

## Checks

`uv run pytest tests/mbb tests/test_id_conventions.py` → **1090 passed, 4 skipped**; ruff + `mypy sportsdataverse/mbb/mbb_ncaa_rapm_league.py` clean; `tools/codegen/generate.py --check` → all generated files current. `uv.lock` untouched.

## Summary by Sourcery

Provide league RAPM estimates with rigorously computed uncertainty measures and tools to validate their scale across players and playing time.

New Features:
- Add posterior and sampling standard errors for offensive, defensive, and net RAPM player estimates.
- Add split-half uncertainty validation and possession-decile reporting helpers.

Bug Fixes:
- Return null uncertainty values when SE computation is disabled and reject non-positive-definite penalized systems instead of producing invalid results.

Enhancements:
- Expose residual variance, effective degrees of freedom, home-court SE, and exact-solve diagnostics alongside league RAPM results.

Documentation:
- Document the distinction between posterior credible-interval SEs and sampling repeatability SEs, including their intended interpretation and validation.

Tests:
- Validate posterior and sandwich SE formulas against dense normal equations, including O/D covariance and disabled-SE behavior.
- Test uncertainty validation and possession-binning contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added posterior and sampling standard-error estimates for player offensive, defensive, and net RAPM results.
  * Added an option to disable standard-error calculations; corresponding output fields are returned as null.
  * Added tools for evaluating standard-error calibration through split-half comparisons and possession-time deciles.
  * Added additional solver diagnostics, including variance, effective degrees of freedom, home-court advantage uncertainty, and solution accuracy metadata.
  * Updated empty-result schemas to include the new standard-error fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->