### PR TITLE
fix(cfb): Fox empty frames carry their schema, so upstream-empty stops looking like a broken parser

### DIFF
--- a/sportsdataverse/cfb/cfb_fox_ext.py
+++ b/sportsdataverse/cfb/cfb_fox_ext.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Union, overload
 
 import polars as pl
 
@@ -88,11 +88,119 @@ def _uri_id(uri: Optional[str]) -> Optional[str]:
     return m.group(1) if m else None
 
 
-def _frame(rows: List[Dict[str, Any]], return_as_pandas: bool) -> Union[pl.DataFrame, "pd.DataFrame"]:
+# Stable column sets -- what each parser always emits, so an empty response still
+# carries a usable schema. Captured from live responses 2026-09-02, not guessed.
+# Fox serialises every value as a string, hence Utf8 throughout.
+_TEAMS_COLUMNS: Sequence[str] = (
+    "fox_team_id",
+    "abbreviation",
+    "name",
+    "slug",
+    "color",
+    "logo_url",
+)
+_SCHEDULE_COLUMNS: Sequence[str] = (
+    "game_id",
+    "date",
+    "status",
+    "week_label",
+    "home_team",
+    "home_team_id",
+    "away_team",
+    "away_team_id",
+    "segment_id",
+)
+_PBP_COLUMNS: Sequence[str] = (
+    "game_id",
+    "quarter",
+    "drive_id",
+    "drive_result",
+    "drive_summary",
+    "drive_team",
+    "play_id",
+    "period",
+    "clock",
+    "field_position",
+    "play_text",
+    "play_team",
+)
+_TEAM_ROSTER_COLUMNS: Sequence[str] = (
+    "team_id",
+    "position_group",
+    "player",
+    "pos",
+    "cls",
+    "ht",
+    "wt",
+    "athlete_id",
+)
+_BOXSCORE_COLUMNS: Sequence[str] = (
+    "game_id",
+    "team",
+    "stat_group",
+    "player",
+    "athlete_id",
+    "stat",
+    "value",
+)
+_STANDINGS_COLUMNS: Sequence[str] = (
+    "team_id",
+    "section",
+    "entity_id",
+)
+_TEAM_STATS_COLUMNS: Sequence[str] = (
+    "team_id",
+    "category",
+    "stat",
+    "stat_abbreviation",
+    "player",
+    "value",
+)
+_TEAM_GAMELOG_COLUMNS: Sequence[str] = (
+    "team_id",
+    "season_type",
+    "category",
+    "game_id",
+    "game_date",
+    "opponent",
+    "stat",
+    "value",
+)
+_ODDS_COLUMNS: Sequence[str] = (
+    "game_id",
+    "team",
+    "spread",
+    "to_win",
+    "total",
+)
+# league_leaders is deliberately absent: every one of its columns is response-shaped
+# (the stat category becomes the columns), so there is no stable set to declare.
+
+
+def _frame(
+    rows: List[Dict[str, Any]],
+    return_as_pandas: bool,
+    columns: Optional[Sequence[str]] = None,
+) -> Union[pl.DataFrame, "pd.DataFrame"]:
+    """Rows -> frame, carrying the documented schema when there are no rows.
+
+    A bare ``pl.DataFrame([])`` is zero-COLUMN, not just zero-row, which makes an
+    upstream-empty response indistinguishable from a broken parser: both surface
+    as a frame with nothing in it, and a caller checking ``df.columns`` learns
+    nothing. Fox returns empty payloads routinely -- a team's gamelog in week 1,
+    a category with no qualifiers -- so this is the normal path, not the edge.
+
+    ``columns`` is the stable key set the parser always emits. Populated frames
+    may be wider (``standings`` and ``league_leaders`` pivot response headers
+    into columns, so their shape depends on the conference or stat requested);
+    the guarantee is only that these keys are always present.
+    """
     if return_as_pandas:
         import pandas as pd
 
-        return pd.DataFrame(rows)
+        return pd.DataFrame(rows, columns=list(columns) if not rows and columns else None)
+    if not rows and columns:
+        return pl.DataFrame(schema={c: pl.Utf8 for c in columns})
     return pl.DataFrame(rows)
 
 
@@ -162,7 +270,7 @@ def fox_cfb_teams(
                 "logo_url": it.get("logoUrl"),
             }
         )
-    return _frame(rows, return_as_pandas)
+    return _frame(rows, return_as_pandas, _TEAMS_COLUMNS)
 
 
 def _fox_team_fullname(team: Optional[dict]) -> Optional[str]:
@@ -347,7 +455,7 @@ def fox_cfb_schedule(
             if gid is not None:
                 seen_games.add(gid)
             rows.append(row)
-    return _frame(rows, return_as_pandas)
+    return _frame(rows, return_as_pandas, _SCHEDULE_COLUMNS)
 
 
 @overload
@@ -420,7 +528,7 @@ def fox_cfb_pbp(
                         "play_team": (p.get("entityLink") or {}).get("title"),
                     }
                 )
-    return _frame(rows, return_as_pandas)
+    return _frame(rows, return_as_pandas, _PBP_COLUMNS)
 
 
 @overload
@@ -488,7 +596,7 @@ def fox_cfb_team_roster(
                 row[name] = val
             row["athlete_id"] = _uri_id(uri)
             rows.append(row)
-    return _frame(rows, return_as_pandas)
+    return _frame(rows, return_as_pandas, _TEAM_ROSTER_COLUMNS)
 
 
 @overload
@@ -567,7 +675,7 @@ def fox_cfb_boxscore(
                             "value": val,
                         }
                     )
-    return _frame(rows, return_as_pandas)
+    return _frame(rows, return_as_pandas, _BOXSCORE_COLUMNS)
 
 
 @overload
@@ -625,7 +733,7 @@ def fox_cfb_standings(
     for sec in raw.get("standingsSections", []) or []:
         for tbl in sec.get("standings", []) or []:  # a list of tables per section
             rows += _table_rows(tbl, extra={"team_id": str(team_id), "section": sec.get("title")})
-    return _frame(rows, return_as_pandas)
+    return _frame(rows, return_as_pandas, _STANDINGS_COLUMNS)
 
 
 @overload
@@ -690,7 +798,7 @@ def fox_cfb_team_stats(
                     "value": ld.get("statValue"),
                 }
             )
-    return _frame(rows, return_as_pandas)
+    return _frame(rows, return_as_pandas, _TEAM_STATS_COLUMNS)
 
 
 @overload
@@ -776,7 +884,7 @@ def fox_cfb_team_gamelog(
                             "value": val,
                         }
                     )
-    return _frame(rows, return_as_pandas)
+    return _frame(rows, return_as_pandas, _TEAM_GAMELOG_COLUMNS)
 
 
 @overload
@@ -921,4 +1029,4 @@ def fox_cfb_odds(
             for name, v in zip(names, r.get("values", []) or []):
                 row[name] = (v or {}).get("odds")
             rows.append(row)
-    return _frame(rows, return_as_pandas)
+    return _frame(rows, return_as_pandas, _ODDS_COLUMNS)

--- a/tests/cfb/test_cfb_fox.py
+++ b/tests/cfb/test_cfb_fox.py
@@ -85,10 +85,20 @@ def test_fox_cfb_team_stats():
 
 
 def test_fox_cfb_team_gamelog():
+    """The schema is asserted unconditionally; the row count only when Fox has rows.
+
+    A bare ``len(df) > 0`` here fails every offseason and every week 1 -- Fox
+    returns ``sectionList: []`` for a team with no games logged yet, which is an
+    upstream state, not a defect. Asserting the columns regardless is what keeps
+    this test able to catch a real parser break: if the parser stopped emitting
+    its keys, the column assertion fails whether or not Fox had data.
+    """
+    raw = fox_cfb_team_gamelog(TEAM, return_parsed=False)
     df = fox_cfb_team_gamelog(TEAM, return_as_pandas=False)
     assert isinstance(df, pl.DataFrame)
-    assert len(df) > 0
     assert {"team_id", "season_type", "category", "game_id", "stat", "value"}.issubset(df.columns)
+    if raw.get("sectionList"):
+        assert len(df) > 0
 
 
 def test_fox_cfb_standings():

--- a/tests/cfb/test_cfb_fox_frame.py
+++ b/tests/cfb/test_cfb_fox_frame.py
@@ -1,0 +1,37 @@
+"""Offline contract test for the Fox empty-frame schema.
+
+Deliberately a separate module: ``tests/cfb/test_cfb_fox.py`` sets
+``pytestmark = skip_if_no_live``, so an offline test placed there would be
+skipped along with the live suite and would guard nothing.
+"""
+
+from __future__ import annotations
+
+from sportsdataverse.cfb.cfb_fox_ext import _TEAM_GAMELOG_COLUMNS, _frame
+
+
+def test_empty_frame_carries_the_documented_schema():
+    """An empty response must still name its columns, in both backends.
+
+    Zero-COLUMN empties are why an upstream-empty Fox response was
+    indistinguishable from a broken parser -- a caller inspecting ``df.columns``
+    learned nothing either way.
+    """
+    empty = _frame([], False, _TEAM_GAMELOG_COLUMNS)
+    assert empty.height == 0
+    assert list(empty.columns) == list(_TEAM_GAMELOG_COLUMNS)
+
+    empty_pd = _frame([], True, _TEAM_GAMELOG_COLUMNS)
+    assert len(empty_pd) == 0
+    assert list(empty_pd.columns) == list(_TEAM_GAMELOG_COLUMNS)
+
+
+def test_the_schema_argument_does_not_disturb_a_populated_frame():
+    rows = [{"team_id": "11", "season_type": "REG", "category": "passing"}]
+    assert list(_frame(rows, False, _TEAM_GAMELOG_COLUMNS).columns) == ["team_id", "season_type", "category"]
+
+
+def test_no_schema_keeps_the_old_behaviour():
+    """Callers that pass no schema (league_leaders, whose columns are
+    response-shaped) must be unchanged."""
+    assert _frame([], False).width == 0


### PR DESCRIPTION
`_frame()` returned a bare `pl.DataFrame(rows)`, which for an empty list is
zero-COLUMN, not just zero-row. Every one of the ten Fox wrappers shared it, so
an empty Fox response and a parser that had stopped emitting its keys produced
the same object: a frame with nothing in it, telling a caller inspecting
df.columns nothing at all.

That is not hypothetical. sdv-py main has been red on `pytest (live APIs, macOS)`
with `test_fox_cfb_team_gamelog` asserting `len(df) > 0`, and diagnosing it meant
fetching the raw payload by hand to discover `sectionList: []` -- Fox simply had
no games logged for that team in week 1, while the sibling `fox_cfb_team_stats`
returned 9 rows on the same host. Upstream was fine. The schema would have said
so immediately.

`_frame` now takes the stable key set and, when there are no rows, builds the
frame from it (both the polars and pandas paths). The column sets were captured
from live responses rather than guessed, and verified not to change any
populated frame's shape.

`league_leaders` deliberately gets no schema: every one of its columns is
response-shaped -- the requested stat category becomes the columns -- so there is
no stable set to declare. `standings` gets only the three keys that are always
present, for the same reason.

The live gamelog test now asserts the schema unconditionally and the row count
only when Fox actually returned sections, so it stops failing every offseason
without losing its ability to catch a real parser break. The contract itself is
pinned by a new offline test, in its own module because test_cfb_fox.py sets
`pytestmark = skip_if_no_live` and an offline test placed there would be skipped
along with the live suite and guard nothing.

Verified: tests/cfb 813 passed / 55 skipped / 2 xfailed; the Fox suite 13 passed
with SDV_PY_LIVE_TESTS=1, including the gamelog test that was failing on main.

## Summary by Sourcery

Ensure empty Fox CFB responses retain meaningful schemas and update validation to distinguish valid upstream emptiness from parsing regressions.

Bug Fixes:
- Preserve stable column schemas for empty Fox CFB responses so upstream-empty data can be distinguished from parser failures.

Enhancements:
- Apply documented schemas across Fox frame-producing endpoints while retaining response-shaped behavior for standings and league leaders.
- Make the live gamelog test validate schema independently of whether Fox returns any rows.

Tests:
- Add offline coverage for empty-frame schemas in both Polars and pandas, populated-frame compatibility, and schema-free behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized parsed Fox college football results with consistent columns, including when no data is returned.
  * Improved handling of empty team game log responses without incorrectly reporting missing games.
  * Preserved existing behavior for populated results and responses without an explicit schema.

* **Tests**
  * Added coverage for empty-result schemas across supported data frame formats.
  * Updated game log validation for responses that contain no games.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->