### PR TITLE
fix(pwhl): recompute null shot geometry per row and decouple is_home from the skater block

### DIFF
--- a/sportsdataverse/pwhl/pwhl_xg_proxy.py
+++ b/sportsdataverse/pwhl/pwhl_xg_proxy.py
@@ -298,17 +298,44 @@ def _shot_geometry(frame: pl.DataFrame) -> pl.DataFrame:
     ``docs/superpowers/specs/2026-06-09-hockeytech-multi-league-scraper-analytics-design.md``).
     No geometry is computed in this module.
 
-    When geometry must be derived (the frame lacks ``shot_distance``/``shot_angle``),
-    ``x_coord`` is range-checked first (:func:`_assert_rink_feet`) so a RAW-scale
-    enrich frame can never be silently scored with the NHL ``goal_x=89``.
-    """
-    if {"shot_distance", "shot_angle"}.issubset(frame.columns):
-        return frame
-    from sportsdataverse.hockeytech._analytics import add_shot_distance_angle
+    Reuse is **per row**, not per frame: a pooled multi-season frame concatenated
+    ``how="diagonal_relaxed"`` carries the columns from the seasons that ship them
+    and NULL for the seasons that don't, so a frame-level short-circuit left the
+    older seasons with null geometry that :func:`_build_xg_features` then fills
+    with ``0.0`` -- 10,593 of 18,031 pooled PWHL shots (58.7%) trained at distance
+    0. Shot rows whose carried geometry is null are recomputed and coalesced in;
+    carried values are never overwritten (feed and recomputed geometry agree to
+    0.0 ft on the seasons that carry both, so this is lossless).
 
+    When geometry must be derived, ``x_coord`` is range-checked first
+    (:func:`_assert_rink_feet`) so a RAW-scale enrich frame can never be silently
+    scored with the NHL ``goal_x=89``.
+    """
+    from sportsdataverse.hockeytech._analytics import _SHOT_EVENTS, add_shot_distance_angle
+
+    has = {"shot_distance", "shot_angle"}.issubset(frame.columns)
+    if has:
+        gap = pl.col("shot_distance").is_null() | pl.col("shot_angle").is_null()
+        if "event" in frame.columns:
+            gap = gap & pl.col("event").is_in(_SHOT_EVENTS)
+        if not frame.select(gap.any()).item():
+            return frame
     _assert_rink_feet(frame)
     f = frame if "event" in frame.columns else frame.with_columns(pl.lit("shot").alias("event"))
-    return add_shot_distance_angle(f)
+    if not has:
+        return add_shot_distance_angle(f)
+    carried = f.with_columns(
+        _carried_distance=pl.col("shot_distance").cast(pl.Float64, strict=False),
+        _carried_angle=pl.col("shot_angle").cast(pl.Float64, strict=False),
+    ).drop("shot_distance", "shot_angle")
+    return (
+        add_shot_distance_angle(carried)
+        .with_columns(
+            shot_distance=pl.coalesce("_carried_distance", "shot_distance"),
+            shot_angle=pl.coalesce("_carried_angle", "shot_angle"),
+        )
+        .drop("_carried_distance", "_carried_angle")
+    )
 
 
 _XG_BASE_FEATURES = ("shot_distance", "shot_angle")
@@ -415,9 +442,11 @@ def _build_xg_features(
 
     - ``rebound`` -- shot within 3s of the prior shot in the game (needs
       ``game_id`` + ``sec_from_start``).
-    - ``is_home`` / ``is_pp`` / ``is_sh`` -- shooter-relative home flag and
-      power-play/short-handed dummies (needs ``team_id`` + ``home_team_id`` +
-      ``skaters_home`` / ``skaters_away``, i.e. the R4 strength columns).
+    - ``is_home`` -- shooter-relative home flag (needs ``team_id`` +
+      ``home_team_id`` ONLY; see the note in the body).
+    - ``is_pp`` / ``is_sh`` / ``empty_net_for`` -- power-play/short-handed/pulled-goalie
+      dummies (need the R4 strength columns ``skaters_home`` / ``skaters_away``
+      in addition to the team ids).
 
     A frame that lacks those columns (e.g. the legacy xG fixture, or a pre-R4
     pbp) degrades to the 2-feature distance/angle model unchanged. At predict
@@ -445,19 +474,25 @@ def _build_xg_features(
             .sort("_ri")
         )
         avail.append("rebound")
+    home = pl.col("team_id") == pl.col("home_team_id")
+    if {"team_id", "home_team_id"}.issubset(f.columns):
+        # `is_home` needs only the team ids -- it is deliberately NOT gated on the R4
+        # strength columns. It used to share their `if`, so a season scored alone
+        # without `skaters_home`/`skaters_away` (2024, 2025) silently lost `is_home`
+        # too and every row scored as away: ~25% lower xG for the same shots.
+        f = f.with_columns(is_home=home.cast(pl.Int64))
+        avail.append("is_home")
     if {"team_id", "home_team_id", "skaters_home", "skaters_away"}.issubset(f.columns):
-        home = pl.col("team_id") == pl.col("home_team_id")
         sk_for = pl.when(home).then(pl.col("skaters_home")).otherwise(pl.col("skaters_away"))
         sk_opp = pl.when(home).then(pl.col("skaters_away")).otherwise(pl.col("skaters_home"))
         f = f.with_columns(
-            is_home=home.cast(pl.Int64),
             is_pp=(sk_for > sk_opp).fill_null(False).cast(pl.Int64),
             is_sh=(sk_for < sk_opp).fill_null(False).cast(pl.Int64),
             # defending team shows >=6 skaters => their goalie is pulled => the
             # shooter faces an empty net (the booster's `empty_net`; PWHL's SH gap).
             empty_net_for=(sk_opp >= 6).fill_null(False).cast(pl.Int64),
         )
-        avail += ["is_home", "is_pp", "is_sh", "empty_net_for"]
+        avail += ["is_pp", "is_sh", "empty_net_for"]
     if "event_type" in f.columns:
         # Shot type -- PWHL's `event_type` on shot rows IS the shot type
         # (Wrist/Snap/Slap/Backhand/Tip; "Default" => all zero). The NHL booster's

--- a/tests/pwhl/test_pwhl_xg_proxy_oracle.py
+++ b/tests/pwhl/test_pwhl_xg_proxy_oracle.py
@@ -753,3 +753,73 @@ def test_strength_calibration_improves_real_pwhl_per_strength_ece() -> None:
     reg_r, reg_c = _bucket_ece(y_r, p_r), _bucket_ece(y_c, p_c)
     assert reg_c <= reg_r + 2e-3, f"overall held-out ECE regressed: {reg_c:.4f} vs {reg_r:.4f}"
     assert roc_auc_score(y_c, p_c) >= roc_auc_score(y_r, p_r) - 0.002, "calibration cost AUC"
+
+
+# ---------------------------------------------------------------------------
+# Pooled-frame regressions (2026-09-02). Two production-affecting defects the
+# hockey model writeup measured on the committed pwhl-data pbp tree:
+#
+#   1. `_shot_geometry` short-circuited on COLUMN PRESENCE, so a pooled frame
+#      concatenated `how="diagonal_relaxed"` from seasons that ship geometry
+#      (2026) and seasons that don't (2024/2025) kept NULL geometry for the
+#      older seasons -- `_build_xg_features` then filled it with 0.0 and the
+#      publisher's single pooled fit trained 10,593 of 18,031 shots (58.7%)
+#      at distance 0.
+#   2. `is_home` shared the `if` of the R4 strength columns, so a season scored
+#      ALONE without `skaters_home`/`skaters_away` lost `is_home` too.
+#
+# Both fixtures below carry REAL PWHL coordinates (the committed 2024+2025
+# shots fixture); the season-asymmetry and the team-id columns are the shapes
+# under test.
+# ---------------------------------------------------------------------------
+
+
+def test_pooled_frame_recomputes_null_geometry(train_shots: pl.DataFrame) -> None:
+    """A pooled frame with season-asymmetric geometry must not train at distance 0."""
+    from sportsdataverse.pwhl.pwhl_xg_proxy import _build_xg_features, _shot_geometry
+
+    from sportsdataverse.hockeytech._analytics import add_shot_distance_angle
+
+    on_net = train_shots.filter(pl.col("event") == "shot")
+    with_geo = add_shot_distance_angle(on_net.filter(pl.col("season") == 2025))
+    without_geo = on_net.filter(pl.col("season") == 2024)
+    pooled = pl.concat([without_geo, with_geo], how="diagonal_relaxed")
+    assert pooled.select(pl.col("shot_distance").is_null().sum()).item() == without_geo.height
+
+    out = _shot_geometry(pooled)
+    assert out.select(pl.col("shot_distance").is_null().sum()).item() == 0
+    assert out.select(pl.col("shot_angle").is_null().sum()).item() == 0
+
+    # carried values are reused verbatim, never overwritten (lossless)
+    carried = with_geo.select("shot_distance").to_series()
+    reused = out.tail(with_geo.height).select("shot_distance").to_series()
+    assert (carried - reused).abs().max() == 0.0
+
+    x, feats, _ = _build_xg_features(pooled)
+    n_zero = int((x[:, feats.index("shot_distance")] == 0.0).sum())
+    assert n_zero == 0, f"{n_zero} shots would train at distance 0"
+
+
+def test_is_home_survives_a_season_scored_without_skater_columns(train_shots: pl.DataFrame) -> None:
+    """`is_home` needs only the team ids -- never zero-filled with the strength block."""
+    from sportsdataverse.pwhl.pwhl_xg_proxy import _build_xg_features
+
+    solo = train_shots.filter((pl.col("event") == "shot") & (pl.col("season") == 2024)).with_columns(
+        team_id=pl.col("game_id") % 2,
+        home_team_id=pl.lit(0),
+    )
+    assert not {"skaters_home", "skaters_away", "strength_state"} & set(solo.columns)
+
+    x, feats, _ = _build_xg_features(solo)
+    assert "is_home" in feats, f"is_home lost with the strength block: {feats}"
+    assert {"is_pp", "is_sh", "empty_net_for"}.isdisjoint(feats)  # those DO need the skaters
+    home_col = x[:, feats.index("is_home")]
+    assert 0 < home_col.sum() < len(home_col), "is_home is constant -- not actually derived"
+
+    # and at predict time, a model fitted WITH the strength block still gets a real
+    # is_home for such a frame (0-fill only applies to the columns genuinely absent).
+    want = ("shot_distance", "shot_angle", "is_home", "is_pp", "is_sh")
+    xw, featsw, _ = _build_xg_features(solo, want=want)
+    assert featsw == want
+    assert xw[:, want.index("is_home")].sum() == home_col.sum()
+    assert xw[:, want.index("is_pp")].sum() == 0.0


### PR DESCRIPTION
Two tracked follow-ups from the 2026-09-01 model-writeup improvement program,
deliberately deferred out of `fastRhockey-pwhl-data#5`. Both are in the PWHL xG
feature builder, and item 1 affects PUBLISHED data.

## 1. `_shot_geometry` short-circuited on column PRESENCE, not per row

`pwhl_model_publish.builders.build_xg` fits ONE model on the pooled seasons
concatenated `how="diagonal_relaxed"`. The 2026 parquet ships
`shot_distance`/`shot_angle`; 2024 and 2025 do not — so the pooled frame carries
the columns with NULL for the older seasons. The frame-level check returned it
untouched, and `_build_xg_features` fills nulls with `0.0`.

Measured on `fastRhockey-pwhl-data/pwhl/pbp/parquet/play_by_play_{2024,2025,2026}.parquet`
(18,031 on-net shots), before → after:

| | before | after |
|---|---:|---:|
| NULL `shot_distance` after `_shot_geometry` | **10,593 (58.7%)** | **0 (0.0%)** |
| distance == 0 rows in the fit matrix | **10,593 (58.7%)** | **0** |

Corrected pooled distance distribution: q0 1.4 / q0.05 8.0 / q0.25 16.4 /
**median 30.0** / q0.75 46.0 / q0.95 65.4 / max 96.6 ft, mean 32.73 ft. Before,
everything up to the median was 0.0 and q0.75 was 23.3.

Reuse is now **per row**: shot rows whose carried geometry is null are
recomputed and coalesced in; carried values are never overwritten. **Lossless**,
verified on the 7,438 shots of 2026 that carry BOTH feed and recomputed
geometry — max abs delta **0.0001 ft** / **0.0016 deg**.

The RAW-scale guard (`_assert_rink_feet`) still runs before any derivation, so a
raw feed-scale enrich frame with partial-null geometry now fails loud instead of
producing silent zeros. A frame whose carried geometry is complete still
short-circuits with no range check — the enrich path is unchanged.

### The published data is affected; a rebuild is your call

There is **no committed PWHL xG booster** — `build_xg` fits at build time and
ships only the scored rows, so nothing needs a model refresh. What was fitted on
the corrupted frame is the **published `pwhl_xg_pbp` release assets** and the
`docs/models/pwhl_xg_eval_card.json` metrics quoted by the writeup.
Publisher-equivalent effect (pooled fit, per-season score):

| season | shots | goals | ΣxG before | goals/ΣxG before | ΣxG after | goals/ΣxG after |
|---|---:|---:|---:|---:|---:|---:|
| 2024 | 4,922 | 385 | 303.2 | **1.270** | 412.2 | **0.934** |
| 2025 | 5,671 | 499 | 339.0 | **1.472** | 473.5 | **1.054** |
| 2026 | 7,438 | 601 | 527.3 | **1.140** | 599.4 | **1.003** |

The "before" column reproduces the writeup's first-render LOSO ratios
(1.24 / 1.49 / 0.84). **A rebuild + republish of `pwhl_xg_pbp` is a deliberate
decision and was NOT taken here** — this PR changes future fits only.

## 2. `is_home` was coupled to the R4 strength columns

`is_home` shared the `if` of `skaters_home`/`skaters_away`, so a season scored
ALONE without them (2024, 2025) lost `is_home` too and every row scored as away.
It needs only `team_id` + `home_team_id`, which those seasons DO carry. It now
has its own guard; `is_pp` / `is_sh` / `empty_net_for` keep the strength guard.

Before: `_build_xg_features` on 2024 alone → `('shot_distance', 'shot_angle',
'rebound', 'is_wrist', …)`, `is_home` absent. After: `is_home` present for 2024,
2025 and 2026 scored alone, with a real (non-constant) value — observed mean
0.5146 / 0.5029 / 0.5204.

## Tests

Two regression tests in `tests/pwhl/test_pwhl_xg_proxy_oracle.py`, both on the
committed **real** 2024+2025 shots fixture:

- `test_pooled_frame_recomputes_null_geometry` — builds the production
  season-asymmetric shape, asserts zero null geometry, zero distance-0 rows in
  the fit matrix, and that carried values are byte-for-byte reused.
- `test_is_home_survives_a_season_scored_without_skater_columns` — asserts
  `is_home` present and non-constant, `is_pp`/`is_sh` correctly absent, and that
  the `want=` predict path still fills only the genuinely-absent columns.

Both **fail on `main`** and pass here (verified by reverting the module and
re-running).

## Gates run locally (the pre-push hook exceeds the tool time cap, so these were run by hand)

- `tools/codegen/generate.py` → wrote 321 doc files; `--check` → **"all generated files current"** (rc 0)
- `pytest tests/ --ignore=tests/codegen` → **5667 passed, 337 skipped, 10 xfailed** (rc 0)
- `pytest tests/codegen` → **174 passed, 11 skipped** (rc 0)
- `mypy sportsdataverse/pwhl/pwhl_xg_proxy.py` → **Success: no issues found**
- `ruff check` / `ruff format` → clean; `uv.lock` unchanged

## Self-review

- **gate-integrity** — no gate or floor moved. The PWHL xG oracle gates in
  `test_pwhl_xg_proxy_oracle.py` (held-out calibration, per-strength Platt ECE)
  all still pass unchanged on the corrected frame, so the fix does not need a
  threshold to accommodate it.
- **silent-no-op** — both tests were shown to FAIL on `main` before being kept,
  and they assert on the OUTPUT (null counts, matrix values, feature tuples), not
  on a code path being taken. The geometry test additionally asserts the carried
  values are unchanged, so a "fix" that recomputed everything and clobbered the
  feed's own numbers would fail it.
- **polars** — `pl.coalesce`, `cast(..., strict=False)`, `is_in`,
  `select(expr.any()).item()`; no pre-1.0 API. The temp-column coalesce avoids
  passing a `Series` into an expression context.
- **id dtype** — `is_home` compares `team_id` to `home_team_id`; the seasons
  disagree on dtype (2024/2025 `Int32`, 2026 `String`), but `diagonal_relaxed`
  promotes BOTH columns together, so the comparison holds. Checked on real data:
  pooled `is_home` mean 0.5133, per-season 0.5146 / 0.5029 / 0.5204 — not
  degenerate under either dtype.

## Summary by Sourcery

Correct PWHL xG feature construction for pooled geometry gaps and independently derived home-team indicators.

Bug Fixes:
- Recompute missing shot geometry per row in pooled PWHL frames while preserving carried feed values, preventing null geometry from becoming zero-distance training data.
- Keep `is_home` available when scoring seasons without skater-strength columns, while retaining strength-dependent feature guards for special-teams fields.

Tests:
- Add regression coverage for season-asymmetric pooled geometry and standalone-season home-team feature generation.