### PR TITLE
docs(mlb): the expected-stats column docs described the bugs as the contract

### DIFF
--- a/docs/docs/mlb/reference/loaders.md
+++ b/docs/docs/mlb/reference/loaders.md
@@ -98,11 +98,11 @@ Release: [mlb_hitting_models](https://github.com/sportsdataverse/sportsdataverse
 |---|---|---|
 | `batter` | Int64 | MLBAM player id of the batter. |
 | `season` | Int64 | Season year. |
-| `pa` | Int64 | Statcast rows charged to the batter for the season, counting balls in play carrying launch data plus every other pitch, so it is a pitch-row total rather than a true plate-appearance count. |
-| `ab` | Int64 | At-bats. |
+| `pa` | Int64 | Plate appearances for the batter in the season, counted as the Statcast rows that END a plate appearance (a non-empty events value). Pitches within a plate appearance are not counted. |
+| `ab` | Int64 | At-bats, derived from the same plate-appearance-ending rows by excluding walks, hit-by-pitches, sacrifice flies, sacrifice bunts and catcher's interference. |
 | `xwoba` | Float64 | Expected wOBA blending the exit-velocity by launch-angle grid's predicted contact value on balls in play with realized wOBA value on walks, hit-by-pitches and strikeouts, over the wOBA denominator; low-sample batters can exceed 1. |
-| `xba` | Float64 | Sum of grid-predicted hit probability over the batter's balls in play divided by ab, which lands far below conventional batting-average scale because ab counts pitch rows rather than at-bats. |
-| `xslg` | Float64 | Sum of grid-predicted total bases over the batter's balls in play divided by ab, which lands far below conventional slugging scale because ab counts pitch rows rather than at-bats. |
+| `xba` | Float64 | Sum of grid-predicted hit probability over the batter's balls in play, divided by at-bats, on the conventional batting-average scale. Balls in play that Statcast did not track are excluded from both the numerator and ab, rather than counted in ab with a zero numerator. |
+| `xslg` | Float64 | Sum of grid-predicted total bases over the batter's balls in play, divided by at-bats, on the conventional slugging scale, with untracked balls in play excluded from both sides as for xba. |
 
 ```python
 load_mlb_expected_stats(seasons=2024)

--- a/docs/docs/mlb/reference/loaders.md
+++ b/docs/docs/mlb/reference/loaders.md
@@ -101,8 +101,8 @@ Release: [mlb_hitting_models](https://github.com/sportsdataverse/sportsdataverse
 | `pa` | Int64 | Plate appearances for the batter in the season, counted as the Statcast rows that END a plate appearance (a non-empty events value). Pitches within a plate appearance are not counted. |
 | `ab` | Int64 | At-bats, derived from the same plate-appearance-ending rows by excluding walks, hit-by-pitches, sacrifice flies, sacrifice bunts and catcher's interference. |
 | `xwoba` | Float64 | Expected wOBA blending the exit-velocity by launch-angle grid's predicted contact value on balls in play with realized wOBA value on walks, hit-by-pitches and strikeouts, over the wOBA denominator; low-sample batters can exceed 1. |
-| `xba` | Float64 | Sum of grid-predicted hit probability over the batter's balls in play, divided by at-bats, on the conventional batting-average scale. Balls in play that Statcast did not track are excluded from both the numerator and ab, rather than counted in ab with a zero numerator. |
-| `xslg` | Float64 | Sum of grid-predicted total bases over the batter's balls in play, divided by at-bats, on the conventional slugging scale, with untracked balls in play excluded from both sides as for xba. |
+| `xba` | Float64 | Grid-predicted hit probability summed over the at-bat balls in play that carry launch data, plus the realized hit for balls in play Statcast did not track, divided by at-bats, on the conventional batting-average scale. An untracked ball in play takes its realized outcome exactly as xwoba does, rather than counting in ab with a zero numerator, which deflated league-mean xBA by the untracked share. |
+| `xslg` | Float64 | The same construction on total bases -- grid-predicted total bases where launch data exists, realized total bases for untracked balls in play -- divided by at-bats, on the conventional slugging scale. |
 
 ```python
 load_mlb_expected_stats(seasons=2024)

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -3044,12 +3044,15 @@ load_mlb_expected_hr:
   xhr_park_adj: The same expected-home-run sum after scaling each ball by its ballpark's Savant home-run park factor over
     100; published values run between 0.77 and 1.26 times xhr_neutral.
 load_mlb_expected_stats:
-  pa: Statcast rows charged to the batter for the season, counting balls in play carrying launch data plus every other pitch,
-    so it is a pitch-row total rather than a true plate-appearance count.
-  xba: Sum of grid-predicted hit probability over the batter's balls in play divided by ab, which lands far below conventional
-    batting-average scale because ab counts pitch rows rather than at-bats.
-  xslg: Sum of grid-predicted total bases over the batter's balls in play divided by ab, which lands far below conventional
-    slugging scale because ab counts pitch rows rather than at-bats.
+  pa: Plate appearances for the batter in the season, counted as the Statcast rows that END a plate appearance (a non-empty
+    events value). Pitches within a plate appearance are not counted.
+  ab: At-bats, derived from the same plate-appearance-ending rows by excluding walks, hit-by-pitches, sacrifice flies,
+    sacrifice bunts and catcher's interference.
+  xba: Sum of grid-predicted hit probability over the batter's balls in play, divided by at-bats, on the conventional
+    batting-average scale. Balls in play that Statcast did not track are excluded from both the numerator and ab, rather
+    than counted in ab with a zero numerator.
+  xslg: Sum of grid-predicted total bases over the batter's balls in play, divided by at-bats, on the conventional
+    slugging scale, with untracked balls in play excluded from both sides as for xba.
   xwoba: Expected wOBA blending the exit-velocity by launch-angle grid's predicted contact value on balls in play with realized
     wOBA value on walks, hit-by-pitches and strikeouts, over the wOBA denominator; low-sample batters can exceed 1.
 load_mlb_oaa:

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -3048,11 +3048,12 @@ load_mlb_expected_stats:
     events value). Pitches within a plate appearance are not counted.
   ab: At-bats, derived from the same plate-appearance-ending rows by excluding walks, hit-by-pitches, sacrifice flies,
     sacrifice bunts and catcher's interference.
-  xba: Sum of grid-predicted hit probability over the batter's balls in play, divided by at-bats, on the conventional
-    batting-average scale. Balls in play that Statcast did not track are excluded from both the numerator and ab, rather
-    than counted in ab with a zero numerator.
-  xslg: Sum of grid-predicted total bases over the batter's balls in play, divided by at-bats, on the conventional
-    slugging scale, with untracked balls in play excluded from both sides as for xba.
+  xba: Grid-predicted hit probability summed over the at-bat balls in play that carry launch data, plus the realized hit
+    for balls in play Statcast did not track, divided by at-bats, on the conventional batting-average scale. An untracked
+    ball in play takes its realized outcome exactly as xwoba does, rather than counting in ab with a zero numerator, which
+    deflated league-mean xBA by the untracked share.
+  xslg: The same construction on total bases -- grid-predicted total bases where launch data exists, realized total bases
+    for untracked balls in play -- divided by at-bats, on the conventional slugging scale.
   xwoba: Expected wOBA blending the exit-velocity by launch-angle grid's predicted contact value on balls in play with realized
     wOBA value on walks, hit-by-pitches and strikeouts, over the wOBA denominator; low-sample batters can exceed 1.
 load_mlb_oaa:


### PR DESCRIPTION
The published column descriptions for `load_mlb_expected_stats` documented two now-fixed defects as if they were the intended contract:

- `pa` — "Statcast rows charged to the batter for the season, counting balls in play carrying launch data plus every other pitch, **so it is a pitch-row total rather than a true plate-appearance count**."
- `xba` / `xslg` — "…**which lands far below conventional batting-average scale because ab counts pitch rows rather than at-bats**."

Both were accurate descriptions of real behaviour when they were written. #421 then made every count a plate-appearance-ender, and #424 stopped untracked balls in play entering `ab` with a zero numerator, which put `xba` back on the conventional scale (league means .2400–.2532 on the seasons verified there). The descriptions were never updated, so the docs now tell a reader the opposite of what the loader returns.

This rewrites `pa`, `xba` and `xslg` to the current contract and adds `ab`, which is in the schema but had no description at all.

Descriptions live in `manual_column_descriptions.yaml`, never in `schemas/**.yaml` — the latter is clobbered on re-capture.

`generate.py --check` reports all generated files current.

Note for after the next `mlb_hitting_models` rebuild: the published assets still carry the pre-fix values, and the observed `woba`/`ba` columns added in #424 will need a loader-schema capture plus their own descriptions once they appear on the release.

## Summary by Sourcery

Update MLB expected-stats documentation to describe the loader’s current plate-appearance and expected-statistics contract.

Enhancements:
- Update MLB expected-stats column descriptions to document plate-appearance-based counting and conventional expected batting and slugging scales.
- Document the previously undescribed `ab` column and align generated loader reference documentation with the current contract.

Documentation:
- Correct the published `load_mlb_expected_stats` documentation for `pa`, `ab`, `xba`, and `xslg` to reflect current loader behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified MLB expected-stat definitions for plate appearances and at-bats.
  * Updated expected batting average and slugging percentage descriptions to explain how untracked balls in play are handled.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->