### PR TITLE
fix(cfb): power rushing missed 3rd-and-2 and every goal-line carry

### DIFF
--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -6660,34 +6660,19 @@ class CFBPlayProcess(object):
                 .when((pl.col("start.distance") >= 2).and_(pl.col("rush") == True))
                 .then(False)
                 .otherwise(None),
-                power_rush_success=pl.when(
-                    (pl.col("start.distance") < 2)
-                    .and_(pl.col("rush") == True)
-                    .and_(pl.col("start.down").is_in([3, 4]))
-                    .and_(pl.col("statYardage") >= pl.col("start.distance")),
-                )
-                .then(True)
-                .when(
-                    (pl.col("start.distance") < 2)
-                    .and_(pl.col("rush") == True)
-                    .and_(pl.col("start.down").is_in([3, 4]))
-                    .and_(pl.col("statYardage") < pl.col("start.distance")),
-                )
-                .then(False)
-                .otherwise(None),
-                power_rush_attempt=pl.when(
-                    (pl.col("start.distance") < 2)
-                    .and_(pl.col("rush") == True)
-                    .and_(pl.col("start.down").is_in([3, 4])),
-                )
-                .then(True)
-                .when(
-                    (pl.col("start.distance") < 2)
-                    .and_(pl.col("rush") == True)
-                    .and_(pl.col("start.down").is_in([3, 4])),
-                )
-                .then(False)
-                .otherwise(None),
+                # Power success is a run on 3rd or 4th down with TWO YARDS OR LESS to go, plus a run
+                # on 1st- or 2nd-and-goal from the two or closer. The old form tested `distance < 2`,
+                # which drops every 3rd-and-2 -- the most common power down there is -- and carried no
+                # goal-line clause at all. The attempt flag's two branches were also identical, so its
+                # False branch was unreachable and the column was True-or-null rather than boolean.
+                _power_situation=(pl.col("rush") == True).and_(
+                    (pl.col("start.down").is_in([3, 4]).and_(pl.col("start.distance") <= 2)).or_(
+                        pl.col("start.down")
+                        .is_in([1, 2])
+                        .and_(pl.col("start.distance") == pl.col("start.yardsToEndzone"))
+                        .and_(pl.col("start.yardsToEndzone") <= 2)
+                    )
+                ),
                 early_down=pl.when(
                     ((pl.col("down_1") == True).or_(pl.col("down_2") == True)).and_(pl.col("scrimmage_play") == True),
                 )
@@ -6699,6 +6684,15 @@ class CFBPlayProcess(object):
                 .then(True)
                 .otherwise(False),
             )
+            .with_columns(
+                power_rush_attempt=pl.when(pl.col("rush") == True).then(pl.col("_power_situation")).otherwise(None),
+                power_rush_success=pl.when(pl.col("_power_situation"))
+                .then(pl.col("statYardage") >= pl.col("start.distance"))
+                .when(pl.col("rush") == True)
+                .then(False)
+                .otherwise(None),
+            )
+            .drop("_power_situation")
             .with_columns(
                 early_down_pass=pl.when((pl.col("pass") == True).and_(pl.col("early_down") == True))
                 .then(True)


### PR DESCRIPTION
Stacked on #426 — it needs that PR's `goal_to_go` correction, since the goal-line clause is expressed as
`distance == yardsToEndzone`.

## The definition

Power success is a run on **3rd or 4th down with two yards or less to go**, plus a run on **1st- or
2nd-and-goal from the two or closer**.

## Three defects

1. **`start.distance < 2`** drops every 3rd-and-2 — the most common power down there is.
2. **No goal-line clause at all**, so a 1st-and-goal from the 1 was not a power attempt.
3. **`power_rush_attempt`'s two `when` branches were identical**, leaving the `False` branch unreachable.
   The column came out True-or-null and never boolean, so it could not be aggregated as one.

## Evidence

ESPN `401864570`. The flag is now `Boolean` with 4 attempts and 54 explicit non-attempts, where it
previously had no `False` values at all:

| team | power | detail |
|---|---|---|
| Florida State | **2 of 2** | 3rd & 2 from the 2, and 1st & goal from the 1 |
| New Mexico State | 2 of 2 | 3rd & 2, 4th & 1 |

Florida State matches that game's official StatBroadcast book exactly (2-2), and the second of its two is
the goal-line carry the old definition could not see.

810 CFB tests pass.

## Summary by Sourcery

Fix college football power rushing metrics to correctly identify qualifying attempts and successes, including 3rd-and-2 and goal-line carries.

Bug Fixes:
- Correct power rushing detection to include all 3rd- and 4th-down runs with two or fewer yards to go and qualifying 1st- and 2nd-and-goal runs from the two-yard line or closer.
- Restore explicit false values for non-power rushing attempts so the metric is consistently boolean and aggregatable.