### PR TITLE
feat(espn): daily as_of_date snapshots of the league-level injuries endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1017,6 +1017,18 @@ across the whole pipeline:
 - **`pyjanitor 0.32.18+` silently switched to pandas 3.x.** Keep the
   defensive `pyjanitor<0.32.18` upper bound in `pyproject.toml` until
   pandas 3 is the project floor.
+- **ESPN injuries come from the LEAGUE endpoint, never the game summary.**
+  The per-game `summary` payload has an `injuries` key that is present and
+  always `[]` — a producer stage built on it runs green forever and emits zero
+  rows (this is why the `espn_cfb_injuries` release tag sat at zero assets
+  while a correctly-wired daily stage ran). The real records come from
+  `espn_{league}_injuries()`, which takes no arguments and returns every team
+  in one request. It reports CURRENT STATE ONLY, so history exists only if it
+  is snapshotted: `sportsdataverse.espn_snapshots.espn_injuries_snapshot()`
+  stamps every row with `as_of_date` for append-only collection. Also note
+  ESPN omits `athlete.id` from that payload entirely — the athlete id is
+  recovered from the player-card link, so do not "simplify" it to a direct
+  key read.
 
 ## Documentation Maintenance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,6 +310,7 @@ files = [
     "sportsdataverse/_deprecation.py",
     "sportsdataverse/_rds.py",
     "sportsdataverse/release.py",
+    "sportsdataverse/espn_snapshots.py",
     "sportsdataverse/_common/__init__.py",
     "sportsdataverse/_common/metrics.py",
     "sportsdataverse/_common/ratings.py",

--- a/sportsdataverse/espn_snapshots.py
+++ b/sportsdataverse/espn_snapshots.py
@@ -1,0 +1,298 @@
+"""Daily snapshots of ESPN endpoints that report CURRENT STATE ONLY.
+
+ESPN's league-level ``injuries`` feed answers "who is hurt right now". It carries
+no history: yesterday's report is gone the moment ESPN updates it. History
+therefore exists only if it is **snapshotted**, so every frame this module emits
+is stamped with an ``as_of_date`` and is meant to be **appended** to the
+previously-collected rows — never to overwrite them.
+
+Why the league endpoint and not the game summary
+------------------------------------------------
+ESPN's per-game ``summary`` payload has an ``injuries`` key, and a producer stage
+built on it can never emit a row: the key is present but always ``[]``. That is
+why the ``espn_cfb_injuries`` release tag sat at zero assets while a correctly
+wired per-game stage ran daily. The **league** endpoint
+(``site.api.espn.com/apis/site/v2/sports/{sport}/{league}/injuries``) is the only
+route to real injury records — do not re-wire the per-game path.
+
+Cost: the endpoint takes **no arguments** and returns every team in one response,
+so a full multi-league snapshot is one request per league per day.
+
+Example:
+    Snapshot one league::
+
+        from sportsdataverse.espn_snapshots import espn_injuries_snapshot
+        df = espn_injuries_snapshot("nfl")
+        print(df.select("as_of_date", "team_id", "athlete_id", "status").head())
+
+    Snapshot every league that reports injuries::
+
+        df = espn_injuries_snapshot(["nfl", "nba", "nhl", "mlb", "wnba", "cfb"])
+
+    Parse a payload you already captured (offline, no network)::
+
+        from sportsdataverse.espn_snapshots import parse_injuries_snapshot
+        df = parse_injuries_snapshot(payload, league="nfl", as_of_date=date(2026, 9, 2))
+
+    See Also:
+        * `cfbfastR`_ -- the R college-football sister package
+        * `hoopR`_ -- the R men's-basketball sister package
+
+    .. _cfbfastR: https://cfbfastR.sportsdataverse.org
+    .. _hoopR: https://hoopR.sportsdataverse.org
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import time
+from datetime import date, datetime, timezone
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+
+import polars as pl
+
+__all__ = [
+    "ESPN_INJURY_LEAGUES",
+    "INJURY_SNAPSHOT_SCHEMA",
+    "espn_injuries_snapshot",
+    "parse_injuries_snapshot",
+]
+
+#: Leagues whose ESPN league-level ``injuries`` endpoint exists. Measured live on
+#: 2026-09-02: ``nfl`` 32 teams / 800 athlete rows, ``mlb`` 30 / 280, ``nba`` 27 / 76,
+#: ``nhl`` 26 / 95, ``wnba`` 13 / 40, ``cfb`` 3 / 3, ``mbb`` 0, ``wbb`` 0. The two
+#: college-basketball leagues answer 200 with an empty list out of season; they are
+#: kept in the tuple because an empty answer is a legitimate observation, and the
+#: caller — not this module — decides not to persist a zero-row day.
+ESPN_INJURY_LEAGUES: tuple[str, ...] = (
+    "nfl",
+    "nba",
+    "wnba",
+    "nhl",
+    "mlb",
+    "cfb",
+    "mbb",
+    "wbb",
+)
+
+#: The frame contract. An empty payload yields these columns with zero rows, so a
+#: caller can concat/append without null-checking the shape first.
+#:
+#: Every id is ``Utf8``. ESPN ships them as numeric strings here, but the same ids
+#: arrive as ints from other ESPN families, and a float-origin id stringifies as
+#: ``"123.0"`` — so ids are pinned to Utf8 at this boundary via :func:`_as_id`,
+#: which goes through ``int`` and never through ``float``.
+INJURY_SNAPSHOT_SCHEMA: Dict[str, Any] = {
+    "as_of_date": pl.Date,
+    "league": pl.Utf8,
+    "team_id": pl.Utf8,
+    "team_display_name": pl.Utf8,
+    "injury_id": pl.Utf8,
+    "athlete_id": pl.Utf8,
+    "athlete_display_name": pl.Utf8,
+    "athlete_short_name": pl.Utf8,
+    "athlete_position": pl.Utf8,
+    "athlete_position_name": pl.Utf8,
+    "status": pl.Utf8,
+    "injury_date": pl.Utf8,
+    "type_id": pl.Utf8,
+    "type_name": pl.Utf8,
+    "type_abbreviation": pl.Utf8,
+    "type_description": pl.Utf8,
+    "detail_type": pl.Utf8,
+    "detail_location": pl.Utf8,
+    "detail_detail": pl.Utf8,
+    "detail_side": pl.Utf8,
+    "detail_return_date": pl.Utf8,
+    "detail_fantasy_status": pl.Utf8,
+    "short_comment": pl.Utf8,
+    "long_comment": pl.Utf8,
+    "source_id": pl.Utf8,
+    "source_description": pl.Utf8,
+}
+
+#: ESPN omits ``athlete.id`` from this payload entirely (verified: 0 of 800 NFL
+#: records carry it on 2026-09-02). The athlete id survives only inside the
+#: player-card link, so it is recovered from there rather than left null — an
+#: injury row with no athlete id cannot be joined to a roster.
+_ATHLETE_ID_RE = re.compile(r"/id/(\d+)")
+
+
+def _as_id(value: Any) -> Optional[str]:
+    """Coerce an ESPN id to ``Utf8``, never via ``float``.
+
+    ``str(123.0)`` is ``"123.0"``, which silently fails every downstream join, so
+    a float id is routed through ``int`` and a non-integral one is dropped rather
+    than stringified wrong. ``bool`` is rejected because it is an ``int`` subclass.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return str(int(value)) if value.is_integer() else None
+    return None
+
+
+def _athlete_id(athlete: Mapping[str, Any]) -> Optional[str]:
+    """Athlete id from ``athlete.id`` when present, else from the player-card link."""
+    direct = _as_id(athlete.get("id"))
+    if direct:
+        return direct
+    for link in athlete.get("links") or []:
+        match = _ATHLETE_ID_RE.search(str((link or {}).get("href") or ""))
+        if match:
+            return match.group(1)
+    return None
+
+
+def _text(container: Any, key: str) -> Optional[str]:
+    """A string field from a possibly-absent nested dict."""
+    if not isinstance(container, Mapping):
+        return None
+    value = container.get(key)
+    return None if value is None else str(value)
+
+
+def parse_injuries_snapshot(
+    payload: Optional[Mapping[str, Any]],
+    *,
+    league: str,
+    as_of_date: Optional[date] = None,
+    return_as_pandas: bool = False,
+) -> Any:
+    """Flatten one league-level ``injuries`` payload to one row per athlete injury.
+
+    The raw payload is one row per TEAM with a nested per-athlete ``injuries``
+    list; this explodes it to the athlete grain and stamps every row with
+    ``as_of_date`` so appended snapshots stay distinguishable.
+
+    Args:
+        payload: Raw JSON dict from ``espn_{league}_injuries(return_parsed=False)``.
+            ``None`` or a malformed payload yields a zero-row frame.
+        league: League slug written into the ``league`` column.
+        as_of_date: Observation date; defaults to today (UTC).
+        return_as_pandas: Return a pandas DataFrame instead of polars.
+
+    Returns:
+        A frame with :data:`INJURY_SNAPSHOT_SCHEMA`'s columns — zero rows when the
+        payload reports no injuries, never a raise.
+
+    Example:
+        Parse a captured payload::
+
+            df = parse_injuries_snapshot(payload, league="nfl")
+    """
+    stamp = as_of_date or datetime.now(timezone.utc).date()
+    teams = (payload or {}).get("injuries") or []
+    rows: List[Dict[str, Any]] = []
+    for team in teams:
+        if not isinstance(team, Mapping):
+            continue
+        team_id = _as_id(team.get("id"))
+        team_name = _text(team, "displayName")
+        for record in team.get("injuries") or []:
+            if not isinstance(record, Mapping):
+                continue
+            athlete = record.get("athlete") or {}
+            athlete = athlete if isinstance(athlete, Mapping) else {}
+            position = athlete.get("position") or {}
+            position = position if isinstance(position, Mapping) else {}
+            type_ = record.get("type") or {}
+            details = record.get("details") or {}
+            details = details if isinstance(details, Mapping) else {}
+            fantasy = details.get("fantasyStatus") or {}
+            source = record.get("source") or {}
+            rows.append(
+                {
+                    "as_of_date": stamp,
+                    "league": league,
+                    "team_id": team_id,
+                    "team_display_name": team_name,
+                    "injury_id": _as_id(record.get("id")),
+                    "athlete_id": _athlete_id(athlete),
+                    "athlete_display_name": _text(athlete, "displayName"),
+                    "athlete_short_name": _text(athlete, "shortName"),
+                    "athlete_position": _text(position, "abbreviation"),
+                    "athlete_position_name": _text(position, "displayName"),
+                    "status": _text(record, "status"),
+                    "injury_date": _text(record, "date"),
+                    "type_id": _as_id((type_ or {}).get("id")),
+                    "type_name": _text(type_, "name"),
+                    "type_abbreviation": _text(type_, "abbreviation"),
+                    "type_description": _text(type_, "description"),
+                    "detail_type": _text(details, "type"),
+                    "detail_location": _text(details, "location"),
+                    "detail_detail": _text(details, "detail"),
+                    "detail_side": _text(details, "side"),
+                    "detail_return_date": _text(details, "returnDate"),
+                    "detail_fantasy_status": _text(fantasy, "description"),
+                    "short_comment": _text(record, "shortComment"),
+                    "long_comment": _text(record, "longComment"),
+                    "source_id": _as_id((source or {}).get("id")),
+                    "source_description": _text(source, "description"),
+                }
+            )
+    df = pl.DataFrame(rows, schema=INJURY_SNAPSHOT_SCHEMA)
+    return df.to_pandas() if return_as_pandas else df
+
+
+def espn_injuries_snapshot(
+    leagues: Union[str, Sequence[str]] = ESPN_INJURY_LEAGUES,
+    *,
+    as_of_date: Optional[date] = None,
+    request_delay: float = 1.5,
+    return_as_pandas: bool = False,
+) -> Any:
+    """Fetch today's injury report for one or more leagues, stamped with the date.
+
+    One request per league, issued **sequentially** with ``request_delay`` seconds
+    between them: ESPN answers aggressive polling with 403, and this endpoint is
+    cheap enough (one call per league per day) that there is nothing to gain from
+    concurrency.
+
+    A league whose payload reports nothing contributes zero rows rather than a
+    null-filled placeholder row, so an empty observation can never be counted or
+    persisted as data.
+
+    Args:
+        leagues: One league slug or a sequence of them; defaults to
+            :data:`ESPN_INJURY_LEAGUES`.
+        as_of_date: Observation date stamped on every row; defaults to today (UTC).
+        request_delay: Seconds to sleep between league requests.
+        return_as_pandas: Return a pandas DataFrame instead of polars.
+
+    Returns:
+        One frame with :data:`INJURY_SNAPSHOT_SCHEMA`'s columns, long over league.
+
+    Raises:
+        ValueError: If a league slug has no ``espn_{league}_injuries`` wrapper.
+
+    Example:
+        Today's NFL report::
+
+            df = espn_injuries_snapshot("nfl")
+
+        Every league that reports injuries::
+
+            df = espn_injuries_snapshot(["nfl", "nba", "nhl", "mlb", "wnba", "cfb"])
+    """
+    slugs = [leagues] if isinstance(leagues, str) else list(leagues)
+    stamp = as_of_date or datetime.now(timezone.utc).date()
+    frames: List[pl.DataFrame] = []
+    for index, slug in enumerate(slugs):
+        if index and request_delay > 0:
+            time.sleep(request_delay)
+        try:
+            module = importlib.import_module(f"sportsdataverse.{slug}")
+            fetch = getattr(module, f"espn_{slug}_injuries")
+        except (ImportError, AttributeError) as exc:
+            raise ValueError(
+                f"no espn_{slug}_injuries wrapper -- known leagues: {', '.join(ESPN_INJURY_LEAGUES)}"
+            ) from exc
+        frames.append(parse_injuries_snapshot(fetch(return_parsed=False), league=slug, as_of_date=stamp))
+    df = pl.concat(frames, how="vertical") if frames else pl.DataFrame(schema=INJURY_SNAPSHOT_SCHEMA)
+    return df.to_pandas() if return_as_pandas else df

--- a/sportsdataverse/espn_snapshots.py
+++ b/sportsdataverse/espn_snapshots.py
@@ -137,13 +137,34 @@ def _as_id(value: Any) -> Optional[str]:
     return None
 
 
+def _mapping(value: Any) -> Mapping[str, Any]:
+    """A nested object as a Mapping, or an empty one.
+
+    ``value or {}`` is not enough: a truthy non-dict (ESPN collapsing an object to
+    a scalar) survives it and then raises ``AttributeError`` on ``.get``.
+    """
+    return value if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> List[Any]:
+    """A nested array as a list, or an empty one.
+
+    Anything that is not a list is dropped rather than iterated. A truthy scalar
+    raises ``TypeError`` when iterated, and a truthy *iterable* non-list (a str,
+    a dict) iterates over characters or keys and silently yields nothing useful —
+    both are malformed input, and this parser's contract is to degrade to zero
+    rows on malformed input rather than raise.
+    """
+    return value if isinstance(value, list) else []
+
+
 def _athlete_id(athlete: Mapping[str, Any]) -> Optional[str]:
     """Athlete id from ``athlete.id`` when present, else from the player-card link."""
     direct = _as_id(athlete.get("id"))
     if direct:
         return direct
-    for link in athlete.get("links") or []:
-        match = _ATHLETE_ID_RE.search(str((link or {}).get("href") or ""))
+    for link in _list(athlete.get("links")):
+        match = _ATHLETE_ID_RE.search(str(_mapping(link).get("href") or ""))
         if match:
             return match.group(1)
     return None
@@ -187,25 +208,22 @@ def parse_injuries_snapshot(
             df = parse_injuries_snapshot(payload, league="nfl")
     """
     stamp = as_of_date or datetime.now(timezone.utc).date()
-    teams = (payload or {}).get("injuries") or []
+    teams = _list(_mapping(payload).get("injuries"))
     rows: List[Dict[str, Any]] = []
     for team in teams:
         if not isinstance(team, Mapping):
             continue
         team_id = _as_id(team.get("id"))
         team_name = _text(team, "displayName")
-        for record in team.get("injuries") or []:
+        for record in _list(team.get("injuries")):
             if not isinstance(record, Mapping):
                 continue
-            athlete = record.get("athlete") or {}
-            athlete = athlete if isinstance(athlete, Mapping) else {}
-            position = athlete.get("position") or {}
-            position = position if isinstance(position, Mapping) else {}
-            type_ = record.get("type") or {}
-            details = record.get("details") or {}
-            details = details if isinstance(details, Mapping) else {}
-            fantasy = details.get("fantasyStatus") or {}
-            source = record.get("source") or {}
+            athlete = _mapping(record.get("athlete"))
+            position = _mapping(athlete.get("position"))
+            type_ = _mapping(record.get("type"))
+            details = _mapping(record.get("details"))
+            fantasy = _mapping(details.get("fantasyStatus"))
+            source = _mapping(record.get("source"))
             rows.append(
                 {
                     "as_of_date": stamp,
@@ -220,7 +238,7 @@ def parse_injuries_snapshot(
                     "athlete_position_name": _text(position, "displayName"),
                     "status": _text(record, "status"),
                     "injury_date": _text(record, "date"),
-                    "type_id": _as_id((type_ or {}).get("id")),
+                    "type_id": _as_id(type_.get("id")),
                     "type_name": _text(type_, "name"),
                     "type_abbreviation": _text(type_, "abbreviation"),
                     "type_description": _text(type_, "description"),
@@ -232,7 +250,7 @@ def parse_injuries_snapshot(
                     "detail_fantasy_status": _text(fantasy, "description"),
                     "short_comment": _text(record, "shortComment"),
                     "long_comment": _text(record, "longComment"),
-                    "source_id": _as_id((source or {}).get("id")),
+                    "source_id": _as_id(source.get("id")),
                     "source_description": _text(source, "description"),
                 }
             )

--- a/tests/test_espn_snapshots.py
+++ b/tests/test_espn_snapshots.py
@@ -151,6 +151,15 @@ def test_malformed_containers_degrade_to_zero_rows(payload):
     assert dict(df.schema) == INJURY_SNAPSHOT_SCHEMA
 
 
+#: The only columns a record carrying nothing but ``id`` can populate. Every other
+#: column in the schema is derived from a nested object, so when that object is
+#: collapsed to the wrong shape its columns MUST come back null. Asserting the
+#: WHOLE row against this set, rather than a per-case list of the fields the case
+#: names, is what makes the test able to fail: it also catches a leak into a field
+#: the case did not name.
+_IDENTITY_COLUMNS = {"as_of_date", "league", "team_id", "injury_id"}
+
+
 @pytest.mark.parametrize(
     "record",
     [
@@ -171,7 +180,12 @@ def test_collapsed_nested_objects_null_their_fields_instead_of_raising(record):
         as_of_date=STAMP,
     )
     assert df.height == 1
-    assert df["injury_id"].to_list() == ["9"]
+    row = df.row(0, named=True)
+    # Identity survives...
+    assert row["injury_id"] == "9"
+    assert row["team_id"] == "1"
+    # ...and NOTHING derived from the collapsed object leaks a value.
+    assert {c for c, v in row.items() if v is not None} == _IDENTITY_COLUMNS
 
 
 def test_a_malformed_team_does_not_cost_the_valid_teams():

--- a/tests/test_espn_snapshots.py
+++ b/tests/test_espn_snapshots.py
@@ -130,6 +130,72 @@ def test_malformed_entries_are_skipped_not_raised():
     assert df["athlete_id"].to_list() == [None]
 
 
+#: Every nested container ESPN could collapse to the wrong shape. Each of these
+#: raised before the ``_list`` / ``_mapping`` guards: a truthy scalar raises
+#: ``TypeError`` when iterated and ``AttributeError`` on ``.get``, and neither
+#: ``value or []`` nor ``value or {}`` catches a truthy one. The parser's contract
+#: is to degrade to zero rows on malformed input, so all of these must parse.
+_MALFORMED = {
+    "payload_is_not_a_mapping": ["nope"],
+    "outer_injuries_is_a_scalar": {"injuries": 5},
+    "team_injuries_is_a_scalar": {"injuries": [{"id": "1", "injuries": 5}]},
+    "team_injuries_is_a_string": {"injuries": [{"id": "1", "injuries": "oops"}]},
+    "team_injuries_is_a_dict": {"injuries": [{"id": "1", "injuries": {"a": 1}}]},
+}
+
+
+@pytest.mark.parametrize("payload", _MALFORMED.values(), ids=list(_MALFORMED))
+def test_malformed_containers_degrade_to_zero_rows(payload):
+    df = parse_injuries_snapshot(payload, league="nfl", as_of_date=STAMP)
+    assert df.height == 0
+    assert dict(df.schema) == INJURY_SNAPSHOT_SCHEMA
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        {"id": "9", "type": 5},
+        {"id": "9", "source": "x"},
+        {"id": "9", "details": 1},
+        {"id": "9", "athlete": 2},
+        {"id": "9", "athlete": {"links": 7}},
+        {"id": "9", "athlete": {"links": [3]}},
+        {"id": "9", "athlete": {"position": 4}},
+    ],
+    ids="type source details athlete links link_elem position".split(),
+)
+def test_collapsed_nested_objects_null_their_fields_instead_of_raising(record):
+    df = parse_injuries_snapshot(
+        {"injuries": [{"id": "1", "injuries": [record]}]},
+        league="nfl",
+        as_of_date=STAMP,
+    )
+    assert df.height == 1
+    assert df["injury_id"].to_list() == ["9"]
+
+
+def test_a_malformed_team_does_not_cost_the_valid_teams():
+    """The whole run must not abort on one bad team -- and the good one still parses."""
+    payload = {
+        "injuries": [
+            {"id": "1", "injuries": 5},
+            {
+                "id": "2",
+                "injuries": [
+                    {
+                        "id": "9",
+                        "athlete": {"links": [{"href": "https://e.com/id/4870808/x"}]},
+                    }
+                ],
+            },
+        ]
+    }
+    df = parse_injuries_snapshot(payload, league="nfl", as_of_date=STAMP)
+    assert df.height == 1
+    assert df["team_id"].to_list() == ["2"]
+    assert df["athlete_id"].to_list() == ["4870808"]
+
+
 # ---------------------------------------------------------------------------
 # Multi-league concat + fetch plumbing
 # ---------------------------------------------------------------------------

--- a/tests/test_espn_snapshots.py
+++ b/tests/test_espn_snapshots.py
@@ -1,0 +1,201 @@
+"""Offline + live tests for :mod:`sportsdataverse.espn_snapshots`.
+
+Every offline assertion runs against a REAL captured payload from
+``tests/fixtures/espn/`` (32 NFL teams / 800 athlete records, 23 CFB teams /
+27 records) — not a hand-written fixture. The bugs this module can plausibly
+ship (a lost athlete id, a float-stringified id, an empty payload counted as a
+row) are all invisible to a synthetic capture.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+
+import polars as pl
+import pytest
+
+from sportsdataverse.espn_snapshots import (
+    ESPN_INJURY_LEAGUES,
+    INJURY_SNAPSHOT_SCHEMA,
+    _as_id,
+    espn_injuries_snapshot,
+    parse_injuries_snapshot,
+)
+from tests.conftest import load_fixture, skip_if_no_live
+
+STAMP = date(2026, 9, 2)
+_ID_COLUMNS = ("team_id", "injury_id", "athlete_id", "type_id", "source_id")
+
+
+def _snapshot(league: str) -> pl.DataFrame:
+    return parse_injuries_snapshot(load_fixture("espn", f"injuries_{league}"), league=league, as_of_date=STAMP)
+
+
+# ---------------------------------------------------------------------------
+# Shape + contract
+# ---------------------------------------------------------------------------
+
+
+def test_nfl_fixture_explodes_to_the_athlete_grain():
+    """The raw payload is one row per TEAM; the snapshot is one row per injury."""
+    raw = load_fixture("espn", "injuries_nfl")
+    expected = sum(len(t.get("injuries") or []) for t in raw["injuries"])
+    df = _snapshot("nfl")
+    assert expected == 800, "fixture drifted; re-derive the expected count"
+    assert df.height == expected
+
+
+def test_schema_matches_the_declared_contract():
+    df = _snapshot("nfl")
+    assert list(df.columns) == list(INJURY_SNAPSHOT_SCHEMA)
+    assert dict(df.schema) == INJURY_SNAPSHOT_SCHEMA
+
+
+def test_every_row_carries_the_observation_stamp_and_league():
+    df = _snapshot("cfb")
+    assert df.height == 27
+    assert df["as_of_date"].unique().to_list() == [STAMP]
+    assert df["league"].unique().to_list() == ["cfb"]
+
+
+# ---------------------------------------------------------------------------
+# Id discipline — these are join keys
+# ---------------------------------------------------------------------------
+
+
+def test_athlete_id_is_recovered_from_the_player_card_link():
+    """ESPN omits ``athlete.id`` from this payload on every record.
+
+    Verified against the capture: 0 of 800 NFL records carry ``athlete.id``.
+    Reading it directly would null the column and make the snapshot unjoinable
+    to any roster, so it is parsed out of the player-card href instead.
+    """
+    raw = load_fixture("espn", "injuries_nfl")
+    direct = sum(
+        1 for team in raw["injuries"] for rec in team.get("injuries") or [] if (rec.get("athlete") or {}).get("id")
+    )
+    assert direct == 0
+    df = _snapshot("nfl")
+    assert df["athlete_id"].null_count() == 0
+    assert df["athlete_id"].str.contains(r"^\d+$").all()
+
+
+def test_ids_are_utf8_and_never_float_stringified():
+    df = _snapshot("nfl")
+    for column in _ID_COLUMNS:
+        assert df.schema[column] == pl.Utf8, column
+        assert not df[column].drop_nulls().str.contains(r"\.").any(), column
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (123, "123"),
+        ("123", "123"),
+        (123.0, "123"),  # never "123.0"
+        (12.5, None),
+        (True, None),  # bool is an int subclass; not an id
+        (None, None),
+        ("", None),
+    ],
+)
+def test_as_id_coerces_without_going_through_float(raw, expected):
+    assert _as_id(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# Empty is an observation, not a row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("payload", [None, {}, {"injuries": []}, {"injuries": None}])
+def test_empty_payload_yields_zero_rows_with_the_full_schema(payload):
+    df = parse_injuries_snapshot(payload, league="mbb", as_of_date=STAMP)
+    assert df.height == 0
+    assert dict(df.schema) == INJURY_SNAPSHOT_SCHEMA
+
+
+def test_out_of_season_league_contributes_no_placeholder_row():
+    """``mbb`` answers 200 with an empty list in September — 0 rows, not 1 null row."""
+    df = _snapshot("mbb")
+    assert df.height == 0
+
+
+def test_malformed_entries_are_skipped_not_raised():
+    payload = {"injuries": ["junk", {"id": "1", "injuries": ["junk", {"id": "9"}]}]}
+    df = parse_injuries_snapshot(payload, league="nfl", as_of_date=STAMP)
+    assert df.height == 1
+    assert df["injury_id"].to_list() == ["9"]
+    assert df["athlete_id"].to_list() == [None]
+
+
+# ---------------------------------------------------------------------------
+# Multi-league concat + fetch plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_leagues_concat_on_one_stable_schema():
+    df = pl.concat([_snapshot("nfl"), _snapshot("cfb")], how="vertical")
+    assert df.height == 827
+    assert sorted(df["league"].unique().to_list()) == ["cfb", "nfl"]
+
+
+def test_unknown_league_raises_rather_than_returning_empty():
+    with pytest.raises(ValueError, match="no espn_notaleague_injuries"):
+        espn_injuries_snapshot("notaleague", request_delay=0)
+
+
+def test_fetch_stamps_one_date_across_leagues(monkeypatch):
+    """A run that straddles UTC midnight must not stamp two different dates."""
+    import sportsdataverse.espn_snapshots as mod
+
+    calls: list[str] = []
+
+    def fake(league: str):
+        calls.append(league)
+        return load_fixture("espn", f"injuries_{league}")
+
+    monkeypatch.setattr(
+        mod.importlib,
+        "import_module",
+        lambda name: type(
+            "M",
+            (),
+            {
+                f"espn_{name.split('.')[-1]}_injuries": staticmethod(
+                    lambda return_parsed=True, _lg=name.split(".")[-1]: fake(_lg)
+                )
+            },
+        ),
+    )
+    df = espn_injuries_snapshot(["nfl", "cfb"], as_of_date=STAMP, request_delay=0)
+    assert calls == ["nfl", "cfb"]
+    assert df["as_of_date"].unique().to_list() == [STAMP]
+    assert df.height == 827
+
+
+def test_league_roster_is_documented():
+    assert set(ESPN_INJURY_LEAGUES) >= {"nfl", "nba", "wnba", "nhl", "mlb", "cfb"}
+
+
+# ---------------------------------------------------------------------------
+# Live
+# ---------------------------------------------------------------------------
+
+
+@skip_if_no_live
+def test_live_nfl_snapshot_returns_joinable_rows():
+    df = espn_injuries_snapshot("nfl", request_delay=0)
+    assert df.height > 0
+    assert dict(df.schema) == INJURY_SNAPSHOT_SCHEMA
+    assert df["athlete_id"].null_count() == 0
+    assert df["team_id"].null_count() == 0
+    assert df["as_of_date"].n_unique() == 1
+
+
+@skip_if_no_live
+def test_live_multi_league_snapshot_is_long_over_league():
+    df = espn_injuries_snapshot(["nfl", "nhl"], request_delay=1.5)
+    assert sorted(df["league"].unique().to_list()) == ["nfl", "nhl"]
+    assert not re.search(r"\.\d", "".join(df["team_id"].drop_nulls().to_list()))


### PR DESCRIPTION
## What

`sportsdataverse.espn_snapshots` — a library-level parser + paced fetcher for ESPN endpoints that report **current state only**, starting with the league-level `injuries` feed.

- `parse_injuries_snapshot(payload, league=, as_of_date=)` — pure, offline-testable; explodes the per-team payload to one row per athlete injury.
- `espn_injuries_snapshot(leagues=..., request_delay=1.5)` — sequential paced fetch, one request per league.

## Relationship to cfbfastR-cfb-data #58 — read this first

[cfbfastR-cfb-data#58](https://github.com/sportsdataverse/cfbfastR-cfb-data/pull/58) (opened concurrently) is **the producer** for this dataset: it owns the 8-league daily append-snapshot stage, the `espn_{league}_injuries` tags, and the publish plumbing. Nothing here competes with that, and this PR must not be read as a second producer.

What this PR adds that #58 does not:

1. **A user-facing parser.** Today `espn_nfl_injuries(return_parsed=True)` returns one row per *team* with the per-athlete records collapsed into a stringified nested cell — unusable without hand-rolling the explode and the non-obvious athlete-id recovery below. This makes the athlete grain a one-liner for library users, not only for producers.
2. **The pitfall documented in the repo where the trap lives.** sdv-py is where `parse_summary_injuries` and the game-summary `injuries` key live, so this is where the next person is most likely to wire the dead per-game path. The `CLAUDE.md` bullet says it cannot ever emit rows.

**Follow-up (not this PR):** #58's private `explode` / `_athlete_id` / `SCHEMA` should collapse onto `parse_injuries_snapshot` once both land, so one implementation survives. Note the two currently disagree on id dtype by repo convention — Utf8 here (sdv-py's ESPN parsers ship ids as ESPN does), Int64 in #58 (cfb-data's published `team_id` convention). Worth settling when they merge.

## Why any of it

ESPN's injuries feed has no history: yesterday's report is gone once ESPN updates it. Every row is stamped with `as_of_date` so a consumer appends daily observations rather than overwriting — the overwrite is what would destroy the only thing worth collecting.

**The per-game route is structurally dead.** ESPN's game `summary` payload has an `injuries` key that is present and always `[]`. That is why the `espn_cfb_injuries` tag has zero assets while a correctly wired daily per-game stage has been running: no producer run can change it.

## Measured live 2026-09-02 (one request per league, no arguments)

| league | teams | athlete rows |
|---|---:|---:|
| nfl | 32 | 800 |
| mlb | 30 | 280 |
| nba | 27 | 76 |
| nhl | 26 | 95 |
| wnba | 13 | 40 |
| cfb | 3 | 3 |
| mbb / wbb | 0 | 0 (out of season) |

## Self-review

- **Ids are join keys.** ESPN omits `athlete.id` from this payload on **every** record (0 of 800 NFL rows in the committed capture) — reading it directly would null the column and make the frame unjoinable to any roster, so it is parsed out of the player-card href. Every id is pinned to `Utf8` via `_as_id`, which routes through `int` and never through `float` (`123.0` → `"123"`, `12.5` → `None`, `True` → `None`); a test asserts no id column contains a `.`.
- **Empty is never a row.** `None` / `{}` / `{"injuries": []}` all yield a zero-row frame carrying the full documented schema — never a null-filled placeholder. Malformed list entries are skipped, not raised.
- **One stamp per run.** `as_of_date` is resolved once before the fetch loop, so a run straddling UTC midnight cannot stamp two dates (tested).
- **Pacing.** Sequential, 1.5s default gap; ESPN answers aggressive polling with 403 and there is nothing to gain from concurrency on one request per league.
- **Not exported from the top-level wildcard**, mirroring `release.py` — producer/analyst support, not part of the generated league surface.

## Verification

- `pytest tests/test_espn_snapshots.py` — 22 passed, 2 skipped
- `SDV_PY_LIVE_TESTS=1 pytest tests/test_espn_snapshots.py` — **24 passed** (live NFL + NFL/NHL multi-league)
- `ruff check` clean; `mypy` — success, 401 source files (module added to the ratchet)
- `tools/codegen/generate.py --check` — all generated files current

Every offline assertion runs against the committed real captures (`tests/fixtures/espn/injuries_*.json`), not synthetic fixtures.

## Summary by Sourcery

Add reusable daily ESPN league-level injury snapshot parsing and fetching for append-only historical collection.

New Features:
- Add a parser that converts ESPN league-level injury payloads into one row per athlete injury with stable identifiers and observation dates.
- Add a sequential, paced multi-league fetcher for daily ESPN injury snapshots with Polars and optional pandas output.

Enhancements:
- Document that ESPN injury data must be collected from league endpoints because the per-game summary route produces no records.
- Define a stable, typed injury snapshot schema with graceful handling of empty and malformed payloads.

Build:
- Add the new snapshot module to the mypy source ratchet.

Documentation:
- Document the league-level injury endpoint, append-only snapshot requirement, and athlete ID recovery behavior.

Tests:
- Add offline and optional live coverage for payload flattening, schema and ID guarantees, malformed inputs, empty observations, multi-league fetching, and date stamping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ESPN injury snapshot support across one or more leagues.
  * Injury records include observation dates and athlete details, enabling historical tracking through repeated snapshots.
  * Results can be returned as either Polars or pandas data.
  * Added resilient handling for empty or malformed injury data.

* **Documentation**
  * Documented the correct ESPN injury data source and snapshot workflow.

* **Tests**
  * Added comprehensive coverage for parsing, date stamping, multiple leagues, malformed data, and athlete identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->