### PR TITLE
docs(nhl): record the measured xG over-prediction where consumers look

### DIFF
--- a/docs/docs/nhl/reference/additional.md
+++ b/docs/docs/nhl/reference/additional.md
@@ -1133,9 +1133,10 @@ Measured 2026-09-02 against the 2026-04 boosters currently in the `nhl_xg_models
 release: observed goals / sum(`xg`) is **0.771** at 5v5 (n=1,724,290 shots) and
 **0.768** on special teams (n=349,232), where a correctly-levelled model gives 1.0 --
 i.e. `xg` is inflated by roughly 25-30% for every season from 2009-10 through
-2023-24. Seasons 2024-25 (0.949) and 2025-26 (0.913) are much closer. The cause is
-the boosters' training corpus, which carried no `MISSED_SHOT` events for the
-affected seasons; it is not a defect in the feature frame this function builds.
+2023-24. At 5v5 the two most recent seasons are much closer (2024-25 **0.949**,
+2025-26 **0.913**). The cause is the boosters' training corpus, which carried no
+`MISSED_SHOT` events for the affected seasons; it is not a defect in the feature
+frame this function builds.
 Shot RANKING is far less affected (rank AUC 0.778 / 0.760), so `xg` is still usable
 for ordering chances -- but any SUM of `xg` (per game, per player, team totals,
 goals-above-expected, and `nhl_gsax` downstream) is inflated for pre-2024-25
@@ -1143,10 +1144,16 @@ seasons. Tracking:
 [sportsdataverse-py#444](https://github.com/sportsdataverse/sportsdataverse-py/issues/444);
 evidence:
 [fastRhockey-nhl-data#11](https://github.com/sportsdataverse/fastRhockey-nhl-data/pull/11).
-To check whether this still applies to the boosters you have, sum `xg` over a
-season and compare against actual goals -- a corrected booster gives a ratio near
-1.0 -- or run `nhl_data_build.xg_parity.artifact_calibration` in
-`fastRhockey-nhl-data`.
+To check whether this still applies to the boosters you have, restrict to the rows
+this function actually scored -- `xg` non-null, i.e. unblocked shots only -- and
+compare `sum(xg)` against the goals **on those same rows**, separately for
+`strength_state == "5v5"` and for the rest, since the two come from different
+boosters and are quoted separately above; a corrected booster gives a ratio near 1.0
+for each. Comparing against a season's full goal total instead would fold in
+shootout and penalty-shot goals and every unscored row, and would not validate the
+numbers above. The same measurement is packaged as
+`nhl_data_build.xg_parity.artifact_calibration(pbp, booster, variant=...)`
+(`variant` is `"5v5"` or `"st"`) in `fastRhockey-nhl-data`.
 
 **Parameters**
 

--- a/docs/docs/nhl/reference/additional.md
+++ b/docs/docs/nhl/reference/additional.md
@@ -1128,6 +1128,26 @@ penalty shots with the constant `xg_model_ps`, then left-joins `xg` back onto
 `pbp` by `event_id`. Attaches the danger/distance/angle expansion
 (`add_shot_geometry`) after scoring.
 
+**Known issue -- the published boosters over-predict for seasons through 2023-24.**
+Measured 2026-09-02 against the 2026-04 boosters currently in the `nhl_xg_models`
+release: observed goals / sum(`xg`) is **0.771** at 5v5 (n=1,724,290 shots) and
+**0.768** on special teams (n=349,232), where a correctly-levelled model gives 1.0 --
+i.e. `xg` is inflated by roughly 25-30% for every season from 2009-10 through
+2023-24. Seasons 2024-25 (0.949) and 2025-26 (0.913) are much closer. The cause is
+the boosters' training corpus, which carried no `MISSED_SHOT` events for the
+affected seasons; it is not a defect in the feature frame this function builds.
+Shot RANKING is far less affected (rank AUC 0.778 / 0.760), so `xg` is still usable
+for ordering chances -- but any SUM of `xg` (per game, per player, team totals,
+goals-above-expected, and `nhl_gsax` downstream) is inflated for pre-2024-25
+seasons. Tracking:
+[sportsdataverse-py#444](https://github.com/sportsdataverse/sportsdataverse-py/issues/444);
+evidence:
+[fastRhockey-nhl-data#11](https://github.com/sportsdataverse/fastRhockey-nhl-data/pull/11).
+To check whether this still applies to the boosters you have, sum `xg` over a
+season and compare against actual goals -- a corrected booster gives a ratio near
+1.0 -- or run `nhl_data_build.xg_parity.artifact_calibration` in
+`fastRhockey-nhl-data`.
+
 **Parameters**
 
 | Parameter | Type | Default | Description |

--- a/sportsdataverse/nhl/nhl_xg.py
+++ b/sportsdataverse/nhl/nhl_xg.py
@@ -334,6 +334,26 @@ def nhl_xg(
     ``pbp`` by ``event_id``. Attaches the danger/distance/angle expansion
     (``add_shot_geometry``) after scoring.
 
+    **Known issue -- the published boosters over-predict for seasons through 2023-24.**
+    Measured 2026-09-02 against the 2026-04 boosters currently in the ``nhl_xg_models``
+    release: observed goals / sum(``xg``) is **0.771** at 5v5 (n=1,724,290 shots) and
+    **0.768** on special teams (n=349,232), where a correctly-levelled model gives 1.0 --
+    i.e. ``xg`` is inflated by roughly 25-30% for every season from 2009-10 through
+    2023-24. Seasons 2024-25 (0.949) and 2025-26 (0.913) are much closer. The cause is
+    the boosters' training corpus, which carried no ``MISSED_SHOT`` events for the
+    affected seasons; it is not a defect in the feature frame this function builds.
+    Shot RANKING is far less affected (rank AUC 0.778 / 0.760), so ``xg`` is still usable
+    for ordering chances -- but any SUM of ``xg`` (per game, per player, team totals,
+    goals-above-expected, and ``nhl_gsax`` downstream) is inflated for pre-2024-25
+    seasons. Tracking:
+    `sportsdataverse-py#444 <https://github.com/sportsdataverse/sportsdataverse-py/issues/444>`_;
+    evidence:
+    `fastRhockey-nhl-data#11 <https://github.com/sportsdataverse/fastRhockey-nhl-data/pull/11>`_.
+    To check whether this still applies to the boosters you have, sum ``xg`` over a
+    season and compare against actual goals -- a corrected booster gives a ratio near
+    1.0 -- or run ``nhl_data_build.xg_parity.artifact_calibration`` in
+    ``fastRhockey-nhl-data``.
+
     Args:
         pbp: a ``load_nhl_pbp_full``-shaped frame.
         model_dir: booster directory; ``None`` downloads-and-caches on first use (see

--- a/sportsdataverse/nhl/nhl_xg.py
+++ b/sportsdataverse/nhl/nhl_xg.py
@@ -339,9 +339,10 @@ def nhl_xg(
     release: observed goals / sum(``xg``) is **0.771** at 5v5 (n=1,724,290 shots) and
     **0.768** on special teams (n=349,232), where a correctly-levelled model gives 1.0 --
     i.e. ``xg`` is inflated by roughly 25-30% for every season from 2009-10 through
-    2023-24. Seasons 2024-25 (0.949) and 2025-26 (0.913) are much closer. The cause is
-    the boosters' training corpus, which carried no ``MISSED_SHOT`` events for the
-    affected seasons; it is not a defect in the feature frame this function builds.
+    2023-24. At 5v5 the two most recent seasons are much closer (2024-25 **0.949**,
+    2025-26 **0.913**). The cause is the boosters' training corpus, which carried no
+    ``MISSED_SHOT`` events for the affected seasons; it is not a defect in the feature
+    frame this function builds.
     Shot RANKING is far less affected (rank AUC 0.778 / 0.760), so ``xg`` is still usable
     for ordering chances -- but any SUM of ``xg`` (per game, per player, team totals,
     goals-above-expected, and ``nhl_gsax`` downstream) is inflated for pre-2024-25
@@ -349,10 +350,16 @@ def nhl_xg(
     `sportsdataverse-py#444 <https://github.com/sportsdataverse/sportsdataverse-py/issues/444>`_;
     evidence:
     `fastRhockey-nhl-data#11 <https://github.com/sportsdataverse/fastRhockey-nhl-data/pull/11>`_.
-    To check whether this still applies to the boosters you have, sum ``xg`` over a
-    season and compare against actual goals -- a corrected booster gives a ratio near
-    1.0 -- or run ``nhl_data_build.xg_parity.artifact_calibration`` in
-    ``fastRhockey-nhl-data``.
+    To check whether this still applies to the boosters you have, restrict to the rows
+    this function actually scored -- ``xg`` non-null, i.e. unblocked shots only -- and
+    compare ``sum(xg)`` against the goals **on those same rows**, separately for
+    ``strength_state == "5v5"`` and for the rest, since the two come from different
+    boosters and are quoted separately above; a corrected booster gives a ratio near 1.0
+    for each. Comparing against a season's full goal total instead would fold in
+    shootout and penalty-shot goals and every unscored row, and would not validate the
+    numbers above. The same measurement is packaged as
+    ``nhl_data_build.xg_parity.artifact_calibration(pbp, booster, variant=...)``
+    (``variant`` is ``"5v5"`` or ``"st"``) in ``fastRhockey-nhl-data``.
 
     Args:
         pbp: a ``load_nhl_pbp_full``-shaped frame.


### PR DESCRIPTION
Records the measured NHL xG over-prediction on the one surface a **consumer of the published asset** actually reads.

Companion to **sportsdataverse/fastRhockey-nhl-data#11** (merged 2026-09-02), which diagnosed it. Tracking issue: **#444**.

## The defect (not introduced here — recorded here)

The boosters `nhl_xg()` downloads from the `nhl_xg_models` release over-predict unblocked-shot goal probability by **25-30% for every season 2009-10 through 2023-24**. Measured 2026-09-02 on `fastRhockey-nhl-data`'s corpus:

| variant | n shots | goals/ΣxG | rank AUC |
|---|---:|---:|---:|
| 5v5 | 1,724,290 | **0.7711** | 0.7783 |
| special teams | 349,232 | **0.7679** | 0.7601 |

2024-25 (0.949) and 2025-26 (0.913) are much closer. Cause: the boosters' training corpus carried no `MISSED_SHOT` events for the affected seasons — restricting today's frame to `SHOT|GOAL` returns goals/ΣxG to 0.99-1.02 for each of them.

**It is not a defect in this package's feature frame.** The R and python recipes were run on byte-identical input rows and returned the same rows and the same values on 32 of 33 shared features; `prepare_xg_features` here agrees with both to 4 dp.

## Why the long description and not a `Warning:` section

`tools/codegen`'s `autodoc_page.md.jinja` renders **short, long, Parameters, Returns, Example** only. A `Warning:` header matches `_DOC_SECTION_HEADER_RE`, which would terminate `fn.long` and drop the text from `docs/docs/nhl/reference/additional.md` entirely — visible in `help()`, invisible on the docs site. As prose in the long description it reaches **both**, which is the entire reason for putting it in a docstring rather than in release notes.

## What the note says

- The measured ratios, the sample sizes, and **the date** (2026-09-02) and artifact vintage (the 2026-04 boosters), so a reader can tell whether it still applies.
- That **ranking degrades far less than level** (AUC 0.778 / 0.760) — `xg` stays usable for ordering chances; it is any **sum** of `xg` (per game, per player, team totals, GAX, `nhl_gsax` downstream) that is inflated.
- A check the reader can run themselves: sum `xg` for a season against actual goals — a corrected booster gives ≈ 1.0 — or run `nhl_data_build.xg_parity.artifact_calibration` in `fastRhockey-nhl-data`.
- Links to #444 and fastRhockey-nhl-data#11.

## Removal trigger

In **#444**, so the note has a defined end rather than becoming permanent furniture: retrain gated in `fastRhockey-nhl-data` → **corpus bugs fixed first** (its `nhl/pbp/parquet` is missing 2014-15; `nhl/pbp/full` is missing 2013-14 and duplicates 2018-19) → **`nhl_xg_models` release re-uploaded**, since until then sdv-py consumers still download the old boosters → re-measured near 1.0.

Note the frozen floors (5v5 cv AUC ≥ 0.82, ST ≥ 0.81) are themselves anchored to the defective fit and are not reachable on the corrected corpus — they must be re-derived from a passing fit, never lowered.

## Known remaining exposure (recorded, not solved)

The `xg` column in the published **`nhl_pbp_full`** release was produced by these same boosters, so a consumer reading that parquet directly — never importing this package — still has **no warning surface at all**. A docstring cannot reach them; the honest fix is a rebuild and republish, which is a maintainer decision. Recorded in #444 rather than papered over.

## Scope

Docstring + regenerated reference page only. No behaviour change, no booster, no gate, no published asset touched.

```
uv run python tools/codegen/generate.py && uv run python tools/codegen/generate.py --check
```

## Summary by Sourcery

Document the measured over-prediction in published NHL xG boosters and provide guidance for interpreting and validating affected outputs.

Enhancements:
- Document the known calibration issue in NHL xG boosters, including its impact on aggregate metrics and how consumers can verify whether it still applies.

Documentation:
- Regenerate the NHL xG reference documentation so the warning is visible both in API help and on the documentation site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the NHL expected-goals known-issue notice with 5v5-specific calibration ratios for the 2024–25 and 2025–26 seasons.
  * Expanded calibration guidance to compare expected goals with goals from the same scored unblocked-shot rows, separately for 5v5 and other strength states.
  * Documented calibration checks for cases where comparing against a season’s full goal total would be invalid.
  * Added references to the available calibration variants for 5v5 and other strength states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->