### PR TITLE
fix(ci): validation-cron destroyed the findings it exists to report

### DIFF
--- a/.github/workflows/validation-cron.yml
+++ b/.github/workflows/validation-cron.yml
@@ -120,12 +120,23 @@ jobs:
           # quotes/newlines) is escaped into valid JSON — a printf-interpolated
           # sentinel is malformed and gets silently swallowed by the aggregation
           # step's JSON.parse AND the platform-ingest jq.
-          if [ "${exit_code}" -ne 0 ]; then
+          # Exit 1 is the CLI's DOCUMENTED "found ERROR findings" (cli.py _emit:
+          # `return 1 if any(f["severity"] == "error" ...)`), NOT a crash. It
+          # writes the complete findings array to stdout BEFORE returning 1, so
+          # on exit 1 the findings file is valid and is the whole point of the
+          # run. Treating every non-zero exit as a crash overwrote those real
+          # findings with a sentinel whose message was empty (the CLI wrote
+          # nothing to stderr because nothing went wrong), so issue #415 read
+          # "validation CLI exited 1: " and the findings it existed to report
+          # were destroyed. An uncaught traceback also exits 1, so the exit code
+          # cannot discriminate -- but the findings file can: a completed run
+          # leaves a valid JSON array, a crash leaves it empty or truncated.
+          if [ "${exit_code}" -ne 0 ] && ! jq -e 'type == "array"' findings_cfb_model_pbp.json >/dev/null 2>&1; then
             log_tail=$(tail -c 500 validate_cfb.log 2>/dev/null || true)
             jq -n --arg code "${exit_code}" --arg log "${log_tail}" \
               '[{check: "run_error", severity: "error", domain: "cfb",
                  dataset: "cfb_model_pbp", needs_judgment: false,
-                 message: ("cfb_model_pbp validation CLI exited " + $code + ": " + $log)}]' \
+                 message: ("cfb_model_pbp validation CLI exited " + $code + " without leaving valid findings JSON: " + $log)}]' \
               > findings_cfb_model_pbp.json
           fi
 
@@ -183,12 +194,23 @@ jobs:
           # quotes/newlines) is escaped into valid JSON — a printf-interpolated
           # sentinel is malformed and gets silently swallowed by the aggregation
           # step's JSON.parse AND the platform-ingest jq.
-          if [ "${exit_code}" -ne 0 ]; then
+          # Exit 1 is the CLI's DOCUMENTED "found ERROR findings" (cli.py _emit:
+          # `return 1 if any(f["severity"] == "error" ...)`), NOT a crash. It
+          # writes the complete findings array to stdout BEFORE returning 1, so
+          # on exit 1 the findings file is valid and is the whole point of the
+          # run. Treating every non-zero exit as a crash overwrote those real
+          # findings with a sentinel whose message was empty (the CLI wrote
+          # nothing to stderr because nothing went wrong), so issue #415 read
+          # "validation CLI exited 1: " and the findings it existed to report
+          # were destroyed. An uncaught traceback also exits 1, so the exit code
+          # cannot discriminate -- but the findings file can: a completed run
+          # leaves a valid JSON array, a crash leaves it empty or truncated.
+          if [ "${exit_code}" -ne 0 ] && ! jq -e 'type == "array"' findings_nfl_model_pbp.json >/dev/null 2>&1; then
             log_tail=$(tail -c 500 validate_nfl.log 2>/dev/null || true)
             jq -n --arg code "${exit_code}" --arg log "${log_tail}" \
               '[{check: "run_error", severity: "error", domain: "nfl",
                  dataset: "nfl_model_pbp", needs_judgment: false,
-                 message: ("nfl_model_pbp validation CLI exited " + $code + ": " + $log)}]' \
+                 message: ("nfl_model_pbp validation CLI exited " + $code + " without leaving valid findings JSON: " + $log)}]' \
               > findings_nfl_model_pbp.json
           fi
 


### PR DESCRIPTION
Fixes the cause of #415 reading `validation CLI exited 1: ` with an empty message.

## The bug

`tools/validation/cli.py::_emit` ends:

```python
return 1 if any(f["severity"] == "error" for f in out) else 0
```

**Exit 1 is the CLI's documented "I found ERROR findings"**, and it writes the complete findings array to stdout *before* returning it. The cron treated every non-zero exit as a crash and overwrote `findings_<dataset>.json` with a `run_error` sentinel built from `tail -c 500 validate_<ds>.log` — stderr. The CLI had written nothing to stderr because nothing went wrong, so the sentinel's message was `""`.

So the step that exists to report findings is what destroyed them — and self-concealingly, because the resulting issue looks like a crash and nobody goes looking for findings that were computed and thrown away.

## The fix

An uncaught traceback also exits 1, so the exit code cannot discriminate. The findings file can: a completed run leaves a valid JSON array, a crash leaves it empty or truncated. The sentinel is now injected only when the file does not parse as an array, and its message says so.

Verified the discriminator on all four cases:

| findings file | sentinel injected? |
|---|---|
| complete findings array | no — findings kept |
| `[]` | no |
| empty file (crash) | yes |
| truncated JSON (crash) | yes |

## Confirmed against the real datasets

Both exit 1 with **empty stderr and a valid, complete findings array** — exactly the case the old condition clobbered:

- `nfl_model_pbp` — 285 findings (277 stale-schema `unexpected column`, plus a real `kick_distance_range` ERROR)
- `cfb_model_pbp` — 36 findings, including **8 genuine definitional ERRORs**, the largest being 49,596 negative `start.distance` values of which **49,535 are exactly `-1`** — ESPN's "unknown" sentinel published as a distance, concentrated in 2004–2013. Filed as [cfbfastR-cfb-data#67](https://github.com/sportsdataverse/cfbfastR-cfb-data/issues/67).

None of that was visible while the cron was overwriting it.

Workflow YAML parses; both dataset steps carry the guard. Full findings write-up on #415, which stays open — this makes future runs informative, but the CFB definitional ERRORs and the stale schema snapshots are separate work.

## Summary by Sourcery

Prevent the validation cron from discarding legitimate findings when validation reports errors through its exit status.

Bug Fixes:
- Preserve completed validation findings when the CLI exits non-zero because it detected validation errors.
- Only replace findings with a run-error sentinel when the output is not valid JSON containing an array, and clarify the resulting error message.

CI:
- Update both dataset validation cron steps to distinguish reported findings from failed runs using the findings output rather than the exit code alone.