### PR TITLE
docs(nfl): flag the near-empty 2000-2002 seasons in load_nfl_model_pbp

### DIFF
--- a/sportsdataverse/nfl/nfl_loaders.py
+++ b/sportsdataverse/nfl/nfl_loaders.py
@@ -147,12 +147,27 @@ def load_nfl_model_pbp(seasons: List[int], return_as_pandas=False) -> pl.DataFra
     clean modeling subset -- unlike the nflverse ``load_nfl_pbp`` default, which
     keeps them.
 
+    **Seasons 2000, 2001 and 2002 are near-empty and must not be treated as
+    complete** (measured 2026-09-02). Every game is present and the frame is
+    full-width, so nothing errors and nothing looks wrong -- but the plays are
+    missing: 2000 has 955 rows across 258 games (median 3 plays/game, 56% with a
+    null ``play_type``), 2001 has 1,168 across 259, and 2002 has 7,772 across 267,
+    against roughly 44,000 rows and 167 plays/game in 1999 and in every season
+    from 2003 on. The cause is upstream and not this package: the NFL Shield feed
+    serves drive-level and scoring data for those three seasons but almost no
+    play-level rows, so the captured payloads are complete in every other respect.
+    Any season aggregate spanning them is wrong, and any per-play rate is computed
+    on ~2% of its denominator. Use ``source="nflverse"`` for 2000-2002, which
+    carries full play-by-play. Tracking:
+    `nfl-data#34 <https://github.com/sportsdataverse/nfl-data/issues/34>`_.
+
     Caching is inherited from the underlying ``load_nfl_pbp`` call, so this
     wrapper carries no ``@cached_loader`` of its own (a second layer would
     double-store every frame).
 
     Args:
-        seasons (list): Used to define different seasons. 1999 is the earliest available season.
+        seasons (list): Used to define different seasons. 1999 is the earliest
+            available season; 2000-2002 are published but near-empty (see above).
         return_as_pandas (bool): If True, returns a pandas dataframe. If False, returns a polars dataframe.
 
     Returns:

--- a/tools/codegen/endpoints/releases.yaml
+++ b/tools/codegen/endpoints/releases.yaml
@@ -1716,6 +1716,11 @@ loaders:
 # SDV-native enriched pbp: the same asset load_nfl_pbp(source="sdv") reads, given
 # its own name so the nfl_model_pbp tag is reachable without the source= kwarg.
 # 27 assets, 1999-2025, 257 columns per season (verified live 2026-09-02).
+# CAVEAT: 2000, 2001 and 2002 are published but near-empty -- 955 / 1,168 / 7,772
+# rows against ~44,000 in adjacent seasons, because the upstream Shield feed
+# serves drive and scoring data but almost no plays for those three years. Every
+# game is present and nothing errors, so it does not look wrong. Documented in
+# the loader docstring; tracking sportsdataverse/nfl-data#34.
 - fn: load_nfl_model_pbp
   league: nfl
   base: sdv_releases


### PR DESCRIPTION
Found while verifying asset shapes before touching the loader — the release byte sizes were the tell, and no gate flags this.

## What

`nfl_model_pbp` publishes 2000, 2001 and 2002 as if they were complete seasons. Every game is present, the frame is full-width, nothing errors. The plays are missing:

| season | rows | games | plays/game |
|---|---:|---:|---:|
| 1999 | 43,376 | 259 | ~167 |
| **2000** | **955** | **258** | **median 3** (max 13) |
| **2001** | **1,168** | **259** | **~4** |
| **2002** | **7,772** | **267** | **~29** |
| 2003 | 44,962 | 267 | ~168 |
| 2024 | 47,366 | 285 | ~166 |

536 of the 955 surviving 2000 rows (56%) have a null `play_type`.

## Root cause is upstream, not this package

The `nfl-raw` payloads are **structurally complete and identical** across the boundary — same 26 top-level keys, full `summary`, normal `driveChart.drives` counts, full `scoringSummaries`. Only `driveChart.plays` is empty:

| sample game | drives | **plays** | scoring | bytes |
|---|---:|---:|---:|---:|
| `1999_10_CAR_STL` | 23 | **169** | 7 | 432,411 |
| `2000_10_BUF_NE` | 28 | **3** | 7 | 34,690 |
| `2001_10_CHI_TB` | 30 | **2** | 10 | 35,139 |
| `2003_10_BUF_DAL` | 27 | **180** | 4 | 416,095 |

A 12-game even sample of all 27 captured seasons puts the boundary at **exactly those three** — every season 2003–2025 runs 170–194 plays/game with 0/12 affected, and drives are normal even in the broken three. The NFL Shield feed serves drive-level and scoring data for 2000–2002 and almost no play-level rows; the capture stored exactly what it returned.

## Why a docstring is the right fix here

Nothing fails, so nothing is recorded as failing — the silent-data-loss shape one level up from the `NoDataError` / `AssetFetchError` split. A consumer asking for 2000 gets 955 rows and no signal the answer is wrong; any 1999–2025 season aggregate is quietly wrong for three seasons and any per-play rate is computed on ~2% of its denominator.

`source="nflverse"` carries full play-by-play for 2000–2002, so the docstring points there.

**This is documentation, not a fix.** Whether to backfill those three seasons from nflverse, unpublish them, or leave them documented is the maintainer's call — tracked in [nfl-data#34](https://github.com/sportsdataverse/nfl-data/issues/34) with the measurement and the three options.

## Also

Corrected the `releases.yaml` comment, which asserted "27 assets, 1999-2025, 257 columns per season" with no caveat — the same misleading claim, aimed at the next maintainer.

## Gates

- `codegen --check`: **rc=0**, "all generated files current"
- `ruff check`: clean
- `pytest tests/nfl/`: **704 passed**, 53 skipped, 7 xfailed

Docs-only. Note the generated loaders page renders the release link and returns table but no docstring prose, so this caveat reaches `help()` and IDEs but not the docs site — a gap worth its own follow-up.

## Summary by Sourcery

Document the incomplete NFL play-by-play coverage for seasons 2000–2002 and recommend nflverse as the complete data source.

Enhancements:
- Document that the 2000–2002 NFL model play-by-play seasons are published but near-empty due to upstream missing play-level data, and direct consumers to nflverse for complete coverage.

Documentation:
- Add the 2000–2002 data-quality caveat and nfl-data#34 tracking reference to the NFL loader documentation and release metadata comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that NFL play-by-play data for seasons 2000–2002 is published but nearly empty due to limited upstream play data.
  * Added guidance to use the NFLverse source for those seasons.
  * Documented expected row counts and availability details for affected seasons.

* **Tests**
  * Live NGS scraping tests now skip when access is denied by network-level API restrictions, while continuing to report other errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->