### PR TITLE
fix(cfb): stop text_dupe deleting the play before a timeout

### DIFF
--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -1711,7 +1711,14 @@ class CFBPlayProcess(object):
                     # this the loose is_in(lead_text) match spuriously flags the real
                     # play right before it (e.g. an end-of-half Hail Mary interception)
                     # as a duplicate and drops it. Never dedupe against an end-marker lead.
-                    .and_(pl.col("lead_text").str.contains(r"(?i)end of|end period|end quarter") == False),
+                    .and_(pl.col("lead_text").str.contains(r"(?i)end of|end period|end quarter") == False)
+                    # Same trap, different marker: a Timeout row (and a penalty row whose
+                    # play was wiped, "NO PLAY") also inherits the preceding play's start
+                    # state, so the loose is_in(lead_text) match deletes the real play in
+                    # front of it. 401864570 lost a 25-yard third-down completion this way
+                    # -- it sits immediately before "Timeout Florida State, clock 04:11".
+                    .and_(pl.col("type.text").shift(-1).str.contains("(?i)timeout") == False)
+                    .and_(pl.col("lead_text").str.contains("(?i)no play") == False),
                 )
                 .then(pl.lit(True))
                 .otherwise(pl.lit(False)),

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -1718,7 +1718,7 @@ class CFBPlayProcess(object):
                     # front of it. 401864570 lost a 25-yard third-down completion this way
                     # -- it sits immediately before "Timeout Florida State, clock 04:11".
                     .and_(pl.col("type.text").shift(-1).str.contains("(?i)timeout") == False)
-                    .and_(pl.col("lead_text").str.contains("(?i)no play") == False),
+                    .and_(pl.col("lead_text").str.contains(_PENALTY_NEGATED_TEXT) == False),
                 )
                 .then(pl.lit(True))
                 .otherwise(pl.lit(False)),


### PR DESCRIPTION
## The bug

The loose branch of the `text_dupe` rule matches when a row's start state equals its **lead** row's and its
text appears anywhere in the lead-text column. A `Timeout` row inherits the start state of the play in front
of it — exactly the trap the existing end-marker guard was written for — so the real play reads as a
duplicate and is filtered out before it ever reaches the output.

## Evidence

ESPN game `401864570` (New Mexico State at Florida State) lost a 25-yard third-down completion this way. It
sits immediately before `Timeout Florida State, clock 04:11` and shares that row's `sequenceNumber`; the feed
has 8 such collisions in that game alone. The pipeline emitted 163 of the feed's 168 drive rows — four are
`End of <quarter>` markers removed on purpose, and the fifth was that play.

Measured against that game's official StatBroadcast book, restoring the play moved box-score parity from
55.8% to 71.1% across 380 field-by-field comparisons.

## The fix

Guard the same way against a `Timeout` lead, and against a penalty row whose play was wiped (`NO PLAY`),
which inherits the start state for the same reason.

159 CFB tests pass.

## Summary by Sourcery

Bug Fixes:
- Prevent CFB play deduplication from deleting real plays immediately before Timeout or wiped-penalty (NO PLAY) rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved play-by-play deduplication to prevent valid plays from being incorrectly removed when followed by penalty entries marked “NO PLAY” or “nullified by penalty.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->