### PR TITLE
test(nfl): skip the NGS live test on a policy deny instead of failing

### DIFF
--- a/tests/nfl/test_nfl_ngs_scrape.py
+++ b/tests/nfl/test_nfl_ngs_scrape.py
@@ -236,8 +236,22 @@ def test_scrape_season_live_passing_2023():
     try:
         df = scrape_ngs_season("passing", 2023)
     except requests.exceptions.HTTPError as exc:  # pragma: no cover - upstream state
-        status = getattr(exc.response, "status_code", None)
-        if status in (401, 403):
+        resp = exc.response
+        status = getattr(resp, "status_code", None)
+        # Narrow to the ONE documented deny, so a future auth/authorization
+        # regression still fails loudly instead of being skipped away.
+        #
+        # The signature is split across body and headers, and only the body half
+        # is reliable to match on: the API Gateway deny message lands in the JSON
+        # body, while "AccessDeniedException" is the value of the x-amzn-errortype
+        # HEADER -- it never appears in the body, so matching it there would make
+        # this branch dead and put the test straight back to failing. Verified
+        # against a live response 2026-09-03.
+        body = getattr(resp, "text", "") or ""
+        errtype = (getattr(resp, "headers", {}) or {}).get("x-amzn-errortype", "")
+        if status == 403 and (
+            "explicit deny in an identity-based policy" in body or "AccessDeniedException" in errtype
+        ):
             pytest.skip(f"NGS denied this network ({status}); see notes/2026-09-02-ngs-recon.md")
         raise
     assert df.height > 0

--- a/tests/nfl/test_nfl_ngs_scrape.py
+++ b/tests/nfl/test_nfl_ngs_scrape.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import polars as pl
 import pytest
+import requests
 
 from sportsdataverse.nfl import nfl_ngs as M
 from sportsdataverse.nfl import scrape_ngs_season, scrape_ngs_week
@@ -218,7 +219,27 @@ def test_teams_lookup_failure_does_not_abort(monkeypatch):
 # --------------------------------------------------------------------------- #
 @skip_if_no_live
 def test_scrape_season_live_passing_2023():
-    df = scrape_ngs_season("passing", 2023)
+    """Skips when NGS denies this network, fails on anything we could have broken.
+
+    Measured 2026-09-02: ``nextgenstats.nfl.com/api`` sits behind AWS API Gateway and
+    returns 403 ``AccessDeniedException`` -- "explicit deny in an identity-based
+    policy" -- to *every* client from some networks, GitHub runners included. It is
+    not an auth wall: a real Chromium browser sends no ``Authorization`` header at
+    all and gets the identical body, so there is no token to obtain and nothing in
+    this package can fix it.
+
+    Failing on that is noise: it reports a policy decision at NFL as a regression
+    here, and it is the reason main has been red. Skipping keeps the test honest --
+    the day the deny lifts it starts passing again on its own, which deleting it
+    would not. Every other failure mode still fails.
+    """
+    try:
+        df = scrape_ngs_season("passing", 2023)
+    except requests.exceptions.HTTPError as exc:  # pragma: no cover - upstream state
+        status = getattr(exc.response, "status_code", None)
+        if status in (401, 403):
+            pytest.skip(f"NGS denied this network ({status}); see notes/2026-09-02-ngs-recon.md")
+        raise
     assert df.height > 0
     for col in (
         "season",


### PR DESCRIPTION
Measured 2026-09-02 with a browser capture: nextgenstats.nfl.com/api sits behind
AWS API Gateway and returns 403 AccessDeniedException -- "explicit deny in an
identity-based policy" -- to every client from some networks, GitHub runners
included. It is NOT an auth wall. A real Chromium browser sends no Authorization
header at all and receives the byte-identical body, and plain Python with the
browser's exact headers gets the same, which rules out fingerprinting, header
shape and TLS/JA3. There is no token to obtain and nothing in this package can
change the outcome.

Hard-failing on that reports a policy decision at NFL as a regression here, and
it is one of the two reasons main has been red. Skipping is not sweeping it under
the rug: the skip carries the status and points at the recon note, every other
failure mode still fails, and the day the deny lifts the test starts passing
again on its own -- which deleting it would not.

Same distinction as today's Fox empty-frame fix: make the upstream-unavailable
case legible instead of letting it masquerade as a defect.

Verified: SDV_PY_LIVE_TESTS=1 -> 9 passed, 1 skipped ("NGS denied this network
(403)"), 1 xfailed.

## Summary by Sourcery

Treat the documented NFL NGS network policy denial as an explicit live-test skip while preserving failures for unexpected errors.

Bug Fixes:
- Prevent the live NFL NGS test from failing when the upstream API explicitly denies the runner's network access.

Enhancements:
- Keep all other NGS live-test failures fatal while making the known upstream policy-deny condition explicit as a skip.

Tests:
- Refine the NFL NGS live test to recognize the documented 403 policy-deny response and report it as a skipped test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the live 2023 passing-data test to skip when the external NGS service explicitly denies access.
  * Unexpected authorization and other HTTP errors continue to fail the test, preserving coverage for genuine issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->