### PR TITLE
docs(football): spring enrichment promised cp/cpoe/xYAC it cannot produce

### DIFF
--- a/sportsdataverse/football/spring_football_ep_wp.py
+++ b/sportsdataverse/football/spring_football_ep_wp.py
@@ -344,9 +344,31 @@ def enrich_spring_football_pbp(
         return_as_pandas: When ``True``, return a ``pandas.DataFrame``.
 
     Returns:
-        ``pbp`` with ``ep``/``epa``/``wp``/``wpa``/``cp``/``cpoe``/xYAC and
-        the other ``enrich_nfl_pbp`` output columns added. Unchanged
+        ``pbp`` with the ``enrich_nfl_pbp`` output columns added. Unchanged
         (zero-row) passthrough when ``pbp`` is empty.
+
+        **Not every output column is populated for spring football**, and the
+        ones that are not are structurally empty rather than occasionally
+        missing -- measured on the committed ``xfl_summary.json`` fixture
+        (159 plays):
+
+        * Populated: ``ep`` (158/159), ``epa`` (157), ``wp`` (158),
+          ``wpa`` (157), ``vegas_wp`` (158).
+        * **Always null**: ``cp``, ``cpoe``, every ``xyac_*`` column, and the
+          fourth-down surface (``first_down_prob``, ``go_boost``,
+          ``fourth_down_recommendation``).
+
+        The cause is upstream of the scorers: :func:`build_spring_football_pbp`
+        emits ``air_yards`` and ``spread_line`` as all-null, because these
+        leagues publish no air-yards charting and carry no betting market. CP
+        and xYAC are air-yards models and the fourth-down surface needs
+        ``total_line``, so none of them has an input to score. They are not
+        broken here and cannot be fixed here -- they would start working the
+        day the builder gains real air yards, which is what
+        ``test_spring_enrichment_output_contract`` is there to notice.
+        The skipped steps emit a ``RuntimeWarning`` per call; that noise is
+        kept on purpose, because suppressing it via ``add_fourth_down=False``
+        would drop 15 columns and break the nfl_parity column-set equality.
 
     Raises:
         ValueError: ``league`` is not a recognized spring-football league.
@@ -367,4 +389,10 @@ def enrich_spring_football_pbp(
     if pbp.height == 0:
         return pbp.to_pandas() if return_as_pandas else pbp
 
+    # Deliberately UNCHANGED -- no add_fourth_down=False here. Passing it would
+    # silence the per-call warning, but it also drops 15 columns and breaks the
+    # "calls enrich_nfl_pbp unchanged" property the nfl_parity tests exist to
+    # prove (test_nfl_parity_shared_core compares column sets exactly). The
+    # warning is the cheaper cost; see the Returns note for why the fourth-down
+    # and air-yards outputs are null for these leagues.
     return enrich_nfl_pbp(pbp, return_as_pandas=return_as_pandas)

--- a/tests/football/test_spring_football_ep_wp.py
+++ b/tests/football/test_spring_football_ep_wp.py
@@ -183,7 +183,7 @@ def test_spring_enrichment_output_contract():
     # Scored: EP/WP derive from down/distance/yardline/clock/score, all of which
     # the builder does produce. Guard on a share, not an exact count, so a
     # re-captured fixture does not turn a working pipeline red.
-    for col in ("ep", "epa", "wp", "wpa"):
+    for col in ("ep", "epa", "wp", "wpa", "vegas_wp"):
         filled = out[col].drop_nulls().len()
         assert filled >= 0.9 * out.height, f"{col} only {filled}/{out.height} populated"
 

--- a/tests/football/test_spring_football_ep_wp.py
+++ b/tests/football/test_spring_football_ep_wp.py
@@ -128,7 +128,7 @@ def test_build_unknown_league_raises():
 def test_enrich_xfl_pbp_produces_model_columns():
     pbp = build_spring_football_pbp(_xfl_summary(), league="xfl")
     out = enrich_spring_football_pbp(pbp, league="xfl")
-    for col in ("ep", "epa", "wp", "wpa"):
+    for col in ("ep", "epa", "wp", "wpa", "vegas_wp"):
         assert col in out.columns
         assert out[col].drop_nulls().len() > 0
     assert out.select(pl.col("epa").drop_nulls().is_finite().all()).item()

--- a/tests/football/test_spring_football_ep_wp.py
+++ b/tests/football/test_spring_football_ep_wp.py
@@ -11,6 +11,7 @@ this port; XFL does).
 from __future__ import annotations
 
 import json
+import warnings
 from pathlib import Path
 
 import polars as pl
@@ -152,3 +153,43 @@ def test_enrich_unknown_league_raises():
     pbp = build_spring_football_pbp(_xfl_summary(), league="xfl")
     with pytest.raises(ValueError):
         enrich_spring_football_pbp(pbp, league="usfl")
+
+
+def test_spring_enrichment_output_contract():
+    """Pin which enrich outputs spring football actually populates.
+
+    The docstring used to promise ``cp``/``cpoe``/xYAC; all three come back
+    100% null, and cp/cpoe do so with no warning at all. The cause is upstream:
+    the builder emits ``air_yards`` and ``spread_line`` as all-null (no
+    air-yards charting, no betting market), so the CP and xYAC air-yards models
+    and the fourth-down surface have nothing to score.
+
+    This asserts the real contract in both directions. If the builder ever
+    gains genuine air yards, the "always null" half starts failing -- which is
+    the point: the docs claim these are structurally empty, and that claim
+    should not outlive the reason for it.
+    """
+    pbp = build_spring_football_pbp(_load_fixture("xfl_summary.json"), league="xfl")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = enrich_spring_football_pbp(pbp, league="xfl")
+
+    assert out.height > 0
+
+    # The inputs whose absence causes everything below.
+    for col in ("air_yards", "spread_line"):
+        assert out[col].drop_nulls().len() == 0, f"{col} gained values — update the Returns note"
+
+    # Scored: EP/WP derive from down/distance/yardline/clock/score, all of which
+    # the builder does produce. Guard on a share, not an exact count, so a
+    # re-captured fixture does not turn a working pipeline red.
+    for col in ("ep", "epa", "wp", "wpa"):
+        filled = out[col].drop_nulls().len()
+        assert filled >= 0.9 * out.height, f"{col} only {filled}/{out.height} populated"
+
+    # Structurally empty for these leagues — see the function's Returns note.
+    for col in ("cp", "cpoe", "xyac_epa", "first_down_prob", "go_boost"):
+        assert out[col].drop_nulls().len() == 0, (
+            f"{col} is now populated for spring football — the Returns note in "
+            "enrich_spring_football_pbp says it cannot be, so one of them is wrong"
+        )


### PR DESCRIPTION
Found while tracing two `RuntimeWarning`s in the live-test log. The warnings turned out to be the visible half of a larger documentation defect.

## The docstring promised outputs that are structurally empty

`enrich_spring_football_pbp`'s Returns block advertised `ep`/`epa`/`wp`/`wpa`/`cp`/`cpoe`/xYAC. Measured on the committed `xfl_summary.json` fixture (159 plays):

| promised | non-null |
|---|---|
| `ep` | 158 / 159 |
| `epa` | 157 / 159 |
| `wp` | 158 / 159 |
| `wpa` | 157 / 159 |
| `vegas_wp` | 158 / 159 |
| **`cp`** | **0 / 159** |
| **`cpoe`** | **0 / 159** |
| **`xyac_epa` and every other `xyac_*`** | **0 / 159** |
| **`first_down_prob`, `go_boost`, `fourth_down_recommendation`** | **0 / 159** |

## Cause is upstream of the scorers

`build_spring_football_pbp` emits `air_yards` and `spread_line` as **all-null** (also measured: 0/159 each) because these leagues publish no air-yards charting and carry no betting market. CP and xYAC are air-yards models and the fourth-down surface needs `total_line`, so none of them has an input to score.

Nothing is broken and nothing can be fixed here — they would start working the day the builder gains real air yards.

**The worse half is the quiet one.** xYAC and fourth-down at least emit a `RuntimeWarning`; `cp`/`cpoe` go silently null while the docstring says they are populated.

## What this changes

- The Returns block now states the measured contract with the counts and the reason.
- A new `test_spring_enrichment_output_contract` locks it in **both directions**: the populated columns must stay populated (≥90% of rows, so a re-captured fixture doesn't turn a working pipeline red) and the structurally-empty ones must stay empty. It asserts `out.height > 0` first so the null checks cannot pass vacuously. If the builder ever gains genuine air yards, the second half starts failing — which is the point: the docs claim these are structurally empty and that claim should not outlive its cause.

## What this deliberately does NOT change

My first attempt also passed `add_fourth_down=False` to silence the warning. **That broke `test_nfl_parity_shared_core` and `test_nfl_parity_on_real_nfl_fixture`** — it drops 15 columns, and this module's stated design is that it calls `enrich_nfl_pbp` *UNCHANGED*; the parity tests prove that by exact column-set equality. The parity tests were right, so it is reverted and the code carries a comment saying why, to stop the next person re-trying it. The per-call warning is the cheaper cost.

## Gates

`tests/football/`: **25 passed, 1 skipped**. ruff clean. Docs-only plus one test — no behaviour change.

## Summary by Sourcery

Document and test the actual spring-football enrichment output contract without changing the shared enrichment behavior.

Enhancements:
- Document the measured spring-football enrichment contract, distinguishing populated outputs from structurally empty CP, xYAC, and fourth-down columns and explaining their unavailable upstream inputs.

Documentation:
- Update the spring-football enrichment Returns documentation to accurately describe populated and always-null outputs and preserve the intentional parity behavior.

Tests:
- Add contract coverage verifying required inputs remain null, core EP/WP outputs stay populated, and unsupported enrichment columns remain empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified which enrichment fields are populated for spring football data and which may remain unavailable due to source-data limitations.
  - Documented the behavior of fourth-down metrics and related fields for spring football plays.

- **Tests**
  - Added regression coverage for spring-football enrichment output, including populated expected-points and win-probability metrics, unavailable air-yard and spread-dependent fields, and valid results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->