### PR TITLE
feat(mlb): seven ncaa_baseball release loaders, with min_season set from what the assets actually contain

### DIFF
--- a/docs/docs/mlb/index.md
+++ b/docs/docs/mlb/index.md
@@ -13,7 +13,7 @@ description: "sdv-py MLB: endpoint references, dataset loaders and parsers for M
 | [ESPN FPI API (fitt v3)](reference/fitt) | 1 | `https://site.web.api.espn.com/apis/fitt/v3/sports` |
 | [MLB Stats API](reference/mlb_api) | 64 | `https://statsapi.mlb.com` |
 | [MLB Statcast (Baseball Savant)](reference/mlb_statcast) | 39 | `https://baseballsavant.mlb.com` |
-| [Dataset loaders](reference/loaders) | 13 | sportsdataverse-data releases |
+| [Dataset loaders](reference/loaders) | 20 | sportsdataverse-data releases |
 | [Additional functions](reference/additional) | 83 | hand-written wrappers, loaders & helpers |
 
 ## Examples
@@ -99,6 +99,7 @@ Each `sportsdataverse` function and its equivalent in the sister R package, [`ba
 | [`espn_mlb_venues`](reference/core#espn_mlb_venues) | [`espn_mlb_venues`](https://billpetti.github.io/baseballr/reference/espn_mlb_venues.html) |
 | [`load_ncaa_baseball_pbp`](reference/loaders#load_ncaa_baseball_pbp) | [`load_ncaa_baseball_pbp`](https://billpetti.github.io/baseballr/reference/load_ncaa_baseball_pbp.html) |
 | [`load_ncaa_baseball_schedule`](reference/loaders#load_ncaa_baseball_schedule) | [`load_ncaa_baseball_schedule`](https://billpetti.github.io/baseballr/reference/load_ncaa_baseball_schedule.html) |
+| [`load_ncaa_baseball_teams`](reference/loaders#load_ncaa_baseball_teams) | [`load_ncaa_baseball_teams`](https://billpetti.github.io/baseballr/reference/load_ncaa_baseball_teams.html) |
 | [`mlb_all_star_final_vote`](reference/mlb_api#mlb_all_star_final_vote) | [`mlb_all_star_final_vote`](https://billpetti.github.io/baseballr/reference/mlb_all_star_final_vote.html) |
 | [`mlb_all_star_write_ins`](reference/mlb_api#mlb_all_star_write_ins) | [`mlb_all_star_write_ins`](https://billpetti.github.io/baseballr/reference/mlb_all_star_write_ins.html) |
 | [`mlb_attendance`](reference/additional#mlb_attendance) | [`mlb_attendance`](https://billpetti.github.io/baseballr/reference/mlb_attendance.html) |

--- a/docs/docs/mlb/reference/loaders.md
+++ b/docs/docs/mlb/reference/loaders.md
@@ -28,6 +28,13 @@ flowchart LR
 | `load_mlb_command_plus` | [mlb_pitching_models](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mlb_pitching_models) | — |
 | `load_ncaa_baseball_pbp` | [ncaa_baseball_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_pbp) | — |
 | `load_ncaa_baseball_schedule` | [ncaa_baseball_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_schedules) | — |
+| `load_ncaa_baseball_teams` | [ncaa_baseball_teams](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_teams) | — |
+| `load_ncaa_baseball_rosters` | [ncaa_baseball_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_rosters) | — |
+| `load_ncaa_baseball_linescore` | [ncaa_baseball_linescore](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_linescore) | — |
+| `load_ncaa_baseball_team_stats` | [ncaa_baseball_team_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_team_stats) | — |
+| `load_ncaa_baseball_player_stats` | [ncaa_baseball_player_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_player_stats) | — |
+| `load_ncaa_baseball_situational_stats` | [ncaa_baseball_situational_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_situational_stats) | — |
+| `load_ncaa_baseball_games` | [ncaa_baseball_games](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_games) | — |
 
 ## `load_mlb_re24_matrix`
 
@@ -276,4 +283,53 @@ Release: [ncaa_baseball_schedules](https://github.com/sportsdataverse/sportsdata
 
 ```python
 load_ncaa_baseball_schedule(seasons=2023)
+```
+
+## `load_ncaa_baseball_teams`
+
+Release: [ncaa_baseball_teams](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_teams) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_teams/ncaa_baseball_teams_{season}.parquet`
+```python
+load_ncaa_baseball_teams(seasons=2025)
+```
+
+## `load_ncaa_baseball_rosters`
+
+Release: [ncaa_baseball_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_rosters/ncaa_baseball_rosters_{season}.parquet`
+```python
+load_ncaa_baseball_rosters(seasons=2025)
+```
+
+## `load_ncaa_baseball_linescore`
+
+Release: [ncaa_baseball_linescore](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_linescore) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_linescore/ncaa_baseball_linescore_{season}.parquet`
+```python
+load_ncaa_baseball_linescore(seasons=2025)
+```
+
+## `load_ncaa_baseball_team_stats`
+
+Release: [ncaa_baseball_team_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_team_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_team_stats/ncaa_baseball_team_stats_{season}.parquet`
+```python
+load_ncaa_baseball_team_stats(seasons=2025)
+```
+
+## `load_ncaa_baseball_player_stats`
+
+Release: [ncaa_baseball_player_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_player_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_player_stats/ncaa_baseball_player_stats_{season}.parquet`
+```python
+load_ncaa_baseball_player_stats(seasons=2025)
+```
+
+## `load_ncaa_baseball_situational_stats`
+
+Release: [ncaa_baseball_situational_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_situational_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_situational_stats/ncaa_baseball_situational_stats_{season}.parquet`
+```python
+load_ncaa_baseball_situational_stats(seasons=2025)
+```
+
+## `load_ncaa_baseball_games`
+
+Release: [ncaa_baseball_games](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_games) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_games/ncaa_baseball_games_{season}.parquet`
+```python
+load_ncaa_baseball_games(seasons=2024)
 ```

--- a/sportsdataverse/mlb/mlb_loaders.py
+++ b/sportsdataverse/mlb/mlb_loaders.py
@@ -28,6 +28,13 @@ __all__ = [
     "load_mlb_command_plus",
     "load_ncaa_baseball_pbp",
     "load_ncaa_baseball_schedule",
+    "load_ncaa_baseball_teams",
+    "load_ncaa_baseball_rosters",
+    "load_ncaa_baseball_linescore",
+    "load_ncaa_baseball_team_stats",
+    "load_ncaa_baseball_player_stats",
+    "load_ncaa_baseball_situational_stats",
+    "load_ncaa_baseball_games",
 ]
 
 
@@ -677,6 +684,288 @@ def load_ncaa_baseball_schedule(seasons, return_as_pandas: bool = False):
         frames.append(df)
     if missing:
         cli_warn("load_ncaa_baseball_schedule: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_ncaa_baseball_teams(seasons, return_as_pandas: bool = False):
+    """Load ncaa_baseball_teams (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_teams
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2024).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+    Raises:
+        SeasonNotFoundError: if a requested season is below 2024.
+
+    Example:
+        Quick start::
+
+            load_ncaa_baseball_teams(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2024:
+            raise SeasonNotFoundError("season cannot be less than 2024")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_teams/ncaa_baseball_teams_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_ncaa_baseball_teams: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_ncaa_baseball_rosters(seasons, return_as_pandas: bool = False):
+    """Load ncaa_baseball_rosters (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_rosters
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2024).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+    Raises:
+        SeasonNotFoundError: if a requested season is below 2024.
+
+    Example:
+        Quick start::
+
+            load_ncaa_baseball_rosters(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2024:
+            raise SeasonNotFoundError("season cannot be less than 2024")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_rosters/ncaa_baseball_rosters_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_ncaa_baseball_rosters: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_ncaa_baseball_linescore(seasons, return_as_pandas: bool = False):
+    """Load ncaa_baseball_linescore (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_linescore
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2024).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+    Raises:
+        SeasonNotFoundError: if a requested season is below 2024.
+
+    Example:
+        Quick start::
+
+            load_ncaa_baseball_linescore(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2024:
+            raise SeasonNotFoundError("season cannot be less than 2024")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_linescore/ncaa_baseball_linescore_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_ncaa_baseball_linescore: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_ncaa_baseball_team_stats(seasons, return_as_pandas: bool = False):
+    """Load ncaa_baseball_team_stats (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_team_stats
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2024).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+    Raises:
+        SeasonNotFoundError: if a requested season is below 2024.
+
+    Example:
+        Quick start::
+
+            load_ncaa_baseball_team_stats(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2024:
+            raise SeasonNotFoundError("season cannot be less than 2024")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_team_stats/ncaa_baseball_team_stats_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_ncaa_baseball_team_stats: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_ncaa_baseball_player_stats(seasons, return_as_pandas: bool = False):
+    """Load ncaa_baseball_player_stats (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_player_stats
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2024).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+    Raises:
+        SeasonNotFoundError: if a requested season is below 2024.
+
+    Example:
+        Quick start::
+
+            load_ncaa_baseball_player_stats(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2024:
+            raise SeasonNotFoundError("season cannot be less than 2024")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_player_stats/ncaa_baseball_player_stats_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_ncaa_baseball_player_stats: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_ncaa_baseball_situational_stats(seasons, return_as_pandas: bool = False):
+    """Load ncaa_baseball_situational_stats (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_situational_stats
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2024).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+    Raises:
+        SeasonNotFoundError: if a requested season is below 2024.
+
+    Example:
+        Quick start::
+
+            load_ncaa_baseball_situational_stats(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2024:
+            raise SeasonNotFoundError("season cannot be less than 2024")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_situational_stats/ncaa_baseball_situational_stats_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn(
+            "load_ncaa_baseball_situational_stats: no data for season(s) {missing} (skipped)".format(missing=missing)
+        )
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_ncaa_baseball_games(seasons, return_as_pandas: bool = False):
+    """Load ncaa_baseball_games (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/ncaa_baseball_games
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2017).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+    Raises:
+        SeasonNotFoundError: if a requested season is below 2017.
+
+    Example:
+        Quick start::
+
+            load_ncaa_baseball_games(seasons=2024)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2017:
+            raise SeasonNotFoundError("season cannot be less than 2017")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/ncaa_baseball_games/ncaa_baseball_games_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_ncaa_baseball_games: no data for season(s) {missing} (skipped)".format(missing=missing))
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()

--- a/sportsdataverse/parsed/mlb.py
+++ b/sportsdataverse/parsed/mlb.py
@@ -300,8 +300,15 @@ from sportsdataverse.mlb import load_mlb_stuff_plus as load_mlb_stuff_plus  # no
 from sportsdataverse.mlb import load_mlb_we_table as load_mlb_we_table  # noqa: F401
 from sportsdataverse.mlb import load_mlb_wpa as load_mlb_wpa  # noqa: F401
 from sportsdataverse.mlb import load_mlb_xera as load_mlb_xera  # noqa: F401
+from sportsdataverse.mlb import load_ncaa_baseball_games as load_ncaa_baseball_games  # noqa: F401
+from sportsdataverse.mlb import load_ncaa_baseball_linescore as load_ncaa_baseball_linescore  # noqa: F401
 from sportsdataverse.mlb import load_ncaa_baseball_pbp as load_ncaa_baseball_pbp  # noqa: F401
+from sportsdataverse.mlb import load_ncaa_baseball_player_stats as load_ncaa_baseball_player_stats  # noqa: F401
+from sportsdataverse.mlb import load_ncaa_baseball_rosters as load_ncaa_baseball_rosters  # noqa: F401
 from sportsdataverse.mlb import load_ncaa_baseball_schedule as load_ncaa_baseball_schedule  # noqa: F401
+from sportsdataverse.mlb import load_ncaa_baseball_situational_stats as load_ncaa_baseball_situational_stats  # noqa: F401
+from sportsdataverse.mlb import load_ncaa_baseball_team_stats as load_ncaa_baseball_team_stats  # noqa: F401
+from sportsdataverse.mlb import load_ncaa_baseball_teams as load_ncaa_baseball_teams  # noqa: F401
 from sportsdataverse.mlb import mae as mae  # noqa: F401
 from sportsdataverse.mlb import mlb_attendance as mlb_attendance  # noqa: F401
 from sportsdataverse.mlb import mlb_baserunning_value as mlb_baserunning_value  # noqa: F401
@@ -529,8 +536,15 @@ __all__ = [
     "load_mlb_we_table",
     "load_mlb_wpa",
     "load_mlb_xera",
+    "load_ncaa_baseball_games",
+    "load_ncaa_baseball_linescore",
     "load_ncaa_baseball_pbp",
+    "load_ncaa_baseball_player_stats",
+    "load_ncaa_baseball_rosters",
     "load_ncaa_baseball_schedule",
+    "load_ncaa_baseball_situational_stats",
+    "load_ncaa_baseball_team_stats",
+    "load_ncaa_baseball_teams",
     "mae",
     "mlb_all_star_ballot",
     "mlb_all_star_final_vote",

--- a/tools/codegen/endpoints/releases.yaml
+++ b/tools/codegen/endpoints/releases.yaml
@@ -1203,6 +1203,62 @@ loaders:
   min_season: 2012
   example_args:
     seasons: 2023
+- fn: load_ncaa_baseball_teams
+  league: mlb
+  base: sdv_releases
+  url: ncaa_baseball_teams/ncaa_baseball_teams_{season}.parquet
+  tag: ncaa_baseball_teams
+  min_season: 2024
+  example_args:
+    seasons: 2025
+- fn: load_ncaa_baseball_rosters
+  league: mlb
+  base: sdv_releases
+  url: ncaa_baseball_rosters/ncaa_baseball_rosters_{season}.parquet
+  tag: ncaa_baseball_rosters
+  min_season: 2024
+  example_args:
+    seasons: 2025
+- fn: load_ncaa_baseball_linescore
+  league: mlb
+  base: sdv_releases
+  url: ncaa_baseball_linescore/ncaa_baseball_linescore_{season}.parquet
+  tag: ncaa_baseball_linescore
+  min_season: 2024
+  example_args:
+    seasons: 2025
+- fn: load_ncaa_baseball_team_stats
+  league: mlb
+  base: sdv_releases
+  url: ncaa_baseball_team_stats/ncaa_baseball_team_stats_{season}.parquet
+  tag: ncaa_baseball_team_stats
+  min_season: 2024
+  example_args:
+    seasons: 2025
+- fn: load_ncaa_baseball_player_stats
+  league: mlb
+  base: sdv_releases
+  url: ncaa_baseball_player_stats/ncaa_baseball_player_stats_{season}.parquet
+  tag: ncaa_baseball_player_stats
+  min_season: 2024
+  example_args:
+    seasons: 2025
+- fn: load_ncaa_baseball_situational_stats
+  league: mlb
+  base: sdv_releases
+  url: ncaa_baseball_situational_stats/ncaa_baseball_situational_stats_{season}.parquet
+  tag: ncaa_baseball_situational_stats
+  min_season: 2024
+  example_args:
+    seasons: 2025
+- fn: load_ncaa_baseball_games
+  league: mlb
+  base: sdv_releases
+  url: ncaa_baseball_games/ncaa_baseball_games_{season}.parquet
+  tag: ncaa_baseball_games
+  min_season: 2017
+  example_args:
+    seasons: 2024
 - fn: load_nba_player_impact
   league: nba
   base: sdv_releases


### PR DESCRIPTION
Adds the seven missing `ncaa_baseball` release loaders, so all nine published `ncaa_baseball_*` tags are now reachable from Python. From the 2026-09-01 data & modeling stocktake, §8 item 5 (ClaudeCowork `notes/2026-09-01-data-model-stocktake/`).

New: `load_ncaa_baseball_teams`, `_rosters`, `_games`, `_linescore`, `_team_stats`, `_player_stats`, `_situational_stats`. `_pbp` and `_schedule` already existed.

## `min_season` is set from what the assets contain, not from the earliest asset

While verifying the loaders I found that four of these tags publish **schema-only** parquet before 2024 — every season byte-identical in size and 0 rows on read, with the correct column schema:

| tag | 2017–2023 asset size | 2024 | 2025 |
|---|---:|---:|---:|
| `player_stats` | 700 B each | 4.50 MB | 4.48 MB |
| `team_stats` | 1,220 B each | 2.12 MB | 2.05 MB |
| `situational_stats` | 700 B each | 4.42 MB | 4.37 MB |
| `linescore` | 1,475 B each | 298 KB | 291 KB |

This is by design upstream, not a failed backfill: `ncaa_baseball_data_build/config.py` documents *"legacy R era 2012-2023, capture era 2024+"*, and those four datasets are labelled `(capture era)` in its REGISTRY. Per-game payloads simply were not captured before 2024.

So those four loaders pin `min_season: 2024`, matching the producer's own era boundary, rather than the 2017 the assets imply. Without that a caller asking for 2019 gets a silent empty frame for a season that looks published. `games` is genuinely populated back to 2017 (39–186 KB per season) and keeps that floor.

## Verified live at the declared floors

| loader | season | rows |
|---|---|---:|
| `teams` | 2025 | 944 |
| `rosters` | 2025 | 12,052 |
| `games` | 2024 | 3,222 |
| `player_stats` | 2025 | 490,203 |
| `linescore` | 2025 | 149,868 |
| `team_stats` | 2025 | 5,589,210 |
| `situational_stats` | 2025 | 616,273 |

`generate.py --check` reports all generated files current; ruff clean; mypy ratchet and the ID/name-matching contract passed on pre-push.

## Follow-up, not in this PR

The 28 empty pre-2024 assets are a producer-side question, tracked as ledger L54: the build loops `FIRST_SEASON..LAST_SEASON` and writes + publishes an asset for seasons outside a dataset's era, so each tag advertises 10 seasons where 3 exist. The fix is to skip those seasons or state the era in the release notes — no re-run needed.

## Summary by Sourcery

Expose the remaining NCAA baseball datasets through season-aware Python loaders with accurate data availability boundaries.

New Features:
- Add seven NCAA baseball release loaders for teams, rosters, games, linescores, team statistics, player statistics, and situational statistics, making all published NCAA baseball datasets accessible through Python.

Bug Fixes:
- Set loader season floors to match seasons containing actual data, preventing requests for schema-only pre-2024 assets from silently returning empty data.

Enhancements:
- Expose the new loaders through the MLB and parsed APIs and support documented season-specific release access.

Documentation:
- Document the seven NCAA baseball loaders, their release assets, season ranges, and usage examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NCAA baseball data loaders for teams, rosters, games, linescores, team and player statistics, and situational statistics.
  * Load data across supported seasons with pandas output options and warnings for unavailable seasons.
  * Added compatibility access through the existing MLB data interface.

* **Documentation**
  * Added reference documentation, usage examples, release information, and data asset links for the new loaders.
  * Updated MLB loader counts and Python–R parity information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->