### PR TITLE
feat(mbb): pooled multi-season RAPM helpers and a weight-scale-correct sigma2

### DIFF
--- a/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
+++ b/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
@@ -51,14 +51,26 @@ before they were kept (see the 2026-09-02 evaluation in the producers'
   stints (keyed by a cross-season person id), weight season ``s`` by
   ``decay ** (t - s)``, and offset each season's per-100 rate by its own
   scoring level so the pooled fit cannot credit a player for his era.
+  :func:`stack_seasons` builds that design and REFUSES a season after the
+  target; :func:`season_slice` cuts the pooled result back to one season's
+  participants and that season's own exposure, which is what a per-season
+  published asset must carry.
 
 **Uncertainty.** :func:`solve_rapm_league` also reports per-player standard
 errors from the ridge POSTERIOR: with the Gaussian prior
 ``beta ~ N(0, sigma^2 / lambda)`` that the penalty encodes and
 possession-weighted Gaussian errors, the posterior covariance is
 ``sigma^2 (X'WX + lambda I)^-1``, where ``sigma^2`` is the weighted residual
-variance on ``n_stints - df_eff`` degrees of freedom (``df_eff`` = trace of
-the ridge hat matrix). This is the Bayesian (credible-interval) SE and is
+variance on ``sum(fit_weight) - df_eff`` degrees of freedom (``df_eff`` =
+trace of the ridge hat matrix). Without ``fit_weight`` that sum IS the stint
+count and the formula is the familiar one; with a decayed multi-season weight
+it is not, because ``w = n_poss`` is inverse-variance weighting (a stint's
+per-100 rate averages ``n_poss`` possessions) while ``w = n_poss * decay`` is
+not: each row then contributes ``decay * sigma^2`` to the weighted residual
+sum, so dividing by the ROW COUNT would deflate ``sigma^2`` -- and every
+published SE with it -- by exactly ``mean(decay)``, which is 0.583 on a
+three-season 0.5-decay pool and has nothing to do with the estimate being
+sharper. This is the Bayesian (credible-interval) SE and is
 what the ``*_se`` columns carry: an interval for the TRUE impact under the
 prior, which widens exactly where the prior is doing the work (a
 low-possession player sits at ~0 +/- the prior SD ``sigma/sqrt(lambda)``).
@@ -89,8 +101,11 @@ __all__ = [
     "STINT_SCHEMA",
     "aggregate_stints",
     "possession_deciles",
+    "season_slice",
+    "stint_exposure",
     "solve_rapm_league",
     "split_half_se_check",
+    "stack_seasons",
     "team_aggregate",
 ]
 
@@ -320,6 +335,136 @@ def _prior_vector(prior_mean: pl.DataFrame, players: "list[str]", n_players: int
     return b0
 
 
+def stint_exposure(stints: pl.DataFrame) -> pl.DataFrame:
+    """``player_id`` -> ``off_poss`` / ``def_poss`` from a stint frame's REAL possessions.
+
+    ``fit_weight`` is deliberately ignored: exposure is a count of possessions
+    PLAYED, never a count of possessions the fit chose to believe. Callers that
+    need a possession total (an SPM prior's exposure shrink, a possession bin)
+    use this so the count means the same thing everywhere.
+
+    Args:
+        stints: :func:`aggregate_stints` output (one season, or a pooled design).
+
+    Returns:
+        One row per player: ``player_id``, ``off_poss``, ``def_poss`` (Int64).
+
+    Example:
+        Season exposure::
+
+            stint_exposure(stints).sort("off_poss", descending=True).head()
+    """
+    parts = [
+        stints.select(pl.col(ids).alias("player_id"), pl.col("n_poss").alias(col)).explode(
+            "player_id", empty_as_null=False
+        )
+        for ids, col in (("off_ids", "off_poss"), ("def_ids", "def_poss"))
+    ]
+    return (
+        pl.concat(parts, how="diagonal")
+        .group_by("player_id")
+        .agg(
+            pl.col("off_poss").sum().fill_null(0).cast(pl.Int64),
+            pl.col("def_poss").sum().fill_null(0).cast(pl.Int64),
+        )
+    )
+
+
+def stack_seasons(per_season: "dict[int, pl.DataFrame]", target: int, decay: float) -> pl.DataFrame:
+    """Pool several seasons' stints into ONE decayed-weight design for ``target``.
+
+    Each season ``s`` contributes its stints with ``fit_weight = decay ** (target
+    - s)`` and ``y_offset`` equal to its own per-100 scoring level minus the
+    target season's, so a pooled fit can neither credit a player for his era's
+    pace nor weight a three-year-old possession like last night's. The stint
+    frames must be keyed by a CROSS-SEASON person id (see
+    ``mbb_ncaa_rapm_input.build_person_keys``) or the pool rates the same human
+    as several different players.
+
+    **Leakage boundary.** A season strictly after ``target`` is refused, not
+    down-weighted: the estimate published for season ``t`` must be computable
+    from what was known at the end of season ``t``.
+
+    Args:
+        per_season: ``{season: stints}``, each the output of
+            :func:`aggregate_stints`. Seasons ``> target`` raise.
+        target: The season the pooled fit is FOR.
+        decay: Per-season weight multiplier in ``(0, 1]``. ``1.0`` pools
+            unweighted; the producers use 0.5 (mbb) / 0.75 (wbb).
+
+    Returns:
+        One vertically concatenated stint frame carrying the extra
+        ``fit_weight`` / ``y_offset`` columns :func:`solve_rapm_league` reads.
+
+    Raises:
+        ValueError: a season is after ``target``, ``decay`` is outside
+            ``(0, 1]``, or ``target`` itself is absent from ``per_season``.
+
+    Example:
+        Three-season pool::
+
+            pooled = stack_seasons({2022: s22, 2023: s23, 2024: s24}, 2024, 0.5)
+            players, info = solve_rapm_league(pooled)
+    """
+    if not (0.0 < decay <= 1.0):
+        raise ValueError(f"stack_seasons: decay must be in (0, 1], got {decay}")
+    if target not in per_season:
+        raise ValueError(f"stack_seasons: target season {target} is not in per_season")
+    future = sorted(s for s in per_season if s > target)
+    if future:
+        raise ValueError(
+            f"stack_seasons: seasons {future} are after target {target} -- a season's "
+            "estimate may never be fitted on its own future"
+        )
+    level_t = _season_level(per_season[target])
+    return pl.concat(
+        [
+            st.with_columns(
+                pl.lit(float(decay ** (target - s))).alias("fit_weight"),
+                pl.lit(_season_level(st) - level_t).alias("y_offset"),
+            )
+            for s, st in sorted(per_season.items())
+        ],
+        how="vertical",
+    )
+
+
+def _season_level(stints: pl.DataFrame) -> float:
+    """Possession-weighted mean points per 100 of a stint frame."""
+    return float(100.0 * stints["pts"].sum() / stints["n_poss"].sum())
+
+
+def season_slice(players: pl.DataFrame, stints: pl.DataFrame) -> pl.DataFrame:
+    """Cut a POOLED fit's players back to ONE season's participants and exposure.
+
+    A fit pooled over seasons ``t-2 .. t`` rates everyone who played in any of
+    them, and its ``off_poss`` / ``def_poss`` are three-season sums. A per-season
+    published asset must be neither: this inner-joins the players to the
+    exposure of ``stints`` (the TARGET season alone), which in one step drops
+    everyone who did not play that season and restores the season's own
+    possession counts. Every other column -- coefficients and standard errors,
+    which are properties of the pooled fit -- is carried through untouched.
+
+    Args:
+        players: First element of a :func:`solve_rapm_league` return.
+        stints: The TARGET season's stints only (:func:`aggregate_stints`
+            output), NOT the pooled design.
+
+    Returns:
+        ``players`` restricted to the season's participants, with ``off_poss`` /
+        ``def_poss`` recomputed from ``stints``.
+
+    Example:
+        Publish one season out of a pooled fit::
+
+            pooled = stack_seasons({2023: s23, 2024: s24}, 2024, 0.5)
+            players, info = solve_rapm_league(pooled)
+            season_2024 = season_slice(players, s24)
+    """
+    out = players.drop("off_poss", "def_poss").join(stint_exposure(stints), on="player_id", how="inner")
+    return out.select([c for c in _PLAYERS_SCHEMA if c in out.columns])
+
+
 def solve_rapm_league(
     stints: pl.DataFrame,
     *,
@@ -441,6 +586,7 @@ def solve_rapm_league(
     if "y_offset" in s.columns:
         y = y - s["y_offset"].to_numpy().astype(np.float64)
     w = n_poss
+    fw = None
     if "fit_weight" in s.columns:
         fw = s["fit_weight"].to_numpy().astype(np.float64)
         if not np.isfinite(fw).all() or (fw < 0).any():
@@ -481,24 +627,11 @@ def solve_rapm_league(
 
     se_info: dict[str, float] = {}
     if compute_se:
-        se, se_info = _posterior_se(x, target, delta, n_players, float(ridge_lambda))
+        se, se_info = _posterior_se(x, target, delta, n_players, float(ridge_lambda), fit_weight=fw)
     else:
         se = {c: np.full(n_players, np.nan) for c in _SE_COLS}  # -> null below, never NaN
 
-    exposure = (
-        pl.concat(
-            [
-                off.select("pid", pl.col("n_poss").alias("off_poss")),
-                dfn.select("pid", pl.col("n_poss").alias("def_poss")),
-            ],
-            how="diagonal",
-        )
-        .group_by("pid")
-        .agg(
-            pl.col("off_poss").sum().fill_null(0).cast(pl.Int64),
-            pl.col("def_poss").sum().fill_null(0).cast(pl.Int64),
-        )
-    )
+    exposure = stint_exposure(s)
     out = (
         pl.DataFrame(
             {
@@ -509,7 +642,7 @@ def solve_rapm_league(
             }
         )
         .with_columns((pl.col("orapm") + pl.col("drapm")).alias("rapm_net"))
-        .join(exposure.rename({"pid": "player_id"}), on="player_id", how="left")
+        .join(exposure, on="player_id", how="left")
         .with_columns(
             pl.col("off_poss").fill_null(0).cast(pl.Int64),
             pl.col("def_poss").fill_null(0).cast(pl.Int64),
@@ -532,7 +665,12 @@ def solve_rapm_league(
 
 
 def _posterior_se(
-    x: Any, yw: np.ndarray, beta: np.ndarray, n_players: int, ridge_lambda: float
+    x: Any,
+    yw: np.ndarray,
+    beta: np.ndarray,
+    n_players: int,
+    ridge_lambda: float,
+    fit_weight: "np.ndarray | None" = None,
 ) -> "tuple[dict[str, np.ndarray], dict[str, float]]":
     """Posterior and sampling SEs of the ridge coefficients from ONE dense Cholesky inverse.
 
@@ -576,7 +714,19 @@ def _posterior_se(
     beta_exact = m @ (x.T @ yw)
     resid = yw - x @ beta
     df_eff = float(dim - ridge_lambda * diag.sum())
-    sigma2 = float(resid @ resid) / max(x.shape[0] - df_eff, 1.0)
+    # Residual degrees of freedom on the FIT-WEIGHT scale, not the row count.
+    # A stint's per-100 rate averages n_poss possessions, so with w = n_poss the
+    # weighting is inverse-variance and E[weighted residual^2] = sigma^2 for
+    # every row -- which is why dividing by (rows - df_eff) is right when there
+    # is no fit_weight. Under a decayed multi-season weight w = n_poss * d the
+    # weighting is no longer inverse-variance: E[weighted residual^2] = d
+    # sigma^2, so the SUM of the weights, not their count, is the denominator.
+    # Dividing by rows would deflate sigma2 by exactly mean(d) -- on a 3-season
+    # 0.5-decay pool that is 0.583, and it would shrink every published SE by
+    # 24% for a reason that has nothing to do with the estimate being sharper.
+    # Reduces to (rows - df_eff) exactly when fit_weight is absent or all ones.
+    dof = float(x.shape[0] if fit_weight is None else fit_weight.sum())
+    sigma2 = float(resid @ resid) / max(dof - df_eff, 1.0)
     p = np.arange(n_players)
     o, d = slice(0, n_players), slice(n_players, 2 * n_players)
     m2_diag = np.einsum("ij,ij->i", m, m)  # diag(M^2)
@@ -610,6 +760,7 @@ def split_half_se_check(
     resolved: pl.DataFrame,
     *,
     ridge_lambda: float = DEFAULT_RIDGE_LAMBDA,
+    refit: "Any | None" = None,
 ) -> "tuple[pl.DataFrame, dict[str, float]]":
     """Odd-vs-even-game refit: are the standard errors on the right scale?
 
@@ -631,6 +782,13 @@ def split_half_se_check(
         resolved: Output of ``resolve_possessions`` WITH its ``contest_id``
             column (integer-like).
         ridge_lambda: Passed to both half fits.
+        refit: Optional ``(half_resolved, half_index) -> (players, info)``
+            replacing the default single-season flat-ridge half fit. Pass it
+            when the PUBLISHED estimator is not that fit -- a pooled or
+            prior-shrunk producer must check the standard errors it actually
+            publishes, and it must split every pooled season by the same
+            parity, or the two halves share possessions and the coverage is
+            inflated by construction.
 
     Returns:
         ``(per_player, summary)``. ``per_player`` has one row per player
@@ -663,7 +821,10 @@ def split_half_se_check(
     fits = []
     for h in (0, 1):
         part = halves.filter(pl.col("_half") == h)
-        players, _ = solve_rapm_league(aggregate_stints(part), ridge_lambda=ridge_lambda)
+        if refit is None:
+            players, _ = solve_rapm_league(aggregate_stints(part), ridge_lambda=ridge_lambda)
+        else:
+            players, _ = refit(part, h)
         fits.append((players, part.get_column("contest_id").n_unique()))
     (pa, n_a), (pb, n_b) = fits
     assert isinstance(pa, pl.DataFrame) and isinstance(pb, pl.DataFrame)

--- a/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
+++ b/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
@@ -397,8 +397,9 @@ def stack_seasons(per_season: "dict[int, pl.DataFrame]", target: int, decay: flo
         ``fit_weight`` / ``y_offset`` columns :func:`solve_rapm_league` reads.
 
     Raises:
-        ValueError: a season is after ``target``, ``decay`` is outside
-            ``(0, 1]``, or ``target`` itself is absent from ``per_season``.
+        ValueError: a season is after ``target``, a season's stints carry no
+            possessions, ``decay`` is outside ``(0, 1]``, or ``target`` itself
+            is absent from ``per_season``.
 
     Example:
         Three-season pool::
@@ -415,6 +416,16 @@ def stack_seasons(per_season: "dict[int, pl.DataFrame]", target: int, decay: flo
         raise ValueError(
             f"stack_seasons: seasons {future} are after target {target} -- a season's "
             "estimate may never be fitted on its own future"
+        )
+    # Guard every frame here, where the season id is known: _season_level divides
+    # by the possession total, so an empty frame would otherwise surface as a bare
+    # ZeroDivisionError naming nothing. A season with nothing to contribute is the
+    # caller's to drop, not something to pool at an undefined level.
+    empty = sorted(s for s, st in per_season.items() if int(st["n_poss"].sum() or 0) == 0)
+    if empty:
+        raise ValueError(
+            f"stack_seasons: seasons {empty} have no usable possessions -- drop them "
+            "before pooling rather than stacking an empty design"
         )
     level_t = _season_level(per_season[target])
     return pl.concat(

--- a/tests/mbb/test_mbb_ncaa_rapm_league.py
+++ b/tests/mbb/test_mbb_ncaa_rapm_league.py
@@ -20,8 +20,11 @@ from sportsdataverse.mbb.mbb_ncaa_rapm_league import (
     STINT_SCHEMA,
     aggregate_stints,
     possession_deciles,
+    stint_exposure,
+    season_slice,
     solve_rapm_league,
     split_half_se_check,
+    stack_seasons,
     team_aggregate,
 )
 
@@ -689,3 +692,132 @@ class TestStackedDesignColumns:
         s = _balanced_stints(n=20).with_columns(pl.lit(-1.0).alias("fit_weight"))
         with pytest.raises(ValueError, match="fit_weight"):
             solve_rapm_league(s, ridge_lambda=100.0, compute_se=False)
+
+
+def _season_stints(extra_id=None, n=40, pts_per_poss=1.0):
+    """One season of stints; ``extra_id`` replaces h5 in half the lineups."""
+    five = _H[:4] + [extra_id] if extra_id else _H
+    rows = []
+    for _ in range(n):
+        rows.append(("Duke", "Iowa", "Duke", 0, _H, _A))
+        rows.append(("Duke", "Iowa", "Duke", 0, five, _A))
+    s = aggregate_stints(_poss(rows))
+    return s.with_columns((pl.col("n_poss") * pts_per_poss).cast(pl.Int64).alias("pts"))
+
+
+class TestStackSeasons:
+    def test_a_season_after_the_target_is_refused(self):
+        # The leakage boundary. Season t's published estimate must be computable
+        # from what was known at the end of season t -- a future season is an
+        # error, never a down-weighted contributor.
+        per = {2023: _season_stints(), 2024: _season_stints(), 2025: _season_stints()}
+        with pytest.raises(ValueError, match=r"\[2025\] are after target 2024"):
+            stack_seasons(per, 2024, 0.5)
+
+    def test_missing_target_and_bad_decay_raise(self):
+        per = {2023: _season_stints()}
+        with pytest.raises(ValueError, match="target season 2024"):
+            stack_seasons(per, 2024, 0.5)
+        with pytest.raises(ValueError, match="decay"):
+            stack_seasons({2024: _season_stints()}, 2024, 0.0)
+
+    def test_weights_decay_and_levels_are_centred_on_the_target(self):
+        older = _season_stints(pts_per_poss=2.0)  # a 200-per-100 era
+        target = _season_stints(pts_per_poss=1.0)  # a 100-per-100 era
+        pooled = stack_seasons({2022: older, 2024: target}, 2024, 0.5)
+        w = dict(zip(pooled["fit_weight"].to_list(), pooled["y_offset"].to_list()))
+        assert sorted(w) == [0.25, 1.0]  # decay ** 2 and decay ** 0
+        assert abs(w[1.0]) < 1e-9  # the target season IS the reference level
+        assert abs(w[0.25] - 100.0) < 1e-6  # the older era's level, relative
+
+    def test_single_season_undecayed_is_the_plain_fit(self):
+        # A no-op test with teeth: the hooks must not perturb a one-season pool.
+        s = _balanced_stints(ppp_starter=2.0, ppp_sub=1.0, n=50)
+        plain, _ = solve_rapm_league(s, ridge_lambda=100.0, compute_se=False)
+        pooled, _ = solve_rapm_league(stack_seasons({2024: s}, 2024, 1.0), ridge_lambda=100.0, compute_se=False)
+        j = plain.join(pooled, on="player_id", suffix="_p")
+        assert (j["orapm_p"] - j["orapm"]).abs().max() < 1e-9
+
+
+class TestSeasonSlice:
+    def test_drops_players_absent_from_the_target_season(self):
+        # h9 played only in 2022. A pooled fit rates him; the 2022-only rating
+        # must not be published as a 2024 row.
+        old = _season_stints(extra_id="h9")
+        target = _season_stints(extra_id="h8")
+        pooled = stack_seasons({2022: old, 2024: target}, 2024, 0.5)
+        players, _ = solve_rapm_league(pooled, ridge_lambda=100.0, compute_se=False)
+        assert "h9" in players["player_id"].to_list()
+        sliced = season_slice(players, target)
+        assert "h9" not in sliced["player_id"].to_list()
+        assert "h8" in sliced["player_id"].to_list()
+        assert set(sliced["player_id"]) == set(stint_exposure(target)["player_id"])
+
+    def test_exposure_is_the_target_season_only_not_the_pooled_sum(self):
+        old = _season_stints()
+        target = _season_stints()
+        pooled = stack_seasons({2022: old, 2023: old, 2024: target}, 2024, 0.5)
+        players, _ = solve_rapm_league(pooled, ridge_lambda=100.0, compute_se=False)
+        sliced = season_slice(players, target)
+        want = stint_exposure(target).sort("player_id")
+        got = sliced.select("player_id", "off_poss", "def_poss").sort("player_id")
+        assert got.equals(want.select("player_id", "off_poss", "def_poss").sort("player_id"))
+        # and the pooled frame really did carry three seasons' worth
+        pooled_poss = players.filter(pl.col("player_id") == "h1")["off_poss"].item()
+        assert pooled_poss == 3 * got.filter(pl.col("player_id") == "h1")["off_poss"].item()
+
+    def test_coefficients_and_standard_errors_pass_through_untouched(self):
+        target = _season_stints()
+        pooled = stack_seasons({2023: _season_stints(), 2024: target}, 2024, 0.5)
+        players, _ = solve_rapm_league(pooled, ridge_lambda=100.0)
+        sliced = season_slice(players, target)
+        assert list(sliced.columns) == list(players.columns)
+        j = players.join(sliced, on="player_id", suffix="_s")
+        for c in ("orapm", "drapm", "rapm_net", "rapm_net_se", "orapm_se", "drapm_se"):
+            assert (j[f"{c}_s"] - j[c]).abs().max() < 1e-12
+
+
+class TestSplitHalfRefitHook:
+    def test_refit_hook_is_used_for_both_halves(self):
+        # The SE gate must test the estimator that is actually PUBLISHED; a
+        # producer that pools or shrinks passes its own half fit here.
+        res = _noisy_resolved(n_poss=2000, n_games=12)
+        seen = []
+
+        def refit(part, h):
+            seen.append(h)
+            return solve_rapm_league(aggregate_stints(part), ridge_lambda=5000.0)
+
+        _pp, summary = split_half_se_check(res, refit=refit)
+        assert seen == [0, 1]
+        pp2, _base = split_half_se_check(res, ridge_lambda=1000.0)
+        # The hook's lambda=5000 shrinks harder than the default 1000: proof the
+        # hook's fit -- not the default one -- produced the frame.
+        j = _pp.join(pp2, on="player_id", suffix="_d")
+        assert j["rapm_net_a"].abs().max() < j["rapm_net_a_d"].abs().max()
+        assert summary["n_players"] == _base["n_players"]
+
+
+class TestSigma2UnderFitWeight:
+    def test_uniform_fit_weight_leaves_sigma2_untouched(self):
+        s = _noisy_resolved(n_poss=3000, n_games=10)
+        st = aggregate_stints(s)
+        _p, base = solve_rapm_league(st, ridge_lambda=1000.0)
+        _p2, one = solve_rapm_league(st.with_columns(pl.lit(1.0).alias("fit_weight")), ridge_lambda=1000.0)
+        assert abs(one["sigma2"] - base["sigma2"]) < 1e-9
+
+    def test_decayed_pool_of_identical_seasons_keeps_the_residual_scale(self):
+        # Two IDENTICAL seasons pooled at decay 0.5: the fit and every row's
+        # residual are unchanged, so the residual VARIANCE must be too. Dividing
+        # the weighted residual sum by the ROW COUNT instead of the weight sum
+        # would report it 25% low (mean decay = 0.75) -- a silent 13% shrink of
+        # every published standard error, bought by nothing.
+        s = _noisy_resolved(n_poss=3000, n_games=10)
+        st = aggregate_stints(s)
+        _p, base = solve_rapm_league(st, ridge_lambda=1000.0)
+        pooled = stack_seasons({2023: st, 2024: st}, 2024, 0.5)
+        _pp, pool_info = solve_rapm_league(pooled, ridge_lambda=1000.0)
+        assert abs(pool_info["sigma2"] / base["sigma2"] - 1.0) < 0.05
+        # and the row-count denominator really would have been ~0.75x
+        rows, dof = pooled.height, float(pooled["fit_weight"].sum())
+        assert abs(dof / rows - 0.75) < 1e-9

--- a/tests/mbb/test_mbb_ncaa_rapm_league.py
+++ b/tests/mbb/test_mbb_ncaa_rapm_league.py
@@ -821,3 +821,11 @@ class TestSigma2UnderFitWeight:
         # and the row-count denominator really would have been ~0.75x
         rows, dof = pooled.height, float(pooled["fit_weight"].sum())
         assert abs(dof / rows - 0.75) < 1e-9
+
+    def test_an_empty_season_frame_is_refused_by_name(self):
+        # _season_level divides by the possession total; an empty frame would
+        # otherwise be a bare ZeroDivisionError naming no season.
+        empty = _season_stints().clear()
+        per = {2023: empty, 2024: _season_stints()}
+        with pytest.raises(ValueError, match=r"seasons \[2023\] have no usable possessions"):
+            stack_seasons(per, 2024, 0.5)


### PR DESCRIPTION
Engine support for turning the measured RAPM stabilisation on in the NCAA
producers (`hoopR-dev/ncaa-mbb-hoops-data`, `wehoop-dev/ncaa-wbb-hoops-data`).
The 2026-09-02 evaluation shipped `prior_mean=` / `fit_weight` / `y_offset` as
default-off hooks; this adds the three pieces a producer needs to actually
publish from a pooled fit, plus one correctness fix the hooks exposed.

## What

* **`stack_seasons(per_season, target, decay)`** — builds the decayed-weight
  multi-season design (`fit_weight = decay ** (t - s)`, `y_offset` = the
  season's own scoring level relative to the target's) and **refuses a season
  after the target**. The leakage boundary lives in one function that every
  caller routes through, rather than in each producer.
* **`season_slice(players, stints)`** — cuts a pooled fit back to one season's
  participants and that season's own exposure, in one inner join. Without it a
  per-season published asset rates everyone in the window and reports
  window-length `off_poss` / `def_poss`.
* **`stint_exposure(stints)`** — the possession count both of those use;
  `solve_rapm_league` now calls it instead of carrying a second copy.
* **`split_half_se_check(..., refit=)`** — lets a producer whose published
  estimator is not the flat single-season fit calibrate the standard errors it
  actually publishes.

## The `sigma2` fix

`sigma2` was `RSS_w / (n_rows - df_eff)`. With `w = n_poss` that is right: a
stint's per-100 rate averages `n_poss` possessions, so the weighting is
inverse-variance and every weighted residual has expectation `sigma^2`. Under a
decayed multi-season weight `w = n_poss * d` it is not — each row contributes
`d * sigma^2` — so the row count is the wrong denominator and `sigma2`, **and
every published `*_se` with it**, deflates by exactly `mean(d)`: 0.583 on a
three-season 0.5-decay pool, a 24% shrink of every interval bought by nothing.
It is now `RSS_w / (sum(fit_weight) - df_eff)`, which is the same number as
before whenever `fit_weight` is absent or all ones — no currently published
value moves.

## Self-review

**gate-integrity.** Nothing in this PR relaxes a threshold; the producer-side
gates are unchanged and the `sigma2` change makes the gated quantity mean the
same thing under both estimators rather than widening a band to fit a new one.
Verified on real data: the flat estimator's `sigma2` over MBB 2011-2026
reproduces the committed 2026-09-01 baseline card to the decimal
(2011 12561.6, 2026 13332.3), i.e. this is a no-op where it must be.

**leakage-boundary.** `stack_seasons` raises on any season after the target
rather than down-weighting it, and a test asserts the raise. `season_slice` is
the frame-level half of the same boundary and is tested against a player who
appears only in a prior season plus an exposure equality against
`stint_exposure` of the target season alone.

**silent-no-op.** Every new behaviour asserts the OUTPUT moved, not that the
call was made: a single undecayed season through `stack_seasons` is
bit-identical to the plain fit (`< 1e-9`); a decayed pool of two IDENTICAL
seasons keeps the residual scale within 5% (the old row-count denominator
reports it 25% low, and the test pins that the weight ratio really is 0.75);
the `refit` hook is proved to have run by shrinking harder than the default
lambda and moving the estimates, not by a spy alone.

`uv run pytest tests/mbb/` — 1113 passed, 4 skipped. `ruff check` /
`ruff format` clean; `mypy sportsdataverse/mbb/mbb_ncaa_rapm_league.py` clean;
`tools/codegen/generate.py` produces no drift (this module is hand-written, not
codegen-driven).

## Summary by Sourcery

Enable pooled multi-season RAPM production with leakage-safe season helpers, estimator-specific validation, and correctly scaled uncertainty estimates.

New Features:
- Add helpers for pooling season data with decay and era-level offsets while enforcing a no-future-season leakage boundary.
- Add season-level slicing that restricts pooled player results and exposure to a target season.
- Allow split-half standard-error validation to refit the estimator used for published results.

Bug Fixes:
- Correct weighted residual variance and published standard errors for decayed multi-season fits by using total fit weight rather than row count.

Enhancements:
- Centralize possession exposure calculation for pooled and season-specific RAPM outputs.

Tests:
- Add coverage for season leakage rejection, decay and offset behavior, season-specific slicing, refit validation, and fit-weighted sigma2 invariants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for combining multiple seasons in adjusted plus-minus analyses using configurable decay weighting.
  - Added tools to limit pooled results to target-season participants and calculate target-season possession exposure.
  - Added an optional refit step for split-half standard-error validation.

- **Bug Fixes**
  - Corrected standard-error calculations for weighted, multi-season analyses so uncertainty estimates reflect fit weights accurately.
  - Prevented future seasons and seasons without usable possessions from being included in target-season analyses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->