### PR TITLE
feat(mbb): RAPM can shrink toward an SPM prior and pool seasons under decay weights

### DIFF
--- a/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
+++ b/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
@@ -38,6 +38,20 @@ A null slot id (an unresolved player, or the ``TEAM`` pseudo-slot) marks the
 possession unusable and it is DROPPED -- "not a rated player" must never be
 imputed. Callers should report the usable fraction.
 
+**Two optional stabilisation hooks**, both no-ops unless used, both measured
+before they were kept (see the 2026-09-02 evaluation in the producers'
+``docs/models/rapm.qmd``):
+
+* ``solve_rapm_league(..., prior_mean=frame)`` shrinks toward a per-player
+  point ``b0`` instead of zero -- the box-score-plus-minus-prior form of
+  RAPM. It is a re-centering of the same ridge, so ``lambda`` and the whole
+  SE path are unchanged.
+* ``fit_weight`` / ``y_offset`` columns on the stints frame carry a
+  decayed-weight STACKED MULTI-SEASON design: pool several seasons'
+  stints (keyed by a cross-season person id), weight season ``s`` by
+  ``decay ** (t - s)``, and offset each season's per-100 rate by its own
+  scoring level so the pooled fit cannot credit a player for his era.
+
 **Uncertainty.** :func:`solve_rapm_league` also reports per-player standard
 errors from the ridge POSTERIOR: with the Gaussian prior
 ``beta ~ N(0, sigma^2 / lambda)`` that the penalty encodes and
@@ -275,20 +289,71 @@ def team_aggregate(stints: pl.DataFrame, players: pl.DataFrame) -> pl.DataFrame:
     )
 
 
+def _prior_vector(prior_mean: pl.DataFrame, players: "list[str]", n_players: int) -> np.ndarray:
+    """``(2P+1)`` prior-mean vector from a ``player_id``/``orapm_prior``/``drapm_prior`` frame."""
+    required = ["player_id", "orapm_prior", "drapm_prior"]
+    missing = [c for c in required if c not in prior_mean.columns]
+    if missing:
+        raise ValueError(f"solve_rapm_league: prior_mean missing columns {missing}")
+    if prior_mean.schema["player_id"] != pl.Utf8:
+        # A wrong-dtype key joins to nothing and silently degrades to the flat ridge.
+        raise TypeError(f"prior_mean.player_id must be Utf8, got {prior_mean.schema['player_id']}")
+    b0: np.ndarray = np.zeros(2 * n_players + 1, dtype=np.float64)
+    lookup = (
+        pl.DataFrame({"player_id": pl.Series(players, dtype=pl.Utf8)})
+        .join(prior_mean.unique(subset=["player_id"]), on="player_id", how="left")
+        .with_columns(pl.col("orapm_prior").fill_null(0.0), pl.col("drapm_prior").fill_null(0.0))
+    )
+    o = lookup["orapm_prior"].to_numpy().astype(np.float64)
+    d = lookup["drapm_prior"].to_numpy().astype(np.float64)
+    if not (np.isfinite(o).all() and np.isfinite(d).all()):
+        raise ValueError("solve_rapm_league: prior_mean carries a non-finite value")
+    if not np.any(o) and not np.any(d):
+        # Every prior landed on zero: either no id overlap or an all-zero frame.
+        # Both are the flat ridge wearing a prior's name -- fail loudly instead.
+        raise ValueError(
+            "solve_rapm_league: prior_mean overlaps no rated player (or is all zero) -- "
+            "refusing to run a flat ridge under a prior-mean label"
+        )
+    b0[:n_players] = o
+    b0[n_players : 2 * n_players] = d
+    return b0
+
+
 def solve_rapm_league(
     stints: pl.DataFrame,
     *,
     ridge_lambda: float = DEFAULT_RIDGE_LAMBDA,
+    prior_mean: "pl.DataFrame | None" = None,
     compute_se: bool = True,
     return_as_pandas: bool = False,
 ) -> "tuple[pl.DataFrame | pd.DataFrame, dict[str, float]]":
     """Weighted sparse joint O/D ridge over matchup stints.
 
     Args:
-        stints: Output of :func:`aggregate_stints`.
+        stints: Output of :func:`aggregate_stints`. Two OPTIONAL columns are
+            honoured when present, both no-ops when absent:
+            ``fit_weight`` (Float64) multiplies the row's possession weight —
+            the decay weight of a stacked multi-season design, where older
+            seasons enter the same fit at ``decay ** (t - s)``; and
+            ``y_offset`` (Float64) is subtracted from the row's per-100 rate
+            before centering, which is how a pooled design removes the
+            season-to-season scoring-level drift that would otherwise credit a
+            player for the era he played in. ``off_poss`` / ``def_poss`` always
+            report real possessions, never weighted ones.
         ridge_lambda: L2 penalty on the possession-weighted normal equations.
             Because rows are weighted by possessions, the same ``lambda`` is
             exactly equivalent to a per-possession ridge with that penalty.
+        prior_mean: Optional frame with ``player_id`` (Utf8), ``orapm_prior``
+            and ``drapm_prior``: the ridge then shrinks each player toward
+            THAT point instead of zero (``beta ~ N(b0, sigma^2 / lambda)``),
+            which is the box-score-plus-minus-prior form of RAPM. Solved by
+            re-centering — ``delta = beta - b0`` against the offset target
+            ``y - X b0`` — so ``lambda`` keeps its meaning and the posterior
+            covariance ``sigma^2 (X'WX + lambda I)^-1`` (hence every ``*_se``
+            column) is unchanged. Players absent from the frame keep a zero
+            prior; a frame that overlaps NO rated player raises rather than
+            silently degrading to the flat ridge.
         compute_se: Also return the posterior standard errors (module
             docstring, "Uncertainty"). Costs one dense Cholesky inverse of the
             ``(2P+1)``-square penalised Gram matrix. One such matrix is
@@ -309,7 +374,10 @@ def solve_rapm_league(
         which to publish). ``info``
         carries ``intercept`` (possession-weighted league mean pts/100),
         ``hca`` (half the home-minus-away offensive gap), ``ridge_lambda``,
-        ``n_stints``, ``n_poss``, the lsqr diagnostics and, with SEs,
+        ``n_stints``, ``n_poss``, ``prior_mean_mad`` (mean |b0| over the
+        player block — 0.0 without a prior, so a prior that silently failed to
+        attach is visible in the output rather than only in the intent), the
+        lsqr diagnostics and, with SEs,
         ``sigma2`` (weighted residual variance on the per-100 scale = ``1e4 x``
         the per-possession points variance, ~1.3e4 in D-I), ``df_eff`` (trace
         of the ridge hat matrix), ``hca_se`` and ``solve_max_abs_dev`` (max
@@ -368,9 +436,17 @@ def solve_rapm_league(
     n_players = len(players)
     n_stints = s.height
 
-    w = s["n_poss"].to_numpy().astype(np.float64)
+    n_poss = s["n_poss"].to_numpy().astype(np.float64)
+    y = 100.0 * s["pts"].to_numpy().astype(np.float64) / n_poss
+    if "y_offset" in s.columns:
+        y = y - s["y_offset"].to_numpy().astype(np.float64)
+    w = n_poss
+    if "fit_weight" in s.columns:
+        fw = s["fit_weight"].to_numpy().astype(np.float64)
+        if not np.isfinite(fw).all() or (fw < 0).any():
+            raise ValueError("solve_rapm_league: fit_weight must be finite and non-negative")
+        w = n_poss * fw
     sw = np.sqrt(w)
-    y = 100.0 * s["pts"].to_numpy().astype(np.float64) / w
     mu = float(np.average(y, weights=w))
 
     # Sparse design: offense block [0, P), defense block [P, 2P) with -1
@@ -386,18 +462,26 @@ def solve_rapm_league(
     vals = np.concatenate([sw[off_rows], -sw[dfn_rows], side * sw])
     x = coo_matrix((vals, (rows, cols)), shape=(n_stints, 2 * n_players + 1)).tocsr()
 
-    beta, istop, itn = lsqr(x, (y - mu) * sw, damp=float(np.sqrt(ridge_lambda)))[:3]
+    b0 = _prior_vector(prior_mean, players, n_players) if prior_mean is not None else None
+    # Prior-mean ridge = flat ridge on the residual-from-prior. The offset target and
+    # `delta` below are what the SE path must see: X @ beta == X @ b0 + X @ delta, so the
+    # residual (hence sigma2) is identical either way, and the posterior covariance does
+    # not depend on the prior MEAN at all.
+    yw = (y - mu) * sw
+    target = yw if b0 is None else yw - x @ b0
+    delta, istop, itn = lsqr(x, target, damp=float(np.sqrt(ridge_lambda)))[:3]
     if istop not in (0, 1, 2):
         # istop=7 is the iteration limit: lsqr hands back a PARTIAL iterate
         # with no error, which must never flow silently into the gate.
         raise RuntimeError(f"lsqr did not converge (istop={istop}, itn={itn}) -- refusing to return a partial solve")
+    beta = delta if b0 is None else delta + b0
     orapm = beta[:n_players]
     drapm = beta[n_players : 2 * n_players]
     hca = float(beta[2 * n_players])
 
     se_info: dict[str, float] = {}
     if compute_se:
-        se, se_info = _posterior_se(x, (y - mu) * sw, beta, n_players, float(ridge_lambda))
+        se, se_info = _posterior_se(x, target, delta, n_players, float(ridge_lambda))
     else:
         se = {c: np.full(n_players, np.nan) for c in _SE_COLS}  # -> null below, never NaN
 
@@ -438,7 +522,8 @@ def solve_rapm_league(
         "hca": hca,
         "ridge_lambda": float(ridge_lambda),
         "n_stints": n_stints,
-        "n_poss": int(w.sum()),
+        "n_poss": int(n_poss.sum()),
+        "prior_mean_mad": 0.0 if b0 is None else float(np.abs(b0[: 2 * n_players]).mean()),
         "lsqr_istop": int(istop),
         "lsqr_itn": int(itn),
         **se_info,

--- a/tests/mbb/test_mbb_ncaa_rapm_league.py
+++ b/tests/mbb/test_mbb_ncaa_rapm_league.py
@@ -560,3 +560,132 @@ class TestSplitHalfSeCheck:
                 resolved.with_columns(pl.lit("g-1").alias("contest_id")),
                 ridge_lambda=50.0,
             )
+
+
+class TestPriorMeanRidge:
+    """``prior_mean=`` shrinks toward b0 instead of zero (SPM-prior RAPM)."""
+
+    def _prior(self, ids, o=0.0, d=0.0):
+        return pl.DataFrame(
+            {
+                "player_id": pl.Series(list(ids), dtype=pl.Utf8),
+                "orapm_prior": [float(o)] * len(ids),
+                "drapm_prior": [float(d)] * len(ids),
+            }
+        )
+
+    def test_none_is_the_unchanged_flat_ridge(self):
+        s = _balanced_stints(ppp_starter=2.0, ppp_sub=1.0, n=50)
+        a, ia = solve_rapm_league(s, ridge_lambda=100.0, compute_se=False)
+        b, ib = solve_rapm_league(s, ridge_lambda=100.0, prior_mean=None, compute_se=False)
+        assert (a["orapm"] - b["orapm"]).abs().max() < 1e-12
+        assert ia["prior_mean_mad"] == 0.0 and ib["prior_mean_mad"] == 0.0
+
+    def test_heavy_penalty_collapses_onto_the_prior_not_zero(self):
+        s = _balanced_stints(ppp_starter=2.0, ppp_sub=1.0, n=50)
+        prior = self._prior(_H + _A + ["h6"], o=3.0, d=-1.0)
+        players, info = solve_rapm_league(s, ridge_lambda=1e9, prior_mean=prior, compute_se=False)
+        assert (players["orapm"] - 3.0).abs().max() < 1e-3
+        assert (players["drapm"] + 1.0).abs().max() < 1e-3
+        assert info["prior_mean_mad"] == pytest.approx(2.0)  # mean(|3|, |-1|)
+
+    def test_output_actually_moved_off_the_flat_fit(self):
+        # silent-no-op guard: the prior must change the ANSWER, not just the call.
+        s = _balanced_stints(ppp_starter=2.0, ppp_sub=1.0, n=50)
+        flat, _ = solve_rapm_league(s, ridge_lambda=500.0, compute_se=False)
+        pri, _ = solve_rapm_league(
+            s, ridge_lambda=500.0, prior_mean=self._prior(_H + _A + ["h6"], o=2.0), compute_se=False
+        )
+        j = flat.join(pri, on="player_id", suffix="_p")
+        assert (j["orapm_p"] - j["orapm"]).abs().max() > 0.1
+
+    def test_posterior_se_is_unchanged_by_the_prior_mean(self):
+        s = _balanced_stints(ppp_starter=2.0, ppp_sub=1.0, n=50)
+        flat, _ = solve_rapm_league(s, ridge_lambda=200.0)
+        pri, _ = solve_rapm_league(s, ridge_lambda=200.0, prior_mean=self._prior(_H + _A + ["h6"], o=1.0, d=0.5))
+        j = flat.join(pri, on="player_id", suffix="_p")
+        # sigma2 shifts a little (different residuals), but the covariance shape does not.
+        assert (j["rapm_net_se_p"] / j["rapm_net_se"]).std() < 1e-9
+
+    def test_zero_overlap_prior_raises_instead_of_flat_ridge(self):
+        s = _balanced_stints(n=20)
+        with pytest.raises(ValueError, match="overlaps no rated player"):
+            solve_rapm_league(s, ridge_lambda=100.0, prior_mean=self._prior(["nobody"], o=5.0))
+
+    def test_wrong_dtype_key_raises(self):
+        s = _balanced_stints(n=20)
+        bad = self._prior(_H, o=1.0).with_columns(pl.lit(1).alias("player_id"))
+        with pytest.raises(TypeError, match="Utf8"):
+            solve_rapm_league(s, ridge_lambda=100.0, prior_mean=bad)
+
+    def test_missing_column_raises(self):
+        s = _balanced_stints(n=20)
+        with pytest.raises(ValueError, match="missing columns"):
+            solve_rapm_league(s, ridge_lambda=100.0, prior_mean=self._prior(_H, o=1.0).drop("drapm_prior"))
+
+
+class TestStackedDesignColumns:
+    """``fit_weight`` / ``y_offset``: the multi-season stacked design's two hooks."""
+
+    def test_uniform_fit_weight_is_a_no_op(self):
+        s = _balanced_stints(ppp_starter=2.0, ppp_sub=1.0, n=50)
+        base, ib = solve_rapm_league(s, ridge_lambda=100.0, compute_se=False)
+        wt, iw = solve_rapm_league(
+            s.with_columns(pl.lit(1.0).alias("fit_weight")), ridge_lambda=100.0, compute_se=False
+        )
+        assert (base["orapm"] - wt["orapm"]).abs().max() < 1e-9
+        assert ib["n_poss"] == iw["n_poss"]  # exposure is real possessions, not weighted
+
+    def test_zero_weight_rows_drop_out_of_the_fit(self):
+        s = _balanced_stints(ppp_starter=2.0, ppp_sub=1.0, n=50)
+        half = s.with_columns(pl.when(pl.int_range(pl.len()) % 2 == 0).then(1.0).otherwise(0.0).alias("fit_weight"))
+        kept = s.filter(pl.int_range(pl.len()) % 2 == 0)
+        a, _ = solve_rapm_league(half, ridge_lambda=100.0, compute_se=False)
+        b, _ = solve_rapm_league(kept, ridge_lambda=100.0, compute_se=False)
+        j = a.join(b, on="player_id", suffix="_k")
+        assert (j["orapm"] - j["orapm_k"]).abs().max() < 1e-8
+
+    def test_off_poss_reports_real_possessions_under_a_decay_weight(self):
+        s = _balanced_stints(n=20).with_columns(pl.lit(0.25).alias("fit_weight"))
+        players, info = solve_rapm_league(s, ridge_lambda=100.0, compute_se=False)
+        assert info["n_poss"] == s["n_poss"].sum()
+        assert players["def_poss"].sum() + players["off_poss"].sum() == 10 * s["n_poss"].sum()
+
+    def test_uniform_y_offset_only_moves_the_intercept(self):
+        s = _balanced_stints(ppp_starter=2.0, ppp_sub=1.0, n=50)
+        base, ib = solve_rapm_league(s, ridge_lambda=100.0, compute_se=False)
+        off, io = solve_rapm_league(s.with_columns(pl.lit(7.0).alias("y_offset")), ridge_lambda=100.0, compute_se=False)
+        assert (base["orapm"] - off["orapm"]).abs().max() < 1e-9
+        assert io["intercept"] == pytest.approx(ib["intercept"] - 7.0)
+
+    def test_y_offset_removes_a_per_season_scoring_level(self):
+        # An older "season" pooled with a newer one, inflated by exactly 100 pts/100
+        # (pts += n_poss). Offsetting it by 100 must reproduce the pooled fit on the
+        # UN-inflated pair, exactly -- and without the offset it must not. The older
+        # season is a SUBSET of the newer one's stints on purpose: a level shift on a
+        # perfectly balanced pool is absorbed whole by the intercept, so only an
+        # unbalanced pool (the real case -- players come and go) can see the offset.
+        s = _balanced_stints(ppp_starter=2.0, ppp_sub=1.0, n=50)
+        old = s.head(s.height // 2)
+        b = old.with_columns((pl.col("pts") + pl.col("n_poss")).alias("pts"))
+        want, _ = solve_rapm_league(pl.concat([s, old], how="vertical"), ridge_lambda=100.0, compute_se=False)
+        centred, _ = solve_rapm_league(
+            pl.concat(
+                [
+                    s.with_columns(pl.lit(0.0).alias("y_offset")),
+                    b.with_columns(pl.lit(100.0).alias("y_offset")),
+                ],
+                how="vertical",
+            ),
+            ridge_lambda=100.0,
+            compute_se=False,
+        )
+        raw, _ = solve_rapm_league(pl.concat([s, b], how="vertical"), ridge_lambda=100.0, compute_se=False)
+        j = want.join(centred, on="player_id", suffix="_c").join(raw, on="player_id", suffix="_r")
+        assert (j["orapm_c"] - j["orapm"]).abs().max() < 1e-9
+        assert (j["orapm_r"] - j["orapm"]).abs().max() > 1e-3
+
+    def test_negative_fit_weight_raises(self):
+        s = _balanced_stints(n=20).with_columns(pl.lit(-1.0).alias("fit_weight"))
+        with pytest.raises(ValueError, match="fit_weight"):
+            solve_rapm_league(s, ridge_lambda=100.0, compute_se=False)


### PR DESCRIPTION
Two additive, **default-off** hooks on `solve_rapm_league`, each kept only because it beat the
flat-ridge baseline on a criterion registered *before* any model code was written. Items 09/12/13/16
(multi-year RAPM) and 27/36 (SPM-prior RAPM) of the model-writeup improvement backlog.

## What this adds

- **`prior_mean=`** — shrink each player toward a per-player point `b0` instead of toward zero (the
  box-score-plus-minus-prior form of RAPM). Implemented as a re-centring: solve
  `delta = beta - b0` against the offset target `y - X b0`, then add `b0` back. Because only the
  *mean* moves, `ridge_lambda` keeps its meaning and the posterior covariance
  `sigma^2 (X'WX + lambda I)^-1` — hence every published `*_se` column — is mathematically
  unchanged. A test asserts the SE ratio has zero spread across players.
- **`fit_weight` / `y_offset`** stint columns — a decayed-weight **stacked multi-season** design:
  pool seasons keyed by a cross-season person id, weight season `s` by `decay ** (t - s)`, and
  offset each season's per-100 rate by its own scoring level so a pooled fit cannot credit a player
  for the era he played in. `off_poss` / `def_poss` keep reporting **real** possessions.

Both are no-ops when unused; every existing caller is byte-identical.

## Why they are here: the measurement

Ten held-out seasons per league (2016-2025), hyperparameters frozen on 2014-2015, ~25% of each
season's games held out by `contest_id % 4 == 0`. Primary criterion is out-of-sample **game-margin
MAE**; the full design, all three criteria, and the leakage boundaries are in
`ClaudeCowork ledgers/2026-09-01-writeup-improvements/reports/rapm-stabilization.md`, and the
re-runnable harness ships in the two producers as `ops/experiments/rapm_stabilization.py`.

| variant | MBB MAE Δ (13,081 games) | pooled 95% CI | WBB MAE Δ (12,398 games) | pooled 95% CI | seasons better |
|---|---|---|---|---|---|
| multi-year | **−0.095** | [−0.114, −0.076] | **−0.280** | [−0.315, −0.244] | 10/10 both |
| SPM prior | **−0.061** | [−0.081, −0.042] | **−0.239** | [−0.275, −0.206] | 10/10 both |
| both | **−0.135** | [−0.162, −0.107] | **−0.442** | [−0.491, −0.389] | 10/10 both |

Next-season Spearman for returning players rises MBB 0.3115 → 0.3300 / 0.3466 / 0.3598 and
WBB 0.4497 → 0.4657 / 0.4731 / 0.4852. The Torvik team-aggregate floor (mbb 0.93 / wbb 0.89) holds
on every gated season for every variant.

**The headline negative finding**: the multi-year gain is *not* concentrated in the low-possession
tail, which is what the backlog item assumed. The absolute Spearman gain is flat across playing
time (+0.022 in the `<100`-possession bin and +0.022 in the `1500+` bin for MBB), so there is no
possession threshold above which it stops helping. The SPM prior *does* have one, at roughly 100
possessions: +0.03…+0.06 above it, and nothing (WBB: −0.005) below, because under ~100 possessions
a player's box *rates* are themselves noise.

## What this deliberately does NOT do

No producer default changes and nothing is published. Flipping the estimator republishes 52 live
assets per league and first needs a re-derived `sigma2` gate band — measured, pooled `sigma2` is
**7,733** against the single-season **13,212** and a publish-blocking band of `[11000, 15000]`,
because decay weights make it a different quantity — plus a season-`t` filter on the published
frame (a pooled fit rates 8,633 persons where the single-season fit rates 4,919). Both are recorded
in the report with the exact publish commands.

The SE-path cost flagged as the likely blocker in the 2026-09-01 design note is **not** one:
measured, the 3-season pooled design is dim 17,267 and `compute_se=True` completes in 24.4 s
(vs 6.4 s single-season). The engine's documented ~20k ceiling binds at a 4-5 season window.

## Tests

13 new tests, 49 passing in `tests/mbb/test_mbb_ncaa_rapm_league.py`; `ruff check`, `ruff format
--check` and `mypy` clean on both files; `tools/codegen/generate.py` produces no drift (this module
is not part of the generated reference surface).

## Self-review

- **silent-no-op** — `prior_mean` raises on zero overlap and on a non-Utf8 key rather than degrading
  to the flat ridge; `info["prior_mean_mad"]` puts the applied prior's magnitude in the *output*; a
  test asserts the prior moved the coefficients by >0.1, not merely that the call was made.
  `y_offset` is verified against an exact pooled reference on an **unbalanced** pool, because on a
  balanced pool a level shift is absorbed whole by the intercept and the test would pass even if
  the hook did nothing.
- **gate-integrity** — no floor was lowered anywhere. The one gate a lever would fail (`sigma2`
  under pooling) is reported as a blocker rather than adjusted. Dev and evaluation seasons are
  disjoint. Caught in my own work: the first decision-rule implementation checked *per-season* CIs,
  which is stricter than the *pooled* CI I had registered and reported all three variants as losses;
  it was fixed to the registered pooled bootstrap rather than left in place.
- **leakage-boundary** — pooling raises if any season exceeds the target; SPM coefficients use only
  seasons `t-3..t-1`; SPM features are aggregated over the fit's own games only; the next-season
  target is always the baseline fit, identical for every variant.

## Summary by Sourcery

Extend RAPM with opt-in prior-based shrinkage and decayed multi-season fitting while preserving existing default behavior.

New Features:
- Add optional prior-mean shrinkage for RAPM player ratings.
- Support decayed multi-season RAPM inputs through fit weights and season-level target offsets.

Enhancements:
- Preserve real possession exposure reporting and posterior standard-error behavior while exposing prior magnitude in solver metadata.
- Validate prior data and fit weights to prevent silent fallback or invalid weighted fits.

Documentation:
- Document the new RAPM stabilization hooks and their input requirements.

Tests:
- Add coverage for prior-mean behavior, validation, unchanged standard errors, weighted fitting, exposure reporting, offsets, and invalid weights.