### PR TITLE
docs(mlb): give mlb_fielding_oaa a returns schema so its column table renders

### DIFF
--- a/docs/docs/mlb/reference/additional.md
+++ b/docs/docs/mlb/reference/additional.md
@@ -1225,7 +1225,15 @@ dynamically from the responsible position's `fielder_{position}` column
 
 **Returns**
 
-one row per `(fielder_id, position)`. | Column | Type | Description | |---|---|---| | fielder_id | Utf8 | Responsible fielder's MLBAM id | | position | Int64 | Position (Savant `hit_location`, 1-9) | | direction | Utf8 | `in`/`back`/`lateral` -- only when `by_direction=True` | | opportunities | Int64 | Balls in play charged to this fielder | | oaa | Float64 | Sum of (out - expected catch probability) |
+one row per `(fielder_id, position)` -- or per `(fielder_id, position, direction)` when `by_direction=True` -- with `opportunities` and `oaa`. The rendered column table comes from the committed returns schema (`tools/codegen/schemas/autodoc/mlb/mlb_fielding_oaa.yaml`); a Markdown table written here would be collapsed onto one line by the docs renderer, which joins the lines of a `Returns:` block.
+
+| col_name | type | description |
+|---|---|---|
+| `fielder_id` | character | Responsible fielder's MLBAM id (the fielder charged with the ball in play). |
+| `position` | integer | Fielding position from Savant's `hit_location`, 1-9. |
+| `direction` | character | Movement direction the catch required -- `in`, `back` or `lateral`. Present only when the call passes `by_direction=True`; the three rows re-group the same scored balls in play, so they sum exactly to the undirected `oaa`. |
+| `opportunities` | integer | Balls in play charged to this fielder (the denominator of the OAA sum). |
+| `oaa` | double | Outs above average -- the sum of (out - expected catch probability) over this fielder's opportunities. |
 
 **Example**
 

--- a/sportsdataverse/mlb/mlb_fielding_oaa.py
+++ b/sportsdataverse/mlb/mlb_fielding_oaa.py
@@ -258,15 +258,13 @@ def mlb_fielding_oaa(
         return_as_pandas: Return a pandas DataFrame instead of polars.
 
     Returns:
-        pl.DataFrame: one row per ``(fielder_id, position)``.
-
-        | Column | Type | Description |
-        |---|---|---|
-        | fielder_id | Utf8 | Responsible fielder's MLBAM id |
-        | position | Int64 | Position (Savant ``hit_location``, 1-9) |
-        | direction | Utf8 | ``in``/``back``/``lateral`` -- only when ``by_direction=True`` |
-        | opportunities | Int64 | Balls in play charged to this fielder |
-        | oaa | Float64 | Sum of (out - expected catch probability) |
+        pl.DataFrame: one row per ``(fielder_id, position)`` -- or per
+        ``(fielder_id, position, direction)`` when ``by_direction=True`` --
+        with ``opportunities`` and ``oaa``. The rendered column table comes
+        from the committed returns schema
+        (``tools/codegen/schemas/autodoc/mlb/mlb_fielding_oaa.yaml``); a
+        Markdown table written here would be collapsed onto one line by the
+        docs renderer, which joins the lines of a ``Returns:`` block.
 
     Example:
         Quick start::

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -19674,6 +19674,12 @@ games:
   start: Kickoff timestamp (ISO 8601 string).
   has_stats: Whether PFF has published stats for the game.
   lock_status: Data lock/publish status for the game.
+mlb_fielding_oaa:
+  fielder_id: Responsible fielder's MLBAM id (the fielder charged with the ball in play).
+  position: Fielding position from Savant's ``hit_location``, 1-9.
+  direction: Movement direction the catch required -- ``in``, ``back`` or ``lateral``. Present only when the call passes ``by_direction=True``; the three rows re-group the same scored balls in play, so they sum exactly to the undirected ``oaa``.
+  opportunities: Balls in play charged to this fielder (the denominator of the OAA sum).
+  oaa: Outs above average -- the sum of (out - expected catch probability) over this fielder's opportunities.
 mlb_run_expectancy_matrix:
   base_state: 3-char base occupancy code ("_" = empty, "1"/"2"/"3" = occupied), e.g. "1_3" for runners on first and third.
   outs: Outs at the start of the base-out state (0-2).

--- a/tools/codegen/schemas/autodoc/mlb/mlb_fielding_oaa.yaml
+++ b/tools/codegen/schemas/autodoc/mlb/mlb_fielding_oaa.yaml
@@ -1,0 +1,18 @@
+schema: mlb_fielding_oaa
+kind: dataframe
+columns:
+- name: fielder_id
+  type: character
+  description: ''
+- name: position
+  type: integer
+  description: ''
+- name: direction
+  type: character
+  description: ''
+- name: opportunities
+  type: integer
+  description: ''
+- name: oaa
+  type: double
+  description: ''


### PR DESCRIPTION
`mlb_fielding_oaa` had no entry under `tools/codegen/schemas/autodoc/mlb/`, so its column table was written as Markdown inside the docstring's `Returns:` block. The docs renderer joins the lines of that block, so the table arrived in `docs/docs/mlb/reference/additional.md` as a single line and rendered as a paragraph rather than a table. Every one of the 116 tables that renders correctly in that same file is schema-driven.

This adds the returns schema, puts the five column descriptions in `manual_column_descriptions.yaml` (never in `schemas/**.yaml`, which is clobbered on re-capture), and replaces the docstring table with a pointer that explains why a table cannot live there.

CodeRabbit reported the symptom on #424 and proposed editing the generated Markdown directly. That was declined there — codegen output is never hand-edited, and the docstring was not malformed — with the real gap tracked as this follow-up.

Verified: `generate.py --check` reports all generated files current; 356 tests pass (`tests/mlb` + `tests/codegen`); ruff clean; `uv.lock` untouched. The regenerated table now carries real per-column descriptions.

## Summary by Sourcery

Make the `mlb_fielding_oaa` returns documentation render as a structured, schema-driven column table.

Enhancements:
- Add a committed returns schema and manual column descriptions for `mlb_fielding_oaa` so its generated documentation renders a readable column table.
- Replace the inline docstring Markdown table with a renderer-compatible explanation that points to the schema-driven table.

Documentation:
- Regenerate the MLB reference documentation to show detailed `mlb_fielding_oaa` column types and descriptions.