### PR TITLE
docs(codegen): backfill returns-column documentation, tighten the deferred ratchet

### DIFF
--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -3402,47 +3402,47 @@ Release: [ncaa_mfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `play_number` | Int64 | Sequential play number within the game (1-indexed). |
 | `offense` | String | Full name of the offense (team in possession) on the play. |
 | `drive_result` | String | Drive result code (`drive_`-prefixed; every drive-level column is carried with this prefix). |
-| `drive_scored` | Boolean |  |
+| `drive_scored` | Boolean | Whether the possession containing this play ended in points for the offense. |
 | `down` | Int64 | Down of the play (1-4). |
 | `distance` | Int64 | Yards to gain for a first down (or to the goal line in goal-to-go situations). |
 | `yard_line` | String | Field-position yard line at the start of the play (0-50 scale from the offense's side). |
-| `yard_line_side` | String |  |
-| `yard_line_number` | Int64 |  |
+| `yard_line_side` | String | Which team's territory the ball was on at the snap ('OFF' own side, 'DEF' opponent side); pairs with yard_line_number for absolute field position. |
+| `yard_line_number` | Int64 | Yard line at the snap (0-50); pairs with yard_line_side for absolute field position. |
 | `play_type` | String | CFBD play type label (e.g. "Rush", "Pass Reception", "Field Goal Good"). |
 | `clock` | String | Game clock display value at the play (`MM:SS`). |
 | `yards_gained` | Int64 | Net yards gained by the offense on the play. |
-| `formation` | String |  |
+| `formation` | String | Offensive formation or personnel grouping reported for the play (e.g. 'Shotgun', 'I-Formation'), when the source narrative names it. |
 | `passer` | String | Name of the dropback player (scrambles included) including plays with penalties. |
 | `rusher` | String | Name of the rusher (no scrambles) including plays with penalties. |
 | `receiver` | String | Name of the receiver including plays with penalties. |
-| `kicker` | String |  |
-| `punter` | String |  |
-| `returner` | String |  |
-| `run_direction` | String |  |
+| `kicker` | String | Name of the player who kicked off, punted, or attempted the field goal/PAT on this play. |
+| `punter` | String | Name of the player who punted on this play. |
+| `returner` | String | Name of the player who fielded or returned the kickoff or punt on this play. |
+| `run_direction` | String | Hole or side the ball carrier ran through on a rush play (e.g. 'left end', 'right guard'), when the narrative reports it. |
 | `qb_scramble` | Boolean | Binary indicator for whether or not the QB scrambled. |
-| `pass_complete` | Boolean |  |
-| `pass_depth` | String |  |
-| `pass_direction` | String |  |
-| `tackler_1` | String |  |
-| `tackler_2` | String |  |
-| `kick_yards` | Int64 |  |
+| `pass_complete` | Boolean | Whether a pass attempt on this play was completed. |
+| `pass_depth` | String | Depth classification of a pass attempt (e.g. 'short', 'deep'), when the narrative reports it. |
+| `pass_direction` | String | Side of the field the pass was thrown to (e.g. 'left', 'middle', 'right'), when the narrative reports it. |
+| `tackler_1` | String | Name of the primary (first-listed) tackler on the play. |
+| `tackler_2` | String | Name of the secondary (assisting) tackler on the play, when the narrative credits an assist. |
+| `kick_yards` | Int64 | Yards traveled on a kickoff. |
 | `return_yards` | Int64 | Yards gained by the return team. Returns may occur on any of: interception, fumble, kickoff, punt, or blocked kicks. |
-| `punt_yards` | Int64 |  |
-| `fg_distance` | Int64 |  |
+| `punt_yards` | Int64 | Gross yards traveled on a punt, before any return. |
+| `fg_distance` | Int64 | Distance in yards of a field goal attempt. |
 | `fg_made` | Boolean | TRUE when the field goal attempt was successful. |
-| `is_first_down` | Boolean |  |
-| `is_touchdown` | Boolean |  |
-| `is_safety` | Boolean |  |
-| `is_fumble` | Boolean |  |
+| `is_first_down` | Boolean | Whether the play resulted in a first down for the offense. |
+| `is_touchdown` | Boolean | Whether the play resulted in a touchdown. |
+| `is_safety` | Boolean | Whether the play resulted in a safety. |
+| `is_fumble` | Boolean | Whether a fumble occurred on the play, regardless of which team recovered it. |
 | `is_turnover` | Boolean | `TRUE` if the play was a turnover. |
-| `turnover_type` | String |  |
+| `turnover_type` | String | Kind of turnover on the play, if any (e.g. 'interception', 'fumble lost'); null when no turnover occurred. |
 | `out_of_bounds` | Boolean | 1 if play description contains ran ob, pushed ob, or sacked ob; 0 otherwise. |
-| `no_play` | Boolean |  |
-| `fair_catch` | Boolean |  |
+| `no_play` | Boolean | Whether the play was negated (e.g. by a penalty on the preceding down) and is excluded from drive/stat totals. |
+| `fair_catch` | Boolean | Whether the returner called a fair catch on a kickoff or punt. |
 | `penalty_flag` | Boolean | TRUE when a penalty was flagged on the play. |
 | `penalty_team` | String | String abbreviation of the team with the penalty. |
 | `penalty_type` | String | String indicating the penalty type of the first penalty in the given play. Will be `NA` if `desc` is missing the type. |
-| `penalty_player` | String |  |
+| `penalty_player` | String | Name of the player penalized on the play, when a penalty occurred. |
 | `penalty_yards` | Int64 | Yards gained (or lost) by the posteam from the penalty. |
 | `end_yard_line` | String | Yard line at the end of the play. |
 | `play_text` | String | Free-form text description of the play from the CFBD feed. |
@@ -3472,8 +3472,8 @@ Release: [ncaa_mfb_pbp_cfbfastr](https://github.com/sportsdataverse/sportsdatave
 | `week` | Int64 | Game week of the season. |
 | `period` | Int64 | Period (quarter) number. |
 | `half` | Int64 | Half indicator (1 or 2). |
-| `clock.minutes` | Int64 |  |
-| `clock.seconds` | Int64 |  |
+| `clock.minutes` | Int64 | Minutes remaining on the game clock at the start of the play (cfbfastR schema column). |
+| `clock.seconds` | Int64 | Seconds remaining within the current minute on the game clock at the start of the play (cfbfastR schema column). |
 | `TimeSecsRem` | Int64 | Seconds remaining in the half at the start of the play. |
 | `Under_two` | Boolean | TRUE when under two minutes remain in the half. |
 | `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
@@ -3554,7 +3554,7 @@ Release: [ncaa_mfb_pbp_cfbfastr](https://github.com/sportsdataverse/sportsdatave
 | `yds_fg` | Int64 | Distance of the field goal attempt in yards. |
 | `drive_result` | String | Drive result code (`drive_`-prefixed; every drive-level column is carried with this prefix). |
 | `drive_scoring` | Boolean | Binary flag for a scoring drive. |
-| `ot_synthesized` | Boolean |  |
+| `ot_synthesized` | Boolean | Whether this row's overtime clock/period fields were synthesized rather than sourced directly -- stats.ncaa.org reports no running clock in overtime, so OT plays are assigned a synthetic countdown. |
 | `lag_pos_team` | String | Possession team on the previous play (lag value). |
 | `lead_pos_team` | String | Possession team on the next play (lead value). |
 | `lag_play_type` | String | Play type on the previous play (lag value). |
@@ -3563,7 +3563,7 @@ Release: [ncaa_mfb_pbp_cfbfastr](https://github.com/sportsdataverse/sportsdatave
 | `lead_play_text` | String | Play text from the next play (lead value). |
 | `change_of_pos_team` | Boolean | Binary flag for change of possession-team on the play. |
 | `play_after_turnover` | Boolean | Binary flag indicating the play immediately following a turnover. |
-| `n_plays_in_game` | UInt32 |  |
+| `n_plays_in_game` | UInt32 | Total number of plays in the game this row belongs to, repeated on every row for convenience. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
 
 ```python
@@ -3579,18 +3579,18 @@ Release: [ncaa_mfb_drives](https://github.com/sportsdataverse/sportsdataverse-da
 |---|---|---|
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
 | `drive_number` | Int64 | Sequential drive number within the game (1-indexed). |
-| `quarter` | Int64 |  |
+| `quarter` | Int64 | Quarter in which the drive started (1-4 for regulation, 5+ for overtime periods). |
 | `period` | Int64 | Period (quarter) number. |
 | `team` | String | Team name. |
 | `start_period` | Int64 | Period (quarter) in which the drive starts. |
-| `start_how` | String |  |
+| `start_how` | String | How the drive began (e.g. 'Kickoff', 'Interception', 'Fumble', 'Downs', 'Punt'). |
 | `start_clock` | String | Game clock display value at the start of the drive. |
 | `start_yard_line` | String | Yard line at the start of the play. |
 | `end_period` | Int64 | Period (quarter) in which the drive ends. |
-| `end_how` | String |  |
+| `end_how` | String | How the drive ended (e.g. 'Touchdown', 'Punt', 'Interception', 'Fumble', 'End of Half'). |
 | `end_clock` | String | Game clock display value at the end of the drive. |
 | `end_yard_line` | String | Yard line at the end of the play. |
-| `n_plays` | Int64 |  |
+| `n_plays` | Int64 | Number of plays run during the drive. |
 | `yards` | Int64 | Total yards gained on the drive. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
 | `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
@@ -3612,12 +3612,12 @@ Release: [ncaa_mfb_schedule](https://github.com/sportsdataverse/sportsdataverse-
 | `opponent_id` | String | ESPN team id of the opponent. |
 | `opponent` | String | Opponent team name. |
 | `result` | String | Drive result code (e.g. `PUNT`, `TD`). |
-| `outcome` | String |  |
+| `outcome` | String | Result of the game from the home team's perspective (e.g. 'W', 'L', 'T'). |
 | `team_score` | Int64 | Offense team score at the time of the play. |
 | `opponent_score` | Int64 | Defense / opponent team score at the time of the play. |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
 | `attendance` | Int64 | Reported attendance at the game. |
-| `academic_year` | Int32 |  |
+| `academic_year` | Int32 | Academic year the game was played in (the ENDING year of the fall/spring split, e.g. 2025 for the 2024 fall season) -- distinct from `season`, which is the STARTING year. |
 | `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
@@ -3636,8 +3636,8 @@ Release: [ncaa_mfb_rosters](https://github.com/sportsdataverse/sportsdataverse-d
 | `player_id` | String | ESPN player id from the roster entry. |
 | `player_name` | String | Full name of player |
 | `jersey` | String | Jersey number. |
-| `statcrew_jersey` | String |  |
-| `player_class` | String |  |
+| `statcrew_jersey` | String | Jersey number as recorded in the NCAA StatCrew roster feed; can differ from the number a player actually wears on a given game day. |
+| `player_class` | String | Player's academic/eligibility class (e.g. 'FR', 'SO', 'JR', 'SR', 'GR'). |
 | `position` | String | Athlete position. |
 | `height` | String | Listed height (inches). |
 | `weight` | Int64 | Listed weight (lbs). |
@@ -3645,7 +3645,7 @@ Release: [ncaa_mfb_rosters](https://github.com/sportsdataverse/sportsdataverse-d
 | `high_school` | String | High school |
 | `games_played` | Int64 | Games played. |
 | `games_started` | Int64 | Games started (goalies). |
-| `academic_year` | Int32 |  |
+| `academic_year` | Int32 | Academic year the roster snapshot covers (the ENDING year of the fall/spring split) -- distinct from `season`, which is the STARTING year. |
 | `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
@@ -3661,7 +3661,7 @@ Release: [ncaa_mfb_teams](https://github.com/sportsdataverse/sportsdataverse-dat
 |---|---|---|
 | `team_id` | String | ESPN team id. |
 | `team_name` | String | Team nickname; `team_detail = TRUE` only. |
-| `academic_year` | Int32 |  |
+| `academic_year` | Int32 | Academic year the team record covers (the ENDING year of the fall/spring split) -- distinct from `season`, which is the STARTING year. |
 | `division` | Int32 | Division in the conference for the team. |
 | `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
@@ -3681,9 +3681,9 @@ Release: [ncaa_mfb_team_stats](https://github.com/sportsdataverse/sportsdatavers
 | `stat` | String | Stat. |
 | `period` | String | Period (quarter) number. |
 | `away_team` | String | Away team name. |
-| `away_value` | String |  |
+| `away_value` | String | Team-stat value for the away team; each row is one stat category for one game, wide by side. |
 | `home_team` | String | Home team name. |
-| `home_value` | String |  |
+| `home_value` | String | Team-stat value for the home team; each row is one stat category for one game, wide by side. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
 | `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
@@ -3704,11 +3704,11 @@ Release: [ncaa_mfb_player_stats](https://github.com/sportsdataverse/sportsdatave
 | `name` | String | Position name (e.g. `Quarterback`). |
 | `position` | String | Athlete position. |
 | `rush_attempts` | String | The number of rushing attempts |
-| `rush_yds_gained` | String |  |
-| `rush_yds_lost` | String |  |
-| `yds_rush` | String |  |
+| `rush_yds_gained` | String | Total positive rushing yards gained on carries, before subtracting yards lost to tackles for loss. |
+| `rush_yds_lost` | String | Total rushing yards lost to tackles for loss on carries. |
+| `yds_rush` | String | Net rushing yards (rush_yds_gained minus rush_yds_lost). |
 | `rush_tds` | String | Team rushing touchdowns. |
-| `rush_long` | String |  |
+| `rush_long` | String | Longest single rush of the game. |
 | `category` | String | CFBD stats category name (e.g. passing, rushing, defensive). |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
 | `pass_attempts` | String | Career pass attempts |
@@ -3716,15 +3716,15 @@ Release: [ncaa_mfb_player_stats](https://github.com/sportsdataverse/sportsdatave
 | `pass_yards` | String | Number of yards gained on pass plays |
 | `interceptions` | String | Passing interceptions. |
 | `pass_tds` | String | Career pass touchdowns thrown |
-| `pass_eff` | String |  |
-| `yds_per_completion` | String |  |
+| `pass_eff` | String | Passer efficiency rating for the game, per the NCAA passer-rating formula. |
+| `yds_per_completion` | String | Passing yards divided by completions. |
 | `pct` | String | Win percentage. |
-| `long_pass` | String |  |
-| `rec` | String |  |
+| `long_pass` | String | Longest completed pass of the game. |
+| `rec` | String | Total receptions for the game. |
 | `receiving_yards` | String | Numeric yards by the receiver_player_name, excluding yards gained in pass plays with laterals. This should equal official receiving statistics but could miss yards gained in pass plays with laterals. Please see the description of `lateral_receiver_player_name` for further information. |
-| `yards_per_reception` | String |  |
-| `rec_td` | String |  |
-| `long_rec` | String |  |
+| `yards_per_reception` | String | Receiving yards divided by receptions. |
+| `rec_td` | String | Receiving touchdowns. |
+| `long_rec` | String | Longest reception of the game. |
 | `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -3707,15 +3707,15 @@ Release: [ncaa_mfb_player_stats](https://github.com/sportsdataverse/sportsdatave
 | `rush_yds_gained` | String | Total positive rushing yards gained on carries, before subtracting yards lost to tackles for loss. |
 | `rush_yds_lost` | String | Total rushing yards lost to tackles for loss on carries. |
 | `yds_rush` | String | Net rushing yards (rush_yds_gained minus rush_yds_lost). |
-| `rush_tds` | String | Team rushing touchdowns. |
+| `rush_tds` | String | Rushing touchdowns for the game. Populated only on this player-game's 'rushing' category row (null on the 'passing'/'receiving' rows for the same player-game) -- the loader returns one row per player-game-category. |
 | `rush_long` | String | Longest single rush of the game. |
 | `category` | String | CFBD stats category name (e.g. passing, rushing, defensive). |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
-| `pass_attempts` | String | Career pass attempts |
+| `pass_attempts` | String | Pass attempts for the game. Populated only on this player-game's 'passing' category row (null on the 'rushing'/'receiving' rows for the same player-game) -- the loader returns one row per player-game-category. |
 | `completions` | String | The number of completed passes. |
 | `pass_yards` | String | Number of yards gained on pass plays |
 | `interceptions` | String | Passing interceptions. |
-| `pass_tds` | String | Career pass touchdowns thrown |
+| `pass_tds` | String | Passing touchdowns thrown for the game. Populated only on this player-game's 'passing' category row (null on the 'rushing'/'receiving' rows for the same player-game) -- the loader returns one row per player-game-category. |
 | `pass_eff` | String | Passer efficiency rating for the game, per the NCAA passer-rating formula. |
 | `yds_per_completion` | String | Passing yards divided by completions. |
 | `pct` | String | Win percentage. |

--- a/docs/docs/mbb/reference/loaders.md
+++ b/docs/docs/mbb/reference/loaders.md
@@ -1433,12 +1433,12 @@ Release: [ncaa_mbb_rapm](https://github.com/sportsdataverse/sportsdataverse-data
 | `person_id` | String | Unique player identifier (V3 endpoints). |
 | `player` | String | Player name. |
 | `team` | String | Team-side label or team identifier. |
-| `orapm` | Float64 |  |
-| `drapm` | Float64 |  |
-| `rapm_net` | Float64 |  |
-| `off_poss` | Int64 |  |
-| `def_poss` | Int64 |  |
-| `estimand` | String |  |
+| `orapm` | Float64 | Offensive regularized adjusted plus-minus: points contributed per 100 possessions on offense, adjusted for the other 9 players on the floor. |
+| `drapm` | Float64 | Defensive regularized adjusted plus-minus: points allowed per 100 possessions on defense, adjusted for the other 9 players on the floor. |
+| `rapm_net` | Float64 | Net RAPM (orapm minus drapm): overall point contribution per 100 possessions. |
+| `off_poss` | Int64 | Offensive possessions the player was on court for; the regression weight behind orapm. |
+| `def_poss` | Int64 | Defensive possessions the player was on court for; the regression weight behind drapm. |
+| `estimand` | String | Which RAPM quantity this row's coefficient estimates ('offense', 'defense', or 'net') -- one row per player per estimand. |
 
 ```python
 load_ncaa_mbb_rapm(seasons=2024)

--- a/docs/docs/mbb/reference/loaders.md
+++ b/docs/docs/mbb/reference/loaders.md
@@ -1434,11 +1434,11 @@ Release: [ncaa_mbb_rapm](https://github.com/sportsdataverse/sportsdataverse-data
 | `player` | String | Player name. |
 | `team` | String | Team-side label or team identifier. |
 | `orapm` | Float64 | Offensive regularized adjusted plus-minus: points contributed per 100 possessions on offense, adjusted for the other 9 players on the floor. |
-| `drapm` | Float64 | Defensive regularized adjusted plus-minus: points allowed per 100 possessions on defense, adjusted for the other 9 players on the floor. |
-| `rapm_net` | Float64 | Net RAPM (orapm minus drapm): overall point contribution per 100 possessions. |
+| `drapm` | Float64 | Defensive regularized adjusted plus-minus: points prevented per 100 possessions on defense (higher is better defense), adjusted for the other 9 players on the floor. |
+| `rapm_net` | Float64 | Net RAPM (orapm plus drapm): overall point contribution per 100 possessions. Verified against live data: rapm_net == orapm + drapm exactly. |
 | `off_poss` | Int64 | Offensive possessions the player was on court for; the regression weight behind orapm. |
 | `def_poss` | Int64 | Defensive possessions the player was on court for; the regression weight behind drapm. |
-| `estimand` | String | Which RAPM quantity this row's coefficient estimates ('offense', 'defense', or 'net') -- one row per player per estimand. |
+| `estimand` | String | Fit-scope tag for the RAPM model that produced this row (observed value: 'league', a Division I-wide fit) -- one row per player-season, not per estimand. |
 
 ```python
 load_ncaa_mbb_rapm(seasons=2024)

--- a/docs/docs/nfl/reference/additional.md
+++ b/docs/docs/nfl/reference/additional.md
@@ -2436,7 +2436,7 @@ Will be removed in a future release. Migrate callers to the unified
 | `opponent` | character | Opposing team of player |
 | `pfr_player_name` | character | Player's name as recorded by PFR |
 | `pfr_player_id` | character | ID from Pro Football Reference |
-| `def_ints` | double | Career interceptions |
+| `def_ints` | double | Interceptions for the week (this loader is per-player-per-week, not career). |
 | `def_targets` | double | Number of passing attempts thrown at or into the coverage area of this defender during the week. |
 | `def_completions_allowed` | double | Number of completions allowed by the defender on passes thrown into their coverage during the week. |
 | `def_completion_pct` | double | Completion percentage allowed by the defender on targets thrown in their coverage during the week. |

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -31,7 +31,7 @@ Polars (or pandas) DataFrame with one row per official: `game_id`, `season`, `of
 | col_name | type | description |
 |---|---|---|
 | `game_id` | integer | Unique game identifier. |
-| `season` | integer | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | integer | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `official_id` | character | Unique official / referee identifier. |
 | `first_name` | character | Player's first name. |
 | `last_name` | character | Player's last name. |
@@ -244,7 +244,7 @@ A single-row wide DataFrame (polars by default). Columns: identity / echo (`seas
 
 | col_name | type | description |
 |---|---|---|
-| `season` | integer | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | integer | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | character | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `total` | logical | Total. |
 | `athlete_id` | integer | Unique athlete identifier (ESPN). |
@@ -463,7 +463,7 @@ Polars dataframe containing schedule dates for the requested season. Returns Non
 | `away_linescores` | list | Points scored by the away team in each period or half of the game. |
 | `away_records` | character | Win-loss record string for the away team at the time of the game. |
 | `game_id` | integer | Unique game identifier. |
-| `season` | integer | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | integer | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | integer | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 
 **Example**

--- a/docs/docs/wbb/reference/loaders.md
+++ b/docs/docs/wbb/reference/loaders.md
@@ -76,7 +76,7 @@ Release: [espn_womens_college_basketball_pbp](https://github.com/sportsdataverse
 | `athlete_id_1` | Int32 | Primary athlete identifier (e.g. shooter). |
 | `athlete_id_2` | Int32 | Secondary athlete identifier (e.g. assister / fouler). |
 | `game_id` | Int32 | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `home_team_id` | Int32 | Unique identifier for the home team. |
 | `home_team_name` | String | Home team name. |
@@ -131,7 +131,7 @@ Release: [espn_womens_college_basketball_player_boxscores](https://github.com/sp
 | col_name | type | description |
 |---|---|---|
 | `game_id` | Int32 | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `game_date` | Date | Game date (YYYY-MM-DD). |
 | `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
@@ -268,7 +268,7 @@ Release: [espn_womens_college_basketball_schedules](https://github.com/sportsdat
 | `away_linescores` | String | Period-by-period scores for the away team as a delimited string from ESPN's schedule feed. |
 | `away_records` | String | Record strings (overall and split records) for the away team from ESPN's schedule feed. |
 | `game_id` | Int32 | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `status_type_alt_detail` | String | Status type alt detail. |
 | `tournament_id` | Int32 | ESPN tournament identifier. |
@@ -296,7 +296,7 @@ Release: [espn_womens_college_basketball_team_boxscores](https://github.com/spor
 | col_name | type | description |
 |---|---|---|
 | `game_id` | Int32 | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `game_date` | Date | Game date (YYYY-MM-DD). |
 | `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
@@ -365,7 +365,7 @@ Release: [wbb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/r
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `team_id` | String | Unique team identifier. |
 | `adj_o` | Float64 | Adj o. |
 | `adj_d` | Float64 | Adj d. |
@@ -390,7 +390,7 @@ Release: [wbb_player_value](https://github.com/sportsdataverse/sportsdataverse-d
 |---|---|---|
 | `player_id` | String | Unique player identifier. |
 | `player` | String | Player name. |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `team_id` | String | Unique team identifier. |
 | `min` | Float64 | Minutes played. |
 | `box_obpm` | Float64 | Box-score offensive plus/minus for the player, the offensive half of box BPM. |
@@ -408,7 +408,7 @@ Release: [espn_womens_college_basketball_game_rosters](https://github.com/sports
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `game_id` | String | Unique game identifier. |
 | `team_id` | Int32 | Unique team identifier. |
 | `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
@@ -442,7 +442,7 @@ Release: [espn_womens_college_basketball_officials](https://github.com/sportsdat
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `game_id` | String | Unique game identifier. |
 | `official_id` | Int32 | Unique official / referee identifier. |
 | `official_uid` | String | ESPN's globally unique resource identifier for the official, read from the core-api items[] uid key; that payload never ships it, so the column is null for every published row. |
@@ -465,7 +465,7 @@ Release: [espn_womens_college_basketball_player_season_stats](https://github.com
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
 | `athlete_display_name` | String | Athlete display name (full). |
 | `athlete_first_name` | String | Player first name; `athlete_detail = TRUE` only. |
@@ -493,7 +493,7 @@ Release: [espn_womens_college_basketball_rosters](https://github.com/sportsdatav
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `team_id` | Int32 | Unique team identifier. |
 | `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
 | `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
@@ -542,7 +542,7 @@ Release: [espn_womens_college_basketball_shots](https://github.com/sportsdataver
 | col_name | type | description |
 |---|---|---|
 | `game_id` | Int32 | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `period_number` | Int32 | Numeric period (1-4 for quarters; 5+ for OT). |
 | `clock_display_value` | String | Game clock display string (e.g. '8:32'). |
 | `team_id` | Int32 | Unique team identifier. |
@@ -573,7 +573,7 @@ Release: [espn_womens_college_basketball_standings](https://github.com/sportsdat
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `group_id` | String | ESPN group id. |
 | `group_name` | String | Group name (conference / division). |
 | `group_abbreviation` | String | Group abbreviation. |
@@ -609,7 +609,7 @@ Release: [espn_womens_college_basketball_team_season_stats](https://github.com/s
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `team_id` | Int32 | Unique team identifier. |
 | `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
 | `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
@@ -637,7 +637,7 @@ Release: [wbb_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `espn_team_id` | Int32 | ESPN team id (canonical key). |
 | `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
 | `player_name` | String | Player name. |
@@ -666,7 +666,7 @@ Release: [wbb_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `game_date` | Date | Game date (YYYY-MM-DD). |
 | `home_espn_team_id` | Int32 | ESPN home team id (NA for bart-only rows). |
 | `away_espn_team_id` | Int32 | ESPN away team id (NA for bart-only rows). |
@@ -691,7 +691,7 @@ Release: [wbb_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `espn_team_id` | Int32 | ESPN team id (canonical key). |
 | `espn_abbreviation` | String | ESPN abbreviation. |
 | `espn_display_name` | String | ESPN display name (school + mascot). |
@@ -721,7 +721,7 @@ Release: [espn_womens_college_basketball_player_core](https://github.com/sportsd
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `athlete_id` | Int64 | Unique athlete identifier (ESPN). |
 | `guid` | String | Stable cross-league team GUID. |
 | `uid` | String | ESPN UID string. |
@@ -774,12 +774,12 @@ Release: [ncaa_wbb_rapm](https://github.com/sportsdataverse/sportsdataverse-data
 | `person_id` | String | Unique player identifier (V3 endpoints). |
 | `player` | String | Player name. |
 | `team` | String | Team-side label or team identifier. |
-| `orapm` | Float64 |  |
-| `drapm` | Float64 |  |
-| `rapm_net` | Float64 |  |
-| `off_poss` | Int64 |  |
-| `def_poss` | Int64 |  |
-| `estimand` | String |  |
+| `orapm` | Float64 | Offensive regularized adjusted plus-minus: points contributed per 100 possessions on offense, adjusted for the other 9 players on the floor. |
+| `drapm` | Float64 | Defensive regularized adjusted plus-minus: points allowed per 100 possessions on defense, adjusted for the other 9 players on the floor. |
+| `rapm_net` | Float64 | Net RAPM (orapm minus drapm): overall point contribution per 100 possessions. |
+| `off_poss` | Int64 | Offensive possessions the player was on court for; the regression weight behind orapm. |
+| `def_poss` | Int64 | Defensive possessions the player was on court for; the regression weight behind drapm. |
+| `estimand` | String | Which RAPM quantity this row's coefficient estimates ('offense', 'defense', or 'net') -- one row per player per estimand. |
 
 ```python
 load_ncaa_wbb_rapm(seasons=2024)

--- a/docs/docs/wbb/reference/loaders.md
+++ b/docs/docs/wbb/reference/loaders.md
@@ -775,11 +775,11 @@ Release: [ncaa_wbb_rapm](https://github.com/sportsdataverse/sportsdataverse-data
 | `player` | String | Player name. |
 | `team` | String | Team-side label or team identifier. |
 | `orapm` | Float64 | Offensive regularized adjusted plus-minus: points contributed per 100 possessions on offense, adjusted for the other 9 players on the floor. |
-| `drapm` | Float64 | Defensive regularized adjusted plus-minus: points allowed per 100 possessions on defense, adjusted for the other 9 players on the floor. |
-| `rapm_net` | Float64 | Net RAPM (orapm minus drapm): overall point contribution per 100 possessions. |
+| `drapm` | Float64 | Defensive regularized adjusted plus-minus: points prevented per 100 possessions on defense (higher is better defense), adjusted for the other 9 players on the floor. |
+| `rapm_net` | Float64 | Net RAPM (orapm plus drapm): overall point contribution per 100 possessions. Verified against live data: rapm_net == orapm + drapm exactly. |
 | `off_poss` | Int64 | Offensive possessions the player was on court for; the regression weight behind orapm. |
 | `def_poss` | Int64 | Defensive possessions the player was on court for; the regression weight behind drapm. |
-| `estimand` | String | Which RAPM quantity this row's coefficient estimates ('offense', 'defense', or 'net') -- one row per player per estimand. |
+| `estimand` | String | Fit-scope tag for the RAPM model that produced this row (observed value: 'league', a Division I-wide fit) -- one row per player-season, not per estimand. |
 
 ```python
 load_ncaa_wbb_rapm(seasons=2024)

--- a/docs/docs/wnba/reference/additional.md
+++ b/docs/docs/wnba/reference/additional.md
@@ -36,7 +36,7 @@ Polars (or pandas) DataFrame with the same columns documented in `sportsdatavers
 | col_name | type | description |
 |---|---|---|
 | `game_id` | integer | Unique game identifier. |
-| `season` | integer | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | integer | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `official_id` | character | Unique official / referee identifier. |
 | `first_name` | character | Player's first name. |
 | `last_name` | character | Player's last name. |
@@ -94,7 +94,7 @@ A single-row wide DataFrame (polars by default). When `raw=True` returns the raw
 
 | col_name | type | description |
 |---|---|---|
-| `season` | integer | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | integer | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | character | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `total` | logical | Total. |
 | `athlete_id` | integer | Unique athlete identifier (ESPN). |
@@ -327,7 +327,7 @@ Polars dataframe containing schedule dates for the requested season. Returns Non
 | `away_linescores` | list | Period-by-period point totals for the away team, stored as a list of integer scores. |
 | `away_records` | character | Win-loss record strings for the away team across relevant splits (e.g., overall, home/away, conference). |
 | `game_id` | integer | Unique game identifier. |
-| `season` | integer | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | integer | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | integer | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 
 **Example**

--- a/docs/docs/wnba/reference/loaders.md
+++ b/docs/docs/wnba/reference/loaders.md
@@ -77,7 +77,7 @@ Release: [espn_wnba_pbp](https://github.com/sportsdataverse/sportsdataverse-data
 | `points_attempted` | Int32 | Point value at stake on the play's shot attempt (1, 2, or 3); 0 for non-shooting plays. |
 | `short_description` | String | Abbreviated ESPN text description of the play. |
 | `game_id` | Int32 | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `home_team_id` | Int32 | Unique identifier for the home team. |
 | `home_team_name` | String | Home team name. |
@@ -133,7 +133,7 @@ Release: [espn_wnba_player_boxscores](https://github.com/sportsdataverse/sportsd
 | col_name | type | description |
 |---|---|---|
 | `game_id` | Int32 | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `game_date` | Date | Game date (YYYY-MM-DD). |
 | `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
@@ -268,7 +268,7 @@ Release: [espn_wnba_schedules](https://github.com/sportsdataverse/sportsdatavers
 | `away_linescores` | String | Stringified list of the away team's period-by-period scores from the ESPN schedule feed. |
 | `away_records` | String | Stringified list of the away team's record summaries (overall/home/away) from the ESPN schedule feed. |
 | `game_id` | Int32 | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `status_type_alt_detail` | String | Status type alt detail. |
 | `game_json` | Boolean | Whether processed game JSON is available. |
@@ -291,7 +291,7 @@ Release: [espn_wnba_team_boxscores](https://github.com/sportsdataverse/sportsdat
 | col_name | type | description |
 |---|---|---|
 | `game_id` | Int32 | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `game_date` | Date | Game date (YYYY-MM-DD). |
 | `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
@@ -361,7 +361,7 @@ Release: [espn_wnba_draft](https://github.com/sportsdataverse/sportsdataverse-da
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `round` | Int32 | Tournament / playoff round. |
 | `round_display_name` | String | Human-readable label for the draft round, read from the ESPN round object's displayName falling back to its name; null whenever ESPN ships the modern flat picks array with no round objects, which is the case for every published season. |
 | `pick` | Int32 | Pick. |
@@ -408,7 +408,7 @@ Release: [espn_wnba_game_rosters](https://github.com/sportsdataverse/sportsdatav
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `game_id` | String | Unique game identifier. |
 | `team_id` | Int32 | Unique team identifier. |
 | `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
@@ -442,7 +442,7 @@ Release: [espn_wnba_officials](https://github.com/sportsdataverse/sportsdatavers
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `game_id` | String | Unique game identifier. |
 | `official_id` | Int32 | Unique official / referee identifier. |
 | `official_uid` | String | ESPN's global uid string for the official, carried straight through from the officials payload; the Core v2 items ESPN serves omit it, so it is null in every published season. |
@@ -465,7 +465,7 @@ Release: [espn_wnba_player_season_stats](https://github.com/sportsdataverse/spor
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
 | `athlete_display_name` | String | Athlete display name (full). |
 | `athlete_first_name` | String | Player first name; `athlete_detail = TRUE` only. |
@@ -493,7 +493,7 @@ Release: [espn_wnba_rosters](https://github.com/sportsdataverse/sportsdataverse-
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `team_id` | Int32 | Unique team identifier. |
 | `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
 | `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
@@ -542,7 +542,7 @@ Release: [espn_wnba_shots](https://github.com/sportsdataverse/sportsdataverse-da
 | col_name | type | description |
 |---|---|---|
 | `game_id` | Int32 | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `period_number` | Int32 | Numeric period (1-4 for quarters; 5+ for OT). |
 | `clock_display_value` | String | Game clock display string (e.g. '8:32'). |
 | `team_id` | Int32 | Unique team identifier. |
@@ -573,7 +573,7 @@ Release: [espn_wnba_standings](https://github.com/sportsdataverse/sportsdatavers
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `group_id` | String | ESPN group id. |
 | `group_name` | String | Group name (conference / division). |
 | `group_abbreviation` | String | Group abbreviation. |
@@ -609,7 +609,7 @@ Release: [espn_wnba_team_season_stats](https://github.com/sportsdataverse/sports
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `team_id` | Int32 | Unique team identifier. |
 | `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
 | `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
@@ -637,7 +637,7 @@ Release: [wnba_crosswalk](https://github.com/sportsdataverse/sportsdataverse-dat
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `espn_team_id` | Int32 | ESPN team id (canonical key). |
 | `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
 | `player_name` | String | Player name. |
@@ -670,7 +670,7 @@ Release: [wnba_crosswalk](https://github.com/sportsdataverse/sportsdataverse-dat
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `game_date` | Date | Game date (YYYY-MM-DD). |
 | `home_espn_team_id` | Int32 | ESPN home team id (NA for bart-only rows). |
@@ -698,7 +698,7 @@ Release: [wnba_crosswalk](https://github.com/sportsdataverse/sportsdataverse-dat
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `espn_team_id` | Int32 | ESPN team id (canonical key). |
 | `espn_abbreviation` | String | ESPN abbreviation. |
 | `espn_display_name` | String | ESPN display name (school + mascot). |
@@ -729,7 +729,7 @@ Release: [espn_wnba_player_core](https://github.com/sportsdataverse/sportsdatave
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `athlete_id` | Int64 | Unique athlete identifier (ESPN). |
 | `guid` | String | Stable cross-league team GUID. |
 | `uid` | String | ESPN UID string. |
@@ -783,7 +783,7 @@ Release: [wnba_player_impact](https://github.com/sportsdataverse/sportsdataverse
 | `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
 | `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
 | `teams` | String | Nested list of member-team membership spans. |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `o_rapm` | Float64 | Offensive RAPM: ridge-regularized on/off impact on team offense, in points per 100 possessions. |
 | `d_rapm` | Float64 | Defensive RAPM: ridge-regularized on/off impact on team defense, in points per 100 possessions. |
@@ -818,7 +818,7 @@ Release: [wnba_stats_coaches](https://github.com/sportsdataverse/sportsdataverse
 | col_name | type | description |
 |---|---|---|
 | `team_id` | Int64 | Unique team identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `coach_id` | Int64 | Unique identifier for coach. |
 | `first_name` | String | Player's first name. |
 | `last_name` | String | Player's last name. |
@@ -842,7 +842,7 @@ Release: [wnba_stats_draft](https://github.com/sportsdataverse/sportsdataverse-d
 |---|---|---|
 | `person_id` | Int64 | Unique player identifier (V3 endpoints). |
 | `player_name` | String | Player name. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `round_number` | Int64 | Numeric round. |
 | `round_pick` | Int64 | Round pick. |
 | `overall_pick` | Int64 | Overall pick. |
@@ -874,7 +874,7 @@ Release: [wnba_stats_game_rosters](https://github.com/sportsdataverse/sportsdata
 | `team_city` | String | Team city or region (e.g. 'Las Vegas'). |
 | `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
 | `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `game_id` | String | Unique game identifier. |
 
 ```python
@@ -892,7 +892,7 @@ Release: [wnba_stats_officials](https://github.com/sportsdataverse/sportsdataver
 | `first_name` | String | Player's first name. |
 | `last_name` | String | Player's last name. |
 | `jersey_num` | String | Jersey number worn by the player. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `game_id` | String | Unique game identifier. |
 
 ```python
@@ -943,7 +943,7 @@ Release: [wnba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-dat
 | `is_jump_ball` | Boolean | True when the event is a jump ball. |
 | `is_timeout` | Boolean | True when the event is a timeout. |
 | `is_period` | Boolean | True for period-start and period-end marker events. |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
 load_wnba_stats_pbp(seasons=2025)
@@ -989,7 +989,7 @@ Release: [wnba_stats_possessions](https://github.com/sportsdataverse/sportsdatav
 | `def_player_3` | Int64 | stats.wnba.com identifier of defensive on-court player 3 of 5 for the possession (unordered slot). |
 | `def_player_4` | Int64 | stats.wnba.com identifier of defensive on-court player 4 of 5 for the possession (unordered slot). |
 | `def_player_5` | Int64 | stats.wnba.com identifier of defensive on-court player 5 of 5 for the possession (unordered slot). |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
 load_wnba_stats_possessions(seasons=2025)
@@ -1015,7 +1015,7 @@ Release: [wnba_stats_game_lineups](https://github.com/sportsdataverse/sportsdata
 | `away_player_3` | Int64 | stats.wnba.com identifier of away on-court player 3 of 5 for the lineup stint. |
 | `away_player_4` | Int64 | stats.wnba.com identifier of away on-court player 4 of 5 for the lineup stint. |
 | `away_player_5` | Int64 | stats.wnba.com identifier of away on-court player 5 of 5 for the lineup stint. |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
 load_wnba_stats_game_lineups(seasons=2025)
@@ -1061,7 +1061,7 @@ Release: [wnba_stats_player_boxscores](https://github.com/sportsdataverse/sports
 | `points` | Int64 | Points scored. |
 | `plus_minus_points` | Float64 | Plus/minus point differential while on court. |
 | `game_id` | String | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
 load_wnba_stats_player_boxscores(seasons=2026)
@@ -1103,7 +1103,7 @@ Release: [wnba_stats_player_game_logs](https://github.com/sportsdataverse/sports
 | `pts` | Int64 | Total points scored. |
 | `plus_minus` | Int64 | Plus-minus point differential. |
 | `video_available` | Int64 | Video available. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `player_id` | Int64 | Unique player identifier. |
 | `player_name` | String | Player name. |
@@ -1122,7 +1122,7 @@ Release: [wnba_stats_rosters](https://github.com/sportsdataverse/sportsdataverse
 | col_name | type | description |
 |---|---|---|
 | `team_id` | Int64 | Unique team identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `league_id` | String | League identifier ('10' = WNBA). |
 | `player` | String | Player name. |
 | `nickname` | String | Team or athlete nickname. |
@@ -1152,7 +1152,7 @@ Release: [wnba_stats_schedules](https://github.com/sportsdataverse/sportsdataver
 | col_name | type | description |
 |---|---|---|
 | `game_id` | String | Unique game identifier. |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `game_date` | String | Game date (YYYY-MM-DD). |
 | `matchup` | String | Matchup. |
@@ -1179,7 +1179,7 @@ Release: [wnba_stats_shots](https://github.com/sportsdataverse/sportsdataverse-d
 | col_name | type | description |
 |---|---|---|
 | `game_id` | String | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
 | `clock` | String | Game clock value. |
 | `team_id` | Int64 | Unique team identifier. |
@@ -1233,7 +1233,7 @@ Release: [wnba_stats_team_boxscores](https://github.com/sportsdataverse/sportsda
 | `points` | Int64 | Points scored. |
 | `plus_minus_points` | Float64 | Plus/minus point differential while on court. |
 | `game_id` | String | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
 load_wnba_stats_team_boxscores(seasons=2026)

--- a/tests/codegen/test_gen_pff.py
+++ b/tests/codegen/test_gen_pff.py
@@ -61,7 +61,11 @@ def test_pff_registered_in_flat_apis():
 
     assert ("pff", "nfl") in g.FLAT_APIS
     assert "premium.pff.com" in g._FLAT_API_DOC["pff"]
-    assert "native/pff" in x._DEFERRED_BUCKETS
+    # native/pff graduated off the deferred-columns backlog (fully backfilled,
+    # 2026-09-03) -- assert it stays fully covered rather than merely deferred.
+    assert "native/pff" not in x._DEFERRED_BUCKETS
+    uncovered = [r for r in x.iter_schema_columns() if r["bucket"] == "native/pff" and x._uncovered(r)]
+    assert not uncovered, f"native/pff regressed: {len(uncovered)} columns lost their description"
 
 
 def test_pff_descriptions_seeded():

--- a/tools/codegen/extract_residual_columns.py
+++ b/tools/codegen/extract_residual_columns.py
@@ -44,36 +44,26 @@ def _bucket_of(path: str) -> str:
 
 
 # Buckets whose blank columns are a TRACKED follow-up, not a coverage failure.
-# The stats.nba.com / stats.wnba.com flat-API family wraps ~150 endpoints whose
-# ~3k+ result-set columns are documented incrementally (the 5 pilot slugs are
-# authored; the long tail is mined opportunistically via the R `_merged` dict).
-# Capturing more endpoints (resolving "untested" -> "live") grows the column
-# surface faster than descriptions are authored, so these buckets are exempted
-# from the residual ratchet and surfaced via deferred_columns() instead. Authoring
-# a column here (manual dict or R dict) still removes it from the deferred count.
-# native/sports247_site_pages: the 247sports.com front-end page-model surface (17
-# entity schemas, 372 columns). The semantically load-bearing columns (ids, FKs,
-# ratings, ranks, status/commit fields — 89 columns) are authored from the OpenAPI
-# `description:` fields; the plain long tail (names, dates, assets, tax rates) is a
-# tracked follow-up, mirroring the nba_stats/wnba_stats decision above.
-# native/on3 + native/pff: the On3 RDB and PFF Premium column tails are likewise
-# authored as pilots with the remainder deferred (see those tracks' plans).
-# loader_schemas: generated dataset-loader return tables gained a `description`
-# column (previously they rendered name+type only), which exposed ~3k columns
-# across 8 leagues in one step. The shared//id columns fill from the R dict for
-# free; the per-dataset statistical tails are authored incrementally, mirroring
-# the nba_stats/wnba_stats decision above. `deferred_columns()` reports the count.
+#
+# nba_stats / wnba_stats / sports247_site_pages / on3 / pff / loader_schemas were
+# once here for the same reason: each family's column surface was captured faster
+# than descriptions could be authored, so the backlog was exempted from the hard
+# residual ratchet and reported separately via deferred_columns(). All six have
+# since been fully backfilled (0 genuinely-uncovered columns as of 2026-09-03) and
+# were promoted OUT of this set -- their coverage is now enforced by the same hard
+# gate as everything else, so a future regression (e.g. capturing a new nba_stats
+# endpoint before its columns are described) is caught immediately instead of
+# quietly reappearing as "deferred." If a bucket like this grows a large new
+# backlog again, re-add it here deliberately rather than letting the gate go red.
+#
+# native/nflpro remains deferred for a different, durable reason (not "not yet
+# authored" but "not authorable"): the Next Gen Stats field names (avgTTT, croeNd,
+# bhPct, ...) have no reachable authoritative label source, and guessing would
+# manufacture authority the capture does not carry. See
+# sdv-internal-refs/nfl/nflpro/catalogs/nfl_pro_secured_returns.md for the full
+# provenance note and the identified (partial) load_nfl_nextgen_stats cross-walk.
 _DEFERRED_BUCKETS = {
-    "native/nba_stats",
-    "native/wnba_stats",
-    "native/sports247_site_pages",
-    "native/on3",
-    "native/pff",
-    # NFL Pro (NGS): 1,036 columns whose descriptions are deliberately absent --
-    # no authoritative label source was reachable, and guessing would manufacture
-    # authority the capture does not carry. Tracked here rather than left invisible.
     "native/nflpro",
-    "loader_schemas",
 }
 
 

--- a/tools/codegen/gen_pff.py
+++ b/tools/codegen/gen_pff.py
@@ -112,8 +112,10 @@ def _report_schema(schemas: dict, ref: str, env_keys: List[str], is_player_detai
     """Build a returns-schema dict from the response envelope's row shape.
 
     Player-detail + matrix + content-less endpoints have no per-row column list in the
-    spec, so they emit a zero-column schema (descriptions are a deferred follow-up via the
-    ``native/pff`` bucket in ``extract_residual_columns._DEFERRED_BUCKETS``).
+    spec, so they emit a zero-column schema. (``native/pff``'s columns were backfilled
+    and graduated off ``extract_residual_columns._DEFERRED_BUCKETS`` on 2026-09-03; a
+    new PFF endpoint with real columns still needs its descriptions authored before
+    the hard residual gate will pass.)
     """
     slug = env_keys[0] if env_keys else ref
     if is_player_detail or not env_keys:

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -3934,6 +3934,7 @@ espn_wbb_game_rosters:
   team_alternate_ids_sdr: Alternate team identifier from ESPN's SDR (Sports Data Reference) system for the athlete's team.
 espn_wbb_player_stats:
   offensive_second_chance_points: Points scored by the player on offensive-rebound put-back opportunities during the season.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 espn_wbb_schedule:
   away_current_rank: Current AP/coaches poll ranking of the away team at the time of the game.
   away_linescores: Points scored by the away team in each period or half of the game.
@@ -3941,6 +3942,7 @@ espn_wbb_schedule:
   home_current_rank: Current AP/coaches poll ranking of the home team at the time of the game.
   home_linescores: Points scored by the home team in each period or half of the game.
   home_records: Win-loss record string for the home team at the time of the game.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 espn_wnba_player_stats:
   defensive_avg48_blocks: Player's blocked shots per 48 minutes of play, drawn from the defensive statistical category.
   defensive_avg48_defensive_rebounds: Player's defensive rebounds per 48 minutes of play, drawn from the defensive statistical
@@ -3971,11 +3973,13 @@ espn_wnba_player_stats:
   offensive_avg48_three_point_field_goals_made: Player's three-point field goals made per 48 minutes of play, drawn from the
     offensive statistical category.
   offensive_avg48_turnovers: Player's turnovers per 48 minutes of play, drawn from the offensive statistical category.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 espn_wnba_schedule:
   away_linescores: Period-by-period point totals for the away team, stored as a list of integer scores.
   away_records: Win-loss record strings for the away team across relevant splits (e.g., overall, home/away, conference).
   home_linescores: Period-by-period point totals for the home team, stored as a list of integer scores.
   home_records: Win-loss record strings for the home team across relevant splits (e.g., overall, home/away, conference).
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 expansion_draft_picks:
   draft_picks: JSON-serialized list of players selected by this franchise in the NHL expansion draft.
 fantasywidget:
@@ -10778,6 +10782,7 @@ load_teams:
 load_wbb_game_rosters:
   athlete_headshot: URL of the player's ESPN headshot image on a.espncdn.com, whose filename is the athlete_id; null when
     ESPN publishes no headshot for that player.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wbb_officials:
   official_display_name: ESPN's displayName for the official, which is identical to official_full_name in every published
     row of the released data.
@@ -10791,6 +10796,7 @@ load_wbb_officials:
     1 to 3 for the standard three-person crew.
   official_uid: ESPN's globally unique resource identifier for the official, read from the core-api items[] uid key; that
     payload never ships it, so the column is null for every published row.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wbb_pbp:
   athlete_name_1: Display name of the first athlete in the ESPN play participants (e.g., the shooter on a shot attempt).
   athlete_name_2: Display name of the second athlete in the ESPN play participants (e.g., the assisting player), when present.
@@ -10804,19 +10810,23 @@ load_wbb_pbp:
   short_description: Shortened version of ESPN's play description text, without score context.
   type_text: Play type text, passed through verbatim from ESPN. ESPN labels the free-throw play type "MadeFreeThrow" for made
     AND missed free throws; filter makes vs. misses with scoring_play, not type_text.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wbb_player_season_stats:
   stat_description: ESPN's prose definition of the statistic named in stat_name, for example The average assists per game
     for avgAssists; combined made-attempted stats carry both definitions joined by a hyphen.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wbb_player_value:
   box_bpm: Total box plus/minus in points per 100 possessions above average, exactly box_obpm plus box_dbpm in every published
     row.
   box_dbpm: Box-score defensive plus/minus for the player, the defensive half of box BPM.
   box_obpm: Box-score offensive plus/minus for the player, the offensive half of box BPM.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wbb_ratings:
   adj_em_z: Within-season z-score of adj_em, computed as adj_em minus the season mean divided by the season standard deviation
     over every team in the frame, so it is mean 0 and standard deviation 1 per season.
   adj_tempo: Opponent-adjusted tempo in possessions per 40 minutes, produced by the same fixed-point adjustment as the efficiencies
     applied to game possessions under the additive model poss = tempo_i + tempo_j minus the league baseline.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wbb_schedule:
   away_current_rank: Poll ranking ESPN listed for the away team at game time (unranked teams carry a sentinel value).
   away_linescores: Period-by-period scores for the away team as a delimited string from ESPN's schedule feed.
@@ -10824,21 +10834,26 @@ load_wbb_schedule:
   home_current_rank: Poll ranking ESPN listed for the home team at game time (unranked teams carry a sentinel value).
   home_linescores: Period-by-period scores for the home team as a delimited string from ESPN's schedule feed.
   home_records: Record strings (overall and split records) for the home team from ESPN's schedule feed.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wbb_shots:
   athlete_name_1: Display name of the shooter credited on the attempt in ESPN's play participants.
   athlete_name_2: Display name of the second athlete tied to the attempt (typically the assister), when present.
   team_mascot: Mascot/nickname of the shooting team from ESPN's team record.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wbb_standings:
   group_short_name: Short display name of the conference or division grouping the row belongs to.
   stat_abbreviation: ESPN's abbreviation for the standings stat, such as GB, OPP PPG or VS CONF; always populated and matching
     stat_short_display_name for about 90 percent of rows.
   stat_description: ESPN's longer wording for the standings stat, for example Overall Record for the Team Season Record entry
     and Current Streak for Streak; null for stats ESPN ships without one, such as vs AP Top 25.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wbb_team_boxscore:
   lead_percentage: Share of game time the team held the lead, as reported in ESPN's team boxscore.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wbb_team_season_stats:
   stat_description: ESPN's prose definition of the team statistic named in stat_name, for example The average blocks per game
     for avgBlocks or the full sentence defining a blocked shot for blocks.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_draft:
   college_abbreviation: Short code for the drafted player's school, read from the athlete's ESPN college block; null throughout
     the published data because ESPN ships no college block on these picks.
@@ -10849,9 +10864,11 @@ load_wnba_draft:
   round_display_name: Human-readable label for the draft round, read from the ESPN round object's displayName falling back
     to its name; null whenever ESPN ships the modern flat picks array with no round objects, which is the case for every published
     season.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_game_rosters:
   athlete_headshot: Direct link to the player's ESPN headshot image, always of the form https://a.espncdn.com/i/headshots/wnba/players/full/{athlete_id}.png,
     and null for the few players ESPN has no photo for.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_officials:
   official_display_name: ESPN's display rendering of the official's name, which is byte-identical to official_full_name on
     every published row and therefore adds nothing.
@@ -10864,6 +10881,7 @@ load_wnba_officials:
     crew and 40 of 573 games in 2024-2025 add a fourth.
   official_uid: ESPN's global uid string for the official, carried straight through from the officials payload; the Core v2
     items ESPN serves omit it, so it is null in every published season.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_pbp:
   athlete_name_1: Display name of the primary athlete on the play (e.g. the shooter, rebounder, or fouler), per ESPN participant
     order.
@@ -10877,11 +10895,13 @@ load_wnba_pbp:
   short_description: Abbreviated ESPN text description of the play.
   type_text: Play type text, passed through verbatim from ESPN. ESPN labels the free-throw play type "MadeFreeThrow" for made
     AND missed free throws; filter makes vs. misses with scoring_play, not type_text.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_player_crosswalk:
   wnba_jersey_num: Jersey number listed on the stats.wnba.com side of the crosswalk.
   wnba_player_id: Player identifier on stats.wnba.com matched to the ESPN player.
   wnba_player_name: Player display name on the stats.wnba.com side of the crosswalk.
   wnba_position: Position listed on the stats.wnba.com side of the crosswalk.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_player_impact:
   adj_rapm: Total prior-informed RAPM (offense plus defense), in points per 100 possessions.
   d_adj_rapm: 'Defensive prior-informed RAPM: ridge shrunk toward a box-score prior, in points per 100 possessions.'
@@ -10898,14 +10918,17 @@ load_wnba_player_impact:
   rapm: 'Total RAPM: offensive plus defensive regularized on/off impact, in points per 100 possessions.'
   spm: 'Statistical plus-minus: offensive plus defensive box-score estimate of the RAPM target, per 100 possessions.'
   war: Wins above replacement implied by the player's impact and playing time, calibrated from team points-per-win.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_player_season_stats:
   stat_description: ESPN's prose definition of the statistic on this row, for example The average number of points scored
     per game for avgPoints; combined made-attempted stats carry both halves joined by a hyphen.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_schedule:
   away_linescores: Stringified list of the away team's period-by-period scores from the ESPN schedule feed.
   away_records: Stringified list of the away team's record summaries (overall/home/away) from the ESPN schedule feed.
   home_linescores: Stringified list of the home team's period-by-period scores from the ESPN schedule feed.
   home_records: Stringified list of the home team's record summaries (overall/home/away) from the ESPN schedule feed.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_schedule_crosswalk:
   fox_away_team_id: Away team identifier on Fox Sports for the matched game.
   fox_home_team_id: Home team identifier on Fox Sports for the matched game.
@@ -10913,10 +10936,12 @@ load_wnba_schedule_crosswalk:
   wnba_game_code: stats.wnba.com game code (date/matchup slug) for the matched game.
   wnba_game_id: Game identifier on stats.wnba.com matched to the ESPN game.
   wnba_home_team_id: Home team identifier on stats.wnba.com for the matched game.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_shots:
   athlete_name_1: Display name of the shooter, per ESPN participant order.
   athlete_name_2: Display name of the secondary athlete on the shot (typically the assister), when present.
   team_mascot: ESPN mascot (nickname) of the shooting team.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_standings:
   group_short_name: Short label of the standings group node the team sits under, read from ESPN shortName; the WNBA conference
     nodes ship only name and abbreviation, so it is null on every published row.
@@ -10924,6 +10949,7 @@ load_wnba_standings:
     is SEED here but POS there) and is null on the record-split rows such as Home and vs. Conf.
   stat_description: ESPN's long-form explanation of the standings stat, such as Clinched Best League Record for clincher or
     Record last 10 games for lasttengames.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_stats_coaches:
   coach_name: Full name of the staff member as the feed renders it, exactly first_name plus a space plus last_name on every
     published row.
@@ -10935,9 +10961,11 @@ load_wnba_stats_coaches:
     every published row is null.
   sub_sort_sequence: 'Secondary display-ordering rank that tracks coach_type exactly: 1 head coach, 2 associate head coach,
     5 assistant coach, 7 trainer.'
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_stats_draft:
   draft_type: 'CONSTANT in the published asset: every row reads ''Draft'', so it does not currently distinguish the main draft
     from any other selection event.'
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_stats_game_lineups:
   away_player_1: stats.wnba.com identifier of away on-court player 1 of 5 for the lineup stint.
   away_player_2: stats.wnba.com identifier of away on-court player 2 of 5 for the lineup stint.
@@ -10949,6 +10977,7 @@ load_wnba_stats_game_lineups:
   home_player_3: stats.wnba.com identifier of home on-court player 3 of 5 for the lineup stint.
   home_player_4: stats.wnba.com identifier of home on-court player 4 of 5 for the lineup stint.
   home_player_5: stats.wnba.com identifier of home on-court player 5 of 5 for the lineup stint.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_stats_pbp:
   is_foul: True when the event is a foul.
   is_free_throw: True when the event is a free throw attempt.
@@ -10960,6 +10989,7 @@ load_wnba_stats_pbp:
   is_substitution: True when the event is a substitution.
   is_timeout: True when the event is a timeout.
   order_index: Stable ordering index of the event within the game's stats.wnba.com play-by-play.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_stats_player_game_logs:
   ast: Assists credited.
   blk: Total shots blocked.
@@ -10983,6 +11013,7 @@ load_wnba_stats_player_game_logs:
   reb: Total rebounds collected.
   stl: Steals recorded.
   tov: Turnovers committed.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_stats_possessions:
   count_as_possession: False only for a possession starting with 2 seconds or less left in the period and no made basket before
     the period ends.
@@ -11006,20 +11037,25 @@ load_wnba_stats_possessions:
   possession_start_type: 'How the possession began: OffDeadball, OffTimeout, OffMadeShot, OffMissedShot, or OffLiveBallTurnover.'
   start_order_index: order_index of the first event in the possession; joins to the wnba_stats_pbp table.
   start_seconds_remaining: Seconds remaining in the period when the possession began.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_stats_rosters:
   exp: Years of WNBA playing experience entering the season ('R' = rookie).
   how_acquired: How the team acquired the player (draft, trade, free agency).
   num: Jersey number worn by the player.
   supplemental_status: Numeric supplemental roster-status code from the stats.wnba.com roster feed.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_stats_schedules:
   away_pts: Final points scored by the away team.
   away_wl: Result for the away team ('W' or 'L'); null before the game is final.
   home_pts: Final points scored by the home team.
   home_wl: Result for the home team ('W' or 'L'); null before the game is final.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_team_boxscore:
   lead_percentage: Share of game time the team spent in the lead, as reported by ESPN.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_team_season_stats:
   stat_description: Human-readable description of the statistic the row reports.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 matchupsrollup:
   def_player_id: Stats API identifier for defensive player identifier associated with this NBA or WNBA Stats row.
   def_player_name: Display name for defensive player name associated with this NBA or WNBA Stats row.
@@ -21587,25 +21623,122 @@ x_era:
   x_woba: Mean estimated_woba_using_speedangle allowed on batted balls.
 load_ncaa_mbb_rapm:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  def_poss: "Defensive possessions the player was on court for; the regression weight behind drapm."
+  drapm: "Defensive regularized adjusted plus-minus: points allowed per 100 possessions on defense, adjusted for the other 9 players on the floor."
+  estimand: "Which RAPM quantity this row's coefficient estimates ('offense', 'defense', or 'net') -- one row per player per estimand."
+  off_poss: "Offensive possessions the player was on court for; the regression weight behind orapm."
+  orapm: "Offensive regularized adjusted plus-minus: points contributed per 100 possessions on offense, adjusted for the other 9 players on the floor."
+  rapm_net: "Net RAPM (orapm minus drapm): overall point contribution per 100 possessions."
 load_ncaa_wbb_rapm:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  def_poss: "Defensive possessions the player was on court for; the regression weight behind drapm."
+  drapm: "Defensive regularized adjusted plus-minus: points allowed per 100 possessions on defense, adjusted for the other 9 players on the floor."
+  estimand: "Which RAPM quantity this row's coefficient estimates ('offense', 'defense', or 'net') -- one row per player per estimand."
+  off_poss: "Offensive possessions the player was on court for; the regression weight behind orapm."
+  orapm: "Offensive regularized adjusted plus-minus: points contributed per 100 possessions on offense, adjusted for the other 9 players on the floor."
+  rapm_net: "Net RAPM (orapm minus drapm): overall point contribution per 100 possessions."
 load_ncaa_mfb_pbp:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  drive_scored: "Whether the possession containing this play ended in points for the offense."
+  fair_catch: "Whether the returner called a fair catch on a kickoff or punt."
+  fg_distance: "Distance in yards of a field goal attempt."
+  formation: "Offensive formation or personnel grouping reported for the play (e.g. 'Shotgun', 'I-Formation'), when the source narrative names it."
+  is_first_down: "Whether the play resulted in a first down for the offense."
+  is_fumble: "Whether a fumble occurred on the play, regardless of which team recovered it."
+  is_safety: "Whether the play resulted in a safety."
+  is_touchdown: "Whether the play resulted in a touchdown."
+  kick_yards: "Yards traveled on a kickoff."
+  kicker: "Name of the player who kicked off, punted, or attempted the field goal/PAT on this play."
+  no_play: "Whether the play was negated (e.g. by a penalty on the preceding down) and is excluded from drive/stat totals."
+  pass_complete: "Whether a pass attempt on this play was completed."
+  pass_depth: "Depth classification of a pass attempt (e.g. 'short', 'deep'), when the narrative reports it."
+  pass_direction: "Side of the field the pass was thrown to (e.g. 'left', 'middle', 'right'), when the narrative reports it."
+  penalty_player: "Name of the player penalized on the play, when a penalty occurred."
+  punt_yards: "Gross yards traveled on a punt, before any return."
+  punter: "Name of the player who punted on this play."
+  returner: "Name of the player who fielded or returned the kickoff or punt on this play."
+  run_direction: "Hole or side the ball carrier ran through on a rush play (e.g. 'left end', 'right guard'), when the narrative reports it."
+  tackler_1: "Name of the primary (first-listed) tackler on the play."
+  tackler_2: "Name of the secondary (assisting) tackler on the play, when the narrative credits an assist."
+  turnover_type: "Kind of turnover on the play, if any (e.g. 'interception', 'fumble lost'); null when no turnover occurred."
+  yard_line_number: "Yard line at the snap (0-50); pairs with yard_line_side for absolute field position."
+  yard_line_side: "Which team's territory the ball was on at the snap ('OFF' own side, 'DEF' opponent side); pairs with yard_line_number for absolute field position."
 load_ncaa_mfb_pbp_cfbfastr:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  clock.minutes: "Minutes remaining on the game clock at the start of the play (cfbfastR schema column)."
+  clock.seconds: "Seconds remaining within the current minute on the game clock at the start of the play (cfbfastR schema column)."
+  n_plays_in_game: "Total number of plays in the game this row belongs to, repeated on every row for convenience."
+  ot_synthesized: "Whether this row's overtime clock/period fields were synthesized rather than sourced directly -- stats.ncaa.org reports no running clock in overtime, so OT plays are assigned a synthetic countdown."
 load_ncaa_mfb_drives:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  end_how: "How the drive ended (e.g. 'Touchdown', 'Punt', 'Interception', 'Fumble', 'End of Half')."
+  n_plays: "Number of plays run during the drive."
+  quarter: "Quarter in which the drive started (1-4 for regulation, 5+ for overtime periods)."
+  start_how: "How the drive began (e.g. 'Kickoff', 'Interception', 'Fumble', 'Downs', 'Punt')."
 load_ncaa_mfb_schedule:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  academic_year: "Academic year the game was played in (the ENDING year of the fall/spring split, e.g. 2025 for the 2024 fall season) -- distinct from `season`, which is the STARTING year."
+  outcome: "Result of the game from the home team's perspective (e.g. 'W', 'L', 'T')."
 load_ncaa_mfb_rosters:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  academic_year: "Academic year the roster snapshot covers (the ENDING year of the fall/spring split) -- distinct from `season`, which is the STARTING year."
+  player_class: "Player's academic/eligibility class (e.g. 'FR', 'SO', 'JR', 'SR', 'GR')."
+  statcrew_jersey: "Jersey number as recorded in the NCAA StatCrew roster feed; can differ from the number a player actually wears on a given game day."
 load_ncaa_mfb_teams:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  academic_year: "Academic year the team record covers (the ENDING year of the fall/spring split) -- distinct from `season`, which is the STARTING year."
 load_ncaa_mfb_team_stats:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  away_value: "Team-stat value for the away team; each row is one stat category for one game, wide by side."
+  home_value: "Team-stat value for the home team; each row is one stat category for one game, wide by side."
 load_ncaa_mfb_player_stats:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  long_pass: "Longest completed pass of the game."
+  long_rec: "Longest reception of the game."
+  pass_eff: "Passer efficiency rating for the game, per the NCAA passer-rating formula."
+  rec: "Total receptions for the game."
+  rec_td: "Receiving touchdowns."
+  rush_long: "Longest single rush of the game."
+  rush_yds_gained: "Total positive rushing yards gained on carries, before subtracting yards lost to tackles for loss."
+  rush_yds_lost: "Total rushing yards lost to tackles for loss on carries."
+  yards_per_reception: "Receiving yards divided by receptions."
+  yds_per_completion: "Passing yards divided by completions."
+  yds_rush: "Net rushing yards (rush_yds_gained minus rush_yds_lost)."
 load_ncaa_mfb_officials:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_ncaa_mfb_linescore:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+espn_wbb_game_officials:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+espn_wnba_game_officials:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wbb_player_boxscore:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wbb_player_core:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wbb_player_crosswalk:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wbb_rosters:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wbb_schedule_crosswalk:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wbb_team_crosswalk:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wnba_player_boxscore:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wnba_player_core:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wnba_rosters:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wnba_stats_game_rosters:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wnba_stats_officials:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wnba_stats_player_boxscores:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wnba_stats_shots:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wnba_stats_team_boxscores:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wnba_team_crosswalk:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -9971,6 +9971,7 @@ load_nfl_pfr_weekly_def:
   def_yards_allowed: Total receiving yards allowed by this defender in coverage during the week per Pro Football Reference.
   def_yards_allowed_per_cmp: Receiving yards allowed per completion by this defender in coverage during the week.
   def_yards_allowed_per_tgt: Receiving yards allowed per target thrown at this defender in coverage during the week.
+  def_ints: "Interceptions for the week (this loader is per-player-per-week, not career)."
 load_nfl_pfr_weekly_pass:
   def_times_blitzed: Number of pass plays on which the defense sent a blitz, as experienced by the quarterback in this weekly
     log.
@@ -21624,19 +21625,19 @@ x_era:
 load_ncaa_mbb_rapm:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   def_poss: "Defensive possessions the player was on court for; the regression weight behind drapm."
-  drapm: "Defensive regularized adjusted plus-minus: points allowed per 100 possessions on defense, adjusted for the other 9 players on the floor."
-  estimand: "Which RAPM quantity this row's coefficient estimates ('offense', 'defense', or 'net') -- one row per player per estimand."
+  drapm: "Defensive regularized adjusted plus-minus: points prevented per 100 possessions on defense (higher is better defense), adjusted for the other 9 players on the floor."
+  estimand: "Fit-scope tag for the RAPM model that produced this row (observed value: 'league', a Division I-wide fit) -- one row per player-season, not per estimand."
   off_poss: "Offensive possessions the player was on court for; the regression weight behind orapm."
   orapm: "Offensive regularized adjusted plus-minus: points contributed per 100 possessions on offense, adjusted for the other 9 players on the floor."
-  rapm_net: "Net RAPM (orapm minus drapm): overall point contribution per 100 possessions."
+  rapm_net: "Net RAPM (orapm plus drapm): overall point contribution per 100 possessions. Verified against live data: rapm_net == orapm + drapm exactly."
 load_ncaa_wbb_rapm:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   def_poss: "Defensive possessions the player was on court for; the regression weight behind drapm."
-  drapm: "Defensive regularized adjusted plus-minus: points allowed per 100 possessions on defense, adjusted for the other 9 players on the floor."
-  estimand: "Which RAPM quantity this row's coefficient estimates ('offense', 'defense', or 'net') -- one row per player per estimand."
+  drapm: "Defensive regularized adjusted plus-minus: points prevented per 100 possessions on defense (higher is better defense), adjusted for the other 9 players on the floor."
+  estimand: "Fit-scope tag for the RAPM model that produced this row (observed value: 'league', a Division I-wide fit) -- one row per player-season, not per estimand."
   off_poss: "Offensive possessions the player was on court for; the regression weight behind orapm."
   orapm: "Offensive regularized adjusted plus-minus: points contributed per 100 possessions on offense, adjusted for the other 9 players on the floor."
-  rapm_net: "Net RAPM (orapm minus drapm): overall point contribution per 100 possessions."
+  rapm_net: "Net RAPM (orapm plus drapm): overall point contribution per 100 possessions. Verified against live data: rapm_net == orapm + drapm exactly."
 load_ncaa_mfb_pbp:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   drive_scored: "Whether the possession containing this play ended in points for the offense."
@@ -21704,6 +21705,9 @@ load_ncaa_mfb_player_stats:
   yards_per_reception: "Receiving yards divided by receptions."
   yds_per_completion: "Passing yards divided by completions."
   yds_rush: "Net rushing yards (rush_yds_gained minus rush_yds_lost)."
+  pass_attempts: "Pass attempts for the game. Populated only on this player-game's 'passing' category row (null on the 'rushing'/'receiving' rows for the same player-game) -- the loader returns one row per player-game-category."
+  pass_tds: "Passing touchdowns thrown for the game. Populated only on this player-game's 'passing' category row (null on the 'rushing'/'receiving' rows for the same player-game) -- the loader returns one row per player-game-category."
+  rush_tds: "Rushing touchdowns for the game. Populated only on this player-game's 'rushing' category row (null on the 'passing'/'receiving' rows for the same player-game) -- the loader returns one row per player-game-category."
 load_ncaa_mfb_officials:
   season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_ncaa_mfb_linescore:


### PR DESCRIPTION
## Summary

Scoped the actual missing-documentation backlog via `deferred_columns()` rather than
guessing: the enforced coverage gate was already at 0, and only 853 columns sat in the
tracked-but-exempt "deferred" bucket — 790 in `native/nflpro` (no authoritative label
source exists, genuinely undocumentable) and 63 in `loader_schemas` (fresh from #455's
NCAA loaders, not yet authored).

- **Backfilled all 63 `loader_schemas` columns** — RAPM/possession fields for the two new
  MBB/WBB rapm loaders, and pbp/drives/rosters/schedule/team_stats/player_stats fields
  for the 10 new NCAA MFB loaders from #455.

- **Fixed a bug #455's own commit message had already diagnosed but deliberately deferred**
  to keep that PR reviewable: a mined R-package description meant for one NBA-stats-style
  function ("Season identifier... or 'YYYY-YY' string") gets applied by `_r_col_desc`'s
  name-only matching to every `wbb`/`wnba` schema's `season` column, regardless of its
  actual type. Verified all 53 affected columns are `Int32`/`Int64` (zero accept the
  string format) before overriding all 53 in `manual_column_descriptions.yaml`, which the
  documented precedence already says wins over the R-dict fallback.

- **Tightened `_DEFERRED_BUCKETS`**: 6 of its 7 buckets (`nba_stats`, `wnba_stats`,
  `sports247_site_pages`, `on3`, `pff`, and now `loader_schemas`) turned out to have ZERO
  genuinely-uncovered columns — fully backfilled in earlier work but never promoted off
  the deferred list, so a future regression there would have silently reappeared as
  "deferred" instead of failing CI. Promoted all 6 off the set, leaving only
  `native/nflpro`. Updated `test_gen_pff.py`'s assertion to match (it asserted membership
  in the now-false set; replaced with an assertion that `native/pff` stays fully covered,
  which is what the check was actually trying to guard).

## Caught along the way

- My first patch attempt used naive line-splitting to insert into the YAML and corrupted
  an unrelated multi-line entry elsewhere in the file — caught immediately by a parse
  check, reverted, and rewritten to respect the file's actual indent structure (2-space
  keys vs. deeper wrapped-continuation lines) before reapplying.
- One hand-written description ("Receptions.") tripped the file's own filler-text length
  check — expanded to be genuinely descriptive.

## Test plan

- [x] `residual_columns()` (enforced gate) stays 0 throughout
- [x] `deferred_columns()` drops from 853 to 790 (all `native/nflpro`)
- [x] Full offline `pytest` — 172 passed (codegen dir), 6/6 `test_manual_descriptions.py`
- [x] `mypy` — clean across 415 files
- [x] `generate.py --check` — clean after two regeneration passes

## Summary by Sourcery

Backfill missing codegen column documentation, correct misleading season descriptions, and tighten coverage enforcement for previously deferred schema families.

Bug Fixes:
- Correct season documentation across WBB and WNBA schemas so integer season columns no longer claim to accept YYYY-YY strings.
- Override misleading name-based season descriptions and correct the weekly defensive interceptions description.

Enhancements:
- Backfill documentation for NCAA MBB/WBB RAPM and NCAA football loader schema columns across play-by-play, drives, schedules, rosters, teams, and player and team statistics.
- Promote fully documented schema families out of the deferred coverage bucket, leaving only the unsourceable NFL Pro fields deferred.
- Strengthen PFF coverage checks to detect regressions rather than accepting deferred status.

Documentation:
- Expand generated loader reference documentation with descriptions for previously undocumented NCAA football, RAPM, and related schema fields.

Tests:
- Update codegen coverage assertions to verify promoted buckets remain fully documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded column descriptions across NCAA football and basketball reference datasets, including play-by-play, team, player, schedule, roster, drive, and RAPM fields.
  * Clarified RAPM metrics, field-position fields, rushing statistics, and synthetic overtime indicators.
  * Updated WBB and WNBA documentation to specify seasons as four-digit starting-year integers; `YYYY-YY` strings are not accepted.
  * Added descriptions for previously undocumented ESPN and PFF-related columns.

* **Tests**
  * Strengthened schema coverage checks for PFF and other previously deferred data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->