### PR TITLE
fix(mlb): untracked balls in play deflated xBA/xSLG; publish observed wOBA/BA

### DIFF
--- a/docs/docs/mlb/reference/additional.md
+++ b/docs/docs/mlb/reference/additional.md
@@ -1147,8 +1147,14 @@ marginal fallback, then aggregates:
   vintage's `woba_denom` column. The numerator excludes those same
   zero-denominator events, and a PA-ending walk/HBP whose `woba_value`
   is null in a given vintage is filled with the fixed weights .69 / .72.
-* `xba = sum(predicted_ba over at-bat balls in play) / ab`
-* `xslg = sum(predicted_tb over at-bat balls in play) / ab`
+* `xba = (sum(predicted_ba over TRACKED at-bat balls in play) +
+  sum(realized hits over UNTRACKED ones)) / ab` -- a ball in play with no
+  launch data cannot be predicted from the grid, so it takes its realized
+  outcome exactly as `xwoba` does, rather than counting in `ab` with a
+  zero numerator (which deflated league-mean xBA by the untracked share).
+* `xslg` -- same construction on total bases.
+* `woba` / `ba` -- the OBSERVED counterparts on the same denominators,
+  so `xwoba - woba` is a luck-vs-skill delta needing no second source.
 
 `pa` counts PLATE-APPEARANCE-ENDING rows only (`events` non-null),
 never raw pitches -- a Statcast search pull carries every pitch, and
@@ -1166,7 +1172,7 @@ corrupted `xba`/`xslg` scales.
 
 **Returns**
 
-One row per (`batter`, `season`): `pa`, `ab`, `xwoba`, `xba`, `xslg`. Empty pull returns a zero-row frame with the documented schema.
+One row per (`batter`, `season`): `pa`, `ab`, `xwoba`, `xba`, `xslg`, plus the observed `woba` / `ba`. Empty pull returns a zero-row frame with the documented schema.
 
 | col_name | type | description |
 |---|---|---|
@@ -1175,8 +1181,10 @@ One row per (`batter`, `season`): `pa`, `ab`, `xwoba`, `xba`, `xslg`. Empty pull
 | `pa` | integer | Plate appearances in the pulled window. |
 | `ab` | integer | At-bats (PA minus walks, HBP, and sacrifices) in the pulled window. |
 | `xwoba` | double | Expected wOBA from the EV x LA empirical grid (contact) plus realized non-contact outcome value, divided by wOBA denominator. |
-| `xba` | double | Expected batting average from the EV x LA empirical grid's hit-indicator cell means. |
-| `xslg` | double | Expected slugging percentage from the EV x LA empirical grid's total-bases cell means. |
+| `xba` | double | Expected batting average from the EV x LA empirical grid's hit-indicator cell means on tracked balls in play, plus the realized hit indicator on balls in play carrying no launch data, over at-bats. |
+| `xslg` | double | Expected slugging percentage from the EV x LA empirical grid's total-bases cell means on tracked balls in play, plus realized total bases on balls in play carrying no launch data, over at-bats. |
+| `woba` | double | Observed wOBA over the same denominator as `xwoba`, so `xwoba - woba` is the batter's contact-quality luck gap without needing a second source. |
+| `ba` | double | Observed batting average over the same at-bat denominator as `xba`, so `xba - ba` is the batted-ball luck gap without needing a second source. |
 
 **Example**
 
@@ -1191,7 +1199,7 @@ print(df.shape)
 df.sort("xwoba", descending=True).head()
 ```
 
-### `mlb_fielding_oaa(bip: "'pl.DataFrame'", *, l2: 'float' = 0.0001, min_fit: 'int' = 50, return_as_pandas: 'bool' = False) -> "'Union[pl.DataFrame, pd.DataFrame]'"` {#mlb_fielding_oaa}
+### `mlb_fielding_oaa(bip: "'pl.DataFrame'", *, l2: 'float' = 0.0001, min_fit: 'int' = 50, by_direction: 'bool' = False, return_as_pandas: 'bool' = False) -> "'Union[pl.DataFrame, pd.DataFrame]'"` {#mlb_fielding_oaa}
 
 Per-fielder outs above average from a per-position catch-probability logistic.
 
@@ -1212,17 +1220,22 @@ dynamically from the responsible position's `fielder_{position}` column
 | `bip` | `DataFrame` |  | Balls-in-play frame with `hc_x`/`hc_y`, `hit_distance_sc`, `launch_angle`, `launch_speed`, `hit_location`, `events`, and the `fielder_1`..`fielder_9` responsible-player columns. MiLB input (e.g. `sportsdataverse.mlb.mlb_statcast_extra.mlb_statcast_search_minors`) runs through the same function -- there is no Savant OAA leaderboard oracle for MiLB. |
 | `l2` | `float` | `0.0001` | L2 penalty for the per-position logistic. Defaults to `1e-4`. |
 | `min_fit` | `int` | `50` | Minimum balls in play for a position to fit its own logistic; below this the position's mean out rate is used. Defaults to `50`. |
+| `by_direction` | `bool` | `False` | Split each fielder-position into `in` / `back` / `lateral` buckets, using the position's own median landing spot as a stand-in for the fielder start coordinates the public feed lacks (a documented approximation). The split re-groups the same scored balls in play, so the three rows sum exactly to the undirected `oaa`. Defaults to `False`. |
 | `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
 
 **Returns**
 
-one row per `(fielder_id, position)`. | Column | Type | Description | |---|---|---| | fielder_id | Utf8 | Responsible fielder's MLBAM id | | position | Int64 | Position (Savant `hit_location`, 1-9) | | opportunities | Int64 | Balls in play charged to this fielder | | oaa | Float64 | Sum of (out - expected catch probability) |
+one row per `(fielder_id, position)`. | Column | Type | Description | |---|---|---| | fielder_id | Utf8 | Responsible fielder's MLBAM id | | position | Int64 | Position (Savant `hit_location`, 1-9) | | direction | Utf8 | `in`/`back`/`lateral` -- only when `by_direction=True` | | opportunities | Int64 | Balls in play charged to this fielder | | oaa | Float64 | Sum of (out - expected catch probability) |
 
 **Example**
 
 ```python
 from sportsdataverse.mlb.mlb_fielding_oaa import mlb_fielding_oaa
 oaa = mlb_fielding_oaa(bip)
+
+# Per-direction splits (sum to the undirected OAA)
+
+mlb_fielding_oaa(bip, by_direction=True)
 
 # Pipeline next step (one line)
 

--- a/sportsdataverse/mlb/mlb_expected_stats.py
+++ b/sportsdataverse/mlb/mlb_expected_stats.py
@@ -27,6 +27,8 @@ _EXPECTED_STATS_SCHEMA = {
     "xwoba": pl.Float64,
     "xba": pl.Float64,
     "xslg": pl.Float64,
+    "woba": pl.Float64,
+    "ba": pl.Float64,
 }
 
 _GRID_SCHEMA = {
@@ -236,8 +238,14 @@ def mlb_expected_stats(
       vintage's ``woba_denom`` column. The numerator excludes those same
       zero-denominator events, and a PA-ending walk/HBP whose ``woba_value``
       is null in a given vintage is filled with the fixed weights .69 / .72.
-    * ``xba = sum(predicted_ba over at-bat balls in play) / ab``
-    * ``xslg = sum(predicted_tb over at-bat balls in play) / ab``
+    * ``xba = (sum(predicted_ba over TRACKED at-bat balls in play) +
+      sum(realized hits over UNTRACKED ones)) / ab`` -- a ball in play with no
+      launch data cannot be predicted from the grid, so it takes its realized
+      outcome exactly as ``xwoba`` does, rather than counting in ``ab`` with a
+      zero numerator (which deflated league-mean xBA by the untracked share).
+    * ``xslg`` -- same construction on total bases.
+    * ``woba`` / ``ba`` -- the OBSERVED counterparts on the same denominators,
+      so ``xwoba - woba`` is a luck-vs-skill delta needing no second source.
 
     ``pa`` counts PLATE-APPEARANCE-ENDING rows only (``events`` non-null),
     never raw pitches -- a Statcast search pull carries every pitch, and
@@ -253,8 +261,8 @@ def mlb_expected_stats(
 
     Returns:
         One row per (``batter``, ``season``): ``pa``, ``ab``, ``xwoba``,
-        ``xba``, ``xslg``. Empty pull returns a zero-row frame with the
-        documented schema.
+        ``xba``, ``xslg``, plus the observed ``woba`` / ``ba``. Empty pull
+        returns a zero-row frame with the documented schema.
 
     Example:
         Quick start::
@@ -327,23 +335,40 @@ def mlb_expected_stats(
             pl.lit(None, dtype=pl.Float64).alias("_pred_slg"),
         )
 
+    #: realized wOBA value with the vintage null-fill -- shared by the observed
+    #: ``woba`` column and by the untracked-batted-ball fallback below.
+    realized_woba = pl.coalesce(
+        pl.col("woba_value"),
+        pl.col("events").replace_strict(_WOBA_VALUE_FALLBACK, default=0.0, return_dtype=pl.Float64),
+    )
+
     bip_agg = bip.group_by("batter", "season").agg(
         pl.col("_pred_woba").filter(~zero_denom).sum().alias("_bip_woba_sum"),
         pl.col("_pred_ba").filter(~non_ab).sum().alias("_bip_ba_sum"),
         pl.col("_pred_slg").filter(~non_ab).sum().alias("_bip_slg_sum"),
+        realized_woba.filter(~zero_denom).sum().alias("_bip_obs_woba_sum"),
+        pl.col("_hit").filter(~non_ab).sum().alias("_bip_obs_ba_sum"),
         (~zero_denom).sum().cast(pl.Float64).alias("_bip_denom"),
         (~non_ab).sum().alias("_ab_from_bip"),
         pl.len().alias("_pa_from_bip"),
     )
 
+    # UNTRACKED-BATTED-BALL SYMMETRY (2026-09 follow-up to the #421 PA-ender
+    # fix): 8-19% of PA-ending balls in play carry no launch_speed/launch_angle
+    # and so cannot be predicted from the grid. They land here, in non_bip_pa.
+    # xwOBA has always given them their REALIZED woba_value; xBA/xSLG did not,
+    # counting them in the `ab` denominator with a zero numerator contribution.
+    # That deflated league-mean xBA by almost exactly the untracked share times
+    # the hit rate (2015: 19.4% untracked -> mean xBA .2026 vs observed BA
+    # .2556; 2021: 8.3% -> .2198 vs .2442), and untracked balls are NOT
+    # degenerate -- their hit rate matches tracked balls to 3 decimals (.325 vs
+    # .324 in 2015). So they take the same realized-outcome fallback xwOBA
+    # already uses. A strikeout/field_out contributes a realized 0, exactly as
+    # before; only untracked batted balls change.
     non_bip_agg = non_bip_pa.group_by("batter", "season").agg(
-        pl.coalesce(
-            pl.col("woba_value"),
-            pl.col("events").replace_strict(_WOBA_VALUE_FALLBACK, default=0.0, return_dtype=pl.Float64),
-        )
-        .filter(~zero_denom)
-        .sum()
-        .alias("_non_bip_woba_sum"),
+        realized_woba.filter(~zero_denom).sum().alias("_non_bip_woba_sum"),
+        pl.col("_hit").filter(~non_ab).sum().alias("_non_bip_ba_sum"),
+        pl.col("_total_bases").filter(~non_ab).sum().alias("_non_bip_slg_sum"),
         (~zero_denom).sum().cast(pl.Float64).alias("_non_bip_denom"),
         (~non_ab).sum().alias("_ab_from_non_bip"),
         pl.len().alias("_pa_from_non_bip"),
@@ -363,10 +388,26 @@ def mlb_expected_stats(
             .then((pl.col("_bip_woba_sum") + pl.col("_non_bip_woba_sum")) / pl.col("_woba_denom"))
             .otherwise(None)
             .alias("xwoba"),
-            pl.when(pl.col("ab") > 0).then(pl.col("_bip_ba_sum") / pl.col("ab")).otherwise(None).alias("xba"),
-            pl.when(pl.col("ab") > 0).then(pl.col("_bip_slg_sum") / pl.col("ab")).otherwise(None).alias("xslg"),
+            pl.when(pl.col("ab") > 0)
+            .then((pl.col("_bip_ba_sum") + pl.col("_non_bip_ba_sum")) / pl.col("ab"))
+            .otherwise(None)
+            .alias("xba"),
+            pl.when(pl.col("ab") > 0)
+            .then((pl.col("_bip_slg_sum") + pl.col("_non_bip_slg_sum")) / pl.col("ab"))
+            .otherwise(None)
+            .alias("xslg"),
+            # Observed counterparts on the SAME denominators, so a luck-vs-skill
+            # delta is `xwoba - woba` / `xba - ba` with no second source.
+            pl.when(pl.col("_woba_denom") > 0)
+            .then((pl.col("_bip_obs_woba_sum") + pl.col("_non_bip_woba_sum")) / pl.col("_woba_denom"))
+            .otherwise(None)
+            .alias("woba"),
+            pl.when(pl.col("ab") > 0)
+            .then((pl.col("_bip_obs_ba_sum") + pl.col("_non_bip_ba_sum")) / pl.col("ab"))
+            .otherwise(None)
+            .alias("ba"),
         )
-        .select("batter", "season", "pa", "ab", "xwoba", "xba", "xslg")
+        .select("batter", "season", "pa", "ab", "xwoba", "xba", "xslg", "woba", "ba")
         .cast(_EXPECTED_STATS_SCHEMA)
     )
 

--- a/sportsdataverse/mlb/mlb_fielding_oaa.py
+++ b/sportsdataverse/mlb/mlb_fielding_oaa.py
@@ -181,11 +181,48 @@ def _fit_catch_logistic(x: "np.ndarray", y: "np.ndarray", l2: float) -> "np.ndar
     return np.clip(1.0 / (1.0 + np.exp(-z)), 1e-9, 1 - 1e-9)
 
 
+def _direction_expr(scored: "pl.DataFrame") -> "pl.Expr":
+    """Classify each ball in play as ``in`` / ``back`` / ``lateral`` for the fielder.
+
+    **Documented approximation.** Savant splits directional OAA against the
+    fielder's tracked START position; the public feed has no start coordinates
+    (the same ceiling the module docstring names), so the position's own MEDIAN
+    landing spot stands in for where that position normally plays. Depth
+    deviation is ``hit_dist - median(hit_dist)`` for the position; lateral
+    deviation is the arc length ``hit_dist * (spray_angle - median(spray_angle))``
+    so both legs are in feet and comparable. The larger leg names the direction:
+    lateral when the sideways move dominates, else ``back`` (deeper than normal
+    depth) or ``in`` (shallower).
+
+    Savant's own ``leaderboard/outfield_directional_outs_above_average``
+    (wrapped as
+    :func:`sportsdataverse.mlb.mlb_statcast.mlb_statcast_leaderboard_outfield_directional_oaa`)
+    is the concurrent-validity oracle for the outfield rows of this split.
+
+    The split is a strict PARTITION of the scored balls in play -- it re-groups
+    the same ``out_gain`` values and never re-fits -- so per-direction OAA sums
+    exactly to the undirected OAA for every fielder-position.
+    """
+    med_dist = pl.col("hit_dist").median().over("position")
+    med_spray = pl.col("spray_angle").median().over("position")
+    depth = pl.col("hit_dist") - med_dist
+    lateral = pl.col("hit_dist") * (pl.col("spray_angle") - med_spray)
+    return (
+        pl.when(lateral.abs() >= depth.abs())
+        .then(pl.lit("lateral"))
+        .when(depth > 0)
+        .then(pl.lit("back"))
+        .otherwise(pl.lit("in"))
+        .alias("direction")
+    )
+
+
 def mlb_fielding_oaa(
     bip: "pl.DataFrame",
     *,
     l2: float = 1e-4,
     min_fit: int = 50,
+    by_direction: bool = False,
     return_as_pandas: bool = False,
 ) -> "Union[pl.DataFrame, pd.DataFrame]":
     """Per-fielder outs above average from a per-position catch-probability logistic.
@@ -212,6 +249,12 @@ def mlb_fielding_oaa(
         min_fit: Minimum balls in play for a position to fit its own
             logistic; below this the position's mean out rate is used.
             Defaults to ``50``.
+        by_direction: Split each fielder-position into ``in`` / ``back`` /
+            ``lateral`` buckets, using the position's own median landing spot
+            as a stand-in for the fielder start coordinates the public feed
+            lacks (a documented approximation). The split re-groups the same
+            scored balls in play, so the three rows sum exactly to the
+            undirected ``oaa``. Defaults to ``False``.
         return_as_pandas: Return a pandas DataFrame instead of polars.
 
     Returns:
@@ -221,6 +264,7 @@ def mlb_fielding_oaa(
         |---|---|---|
         | fielder_id | Utf8 | Responsible fielder's MLBAM id |
         | position | Int64 | Position (Savant ``hit_location``, 1-9) |
+        | direction | Utf8 | ``in``/``back``/``lateral`` -- only when ``by_direction=True`` |
         | opportunities | Int64 | Balls in play charged to this fielder |
         | oaa | Float64 | Sum of (out - expected catch probability) |
 
@@ -229,6 +273,10 @@ def mlb_fielding_oaa(
 
             from sportsdataverse.mlb.mlb_fielding_oaa import mlb_fielding_oaa
             oaa = mlb_fielding_oaa(bip)
+
+        Per-direction splits (sum to the undirected OAA)::
+
+            mlb_fielding_oaa(bip, by_direction=True)
 
         Pipeline next step (one line)::
 
@@ -286,10 +334,16 @@ def mlb_fielding_oaa(
     scored = f.with_columns(pl.Series("p_catch", p_catch)).with_columns(
         (pl.col("is_out") - pl.col("p_catch")).alias("out_gain")
     )
+
+    keys = ["fielder_id", "position"]
+    if by_direction:
+        scored = scored.with_columns(_direction_expr(scored))
+        keys = ["fielder_id", "position", "direction"]
+
     out = (
-        scored.group_by(["fielder_id", "position"])
+        scored.group_by(keys)
         .agg(pl.len().alias("opportunities"), pl.col("out_gain").sum().alias("oaa"))
         .sort("oaa", descending=True)
-        .select("fielder_id", "position", "opportunities", "oaa")
+        .select(*keys, "opportunities", "oaa")
     )
     return out.to_pandas() if return_as_pandas else out

--- a/tests/mlb/test_mlb_expected_stats.py
+++ b/tests/mlb/test_mlb_expected_stats.py
@@ -92,7 +92,7 @@ def test_mlb_expected_stats_schema_and_pandas() -> None:
         )
 
     out = mlb_expected_stats("2024-06-01", "2024-06-21", puller=_fake_puller)
-    assert out.columns == ["batter", "season", "pa", "ab", "xwoba", "xba", "xslg"]
+    assert out.columns == ["batter", "season", "pa", "ab", "xwoba", "xba", "xslg", "woba", "ba"]
     assert out.schema["batter"] == pl.Int64
     assert out.schema["season"] == pl.Int64
     assert out.height == 1
@@ -124,7 +124,7 @@ def test_mlb_expected_stats_empty_pull_returns_documented_schema() -> None:
 
     out = mlb_expected_stats("2024-06-01", "2024-06-21", puller=_empty_puller)
     assert out.height == 0
-    assert out.columns == ["batter", "season", "pa", "ab", "xwoba", "xba", "xslg"]
+    assert out.columns == ["batter", "season", "pa", "ab", "xwoba", "xba", "xslg", "woba", "ba"]
 
 
 def _pitchy_puller_factory(rows: dict):
@@ -212,3 +212,48 @@ def test_batted_ball_row_without_events_is_ignored_everywhere() -> None:
     assert row["pa"] == 2  # the events-less batted ball is not a PA
     assert row["ab"] == 2  # single + strikeout
     assert abs(row["xwoba"] - (0.9 + 0.0) / 2) < 1e-9
+
+
+def test_untracked_batted_ball_gets_its_realized_outcome_in_xba_and_xslg() -> None:
+    """Regression (2026-09 follow-up to #421): a PA-ending ball in play with NO
+    launch data cannot be grid-predicted, but it still counts in `ab`. Before
+    this fix it contributed a zero numerator, deflating league-mean xBA by
+    ~(untracked share x hit rate) — measured .2026 vs an observed BA of .2556
+    on the real 2015 season (19.4% untracked). xwOBA already used the realized
+    value for these rows; xBA/xSLG now do the same."""
+    rows = {
+        "batter": [1, 1],
+        "game_date": ["2024-06-01"] * 2,
+        "type": ["X", "X"],
+        "events": ["single", "double"],  # the double has no launch data
+        "launch_speed": [95.0, None],
+        "launch_angle": [10.0, None],
+        "woba_value": [0.9, 1.25],
+    }
+    out = mlb_expected_stats("2024-06-01", "2024-06-21", puller=_pitchy_puller_factory(rows))
+    row = out.row(0, named=True)
+    assert row["ab"] == 2
+    # tracked single -> grid mean (1.0 hit, 1.0 base); untracked double -> realized 1 hit, 2 bases
+    assert abs(row["xba"] - (1.0 + 1.0) / 2) < 1e-9  # NOT 0.5, which the pre-fix numerator gave
+    assert abs(row["xslg"] - (1.0 + 2.0) / 2) < 1e-9
+
+
+def test_observed_woba_and_ba_ship_beside_the_expected_columns() -> None:
+    """The observed columns use the SAME denominators as their x-counterparts,
+    so `xwoba - woba` / `xba - ba` is a luck-vs-skill delta with no second
+    source."""
+    rows = {
+        "batter": [1] * 4,
+        "game_date": ["2024-06-01"] * 4,
+        "type": ["X", "X", "S", "B"],
+        "events": ["single", "field_out", "strikeout", "walk"],
+        "launch_speed": [95.0, 80.0, None, None],
+        "launch_angle": [10.0, -5.0, None, None],
+        "woba_value": [0.9, 0.0, 0.0, 0.7],
+    }
+    out = mlb_expected_stats("2024-06-01", "2024-06-21", puller=_pitchy_puller_factory(rows))
+    row = out.row(0, named=True)
+    assert row["pa"] == 4 and row["ab"] == 3
+    assert abs(row["woba"] - (0.9 + 0.0 + 0.0 + 0.7) / 4) < 1e-9  # realized, all four PA
+    assert abs(row["ba"] - 1.0 / 3) < 1e-9  # one real hit in three at-bats
+    assert row["xwoba"] is not None and row["xba"] is not None

--- a/tests/mlb/test_mlb_fielding_oaa.py
+++ b/tests/mlb/test_mlb_fielding_oaa.py
@@ -73,3 +73,40 @@ def test_oaa_return_as_pandas():
 
     out = mlb_fielding_oaa(_oaa_frame(), return_as_pandas=True)
     assert isinstance(out, pd.DataFrame)
+
+
+def test_by_direction_splits_partition_the_undirected_oaa():
+    """The in/back/lateral split re-groups the SAME scored balls in play and
+    never re-fits, so each fielder-position's three rows must sum exactly to
+    its undirected OAA (and opportunities). A split that re-fit per direction
+    — the tempting implementation — would not satisfy this."""
+    import numpy as np
+
+    rng = np.random.default_rng(0)
+    n = 400
+    bip = pl.DataFrame(
+        {
+            "hc_x": rng.normal(125, 40, n),
+            "hc_y": rng.normal(120, 40, n),
+            "hit_distance_sc": rng.normal(300, 60, n),
+            "launch_angle": rng.normal(25, 12, n),
+            "launch_speed": rng.normal(90, 12, n),
+            "hit_location": rng.choice([7, 8, 9], n),
+            "events": rng.choice(["field_out", "single"], n),
+            "fielder_7": rng.integers(1, 6, n),
+            "fielder_8": rng.integers(1, 6, n),
+            "fielder_9": rng.integers(1, 6, n),
+        }
+    )
+    plain = mlb_fielding_oaa(bip)
+    split = mlb_fielding_oaa(bip, by_direction=True)
+
+    assert set(split["direction"].unique().to_list()) <= {"in", "back", "lateral"}
+    joined = (
+        split.group_by(["fielder_id", "position"])
+        .agg(pl.col("oaa").sum().alias("split_oaa"), pl.col("opportunities").sum().alias("split_opps"))
+        .join(plain, on=["fielder_id", "position"], how="inner")
+    )
+    assert joined.height == plain.height  # every fielder-position survives the split
+    assert float((joined["split_oaa"] - joined["oaa"]).abs().max()) < 1e-9
+    assert int((joined["split_opps"] - joined["opportunities"]).abs().max()) == 0

--- a/tools/codegen/schemas/autodoc/mlb/mlb_expected_stats.yaml
+++ b/tools/codegen/schemas/autodoc/mlb/mlb_expected_stats.yaml
@@ -18,7 +18,17 @@ columns:
   description: Expected wOBA from the EV x LA empirical grid (contact) plus realized non-contact outcome value, divided by wOBA denominator.
 - name: xba
   type: double
-  description: Expected batting average from the EV x LA empirical grid's hit-indicator cell means.
+  description: Expected batting average from the EV x LA empirical grid's hit-indicator cell means on tracked balls
+    in play, plus the realized hit indicator on balls in play carrying no launch data, over at-bats.
 - name: xslg
   type: double
-  description: Expected slugging percentage from the EV x LA empirical grid's total-bases cell means.
+  description: Expected slugging percentage from the EV x LA empirical grid's total-bases cell means on tracked balls
+    in play, plus realized total bases on balls in play carrying no launch data, over at-bats.
+- name: woba
+  type: double
+  description: Observed wOBA over the same denominator as `xwoba`, so `xwoba - woba` is the batter's contact-quality
+    luck gap without needing a second source.
+- name: ba
+  type: double
+  description: Observed batting average over the same at-bat denominator as `xba`, so `xba - ba` is the batted-ball
+    luck gap without needing a second source.


### PR DESCRIPTION
Found while verifying #421 end-to-end against real Savant seasons for the
baseballr-data model-writeup review (baseballr-data#14).

#421 put every plate-appearance ender into the denominators, which exposed a
second asymmetry one layer down. **8-19% of PA-ending balls in play carry no
`launch_speed`/`launch_angle`** and cannot be predicted from the EV x LA grid.
`xwoba` has always given those rows their realized `woba_value`; `xba`/`xslg`
did not -- they counted in the `ab` denominator with a **zero numerator**.

Measured on real cached Savant seasons (qualified league mean, PA >= 100):

| season | untracked | mean xBA before -> after | observed BA | corr(xwOBA,xBA) before -> after |
|---|---|---|---|---|
| 2015 | 19.4% | .2026 -> **.2519** | .2556 | +0.622 -> **+0.773** |
| 2016 | 17.8% | .2090 -> **.2532** | .2575 | +0.588 -> **+0.762** |
| 2017 | 15.6% | .2142 -> **.2530** | .2559 | +0.612 -> **+0.768** |
| 2018 | 13.7% | .2141 -> **.2462** | .2493 | +0.656 -> **+0.785** |
| 2019 | 13.1% | .2190 -> **.2487** | .2526 | +0.709 -> **+0.791** |
| 2020 | 13.5% | .2229 -> **.2425** | .2439 | +0.746 -> **+0.793** |
| 2021 | 8.3% | .2198 -> **.2400** | .2442 | +0.688 -> **+0.797** |

The deficit tracked the untracked share almost exactly. Untracked balls are
**not** degenerate -- their hit rate matches tracked balls to three decimals
(.325 vs .324 in 2015) -- so they take the same realized-outcome fallback
xwOBA already used. A strikeout or field_out contributes a realized zero
exactly as before; only untracked batted balls change.

Also in this PR:

- **Observed `woba` / `ba` columns** on the same denominators as their
  expected counterparts, so a luck-vs-skill delta is `xwoba - woba` with no
  second source (max league gap .0012 wOBA / .0024 BA across 2015-2021).
- **`mlb_fielding_oaa(by_direction=True)`** for in/back/lateral splits. It
  re-groups the same scored balls in play rather than re-fitting, so the rows
  **partition** the undirected OAA -- asserted in tests, and on the real 2021
  season all 1,832 fielder-positions survive with max drift 3.6e-15. The
  direction proxy stands in for the fielder start coordinates the public feed
  lacks (documented approximation; Savant's outfield directional OAA
  leaderboard is named as the concurrent oracle).

Tests: 182 MLB tests pass (3 new regressions, each of which fails against the
pre-fix behaviour). Returns-table schema + generated reference docs
regenerated; codegen drift gate green.

## Summary by Sourcery

Correct MLB expected batting statistics for untracked balls in play and expose observed and directional fielding metrics.

New Features:
- Add observed wOBA and batting average outputs alongside expected statistics using matching denominators.
- Add optional directional in/back/lateral breakdowns to MLB fielding OAA while preserving the undirected totals.

Bug Fixes:
- Correct xBA and xSLG for PA-ending balls in play without launch data by incorporating their realized outcomes instead of treating them as zero expected contributions.

Documentation:
- Update MLB reference documentation and generated schemas for the corrected expected-statistic behavior, observed metrics, and directional fielding OAA output.

Tests:
- Add regression coverage for untracked batted-ball expected statistics, observed metrics, and directional OAA partitioning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `mlb_expected_stats` now includes observed batting average (`ba`) and weighted on-base average (`woba`) alongside expected metrics.
  - Expected batting metrics account for realized outcomes when batted-ball tracking data is unavailable.
  - `mlb_fielding_oaa` supports optional directional breakdowns: `in`, `back`, and `lateral`.

- **Documentation**
  - Updated statistical definitions, output schemas, parameter references, and directional OAA examples.

- **Tests**
  - Added coverage for observed batting metrics, untracked batted-ball outcomes, and directional OAA reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->