### PR TITLE
fix(ratings): one zero-possession box row no longer takes a whole season non-finite

### DIFF
--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -8315,7 +8315,7 @@ Per-team, per-game possessions + raw offensive/defensive efficiency.
 
 **Returns**
 
-One row per (game_id, team_id): `game_id, season, date, team_id, opp_team_id, is_home, neutral_site, poss, off_eff, def_eff`. Empty input returns that schema with zero rows.
+One row per (game_id, team_id): `game_id, season, date, team_id, opp_team_id, is_home, neutral_site, poss, off_eff, def_eff`. Empty input returns that schema with zero rows. Team-game rows whose possession estimate is non-positive (an all-zero ESPN boxscore shell) are dropped with a `UserWarning` -- their efficiency is undefined, and one of them poisons the whole season's fixed point.
 
 **Example**
 

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -7422,7 +7422,7 @@ Per-team, per-game possessions + raw offensive/defensive efficiency.
 
 **Returns**
 
-One row per (game_id, team_id): `game_id, season, date, team_id, opp_team_id, is_home, neutral_site, poss, off_eff, def_eff`. Empty input returns that schema with zero rows.
+One row per (game_id, team_id): `game_id, season, date, team_id, opp_team_id, is_home, neutral_site, poss, off_eff, def_eff`. Empty input returns that schema with zero rows. Team-game rows whose possession estimate is non-positive (an all-zero ESPN boxscore shell) are dropped with a `UserWarning` -- their efficiency is undefined, and one of them poisons the whole season's fixed point.
 
 **Example**
 

--- a/sportsdataverse/_common/ratings.py
+++ b/sportsdataverse/_common/ratings.py
@@ -31,6 +31,8 @@ moved. See each per-sport module for the byte-for-byte migration.
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import polars as pl
 
@@ -52,6 +54,40 @@ _ITER_SCHEMA: dict[str, pl.PolarsDataType] = {
     "raw_def": pl.Float64,
     "games": pl.Int64,
 }
+
+
+def drop_unusable_possession_rows(paired: pl.DataFrame) -> pl.DataFrame:
+    """Drop game rows whose possession estimate is not usable (``poss <= 0`` / null).
+
+    ESPN ships the occasional boxscore shell -- a final score with every
+    shooting counter zeroed (MBB game ``310573129``, 2011-02-26; WBB game
+    ``400768032``, 2015-03-10) -- which makes ``poss`` exactly ``0`` and the
+    efficiency ``100 * pts / 0`` an infinity. One such row is enough to take a
+    whole season down: :func:`~sportsdataverse._common.ratings.iterative_opponent_adjust`
+    centres on the data's own mean, and ``mean([..., inf])`` is ``inf``, so
+    every team's fixed point (not just the two teams in that game) converges to
+    a non-finite rating. ``raw_o``/``raw_d`` are per-team sums that never touch
+    the mean, which is why they stay finite and the failure looks selective.
+
+    The row carries no information -- there is no possession estimate to be had
+    from an all-zero box -- so it is dropped from both the efficiency and the
+    tempo path, with a warning naming the games.
+    """
+    if paired.height == 0:
+        return paired
+    usable = paired.filter(pl.col("poss").is_not_null() & pl.col("poss").is_finite() & (pl.col("poss") > 0.0))
+    dropped = paired.height - usable.height
+    if dropped:
+        games = paired.join(usable.select("game_id", "team_id"), on=["game_id", "team_id"], how="anti")[
+            "game_id"
+        ].unique(maintain_order=True)
+        warnings.warn(
+            f"raw_game_efficiency: dropped {dropped} team-game row(s) with a non-positive possession "
+            f"estimate (empty boxscore) from {games.len()} game(s): {games.head(10).to_list()}",
+            UserWarning,
+            stacklevel=3,
+        )
+    return usable
 
 
 def opponent_adjusted_ridge(

--- a/sportsdataverse/_common/ratings.py
+++ b/sportsdataverse/_common/ratings.py
@@ -72,10 +72,21 @@ def drop_unusable_possession_rows(paired: pl.DataFrame) -> pl.DataFrame:
     The row carries no information -- there is no possession estimate to be had
     from an all-zero box -- so it is dropped from both the efficiency and the
     tempo path, with a warning naming the games.
+
+    A shell on ONE side only is the same defect with a quieter symptom: the
+    pairwise average stays positive, so nothing goes infinite, but both teams
+    are scored against half the real possessions. WBB 2018 has three such games
+    (``400998743``, ``400994687``, ``400998215``) which handed a team an
+    efficiency of 272 and, where both boxes were partial, 1452. So a row is
+    kept only when BOTH sides' own possession estimates are positive.
     """
     if paired.height == 0:
         return paired
-    usable = paired.filter(pl.col("poss").is_not_null() & pl.col("poss").is_finite() & (pl.col("poss") > 0.0))
+    usable_expr = pl.col("poss").is_not_null() & pl.col("poss").is_finite() & (pl.col("poss") > 0.0)
+    for side in ("team_poss", "opp_poss"):
+        if side in paired.columns:
+            usable_expr = usable_expr & pl.col(side).is_not_null() & pl.col(side).is_finite() & (pl.col(side) > 0.0)
+    usable = paired.filter(usable_expr)
     dropped = paired.height - usable.height
     if dropped:
         games = paired.join(usable.select("game_id", "team_id"), on=["game_id", "team_id"], how="anti")[

--- a/sportsdataverse/errors.py
+++ b/sportsdataverse/errors.py
@@ -174,6 +174,34 @@ class NoDataError(SportsDataverseError):
 NoESPNDataError = NoDataError
 
 
+class InsufficientInputError(SportsDataverseError):
+    """Raised when the inputs arrived intact but cannot support the computation.
+
+    Distinct from both :class:`NoDataError` (nothing came back) and
+    :class:`AssetFetchError` (the fetch failed): here the frame is present and
+    well-formed, but a term the model needs is structurally absent, so any
+    number produced from it would be wrong rather than missing. The canonical
+    case is a boxscore era whose ``turnovers`` column is uniformly ``0`` --
+    the possession estimate ``FGA - OREB + TO + 0.44 * FTA`` then omits ~23% of
+    possessions and every efficiency/tempo rating built on it is distorted by
+    each team's own (unobserved) turnover rate.
+
+    Raise it instead of emitting a plausible-looking number; a caller building
+    a published asset should record the season as unbuildable.
+
+    Example:
+        Skip a season whose inputs cannot support a rating::
+
+            from sportsdataverse.errors import InsufficientInputError
+            from sportsdataverse.wbb import wbb_team_ratings
+
+            try:
+                ratings = wbb_team_ratings(2008)
+            except InsufficientInputError as exc:
+                print(f"not buildable: {exc}")
+    """
+
+
 class EraCoverageWarning(UserWarning):
     """Warned when NFL model features are built for a season past the validated era range.
 

--- a/sportsdataverse/mbb/mbb_team_ratings.py
+++ b/sportsdataverse/mbb/mbb_team_ratings.py
@@ -22,7 +22,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import polars as pl
 
-from sportsdataverse._common.ratings import iterative_opponent_adjust
+from sportsdataverse._common.ratings import drop_unusable_possession_rows, iterative_opponent_adjust
+from sportsdataverse.errors import InsufficientInputError
 from sportsdataverse.mbb.mbb_loaders import load_mbb_schedule, load_mbb_team_boxscore
 from sportsdataverse.mbb.mbb_prediction_constants import get_constants
 
@@ -55,6 +56,36 @@ _BOX_REQUIRED = (
 _SCHED_REQUIRED = ("game_id", "season", "date", "home_team_id", "away_team_id", "neutral_site")
 
 
+def _assert_possession_inputs(team_box: pl.DataFrame) -> None:
+    """Refuse a boxscore whose ``turnovers`` are structurally absent (all zero).
+
+    A real basketball game always has turnovers, so a frame in which *no* row
+    carries a positive one is a schema gap wearing a zero -- ESPN's pre-2013
+    women's team box is exactly that (``turnovers`` is ``0`` in 100% of rows
+    for WBB 2003-2012, and populated from 2013). Zeros are not nulls, so no
+    null check sees it, and the possession estimate silently loses the whole
+    turnover term (~16 of ~71 possessions per team-game, ~23%). The damage is
+    not a constant rescale that a level band could absorb: each team's poss is
+    understated by *its own* turnover count, so the induced error is
+    correlated with turnover rate and reorders teams.
+
+    Raises:
+        InsufficientInputError: When the frame has rows and no positive turnover.
+    """
+    if team_box.height == 0 or "turnovers" not in team_box.columns:
+        return
+    tov = team_box["turnovers"].cast(pl.Float64, strict=False)
+    if tov.null_count() == tov.len():
+        return
+    if float(tov.max() or 0.0) <= 0.0:
+        raise InsufficientInputError(
+            f"team boxscore carries no turnovers (0 in all {team_box.height} rows): the possession "
+            "estimate FGA - OREB + TO + 0.44*FTA is missing its turnover term (~23% of possessions), "
+            "so efficiency and tempo would be distorted by each team's own turnover rate. This is the "
+            "ESPN pre-2013 women's box schema -- the season is not ratable from these inputs."
+        )
+
+
 def raw_game_efficiency(schedule: pl.DataFrame, team_box: pl.DataFrame) -> pl.DataFrame:
     """Per-team, per-game possessions + raw offensive/defensive efficiency.
 
@@ -78,7 +109,16 @@ def raw_game_efficiency(schedule: pl.DataFrame, team_box: pl.DataFrame) -> pl.Da
     Returns:
         One row per (game_id, team_id): ``game_id, season, date, team_id,
         opp_team_id, is_home, neutral_site, poss, off_eff, def_eff``. Empty
-        input returns that schema with zero rows.
+        input returns that schema with zero rows. Team-game rows whose
+        possession estimate is non-positive (an all-zero ESPN boxscore shell)
+        are dropped with a ``UserWarning`` -- their efficiency is undefined,
+        and one of them poisons the whole season's fixed point.
+
+    Raises:
+        InsufficientInputError: When ``team_box`` has rows but no positive
+            ``turnovers`` -- the possession estimate's turnover term is
+            structurally absent (ESPN's pre-2013 women's box), so no rating
+            built from it would be meaningful.
 
     Example:
         Quick start::
@@ -98,6 +138,7 @@ def raw_game_efficiency(schedule: pl.DataFrame, team_box: pl.DataFrame) -> pl.Da
         or any(c not in schedule.columns for c in _SCHED_REQUIRED)
     ):
         return pl.DataFrame(schema=_EFF_SCHEMA)
+    _assert_possession_inputs(team_box)
     box = team_box.select(
         pl.col("game_id").cast(pl.Utf8),
         pl.col("team_id").cast(pl.Utf8),
@@ -118,10 +159,11 @@ def raw_game_efficiency(schedule: pl.DataFrame, team_box: pl.DataFrame) -> pl.Da
         box.join(opp, on="game_id")
         .filter(pl.col("team_id") != pl.col("opp_team_id"))
         .with_columns((0.5 * (pl.col("team_poss") + pl.col("opp_poss"))).alias("poss"))
-        .with_columns(
-            (100.0 * pl.col("pts") / pl.col("poss")).alias("off_eff"),
-            (100.0 * pl.col("opp_pts") / pl.col("poss")).alias("def_eff"),
-        )
+    )
+    paired = drop_unusable_possession_rows(paired)
+    paired = paired.with_columns(
+        (100.0 * pl.col("pts") / pl.col("poss")).alias("off_eff"),
+        (100.0 * pl.col("opp_pts") / pl.col("poss")).alias("def_eff"),
     )
 
     sched = schedule.select(
@@ -363,6 +405,12 @@ def mbb_team_ratings(
         One row per (season, team_id) with columns ``season, team_id, adj_o,
         adj_d, adj_em, adj_tempo, raw_o, raw_d, games, rank, adj_em_z``. Empty
         input returns that schema with zero rows.
+
+    Raises:
+        InsufficientInputError: When a requested season's team boxscore has no
+            turnovers at all (ESPN's pre-2013 women's box schema), so its
+            possession estimate -- and every rating derived from it -- would be
+            wrong rather than merely missing.
 
     Example:
         Quick start::

--- a/sportsdataverse/nba/nba_team_ratings.py
+++ b/sportsdataverse/nba/nba_team_ratings.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Literal, Union, overload
 import numpy as np
 import polars as pl
 
-from sportsdataverse._common.ratings import iterative_opponent_adjust
+from sportsdataverse._common.ratings import drop_unusable_possession_rows, iterative_opponent_adjust
 from sportsdataverse.nba.nba_loaders import load_nba_schedule, load_nba_team_boxscore
 from sportsdataverse.nba.nba_prediction_constants import as_of_ratings_split, get_constants
 
@@ -110,10 +110,14 @@ def raw_game_efficiency(schedule: pl.DataFrame, team_box: pl.DataFrame) -> pl.Da
         box.join(opp, on="game_id")
         .filter(pl.col("team_id") != pl.col("opp_team_id"))
         .with_columns((0.5 * (pl.col("team_poss") + pl.col("opp_poss"))).alias("poss"))
-        .with_columns(
-            (100.0 * pl.col("pts") / pl.col("poss")).alias("off_rtg"),
-            (100.0 * pl.col("opp_pts") / pl.col("poss")).alias("def_rtg"),
-        )
+    )
+    # Same guard as the MBB/WBB engine: one all-zero boxscore shell gives
+    # poss == 0 -> an infinite rating -> a non-finite league mean -> a
+    # non-finite fixed point for EVERY team. Drop the unusable rows first.
+    paired = drop_unusable_possession_rows(paired)
+    paired = paired.with_columns(
+        (100.0 * pl.col("pts") / pl.col("poss")).alias("off_rtg"),
+        (100.0 * pl.col("opp_pts") / pl.col("poss")).alias("def_rtg"),
     )
 
     sched = schedule.select(

--- a/tests/mbb/test_mbb_team_ratings.py
+++ b/tests/mbb/test_mbb_team_ratings.py
@@ -399,3 +399,24 @@ def test_structurally_absent_turnovers_are_refused():
         pl.when(pl.col("team_id") == "A").then(0.0).otherwise(pl.col("turnovers")).alias("turnovers")
     )
     assert raw_game_efficiency(sched, one_zero).height == 2
+
+
+def test_one_sided_shell_is_dropped_too():
+    """A shell on ONE side keeps `poss` positive but halves it -- WBB 2018 game 400998743
+    scored a team at 272 efficiency (and 1452 where both boxes were partial)."""
+    sched, box = _season_with_shell_game()
+    # make the shell one-sided: give team B a real box in that game
+    box = box.with_columns(
+        pl.when((pl.col("game_id") == "SHELL") & (pl.col("team_id") == "B"))
+        .then(69.0)
+        .otherwise(pl.col("field_goals_attempted"))
+        .alias("field_goals_attempted"),
+        pl.when((pl.col("game_id") == "SHELL") & (pl.col("team_id") == "B"))
+        .then(7.0)
+        .otherwise(pl.col("turnovers"))
+        .alias("turnovers"),
+    )
+    with pytest.warns(UserWarning, match="non-positive possession"):
+        eff = raw_game_efficiency(sched, box)
+    assert "SHELL" not in eff["game_id"].to_list()
+    assert eff["off_eff"].max() < 200.0

--- a/tests/mbb/test_mbb_team_ratings.py
+++ b/tests/mbb/test_mbb_team_ratings.py
@@ -1,7 +1,9 @@
 import datetime
 
 import polars as pl
+import pytest
 
+from sportsdataverse.errors import InsufficientInputError
 from sportsdataverse.mbb.mbb_team_ratings import adjust_efficiency, adjust_tempo, raw_game_efficiency
 
 
@@ -298,3 +300,102 @@ def test_raw_game_efficiency_columnless_inputs_return_typed_empty():
     out = raw_game_efficiency(pl.DataFrame(), pl.DataFrame())
     assert out.height == 0
     assert dict(out.schema) == dict(mod._EFF_SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# Regression: one all-zero boxscore shell used to take a whole season non-finite
+# (published mbb_ratings_2011: 346/346 qualified teams NaN in adj_o/adj_d/adj_em
+# from ESPN game 310573129; wbb_ratings_2015: 335/335 from game 400768032).
+# ---------------------------------------------------------------------------
+
+
+def _season_with_shell_game():
+    """A 4-team round robin PLUS one game whose box is a scoreline with zero counters."""
+    teams = ["A", "B", "C", "D"]
+    sched_rows, box_rows = [], []
+    gid = 0
+    for i, home in enumerate(teams):
+        for away in teams[i + 1 :]:
+            gid += 1
+            sched_rows.append(
+                {
+                    "game_id": f"G{gid}",
+                    "season": 2011,
+                    "date": datetime.date(2011, 1, 1),
+                    "home_team_id": home,
+                    "away_team_id": away,
+                    "neutral_site": False,
+                }
+            )
+            for t, pts in ((home, 75.0), (away, 70.0)):
+                box_rows.append(
+                    {
+                        "game_id": f"G{gid}",
+                        "team_id": t,
+                        "field_goals_attempted": 60.0,
+                        "offensive_rebounds": 10.0,
+                        "turnovers": 12.0,
+                        "free_throws_attempted": 20.0,
+                        "team_score": pts,
+                    }
+                )
+    # the shell: a real final score, every counter zeroed -> poss == 0
+    sched_rows.append(
+        {
+            "game_id": "SHELL",
+            "season": 2011,
+            "date": datetime.date(2011, 2, 26),
+            "home_team_id": "A",
+            "away_team_id": "B",
+            "neutral_site": False,
+        }
+    )
+    for t, pts in (("A", 76.0), ("B", 78.0)):
+        box_rows.append(
+            {
+                "game_id": "SHELL",
+                "team_id": t,
+                "field_goals_attempted": 0.0,
+                "offensive_rebounds": 0.0,
+                "turnovers": 0.0,
+                "free_throws_attempted": 0.0,
+                "team_score": pts,
+            }
+        )
+    return pl.DataFrame(sched_rows), pl.DataFrame(box_rows)
+
+
+def test_zero_possession_row_is_dropped_and_warns():
+    sched, box = _season_with_shell_game()
+    with pytest.warns(UserWarning, match="non-positive possession"):
+        eff = raw_game_efficiency(sched, box)
+    assert "SHELL" not in eff["game_id"].to_list()
+    assert eff.height == 12  # 6 round-robin games x 2 team rows
+    for c in ("poss", "off_eff", "def_eff"):
+        assert eff[c].is_finite().all()
+
+
+def test_one_shell_game_does_not_poison_the_whole_season():
+    """The bug: `avg = off.mean()` is inf, so EVERY team's fixed point goes non-finite."""
+    sched, box = _season_with_shell_game()
+    with pytest.warns(UserWarning):
+        eff = raw_game_efficiency(sched, box)
+    ratings = adjust_efficiency(eff, league="mens")
+    tempo = adjust_tempo(eff, league="mens")
+    assert ratings.height == 4
+    for c in ("adj_o", "adj_d", "adj_em", "raw_o", "raw_d"):
+        assert ratings[c].is_finite().all(), f"{c} went non-finite"
+    assert tempo["adj_tempo"].is_finite().all()
+
+
+def test_structurally_absent_turnovers_are_refused():
+    """WBB 2003-2012: `turnovers` is 0 in 100% of team rows (a schema gap, not a value)."""
+    sched, box = _mini()
+    zeroed = box.with_columns(pl.lit(0.0).alias("turnovers"))
+    with pytest.raises(InsufficientInputError, match="no turnovers"):
+        raw_game_efficiency(sched, zeroed)
+    # a frame that merely CONTAINS a zero is fine
+    one_zero = box.with_columns(
+        pl.when(pl.col("team_id") == "A").then(0.0).otherwise(pl.col("turnovers")).alias("turnovers")
+    )
+    assert raw_game_efficiency(sched, one_zero).height == 2

--- a/tests/nba/test_nba_team_ratings.py
+++ b/tests/nba/test_nba_team_ratings.py
@@ -233,3 +233,49 @@ def test_nba_team_ratings_public_entry_point(monkeypatch: pytest.MonkeyPatch) ->
     out_pd = nba_team_ratings(2024, league_id="00", return_as_pandas=True)
     assert type(out_pd).__name__ == "DataFrame"
     assert hasattr(out_pd, "iloc")
+
+
+def test_zero_possession_shell_row_is_dropped() -> None:
+    """Twin of the MBB/WBB guard: an all-zero boxscore shell must not reach the fixed point.
+
+    `poss == 0` makes the rating infinite and the league mean the engine centres
+    on infinite with it, so one shell row would take every team non-finite (it
+    did, in published mbb_ratings_2011 / wbb_ratings_2015).
+    """
+    sched, box = _mini_schedule_box()
+    sched = pl.concat(
+        [
+            sched,
+            pl.DataFrame(
+                {
+                    "game_id": ["G2"],
+                    "season": [2024],
+                    "date": [dt.date(2024, 1, 2)],
+                    "home_team_id": ["A"],
+                    "away_team_id": ["B"],
+                    "neutral_site": [False],
+                }
+            ),
+        ]
+    )
+    box = pl.concat(
+        [
+            box,
+            pl.DataFrame(
+                {
+                    "game_id": ["G2", "G2"],
+                    "team_id": ["A", "B"],
+                    "field_goals_attempted": [0.0, 0.0],
+                    "offensive_rebounds": [0.0, 0.0],
+                    "turnovers": [0.0, 0.0],
+                    "free_throws_attempted": [0.0, 0.0],
+                    "team_score": [101.0, 99.0],
+                }
+            ),
+        ]
+    )
+    with pytest.warns(UserWarning, match="non-positive possession"):
+        eff = raw_game_efficiency(sched, box)
+    assert eff["game_id"].to_list() == ["G1", "G1"]
+    assert eff["off_rtg"].is_finite().all()
+    assert adjust_efficiency(eff)["adj_off_rtg"].is_finite().all()


### PR DESCRIPTION
Repairs the two published basketball ratings artifacts that are entirely non-finite, and refuses — rather
than fakes — the seasons whose inputs cannot support a rating. Diagnosis and every number below come from
the real released assets.

## 1. One zero-possession row took a whole season non-finite

ESPN ships the occasional boxscore *shell*: a real final score with FGA, OREB, TO and FTA all zero.
`poss = FGA - OREB + TO + 0.44*FTA` is then exactly 0 and `off_eff = 100 * pts / 0 = +inf`.

`iterative_opponent_adjust` centres on the data's own mean (`baseline=None` for MBB/WBB), and
`mean([…, inf]) == inf`, so `contrib_o = off - (adj_d[oi] - avg) - loc_o` is non-finite for **every** row —
all 604 teams of `mbb_ratings_2011` and all 335 of `wbb_ratings_2015`. `raw_o`/`raw_d` are per-team
bincount sums that never touch the mean, which is why they stayed finite and the failure looked selective.

```
mens 2011   : eff rows 11508 | poss min 0.0 | off_eff inf=2 -> game 310573129 (76-78, all counters 0)
              mean(off_eff) over ALL rows = inf        <-- `avg` in the fixed point
womens 2015 : eff rows  3186 | poss min 0.0 | off_eff inf=2 -> game 400768032 (56-57, all counters 0)
mens 2012   : bad rows 0, mean(off_eff) = 101.998      (control)
```

Such a row carries no information, so `_common.ratings.drop_unusable_possession_rows` drops it before the
rates are formed — covering the tempo path too — with a `UserWarning` naming the games. **Nothing is
imputed.** The helper is shared, and `nba/nba_team_ratings.raw_game_efficiency` (NBA + WNBA), which is
byte-identical, now calls it as well.

**A one-sided shell is the same defect with a quieter symptom** (second commit): the pairwise average stays
positive, so nothing goes infinite and no gate fires, but both teams are scored against half the real
possessions. WBB 2018 has three such games (`400998743`, `400994687`, `400998215`) whose surviving per-game
efficiencies are 272.7, 258.6 and — where the opposing box was also partial — 1176.5 and 1452.2, carrying a
team to a season `raw_o` of 137.6. A row is now kept only when **both** sides' own estimates are positive.

## 2. A season whose box has no turnovers is refused, not rescaled

Released `wbb_team_box`: `turnovers` is **0 in 100% of rows** for every season through 2012 (`null%` 0.0 — a
schema gap wearing a zero, so no null check saw it) and populated from 2013 (mean 16.13). The possession
estimate then loses ~23% of possessions — poss 54.6 vs ~70.9 per team-game.

| season | FGA | OREB | **TO** | FTA | poss | 100·PTS/poss | zero% TO |
|---|---|---|---|---|---|---|---|
| 2008 | 57.82 | 11.11 | **0.00** | 17.87 | 54.58 | 117.71 | **100.0** |
| 2012 | 58.44 | 11.48 | **0.00** | 17.78 | 54.79 | 114.84 | **100.0** |
| 2013 | 58.59 | 11.14 | 16.13 | 16.87 | 70.99 | 88.07 | 0.0 |
| 2026 | 58.84 | 11.57 | 16.41 | 16.67 | 71.02 | 92.39 | 0.0 |

Zeroing turnovers on a **real modern season** reproduces the observed pre-2013 levels (2017 mean adj_o
91.9 → 118.6, tempo 69.9 → 54.1; 2026 93.2 → 121.1, 70.8 → 54.5, against the observed 2008 of 119.4 / 54.5),
so it is a missing input, not an era. Not recoverable — every box possession estimate needs TO, the 2008
player box is 99.8% zeros, and 2010/2012 player sums reach only 11.5–11.9 vs the modern 15.8–16.4 team
level. `raw_game_efficiency` therefore raises the new `InsufficientInputError` rather than emitting a
wrong-scale rating (MBB is unaffected: turnovers present in every season).

## 3. Verification on real data

| league | season | before | after |
|---|---|---|---|
| mens | **2011** | 346/346 qualified non-finite | 0; adj_o 102.969 / adj_d 102.320 / adj_em 0.649 / tempo 66.788 / sd 14.090 |
| womens | **2015** | 78/78 non-finite | 0; 96.587 / 90.088 / 6.500 / 70.306 / 12.212 — and `wbb_box_bpm(2015)` returns 3,954 rows with **0** non-finite box BPM (published asset: 974 NaN) |
| womens | 2018 | 4 per-game efficiencies > 200 (max 1452.2), season raw_o 137.6 | 6 rows dropped from 3 games; raw_o 123.2, adj_o 93.040 → 92.768 |
| womens | 2008–2012 | 119.4–123.1 adj_o, 54.3–55.6 tempo | `InsufficientInputError` |

**Full-history sweep after the fix** (MBB 2003–2026 + WBB 2013–2026, 36 rateable season-leagues): **zero**
non-finite seasons; MBB mean adj_o 101.83–110.24 / tempo 65.08–69.61, WBB 91.85–98.79 / 69.90–71.30 — all
inside the producers' bands. Shells exist in exactly the three seasons named above.

`pytest tests/mbb tests/wbb tests/nba tests/common tests/codegen`: **2231 passed, 75 skipped, 1 xfailed**.
`generate.py --check`: all generated files current (the two regenerated `additional.md` pages are in the
first commit). ruff + the mypy ratchet clean.

## Self-review (gate-integrity + silent-no-op)

- **No NaN was filled** and **no band, floor or tolerance was widened.** Rows with no possession estimate are dropped; the only threshold that moved is a producer season floor *raised* (2008 → 2013, in the wehoop-wbb-data PR), which refuses more.
- The regression tests assert on the **output** — every team finite in a season *containing* a shell game — not that a code path ran. A test asserting only "the row was dropped" would pass the buggy code.
- The guard was verified to **fire** on real data and the drop verified to **change** the output (346→0, 78→0); the turnovers guard stopped my own counterfactual script mid-run.
- Dropped rows are announced by a warning naming the game ids: 2 rows of 11,508 (MBB 2011), 2 of 3,186 (WBB 2015), 6 of ~10,000 (WBB 2018). Seasons with no bad rows are byte-identical to before (2026 controls, both leagues).
- Still not guarded, stated rather than hidden: a *partial* box with small positive counters on both sides, and a season where turnovers were absent for only some games. Neither appears in the current data (per-season zero-rates measured), but a per-game plausibility band would be the thing that catches them.

Companion producer PRs: sportsdataverse/hoopR-mbb-data#28, sportsdataverse/wehoop-wbb-data#35.
Nothing published; the republish commands are in each of those.

## Summary by Sourcery

Prevent invalid basketball ratings by removing unusable boxscore shells and refusing seasons with structurally incomplete possession data.

Bug Fixes:
- Prevent non-finite season ratings caused by zero-possession boxscore shells by dropping unusable team-game rows with a warning.
- Reject seasons whose possession inputs contain no turnover data instead of producing distorted ratings.
- Filter one-sided incomplete boxscore shells that would otherwise create inflated efficiencies.

Enhancements:
- Share possession-validity handling across MBB, WBB, NBA, and WNBA rating calculations.
- Add an explicit error type for structurally insufficient rating inputs.

Documentation:
- Document the warning and behavior for dropped non-positive-possession rows in MBB and WBB rating references.

Tests:
- Add regression coverage for zero-possession, one-sided shell, and structurally absent turnover inputs across basketball rating engines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved rating calculations by excluding unusable box-score rows with non-positive possession estimates and issuing a warning.
  - Added clear errors when required structural input data is unavailable, rather than producing misleading results.

- **Bug Fixes**
  - Prevented zero-possession box scores from causing infinite or non-finite team ratings and season adjustments.

- **Documentation**
  - Updated men’s and women’s basketball reference documentation to describe warnings and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->