### PR TITLE
feat(release): expose write_release_sidecars for producers that own their gh transport

### DIFF
--- a/sportsdataverse/release.py
+++ b/sportsdataverse/release.py
@@ -73,6 +73,7 @@ __all__ = [
     "gh_cli_release_upload",
     "sportsdataverse_save",
     "sportsdataverse_upload",
+    "write_release_sidecars",
 ]
 
 
@@ -333,6 +334,54 @@ def _create_package_function(temp_dir: Path, pkg_function: str) -> list[Path]:
     return [txt, js]
 
 
+def write_release_sidecars(dest_dir: str | Path, pkg_function: str | None = None) -> list[Path]:
+    """Write the release metadata sidecars R attaches to every published tag.
+
+    Always writes ``timestamp.txt`` + ``timestamp.json``; adds
+    ``package_function.txt`` + ``package_function.json`` when ``pkg_function``
+    is given. This is the writer half of :func:`sportsdataverse_upload`, split
+    out so a producer that owns its own ``gh`` transport -- most of the
+    ``-data`` repos upload one file per invocation with a longer timeout, and
+    inject the runner to keep their tests offline -- can still emit the same
+    four files rather than re-deriving them.
+
+    Args:
+        dest_dir: Directory to write into. Must already exist.
+        pkg_function: Related package function name, e.g.
+            ``"hoopR::load_nba_pbp()"``. When None the package_function pair
+            is skipped.
+
+    Returns:
+        The written paths, timestamp pair first.
+
+    Example:
+        Quick start::
+
+            import tempfile
+            from pathlib import Path
+            from sportsdataverse.release import write_release_sidecars
+
+            with tempfile.TemporaryDirectory() as td:
+                paths = write_release_sidecars(Path(td), "hoopR::load_nba_pbp()")
+                print([p.name for p in paths])
+
+        Upload them through a producer's own runner::
+
+            for sidecar in write_release_sidecars(Path(td), pkg_fn):
+                run(["release", "upload", tag, str(sidecar), "--repo", repo, "--clobber"])
+
+        See Also:
+            * `hoopR`_ -- the R package whose ``sportsdataverse_save()`` this mirrors
+
+        .. _hoopR: https://hoopR.sportsdataverse.org
+    """
+    dest = Path(dest_dir)
+    sidecars = _create_timestamp_file(dest)
+    if pkg_function is not None:
+        sidecars += _create_package_function(dest, pkg_function)
+    return sidecars
+
+
 def sportsdataverse_upload(
     files: Iterable[str | Path],
     tag: str,
@@ -384,9 +433,7 @@ def sportsdataverse_upload(
     def _upload_once(force_clobber: bool) -> bool:
         temp_dir = Path(tempfile.mkdtemp(prefix="sdv_release_"))
         try:
-            sidecars = _create_timestamp_file(temp_dir)
-            if pkg_function is not None:
-                sidecars += _create_package_function(temp_dir, pkg_function)
+            sidecars = write_release_sidecars(temp_dir, pkg_function)
             return gh_cli_release_upload(
                 [*files, *sidecars],
                 tag=tag,

--- a/sportsdataverse/release.py
+++ b/sportsdataverse/release.py
@@ -40,7 +40,7 @@ import time
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from typing import Any
 
 import polars as pl
@@ -73,6 +73,7 @@ __all__ = [
     "gh_cli_release_upload",
     "sportsdataverse_save",
     "sportsdataverse_upload",
+    "upload_release_sidecars",
     "write_release_sidecars",
 ]
 
@@ -380,6 +381,68 @@ def write_release_sidecars(dest_dir: str | Path, pkg_function: str | None = None
     if pkg_function is not None:
         sidecars += _create_package_function(dest, pkg_function)
     return sidecars
+
+
+def upload_release_sidecars(
+    tag: str,
+    *,
+    runner: Callable[[list[str]], Any],
+    pkg_function: str | None = None,
+    repo: str = DEFAULT_REPO,
+) -> list[str]:
+    """Write the release sidecars and push them through a caller's ``gh`` runner.
+
+    The producer repos each own their upload transport -- one ``gh release
+    upload`` per file, a longer subprocess timeout for 100MB+ assets, and an
+    injected ``runner`` so their tests never touch the network. This lets them
+    stamp a tag with the same four files :func:`sportsdataverse_upload` writes
+    without giving up any of that: the sidecars are written to a temp dir and
+    handed to ``runner`` one at a time, exactly like their own data assets.
+
+    Call it once per tag AFTER the data assets land, so the timestamp reflects
+    the finished upload rather than the start of it.
+
+    Args:
+        tag: Release tag to stamp.
+        runner: Callable taking a ``gh`` argument list, e.g. the producer's
+            ``_gh``. Injectable so tests stay offline.
+        pkg_function: Related package function name. When None only the
+            timestamp pair is uploaded.
+        repo: Target repository. Defaults to ``sportsdataverse/sportsdataverse-data``.
+
+    Returns:
+        The uploaded sidecar file names, in upload order.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.release import upload_release_sidecars
+            upload_release_sidecars(
+                "espn_nba_pbp",
+                runner=_gh,
+                pkg_function="hoopR::load_nba_pbp()",
+                repo="sportsdataverse/sportsdataverse-data",
+            )
+
+        Hermetic test::
+
+            calls = []
+            upload_release_sidecars("t", runner=calls.append)
+
+        See Also:
+            * `hoopR`_ -- the R package whose ``sportsdataverse_save()`` this mirrors
+
+        .. _hoopR: https://hoopR.sportsdataverse.org
+    """
+    uploaded: list[str] = []
+    temp_dir = Path(tempfile.mkdtemp(prefix="sdv_sidecars_"))
+    try:
+        for sidecar in write_release_sidecars(temp_dir, pkg_function):
+            runner(["release", "upload", tag, str(sidecar), "--repo", repo, "--clobber"])
+            uploaded.append(sidecar.name)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+    return uploaded
 
 
 def sportsdataverse_upload(

--- a/tests/release/test_release_parity.py
+++ b/tests/release/test_release_parity.py
@@ -453,3 +453,28 @@ def test_gh_token_fallback_from_github_pat(monkeypatch):
     monkeypatch.setenv("GH_TOKEN", "explicit")
     assert release._gh_env()["GH_TOKEN"] == "explicit"
     assert os.environ.get("GH_TOKEN") == "explicit"
+
+
+def test_write_release_sidecars_writes_all_four(tmp_path):
+    """The public writer emits the same four files the R upload attaches."""
+    from sportsdataverse.release import write_release_sidecars
+
+    paths = write_release_sidecars(tmp_path, "hoopR::load_nba_pbp()")
+
+    assert [p.name for p in paths] == [
+        "timestamp.txt",
+        "timestamp.json",
+        "package_function.txt",
+        "package_function.json",
+    ]
+    assert json.loads((tmp_path / "package_function.json").read_text()) == {"package_function": "hoopR::load_nba_pbp()"}
+    assert "last_updated" in json.loads((tmp_path / "timestamp.json").read_text())
+
+
+def test_write_release_sidecars_omits_package_function_when_none(tmp_path):
+    from sportsdataverse.release import write_release_sidecars
+
+    paths = write_release_sidecars(tmp_path)
+
+    assert [p.name for p in paths] == ["timestamp.txt", "timestamp.json"]
+    assert not (tmp_path / "package_function.json").exists()

--- a/tests/release/test_release_parity.py
+++ b/tests/release/test_release_parity.py
@@ -478,3 +478,38 @@ def test_write_release_sidecars_omits_package_function_when_none(tmp_path):
 
     assert [p.name for p in paths] == ["timestamp.txt", "timestamp.json"]
     assert not (tmp_path / "package_function.json").exists()
+
+
+def test_upload_release_sidecars_pushes_four_through_the_runner():
+    """A producer's own gh runner uploads the same four files, one per call."""
+    from sportsdataverse.release import upload_release_sidecars
+
+    calls: list[list[str]] = []
+    names = upload_release_sidecars(
+        "espn_nba_pbp",
+        runner=calls.append,
+        pkg_function="hoopR::load_nba_pbp()",
+        repo="sportsdataverse/sportsdataverse-data",
+    )
+
+    assert names == [
+        "timestamp.txt",
+        "timestamp.json",
+        "package_function.txt",
+        "package_function.json",
+    ]
+    assert len(calls) == 4
+    for call, name in zip(calls, names):
+        assert call[:3] == ["release", "upload", "espn_nba_pbp"]
+        assert call[3].endswith(name)
+        assert call[4:] == ["--repo", "sportsdataverse/sportsdataverse-data", "--clobber"]
+
+
+def test_upload_release_sidecars_cleans_up_its_temp_dir():
+    from sportsdataverse.release import upload_release_sidecars
+
+    paths: list[str] = []
+    upload_release_sidecars("t", runner=lambda a: paths.append(a[3]))
+
+    assert len(paths) == 2  # timestamp pair only
+    assert not any(Path(p).exists() for p in paths)


### PR DESCRIPTION
## Why

Every published tag on `sportsdataverse/sportsdataverse-data` is supposed to carry the four sidecars R's `sportsdataverse_save()` attaches — `timestamp.txt`/`.json` and `package_function.txt`/`.json`. Audited across all 241 tags today:

| | tags |
|---|---:|
| no sidecar at all | 133 |
| sidecar present but **stale** (older than the newest data asset by >1h) | 95 |
| sidecar in sync | 13 |

Worst offenders: `ncaa_baseball_pbp` 1271d stale, `espn_cfb_pbp` / `espn_cfb_rosters` 1214d, then the whole ESPN NBA/WNBA/MBB/WBB families at 37-50d — all dating to the R→Python producer flips.

Root cause is structural: the sidecar writer was private, reachable only through `sportsdataverse_upload()`. Each of the 15 Python `-data` producers owns its own `gh release upload` loop (one file per invocation, a longer timeout for 100MB+ pbp csvs, an injected `runner` that keeps their tests offline), so none of them could emit the sidecars without re-deriving the format — and none did.

## What

Split the writer out as a public `write_release_sidecars(dest_dir, pkg_function)`; `sportsdataverse_upload()` now calls it. No behaviour change — the private `_create_timestamp_file` / `_create_package_function` are untouched and still the implementation.

This unblocks the producer-side follow-ups, which push the four files through their own transport:

```python
with tempfile.TemporaryDirectory() as td:
    for sidecar in write_release_sidecars(Path(td), spec.pkg_function):
        run(["release", "upload", spec.tag, str(sidecar), "--repo", repo, "--clobber"])
```

## Test

Two new cases in `tests/release/test_release_parity.py` — all four files with a `pkg_function`, timestamp pair only without one. `29 passed` in `tests/release/`; ruff + mypy clean; codegen regen leaves the tree clean.

## Summary by Sourcery

Enable independently managed release producers to attach the standard metadata sidecars to published tags.

New Features:
- Expose release sidecar generation for producers that manage their own GitHub release transport.
- Provide a runner-based helper for uploading timestamp and optional package-function sidecars per release.

Enhancements:
- Reuse the public sidecar writer from the existing release upload flow while preserving its behavior.

Tests:
- Add coverage for generating, uploading, and cleaning up release sidecars.