### PR TITLE
fix(validation): distance_non_negative flagged this package's own no-down sentinel

### DIFF
--- a/tests/contracts/test_definitional.py
+++ b/tests/contracts/test_definitional.py
@@ -418,3 +418,43 @@ def test_cfb_pbp_sack_without_yardage_is_warn():
     by_rule = _findings_by_rule(definitional.run("cfb_pbp", frame, _pbp_ctx()))
     f = by_rule["sack_requires_yds_sacked"]
     assert f.severity is Severity.WARN and f.needs_judgment and f.metric == 1.0
+
+
+def test_distance_non_negative_ignores_the_no_down_sentinel():
+    """A PAT row carrying the -1 no-down sentinel is not a distance violation.
+
+    ``cfb_pbp`` normalizes extra-point and two-point rows onto
+    ``start.down = start.distance = -1`` so they stay out of down-based logic;
+    those rows are ``scrimmage_play=False``. Before this rule was scoped to
+    scrimmage plays it reported ~49.5k ERRORs per run on the published assets
+    (45,500 of them extra points) and buried the ~61 rows that carry a real
+    down with a negative distance. See cfbfastR-cfb-data#67.
+    """
+    frame = pl.DataFrame(
+        {
+            "game_id": [1, 2],
+            "rush": [False, False],
+            "pass": [False, False],
+            "start.distance": [-1, -1],  # the sentinel, on non-scrimmage rows
+        }
+    )
+    assert "distance_non_negative" not in _findings_by_rule(definitional.run("cfb_model_pbp", frame, _ctx()))
+
+
+def test_distance_non_negative_still_catches_a_real_scrimmage_violation():
+    """The narrowing must not make the rule unable to fail.
+
+    A rush or pass with a negative distance is the case the rule exists for and
+    is not explained by the sentinel convention.
+    """
+    frame = pl.DataFrame(
+        {
+            "game_id": [1, 2, 3],
+            "rush": [True, False, False],
+            "pass": [False, True, False],
+            "start.distance": [-5, -3, -1],  # two scrimmage violations + one sentinel
+        }
+    )
+    f = _findings_by_rule(definitional.run("cfb_model_pbp", frame, _ctx()))["distance_non_negative"]
+    assert f.severity is Severity.ERROR
+    assert f.metric == 2.0  # the sentinel row is excluded, the two real ones are not

--- a/tools/validation/checks/definitional.py
+++ b/tools/validation/checks/definitional.py
@@ -148,10 +148,19 @@ _CFB_RULES: tuple[Rule, ...] = (
         "a rush/pass play must start on down 1-4",
     ),
     Rule(
+        # Scoped to scrimmage plays on purpose. ``-1`` is this package's OWN
+        # no-down sentinel, not bad data: cfb_pbp normalizes extra-point and
+        # two-point rows onto ``start.down = start.distance = -1`` so they stay
+        # out of down-based logic, and those rows are ``scrimmage_play=False``.
+        # Unscoped, this rule reported ~49.5k ERRORs per run on the published
+        # assets -- 45,500 extra points, 2,117 misses, 1,583 two-point tries --
+        # and buried the ~61 rows that carry a REAL down (1-4) with a negative
+        # distance, which is the thing worth finding. Measured 2026-09-03 over
+        # 2004-2025 (3.27M rows); see cfbfastR-cfb-data#67.
         "distance_non_negative",
-        ("start.distance",),
-        _c("start.distance") < 0,
-        "distance-to-first-down cannot be negative",
+        ("rush", "pass", "start.distance"),
+        _CFB_SCRIMMAGE & (_c("start.distance") < 0),
+        "distance-to-first-down cannot be negative on a scrimmage play",
     ),
     Rule(
         "distance_within_yards_to_endzone",


### PR DESCRIPTION
Found while chasing what I filed as a data defect in cfbfastR-cfb-data#67. **The data is fine; the rule was wrong** — I retracted that report.

## The rule was the odd one out

`distance_non_negative` was unscoped while the rules immediately above and below it both scope to `_CFB_SCRIMMAGE`:

```python
# scrimmage_down_in_1_4            -> _CFB_SCRIMMAGE & ...
# distance_non_negative            -> _c("start.distance") < 0     # <- unscoped
# distance_within_yards_to_endzone -> _CFB_SCRIMMAGE & ...
```

So it reported every row with a negative distance, including the ones where `-1` is **this package's own sentinel**. `cfb_pbp.py` deliberately normalizes extra-point and two-point rows onto `start.down = start.distance = -1`, with the reasoning in the code:

> Force the sentinel so these no-down scoring plays stay out of down-based logic consistently. Extra-point rows are `scrimmage_play=False`, so this never touches scrimmage aggregates.

## Measured on the published assets (2004–2025, 3.27M rows)

49,596 rows trip the rule. **49,533 of them also carry `start.down == -1`:**

| type.text | rows |
|---|---:|
| Extra Point Good | 45,500 |
| Extra Point Missed | 2,117 |
| Two-Point Conversion Missed / Good | 1,583 |
| 2pt Conversion | 200 |
| Penalty / Rush / Pass Completion | 172 |

The era shape that reads like a regression — concentrated 2004–2013, ~0 after 2014 — is a **format change**, not a fix that missed seasons: modern games have no separate extra-point rows.

## What the noise was burying

**~61 rows carry a REAL down with a negative distance** — 35 on 1st, 12 on 2nd, 10 on 3rd, 4 on 4th. Not explained by the sentinel convention, and exactly what the rule exists to surface. They were **0.12%** of its output, which is why I misread the whole population as corrupt.

## Tests

Two, and I verified both **FAIL against the unscoped rule** before trusting them:

- a PAT row carrying the sentinel must not be reported;
- a rush/pass with a negative distance still must be — asserted as `metric == 2.0` with a sentinel row mixed into the same frame, so the narrowing cannot have made the rule unable to fail.

`tests/contracts/test_definitional.py`: **33 passed**. ruff clean.

This also removes ~49.5k false ERRORs per run from the validation cron that #448 just taught to report its findings instead of deleting them.

## Summary by Sourcery

Prevent the distance validation from flagging non-scrimmage scoring sentinels while continuing to detect genuine scrimmage-play violations.

Bug Fixes:
- Scope the negative-distance validation rule to scrimmage plays so package-defined no-down sentinel rows are no longer reported as violations.

Tests:
- Add coverage ensuring sentinel rows are ignored while real negative distances on rush and pass plays remain errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated football play validation to evaluate negative starting distance only for scrimmage plays.
  * Extra-point and two-point plays using the standard `-1` sentinel are no longer incorrectly reported as violations.
  * Genuine negative-distance issues on rushing and passing plays continue to be reported as errors.
  * Added coverage to verify both corrected behavior and detection of real violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->