### PR TITLE
test(nfl): compare cross-game epa with a tolerance, not bit-exact equality

### DIFF
--- a/tests/nfl/test_enrich.py
+++ b/tests/nfl/test_enrich.py
@@ -35,6 +35,8 @@ actually reached the scorer for kickoff / down-NA rows.
 
 from __future__ import annotations
 
+import math
+
 import polars as pl
 import pytest
 
@@ -406,8 +408,26 @@ class TestLeadDiffWiring:
         out_g1 = enrich_nfl_pbp(g1, method="lead_diff")
         merged = out.filter(pl.col("game_id") == "2023_01_AAA_BBB").sort("play_id")
         solo = out_g1.sort("play_id")
-        # epa column must match between the two-game and single-game runs
-        assert merged["epa"].to_list() == solo["epa"].to_list(), "epa leaked across game boundary"
+
+        # The epa column must match between the two-game and single-game runs.
+        #
+        # Compared with a tolerance, NOT `==`, and that is load-bearing: polars
+        # rewrites a division by a literal into a multiplication by its reciprocal
+        # on larger frames, so `(100 - yardline) / 10` is evaluated as `92.0 / 10.0`
+        # (0x1.2666666666666p+3) on the 5-row frame and as `92.0 * 0.1`
+        # (0x1.2666666666667p+3) on the 10-row one. That is a 1-ULP difference in
+        # `ep` which first-differencing carries into `epa` -- an artefact of frame
+        # SIZE, not of a cross-game leak. A real leak would move epa by whole
+        # points (the boundary play would derive from the other game's ep), so a
+        # 1e-9 tolerance still fails loudly on the thing this test exists to catch.
+        got, want = merged["epa"].to_list(), solo["epa"].to_list()
+        assert len(got) == len(want), "row count differs between the two runs"
+        for i, (a, b) in enumerate(zip(got, want)):
+            assert (a is None) == (b is None), f"epa null-ness differs at play {i + 1}: {a!r} vs {b!r}"
+            if a is not None:
+                assert math.isclose(a, b, rel_tol=1e-9, abs_tol=1e-9), (
+                    f"epa leaked across game boundary at play {i + 1}: {a!r} vs {b!r}"
+                )
 
     def test_idempotent(self, patched) -> None:  # noqa: ANN001
         once = enrich_nfl_pbp(_synthetic_frame(), method="lead_diff")


### PR DESCRIPTION
## The failure

`test_no_cross_game_leak_in_epa` has been failing on `main`. It is **not** a leak — the two runs differ by 2e-15:

```
At index 0 diff: 6.700000000000001 != 6.699999999999999
```

## Root cause

The test asserts `epa` is **bit-identical** between a two-game frame and a one-game frame. But polars rewrites a division by a literal into a multiplication by its reciprocal on larger frames, so the stub scorer's `(100 - yardline_100) / 10` is evaluated two different ways for the same input:

| frame | arithmetic | result |
|---|---|---|
| 5 rows | `92.0 / 10.0` (true divide) | `0x1.2666666666666p+3` |
| 10 rows | `92.0 * 0.1` (reciprocal multiply) | `0x1.2666666666667p+3` |

Verified in isolation on the real 34-column frame: identical dtype (`Int64`), identical values, identical column order — **only the row count differs**. First-differencing carries that 1 ULP from `ep` into `epa`.

So the assertion is testing an invariant polars does not offer. The test's *intent* — that the boundary play must not derive `epa` from the next game's first play — is sound and unchanged.

## The fix

Compare with a tolerance instead of `==`:

- null-ness still compared **exactly** (that is structural, not floating-point)
- values compared with `rel_tol=1e-9, abs_tol=1e-9`

A real cross-game leak moves `epa` by **whole points**, so 1e-9 is still a sharp test. I asserted that directly while fixing it: injecting a whole-point divergence is still caught, while the 1-ULP rows are tolerated.

The comment in the test records the root cause so nobody "fixes" it back to `==`.

**No production code changes** — `ep_wp.py` is untouched. `tests/nfl/test_enrich.py`: 15/15 pass.

## Summary by Sourcery

Make the cross-game EPA isolation test robust to insignificant floating-point variation without weakening its leak detection.

Bug Fixes:
- Prevent the cross-game EPA regression test from failing on harmless floating-point differences caused by frame-size-dependent arithmetic evaluation.

Enhancements:
- Preserve exact checks for EPA nullness and row counts while using a tight tolerance for numeric comparisons, ensuring genuine whole-point cross-game leaks remain detectable.

Tests:
- Strengthen the cross-game EPA isolation test to tolerate one-ULP differences while continuing to catch boundary leakage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of EPA cross-game data by allowing small floating-point differences while still checking missing values and results.
  * Added more reliable comparisons to reduce false test failures caused by numeric precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->