### PR TITLE
docs(loaders): precise season description for 12 NCAA WBB loaders

### DIFF
--- a/docs/docs/wbb/reference/loaders.md
+++ b/docs/docs/wbb/reference/loaders.md
@@ -878,7 +878,7 @@ Release: [ncaa_wbb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `is_team_turnover` | Boolean | Flag marking a turnover charged to the team rather than an individual player. |
 | `timeout_type` | String | Type of timeout called (e.g. full, 30-second, media). |
 | `challenge_outcome` | String | Outcome of a coach's challenge or video-review event, when present. |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
 load_ncaa_wbb_pbp(seasons=2024)
@@ -897,7 +897,7 @@ Release: [ncaa_wbb_schedule](https://github.com/sportsdataverse/sportsdataverse-
 | `away` | String | Away record. |
 | `home_score` | Int64 | Home team score at the time of the play. |
 | `away_score` | Int64 | Away team score at the time of the play. |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
 load_ncaa_wbb_schedule(seasons=2024)
@@ -1034,7 +1034,7 @@ Release: [ncaa_wbb_player_box](https://github.com/sportsdataverse/sportsdatavers
 | `player_id` | String | Unique player identifier. |
 | `clean_name` | String | Normalized (diacritics- and punctuation-cleaned) player name used to join across the NCAA datasets. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
 load_ncaa_wbb_player_box(seasons=2024)
@@ -1127,7 +1127,7 @@ Release: [ncaa_wbb_team_box](https://github.com/sportsdataverse/sportsdataverse-
 | `team_ncaa_team_id` | String | stats.ncaa.org team identifier of the team the row belongs to. |
 | `team_espn_team_id` | String | ESPN team identifier of the team, via the NCAA-to-ESPN crosswalk. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
 load_ncaa_wbb_team_box(seasons=2024)
@@ -1140,7 +1140,7 @@ Release: [ncaa_wbb_rosters](https://github.com/sportsdataverse/sportsdataverse-d
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `team` | String | Team-side label or team identifier. |
 | `player` | String | Player name. |
 | `games` | Int64 | Games played. |
@@ -1156,7 +1156,7 @@ Release: [ncaa_wbb_team_rosters](https://github.com/sportsdataverse/sportsdatave
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `team_id` | String | Unique team identifier. |
 | `team` | String | Team-side label or team identifier. |
 | `player_id` | String | Unique player identifier. |
@@ -1187,7 +1187,7 @@ Release: [ncaa_wbb_team_ids](https://github.com/sportsdataverse/sportsdataverse-
 | `team` | String | Team-side label or team identifier. |
 | `conference` | String | Filter players or teams by conference. |
 | `id` | String | Unique play identification number |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
 load_ncaa_wbb_team_ids(seasons=2024)
@@ -1255,7 +1255,7 @@ Release: [ncaa_wbb_possessions](https://github.com/sportsdataverse/sportsdataver
 | `away_5_player_id` | String | stats.ncaa.org player identifier for the away slot-5 on-floor player. |
 | `away_5_clean_name` | String | Normalized (diacritics- and punctuation-cleaned) name of the away slot-5 on-floor player. |
 | `espn_game_id` | String | ESPN game id (NA for bart-only rows). |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
 load_ncaa_wbb_possessions(seasons=2024)
@@ -1344,7 +1344,7 @@ Release: [ncaa_wbb_lineups](https://github.com/sportsdataverse/sportsdataverse-d
 | `opp_foul` | Int64 | Opponent fouls committed while the lineup was on the floor during the stint. |
 | `stint_num` | Int64 | Sequential on-floor stint number for the lineup within the game. |
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 
 ```python
 load_ncaa_wbb_lineups(seasons=2024)
@@ -1358,7 +1358,7 @@ Release: [ncaa_wbb_matchup_stints](https://github.com/sportsdataverse/sportsdata
 | col_name | type | description |
 |---|---|---|
 | `contest_id` | String | stats.ncaa.org contest (game) identifier. |
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `game_date` | String | Game date (YYYY-MM-DD). |
 | `home` | String | Home. |
 | `away` | String | Away record. |
@@ -1402,7 +1402,7 @@ Release: [ncaa_wbb_shots](https://github.com/sportsdataverse/sportsdataverse-dat
 
 | col_name | type | description |
 |---|---|---|
-| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int64 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `team_id` | String | Unique team identifier. |
 | `shooter_id` | String | Unique identifier for shooter. |
 | `shot_x` | Float64 | Court x-coordinate of the attempt in feet, decoded from the stats.ncaa.org shot-chart map. |
@@ -1440,7 +1440,7 @@ Release: [ncaa_wbb_rapm_within_team](https://github.com/sportsdataverse/sportsda
 | `team_off_poss` | Float64 | Team offensive possessions underlying the within-team fit. |
 | `num_players` | Int64 | Number of players in the team's RAPM design matrix. |
 | `rapm_net` | Float64 | Net RAPM — the sum of the offensive and defensive components, per 100 possessions. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season` | Int32 | Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted. |
 | `player_id` | String | Unique player identifier. |
 | `team_id` | String | Unique team identifier. |
 | `person_id` | String | Unique player identifier (V3 endpoints). |

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -9429,6 +9429,7 @@ load_ncaa_wbb_lineups:
   tp_ast: Assisted three-point makes by the lineup during the stint.
   tpa: Three-pointers attempted by the lineup during the stint.
   tpm: Three-pointers made by the lineup during the stint.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_ncaa_wbb_matchup_stints:
   away_1: Name of the away team's on-floor player in lineup slot 1 for the stint.
   away_2: Name of the away team's on-floor player in lineup slot 2 for the stint.
@@ -9457,6 +9458,7 @@ load_ncaa_wbb_matchup_stints:
   start_away_score: Away team score when the stint began.
   start_home_score: Home team score when the stint began.
   start_seconds: Elapsed game seconds at which the stint began.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_ncaa_wbb_pbp:
   assist_player: Name of the player credited with the assist on a made shot, when present.
   away_1: Name of the away team's on-floor player in lineup slot 1 for the event, from the substitution walk-forward.
@@ -9527,6 +9529,7 @@ load_ncaa_wbb_pbp:
     substitution data.
   timeout_type: Type of timeout called (e.g. full, 30-second, media).
   turnover_type: Parsed turnover subtype (e.g. lost ball, bad pass, travel).
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_ncaa_wbb_player_box:
   ast_half: Assists in halfcourt possessions.
   ast_trans: Assists in transition possessions.
@@ -9629,6 +9632,7 @@ load_ncaa_wbb_player_box:
   tpm_unast: Three-pointers made in the unassisted split (makes for which no assist was credited).
   ts_pct_half: True-shooting percentage in halfcourt possessions.
   ts_pct_trans: True-shooting percentage in transition possessions.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_ncaa_wbb_possessions:
   away_1: Name of the away team's on-floor player in lineup slot 1 for the possession, from the substitution walk-forward.
   away_1_clean_name: Normalized (diacritics- and punctuation-cleaned) name of the away slot-1 on-floor player.
@@ -9674,6 +9678,7 @@ load_ncaa_wbb_possessions:
   poss_team_espn_team_id: ESPN team identifier of the team in possession, via the NCAA-to-ESPN crosswalk.
   poss_team_ncaa_team_id: stats.ncaa.org team identifier of the team in possession.
   start_event_type: Event type that opened the possession (e.g., a defensive rebound or a made-basket inbound).
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_ncaa_wbb_rapm_within_team:
   num_players: Number of players in the team's RAPM design matrix.
   player_code: Short unique-within-team player code generated from the player's name (hoop-explorer convention).
@@ -9681,6 +9686,7 @@ load_ncaa_wbb_rapm_within_team:
   rapm_net: Net RAPM — the sum of the offensive and defensive components, per 100 possessions.
   rapm_off: Ridge-regressed offensive RAPM per 100 possessions, estimated relative to the player's own teammates.
   team_off_poss: Team offensive possessions underlying the within-team fit.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_ncaa_wbb_shots:
   dist_ft: Shot distance from the basket in feet.
   made: Whether the shot was made.
@@ -9692,6 +9698,7 @@ load_ncaa_wbb_shots:
   shot_x: Court x-coordinate of the attempt in feet, decoded from the stats.ncaa.org shot-chart map.
   shot_y: Court y-coordinate of the attempt in feet, decoded from the stats.ncaa.org shot-chart map.
   shot_zone: Labeled zone of the attempt (rim, mid-range, or three-point).
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_ncaa_wbb_team_box:
   ast_rate: Share of the team's made field goals that were assisted.
   away_ncaa_team_id: stats.ncaa.org team identifier for the away team.
@@ -9752,9 +9759,11 @@ load_ncaa_wbb_team_box:
   tpa: Three-point attempts.
   tpm: Three-pointers made.
   tpp: Three-point percentage.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_ncaa_wbb_team_rosters:
   clean_name: Normalized (diacritics- and punctuation-cleaned) player name used to join across the NCAA datasets.
   ht_inches: Player height converted to total inches from the stats.ncaa.org roster listing.
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_nfl_contracts:
   cols: Number of contract columns returned in the contracts dataset (metadata artifact from the loader).
 load_nfl_depth_charts:
@@ -21745,4 +21754,10 @@ load_wnba_stats_shots:
 load_wnba_stats_team_boxscores:
   season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_team_crosswalk:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_ncaa_wbb_rosters:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_ncaa_wbb_schedule:
+  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_ncaa_wbb_team_ids:
   season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."


### PR DESCRIPTION
## Summary

Extracts the unique content from #459 ("correct the season description on the
remaining 59 loaders"), which cannot be cleanly rebased onto current main: its
branch history carries a divergent duplicate of #455's commit (different hash,
same content), so a rebase conflicts on that already-merged change rather than
on anything new.

Compared #459's 59-schema fix against #460's 53-schema fix (both already
merged) directly via a YAML diff rather than guessing:

| | #459 (59 schemas) | #460 (53 schemas, merged) |
|---|---|---|
| Overlap | 47 | 47 |
| Unique | 12 `load_ncaa_wbb_*` loaders | 6 ESPN direct wrappers |

Unlike the other 100 schemas fixed across both PRs, these 12 weren't carrying
a *wrong* description on `main` — the R-dict fallback for `league='ncaa'`
already resolves to the correct, if generic, "Season year." So this is a
precision upgrade (explicitly ruling out the `'YYYY-YY'` string format these
columns, all `Int32`/`Int64`, don't accept), not a bug fix. Wording is
byte-identical to the 53 corrected in #460.

PR #459 is being closed unmerged with a comment pointing here — its content
is now fully subsumed between #460 (merged) and this PR.

## Test plan

- [x] YAML diff confirmed purely additive (0 lines removed) before regenerating
- [x] `mypy` — clean across 415 files
- [x] `generate.py --check` — clean after two regeneration passes

## Summary by Sourcery

Precisely document the accepted season format across the remaining NCAA women's basketball loaders.

Enhancements:
- Clarify the season field documentation for 12 NCAA women's basketball loaders to specify that it accepts a 4-digit starting year integer and not a 'YYYY-YY' string.

Documentation:
- Update generated NCAA women's basketball loader reference documentation and source column descriptions with the precise season format.

Tests:
- Verify the documentation changes are additive and that type checking and documentation generation checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that NCAA women’s basketball loader `season` values must be 4-digit starting years represented as integers.
  - Documented that `YYYY-YY` season strings are not accepted across applicable datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->