### PR TITLE
feat(release): let a sidecar back-fill record when the data actually moved

### DIFF
--- a/sportsdataverse/release.py
+++ b/sportsdataverse/release.py
@@ -305,20 +305,31 @@ def gh_cli_rate_limits(verbose: bool = True) -> dict[str, Any]:
     return all_rates
 
 
-def _timestamp_now() -> str:
-    """Timestamp string matching R ``format(Sys.time(), tz="America/Toronto", usetz=TRUE)``."""
+def _timestamp_now(as_of: datetime | None = None) -> str:
+    """Timestamp string matching R ``format(Sys.time(), tz="America/Toronto", usetz=TRUE)``.
+
+    ``as_of`` renders a moment other than now, in the same format and zone. A
+    naive datetime is read as UTC -- the GitHub API's asset timestamps, which
+    are the only thing this is fed, are UTC.
+    """
     try:
         from zoneinfo import ZoneInfo
 
-        now = datetime.now(ZoneInfo("America/Toronto"))
+        zone = ZoneInfo("America/Toronto")
+        if as_of is None:
+            moment = datetime.now(zone)
+        else:
+            if as_of.tzinfo is None:
+                as_of = as_of.replace(tzinfo=timezone.utc)
+            moment = as_of.astimezone(zone)
     except Exception:  # ponytail: no tzdata on this box -> local time is fine
-        now = datetime.now().astimezone()
-    return now.strftime("%Y-%m-%d %H:%M:%S %Z")
+        moment = datetime.now().astimezone() if as_of is None else as_of.astimezone()
+    return moment.strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
-def _create_timestamp_file(temp_dir: Path) -> list[Path]:
+def _create_timestamp_file(temp_dir: Path, as_of: datetime | None = None) -> list[Path]:
     """timestamp.txt + timestamp.json sidecars (upload.R L46-59)."""
-    update_time = _timestamp_now()
+    update_time = _timestamp_now(as_of)
     txt = temp_dir / "timestamp.txt"
     txt.write_text(update_time + "\n")
     js = temp_dir / "timestamp.json"
@@ -335,7 +346,11 @@ def _create_package_function(temp_dir: Path, pkg_function: str) -> list[Path]:
     return [txt, js]
 
 
-def write_release_sidecars(dest_dir: str | Path, pkg_function: str | None = None) -> list[Path]:
+def write_release_sidecars(
+    dest_dir: str | Path,
+    pkg_function: str | None = None,
+    as_of: datetime | None = None,
+) -> list[Path]:
     """Write the release metadata sidecars R attaches to every published tag.
 
     Always writes ``timestamp.txt`` + ``timestamp.json``; adds
@@ -351,6 +366,11 @@ def write_release_sidecars(dest_dir: str | Path, pkg_function: str | None = None
         pkg_function: Related package function name, e.g.
             ``"hoopR::load_nba_pbp()"``. When None the package_function pair
             is skipped.
+        as_of: The moment to record as ``last_updated``. Defaults to now, which
+            is what a live publish wants. Pass the release asset's own
+            ``updated_at`` when back-filling a tag that was published long ago
+            -- stamping such a tag with "now" would assert the data moved
+            today, which is a worse answer than the missing one it replaces.
 
     Returns:
         The written paths, timestamp pair first.
@@ -377,7 +397,7 @@ def write_release_sidecars(dest_dir: str | Path, pkg_function: str | None = None
         .. _hoopR: https://hoopR.sportsdataverse.org
     """
     dest = Path(dest_dir)
-    sidecars = _create_timestamp_file(dest)
+    sidecars = _create_timestamp_file(dest, as_of)
     if pkg_function is not None:
         sidecars += _create_package_function(dest, pkg_function)
     return sidecars
@@ -389,6 +409,7 @@ def upload_release_sidecars(
     runner: Callable[[list[str]], Any],
     pkg_function: str | None = None,
     repo: str = DEFAULT_REPO,
+    as_of: datetime | None = None,
 ) -> list[str]:
     """Write the release sidecars and push them through a caller's ``gh`` runner.
 
@@ -409,6 +430,8 @@ def upload_release_sidecars(
         pkg_function: Related package function name. When None only the
             timestamp pair is uploaded.
         repo: Target repository. Defaults to ``sportsdataverse/sportsdataverse-data``.
+        as_of: The moment to record as ``last_updated``; defaults to now. Only
+            a back-fill of an already-published tag should pass this.
 
     Returns:
         The uploaded sidecar file names, in upload order.
@@ -437,7 +460,7 @@ def upload_release_sidecars(
     uploaded: list[str] = []
     temp_dir = Path(tempfile.mkdtemp(prefix="sdv_sidecars_"))
     try:
-        for sidecar in write_release_sidecars(temp_dir, pkg_function):
+        for sidecar in write_release_sidecars(temp_dir, pkg_function, as_of):
             runner(["release", "upload", tag, str(sidecar), "--repo", repo, "--clobber"])
             uploaded.append(sidecar.name)
     finally:

--- a/tests/release/test_release_parity.py
+++ b/tests/release/test_release_parity.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import gzip
 import json
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import polars as pl
@@ -513,3 +513,62 @@ def test_upload_release_sidecars_cleans_up_its_temp_dir():
 
     assert len(paths) == 2  # timestamp pair only
     assert not any(Path(p).exists() for p in paths)
+
+
+def test_write_release_sidecars_defaults_to_now(tmp_path):
+    """A live publish stamps the current moment -- unchanged behaviour."""
+    from sportsdataverse.release import write_release_sidecars
+
+    write_release_sidecars(tmp_path)
+    stamped = json.loads((tmp_path / "timestamp.json").read_text())["last_updated"]
+
+    assert stamped.startswith(datetime.now().strftime("%Y-%m-%d")) or stamped.startswith(
+        (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+    )
+
+
+def test_write_release_sidecars_honours_as_of(tmp_path):
+    """A back-fill records when the data actually moved, not when we stamped it.
+
+    Stamping a tag whose assets last changed in 2023 with today's date would
+    assert the data moved today -- a worse answer than the missing one.
+    """
+    from sportsdataverse.release import write_release_sidecars
+
+    write_release_sidecars(tmp_path, as_of=datetime(2023, 3, 5, 13, 4, 56, tzinfo=timezone.utc))
+    stamped = json.loads((tmp_path / "timestamp.json").read_text())["last_updated"]
+
+    assert stamped.startswith("2023-03-05")
+    assert (tmp_path / "timestamp.txt").read_text().strip() == stamped
+
+
+def test_as_of_reads_a_naive_datetime_as_utc(tmp_path):
+    """GitHub's asset timestamps are UTC and parse naive; do not let them drift."""
+    from sportsdataverse.release import write_release_sidecars
+
+    write_release_sidecars(tmp_path, as_of=datetime(2023, 3, 5, 13, 4, 56))
+    naive = json.loads((tmp_path / "timestamp.json").read_text())["last_updated"]
+
+    write_release_sidecars(tmp_path, as_of=datetime(2023, 3, 5, 13, 4, 56, tzinfo=timezone.utc))
+    aware = json.loads((tmp_path / "timestamp.json").read_text())["last_updated"]
+
+    assert naive == aware
+
+
+def test_upload_release_sidecars_passes_as_of_through():
+    from sportsdataverse.release import upload_release_sidecars
+
+    seen: dict[str, str] = {}
+
+    def _runner(argv: list[str]) -> None:
+        path = Path(argv[3])
+        seen[path.name] = path.read_text()
+
+    upload_release_sidecars(
+        "ncaa_baseball_pbp",
+        runner=_runner,
+        pkg_function="sportsdataverse.baseball.load_ncaa_baseball_pbp()",
+        as_of=datetime(2023, 3, 5, 13, 4, 56, tzinfo=timezone.utc),
+    )
+
+    assert json.loads(seen["timestamp.json"])["last_updated"].startswith("2023-03-05")


### PR DESCRIPTION
## Why

Follow-up to #429. That wired the release sidecars into all 14 Python publishers, and the mechanism is working — `wehoop-wnba-data`'s scheduled run stamped all 13 of its tags on the first pass.

What it does **not** fix is the back-catalogue. Re-audited today across the 241 tags on `sportsdataverse-data`: **132 have no sidecar, 83 are stale, 26 are in sync.** Those correct themselves as each producer runs — except where nothing runs. `ncaa-mfb-football-data` has no cron at all (its build reads a sibling raw checkout, so it cannot run in CI as written), and the four `phf_*` tags belong to `fastRhockey-data`, an R archive for a league that no longer exists.

Those need a deliberate back-fill, and a back-fill has a trap: `write_release_sidecars` always stamped `now`. Writing today's date onto `ncaa_baseball_pbp`, whose assets last changed in March 2023, would assert the data moved today — the same confident-wrong-answer failure the sidecar work existed to remove, and strictly worse than the missing value it replaces.

## What

`as_of` on `write_release_sidecars` / `upload_release_sidecars`, threaded to `_timestamp_now`. Additive, defaults to `None` = now, so every live publisher is unchanged. A naive datetime is read as UTC, because the only thing that will feed it is the GitHub API's asset `updated_at`.

## Test

Four cases: the default still stamps now; `as_of` renders the given moment in both files; a naive datetime and its UTC-aware twin produce identical output (so an API timestamp cannot drift by the local offset); and `upload_release_sidecars` passes it through to the bytes that land.

`35 passed` in `tests/release/`, ruff + mypy clean, codegen regen leaves the tree clean.

## Summary by Sourcery

Allow release sidecars to record the data's actual update time when back-filling historical releases.

New Features:
- Support recording release sidecar timestamps from a specified historical moment for back-filling existing releases.

Bug Fixes:
- Prevent back-filled sidecars from falsely claiming that old release data was updated at the time of the back-fill.
- Treat naive API timestamps as UTC so historical timestamps remain consistent across environments.

Enhancements:
- Preserve the existing default behavior of stamping live releases with the current time while propagating the optional timestamp through sidecar uploads.

Tests:
- Add coverage for default timestamps, historical timestamps, UTC normalization, and upload propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional timestamp override for release sidecars, allowing existing release tags to be backfilled with a specified date and time.
  * Supports both timezone-aware and timezone-naive timestamps, with consistent timezone handling across generated files.
* **Documentation**
  * Updated public documentation to describe the timestamp override option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->