### PR TITLE
docs(cfb): correct the player-leader rank descriptions and add their percentiles

### DIFF
--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -1954,18 +1954,18 @@ Release: [espn_cfb_passing](https://github.com/sportsdataverse/sportsdataverse-d
 | `dropbacks` | Float64 | Dropbacks taken by the passer. |
 | `sack_adj_yards` | Float64 | Passing yards adjusted for sack yardage lost. |
 | `yardsdropback` | Float64 | Yards per dropback. |
-| `TEPA_rank` | Float64 | National rank of the team's total EPA summed over every play, where 1 is best. |
-| `EPAgame_rank` | Float64 | National rank of the team's EPA generated per game, where 1 is best. |
-| `EPAplay_rank` | Float64 | National rank of the team's EPA generated per play, where 1 is best. |
-| `success_rank` | Float64 | National rank of the team's success rate across the team plays, where 1 is best. |
-| `comppct_rank` | Float64 | National rank of the team's completion percentage, where 1 is best. |
-| `yards_rank` | Float64 | National rank of the team's total yards, where 1 is best. |
-| `yardsplay_rank` | Float64 | National rank of the team's yards per play, where 1 is best. |
-| `yardsgame_rank` | Float64 | National rank of the team's yards per game, where 1 is best. |
-| `sack_adj_yards_rank` | Float64 | National rank of the team's passing yards adjusted for sack yardage lost, where 1 is best. |
-| `yardsdropback_rank` | Float64 | National rank of the team's yards per dropback, where 1 is best. |
-| `detmer_rank` | Float64 | National rank of the team's detmer rating -- the composite passing-efficiency measure this pipeline publishes, named for the college passing-efficiency tradition, where 1 is best. |
-| `detmergame_rank` | Float64 | National rank of the team's detmer rating expressed per game, where 1 is best. |
+| `TEPA_rank` | Float64 | Rank of the passer's total EPA summed over every play among passers clearing the leaderboard minimum of 14 dropbacks per team game, where 1 is best. |
+| `EPAgame_rank` | Float64 | Rank of the passer's EPA generated per game among passers clearing the leaderboard minimum of 14 dropbacks per team game, where 1 is best. |
+| `EPAplay_rank` | Float64 | Rank of the passer's EPA generated per play among passers clearing the leaderboard minimum of 14 dropbacks per team game, where 1 is best. |
+| `success_rank` | Float64 | Rank of the passer's success rate across their plays among passers clearing the leaderboard minimum of 14 dropbacks per team game, where 1 is best. |
+| `comppct_rank` | Float64 | Rank of the passer's completion percentage among passers clearing the leaderboard minimum of 14 dropbacks per team game, where 1 is best. |
+| `yards_rank` | Float64 | Rank of the passer's total yards among passers clearing the leaderboard minimum of 14 dropbacks per team game, where 1 is best. |
+| `yardsplay_rank` | Float64 | Rank of the passer's yards per play among passers clearing the leaderboard minimum of 14 dropbacks per team game, where 1 is best. |
+| `yardsgame_rank` | Float64 | Rank of the passer's yards per game among passers clearing the leaderboard minimum of 14 dropbacks per team game, where 1 is best. |
+| `sack_adj_yards_rank` | Float64 | Rank of the passer's passing yards adjusted for sack yardage lost among passers clearing the leaderboard minimum of 14 dropbacks per team game, where 1 is best. |
+| `yardsdropback_rank` | Float64 | Rank of the passer's yards per dropback among passers clearing the leaderboard minimum of 14 dropbacks per team game, where 1 is best. |
+| `detmer_rank` | Float64 | Rank of the passer's detmer rating -- the composite passing-efficiency measure this pipeline publishes, named for the college passing-efficiency tradition among passers clearing the leaderboard minimum of 14 dropbacks per team game, where 1 is best. |
+| `detmergame_rank` | Float64 | Rank of the passer's detmer rating expressed per game among passers clearing the leaderboard minimum of 14 dropbacks per team game, where 1 is best. |
 | `fbs_class` | String | Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference membership. Null for teams outside FBS. |
 
 ```python
@@ -2041,14 +2041,14 @@ Release: [espn_cfb_receiving](https://github.com/sportsdataverse/sportsdataverse
 | `yardsplay` | Float64 | Yards per play. |
 | `yardsgame` | Float64 | Yards per game. |
 | `catchpct` | Float64 | Catch rate on a 0-to-1 scale, receptions divided by targets for the season. |
-| `TEPA_rank` | Float64 | National rank of the team's total EPA summed over every play, where 1 is best. |
-| `EPAgame_rank` | Float64 | National rank of the team's EPA generated per game, where 1 is best. |
-| `EPAplay_rank` | Float64 | National rank of the team's EPA generated per play, where 1 is best. |
-| `success_rank` | Float64 | National rank of the team's success rate across the team plays, where 1 is best. |
+| `TEPA_rank` | Float64 | Rank of the receiver's total EPA summed over every play among receivers clearing the leaderboard minimum of 1.875 targets per team game, where 1 is best. |
+| `EPAgame_rank` | Float64 | Rank of the receiver's EPA generated per game among receivers clearing the leaderboard minimum of 1.875 targets per team game, where 1 is best. |
+| `EPAplay_rank` | Float64 | Rank of the receiver's EPA generated per play among receivers clearing the leaderboard minimum of 1.875 targets per team game, where 1 is best. |
+| `success_rank` | Float64 | Rank of the receiver's success rate across their plays among receivers clearing the leaderboard minimum of 1.875 targets per team game, where 1 is best. |
 | `catchpct_rank` | Float64 | Season rank of catchpct with the best catch rate first, computed only for receivers clearing the leaderboard minimum of 1.875 targets per team game and using averaged ranks for ties. |
-| `yards_rank` | Float64 | National rank of the team's total yards, where 1 is best. |
-| `yardsplay_rank` | Float64 | National rank of the team's yards per play, where 1 is best. |
-| `yardsgame_rank` | Float64 | National rank of the team's yards per game, where 1 is best. |
+| `yards_rank` | Float64 | Rank of the receiver's total yards among receivers clearing the leaderboard minimum of 1.875 targets per team game, where 1 is best. |
+| `yardsplay_rank` | Float64 | Rank of the receiver's yards per play among receivers clearing the leaderboard minimum of 1.875 targets per team game, where 1 is best. |
+| `yardsgame_rank` | Float64 | Rank of the receiver's yards per game among receivers clearing the leaderboard minimum of 1.875 targets per team game, where 1 is best. |
 | `fbs_class` | String | Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference membership. Null for teams outside FBS. |
 
 ```python
@@ -2082,13 +2082,13 @@ Release: [espn_cfb_rushing](https://github.com/sportsdataverse/sportsdataverse-d
 | `EPAgame` | Float64 | EPA generated per game. |
 | `yardsplay` | Float64 | Yards per play. |
 | `yardsgame` | Float64 | Yards per game. |
-| `TEPA_rank` | Float64 | National rank of the team's total EPA summed over every play, where 1 is best. |
-| `EPAgame_rank` | Float64 | National rank of the team's EPA generated per game, where 1 is best. |
-| `EPAplay_rank` | Float64 | National rank of the team's EPA generated per play, where 1 is best. |
-| `success_rank` | Float64 | National rank of the team's success rate across the team plays, where 1 is best. |
-| `yards_rank` | Float64 | National rank of the team's total yards, where 1 is best. |
-| `yardsplay_rank` | Float64 | National rank of the team's yards per play, where 1 is best. |
-| `yardsgame_rank` | Float64 | National rank of the team's yards per game, where 1 is best. |
+| `TEPA_rank` | Float64 | Rank of the rusher's total EPA summed over every play among rushers clearing the leaderboard minimum of 6.25 plays per team game, where 1 is best. |
+| `EPAgame_rank` | Float64 | Rank of the rusher's EPA generated per game among rushers clearing the leaderboard minimum of 6.25 plays per team game, where 1 is best. |
+| `EPAplay_rank` | Float64 | Rank of the rusher's EPA generated per play among rushers clearing the leaderboard minimum of 6.25 plays per team game, where 1 is best. |
+| `success_rank` | Float64 | Rank of the rusher's success rate across their plays among rushers clearing the leaderboard minimum of 6.25 plays per team game, where 1 is best. |
+| `yards_rank` | Float64 | Rank of the rusher's total yards among rushers clearing the leaderboard minimum of 6.25 plays per team game, where 1 is best. |
+| `yardsplay_rank` | Float64 | Rank of the rusher's yards per play among rushers clearing the leaderboard minimum of 6.25 plays per team game, where 1 is best. |
+| `yardsgame_rank` | Float64 | Rank of the rusher's yards per game among rushers clearing the leaderboard minimum of 6.25 plays per team game, where 1 is best. |
 | `fbs_class` | String | Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference membership. Null for teams outside FBS. |
 
 ```python

--- a/tools/codegen/gen_cfb_player_percentile_descriptions.py
+++ b/tools/codegen/gen_cfb_player_percentile_descriptions.py
@@ -70,10 +70,22 @@ SUBJECT = {
     ),
 }
 
-# "National rank of the team's <noun>, where 1 is best." -> <noun>
-_RANK_RE = re.compile(
-    r"^National rank of the team's (?P<noun>.+?),\s*where 1 is best\.?$",
-    re.IGNORECASE,
+# Two accepted shapes, so the script is re-runnable against a tree it has
+# already been applied to. Matching only the first would make a second run
+# report every column as unparsed and compose nothing -- idempotent on the
+# INPUT is not the same as idempotent on its own OUTPUT.
+#
+#   1. team-grid leftover: "National rank of the team's <noun>, where 1 is best."
+#   2. this script's own:  "Rank of the <subject>'s <noun> among <pop>, where 1 is best."
+_RANK_PATTERNS = (
+    re.compile(
+        r"^National rank of the team's (?P<noun>.+?),\s*where 1 is best\.?$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^Rank of the \w+'s (?P<noun>.+?) among .+?,\s*where 1 is best\.?$",
+        re.IGNORECASE,
+    ),
 )
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -94,7 +106,10 @@ def _noun(existing: str | None) -> str | None:
     """Metric phrase out of an existing ``_rank`` description, else None."""
     if not existing:
         return None
-    m = _RANK_RE.match(existing.strip())
+    m = next(
+        (m for p in _RANK_PATTERNS if (m := p.match(existing.strip()))),
+        None,
+    )
     if not m:
         return None
     noun = NOUN_FIXUPS.get((raw := m.group("noun").strip()), raw)
@@ -127,12 +142,15 @@ def main() -> None:
 
     out: dict[str, dict[str, str]] = {t: {} for t in TARGETS}
     unparsed: list[str] = []
+    pending: list[str] = []
 
     for t in TARGETS:
         subject, population = SUBJECT[t]
         curated = manual.get(t) or {}
-        for entry in schemas.get(t, []):
-            col = entry["name"] if isinstance(entry, dict) else str(entry)
+        declared = {
+            (e["name"] if isinstance(e, dict) else str(e)) for e in schemas.get(t, [])
+        }
+        for col in sorted(declared):
             if not col.endswith("_rank"):
                 continue
             base = col[: -len("_rank")]
@@ -141,13 +159,27 @@ def main() -> None:
                 unparsed.append(f"{t}.{col}")
                 continue
             out[t][col] = rank_desc(noun, subject, population)
-            out[t][f"{base}_pct"] = pct_desc(noun, population)
+            # Emit the _pct sibling ONLY when the column is actually declared.
+            # tests/codegen/test_manual_descriptions.py::test_no_orphan_manual_entries
+            # fails on any manual key without a matching schema column, so a
+            # description cannot be written ahead of the column existing --
+            # runtime tolerates it (the lookup is manual[schema][col]) but the
+            # suite deliberately does not. The _pct columns land when
+            # cfbfastR-cfb-data#50's rebuilt assets are published and
+            # loader_schemas.yaml is re-captured; this generator then emits them
+            # on the next run with no edit here.
+            pct_col = f"{base}_pct"
+            if pct_col in declared:
+                out[t][pct_col] = pct_desc(noun, population)
+            else:
+                pending.append(f"{t}.{pct_col}")
 
     total = sum(len(v) for v in out.values())
     ranks = sum(1 for v in out.values() for c in v if c.endswith("_rank"))
     pcts = sum(1 for v in out.values() for c in v if c.endswith("_pct"))
     print(f"composed {total} descriptions across {len(TARGETS)} schemas ({ranks} corrected _rank, {pcts} new _pct)")
     print(f"UNPARSED (skipped, never invented): {len(unparsed)}")
+    print(f"PENDING _pct (column not declared yet, skipped): {len(pending)}")
     for u in sorted(unparsed)[:40]:
         print(f"   {u}")
 

--- a/tools/codegen/gen_cfb_player_percentile_descriptions.py
+++ b/tools/codegen/gen_cfb_player_percentile_descriptions.py
@@ -1,0 +1,161 @@
+"""Compose `_rank` + `_pct` descriptions for the cfb PLAYER leader loaders.
+
+Sibling of ``gen_cfb_summary_descriptions.py``, which covers the *team* grid
+(``load_cfb_team_summaries``). This one covers the three player-grain loaders --
+``load_cfb_passing`` / ``load_cfb_rushing`` / ``load_cfb_receiving`` -- which the
+team generator's ``targets`` tuple deliberately does not include.
+
+Two jobs.
+
+1. FIX the existing ``_rank`` descriptions. They currently read "National rank
+   of the TEAM's ...", copy-pasted from the team grid, and they are wrong: these
+   loaders are player-grain. Measured on the published ``cfb_passing_2025``
+   asset -- 567 rows, 566 distinct ``player_id``, ``EPAgame_rank`` spanning
+   1..137 and varying across passers within a team for 128 of 136 teams. They
+   are ranks among qualified PLAYERS.
+
+2. ADD the ``_pct`` siblings introduced by cfbfastR-cfb-data#50.
+
+Both are mechanical, which is the point: the next ranked metric gets correct
+text for free instead of another hand-copied line that drifts.
+
+The metric noun is NOT invented here -- it is lifted from the existing curated
+``_rank`` description, which was transcribed from the producer. This script only
+corrects the SUBJECT of that sentence and derives the percentile sibling. A
+``_rank`` description it cannot parse is reported and skipped, never guessed.
+
+Semantics the ``_pct`` text has to carry, all three from the producer
+(``team_summaries.py::_attach_leader_ranks`` / ``_pct``):
+
+* the population is QUALIFIERS, not every player -- 137 of 567 passers qualified
+  in 2025, so the median qualifier is nothing like the median passer;
+* direction lives in ``_rank`` already, so an ascending metric (interceptions,
+  sacks taken, fumbles) needs no separate wording -- 100 is always good;
+* a null metric yields a null percentile and is excluded from the denominator,
+  so "unknown" never renders as "worst".
+
+Output is a side file for the maintainer to merge into
+manual_column_descriptions.yaml, matching the sibling generator's contract.
+Enumeration is driven off loader_schemas.yaml (the stable declared schema) so
+the script is idempotent -- driving off "what is still undescribed" would make a
+second run a no-op and a re-merge would wipe the block it just wrote.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+TARGETS = ("load_cfb_passing", "load_cfb_rushing", "load_cfb_receiving")
+
+# Row subject and the ACTUAL qualifier gate per loader, both transcribed from
+# the producer (team_summaries.py `min_expr=` at the three _attach_leader_ranks
+# call sites). Naming the threshold rather than saying "qualified" is the whole
+# point: "qualified" invites a reader to assume the population is every player,
+# and it is not -- 137 of 567 passers cleared the gate in 2025, so the median
+# qualifier sits nowhere near the median passer. The existing curated text for
+# catchpct_rank already does this; the rest should match it.
+SUBJECT = {
+    "load_cfb_passing": (
+        "passer",
+        "passers clearing the leaderboard minimum of 14 dropbacks per team game",
+    ),
+    "load_cfb_rushing": (
+        "rusher",
+        "rushers clearing the leaderboard minimum of 6.25 plays per team game",
+    ),
+    "load_cfb_receiving": (
+        "receiver",
+        "receivers clearing the leaderboard minimum of 1.875 targets per team game",
+    ),
+}
+
+# "National rank of the team's <noun>, where 1 is best." -> <noun>
+_RANK_RE = re.compile(
+    r"^National rank of the team's (?P<noun>.+?),\s*where 1 is best\.?$",
+    re.IGNORECASE,
+)
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCHEMAS = ROOT / "tools" / "codegen" / "schemas" / "loader_schemas.yaml"
+MANUAL = ROOT / "tools" / "codegen" / "manual_column_descriptions.yaml"
+
+
+# Nouns whose wording is team-grid leftover and wrong on a player frame.
+# Verified against the producer: summarize_passer/rusher/receiver group by
+# player and take `success=pl.col("success").mean()`, so the mean is over that
+# PLAYER's plays, not the team's.
+NOUN_FIXUPS = {
+    "success rate across the team plays": "success rate across their plays",
+}
+
+
+def _noun(existing: str | None) -> str | None:
+    """Metric phrase out of an existing ``_rank`` description, else None."""
+    if not existing:
+        return None
+    m = _RANK_RE.match(existing.strip())
+    if not m:
+        return None
+    noun = NOUN_FIXUPS.get((raw := m.group("noun").strip()), raw)
+    # A noun still mentioning the team is team-grid wording that has not been
+    # verified against the player producer. Report it rather than ship text
+    # that says "team" on a per-player row.
+    if "team" in noun.lower():
+        return None
+    return noun
+
+
+def rank_desc(noun: str, subject: str, population: str) -> str:
+    return f"Rank of the {subject}'s {noun} among {population}, where 1 is best."
+
+
+def pct_desc(noun: str, population: str) -> str:
+    return (
+        f"Percentile (0-100) of {noun} among {population}, where 100 is best. "
+        f"Direction is already encoded in the matching rank, so a lower-is-better "
+        f"metric still scores 100 at its best. Null when the metric is null, and "
+        f"null rows are excluded from the denominator."
+    )
+
+
+def main() -> None:
+    import yaml
+
+    schemas = yaml.safe_load(SCHEMAS.read_text(encoding="utf-8"))
+    manual = yaml.safe_load(MANUAL.read_text(encoding="utf-8")) or {}
+
+    out: dict[str, dict[str, str]] = {t: {} for t in TARGETS}
+    unparsed: list[str] = []
+
+    for t in TARGETS:
+        subject, population = SUBJECT[t]
+        curated = manual.get(t) or {}
+        for entry in schemas.get(t, []):
+            col = entry["name"] if isinstance(entry, dict) else str(entry)
+            if not col.endswith("_rank"):
+                continue
+            base = col[: -len("_rank")]
+            noun = _noun(curated.get(col))
+            if noun is None:
+                unparsed.append(f"{t}.{col}")
+                continue
+            out[t][col] = rank_desc(noun, subject, population)
+            out[t][f"{base}_pct"] = pct_desc(noun, population)
+
+    total = sum(len(v) for v in out.values())
+    ranks = sum(1 for v in out.values() for c in v if c.endswith("_rank"))
+    pcts = sum(1 for v in out.values() for c in v if c.endswith("_pct"))
+    print(f"composed {total} descriptions across {len(TARGETS)} schemas ({ranks} corrected _rank, {pcts} new _pct)")
+    print(f"UNPARSED (skipped, never invented): {len(unparsed)}")
+    for u in sorted(unparsed)[:40]:
+        print(f"   {u}")
+
+    dest = pathlib.Path("_player_percentile_descs.yaml")
+    with dest.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(out, fh, sort_keys=True, allow_unicode=True, width=120)
+    print(f"wrote {dest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/codegen/gen_cfb_player_percentile_descriptions.py
+++ b/tools/codegen/gen_cfb_player_percentile_descriptions.py
@@ -147,9 +147,7 @@ def main() -> None:
     for t in TARGETS:
         subject, population = SUBJECT[t]
         curated = manual.get(t) or {}
-        declared = {
-            (e["name"] if isinstance(e, dict) else str(e)) for e in schemas.get(t, [])
-        }
+        declared = {(e["name"] if isinstance(e, dict) else str(e)) for e in schemas.get(t, [])}
         for col in sorted(declared):
             if not col.endswith("_rank"):
                 continue

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -3922,6 +3922,8 @@ espn_nhl_schedule:
   home_records: Serialized win-loss-overtime record string for the home team at the time of the scheduled game.
   venue_address_country: Country name or code for the country in which the game venue is located, as provided by ESPN's schedule
     endpoint.
+espn_wbb_game_officials:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 espn_wbb_game_rosters:
   athlete_href: ESPN API resource URL for the athlete's full profile endpoint.
   birth_country_alternate_id: Alternate identifier for the athlete's country of birth used in ESPN's country-flag system.
@@ -3934,7 +3936,7 @@ espn_wbb_game_rosters:
   team_alternate_ids_sdr: Alternate team identifier from ESPN's SDR (Sports Data Reference) system for the athlete's team.
 espn_wbb_player_stats:
   offensive_second_chance_points: Points scored by the player on offensive-rebound put-back opportunities during the season.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 espn_wbb_schedule:
   away_current_rank: Current AP/coaches poll ranking of the away team at the time of the game.
   away_linescores: Points scored by the away team in each period or half of the game.
@@ -3942,7 +3944,9 @@ espn_wbb_schedule:
   home_current_rank: Current AP/coaches poll ranking of the home team at the time of the game.
   home_linescores: Points scored by the home team in each period or half of the game.
   home_records: Win-loss record string for the home team at the time of the game.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+espn_wnba_game_officials:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 espn_wnba_player_stats:
   defensive_avg48_blocks: Player's blocked shots per 48 minutes of play, drawn from the defensive statistical category.
   defensive_avg48_defensive_rebounds: Player's defensive rebounds per 48 minutes of play, drawn from the defensive statistical
@@ -3973,13 +3977,13 @@ espn_wnba_player_stats:
   offensive_avg48_three_point_field_goals_made: Player's three-point field goals made per 48 minutes of play, drawn from the
     offensive statistical category.
   offensive_avg48_turnovers: Player's turnovers per 48 minutes of play, drawn from the offensive statistical category.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 espn_wnba_schedule:
   away_linescores: Period-by-period point totals for the away team, stored as a list of integer scores.
   away_records: Win-loss record strings for the away team across relevant splits (e.g., overall, home/away, conference).
   home_linescores: Period-by-period point totals for the home team, stored as a list of integer scores.
   home_records: Win-loss record strings for the home team across relevant splits (e.g., overall, home/away, conference).
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 expansion_draft_picks:
   draft_picks: JSON-serialized list of players selected by this franchise in the NHL expansion draft.
 fantasywidget:
@@ -5775,21 +5779,46 @@ load_cfb_model_pbp:
   wp_model_version: Version of the win-probability model that scored the play.
 load_cfb_passing:
   EPAgame: EPA generated per game.
-  EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
+  EPAgame_pct: Percentile (0-100) of EPA generated per game among passers clearing the leaderboard minimum of 14 dropbacks
+    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
+    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  EPAgame_rank: Rank of the passer's EPA generated per game among passers clearing the leaderboard minimum of 14 dropbacks
+    per team game, where 1 is best.
   EPAplay: EPA generated per play.
-  EPAplay_rank: National rank of the team's EPA generated per play, where 1 is best.
+  EPAplay_pct: Percentile (0-100) of EPA generated per play among passers clearing the leaderboard minimum of 14 dropbacks
+    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
+    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  EPAplay_rank: Rank of the passer's EPA generated per play among passers clearing the leaderboard minimum of 14 dropbacks
+    per team game, where 1 is best.
   TEPA: Total EPA summed over every play.
-  TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
+  TEPA_pct: Percentile (0-100) of total EPA summed over every play among passers clearing the leaderboard minimum of 14 dropbacks
+    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
+    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  TEPA_rank: Rank of the passer's total EPA summed over every play among passers clearing the leaderboard minimum of 14 dropbacks
+    per team game, where 1 is best.
   att: Pass attempts thrown.
   comp: Completed passes.
   comppct: Completion percentage.
-  comppct_rank: National rank of the team's completion percentage, where 1 is best.
+  comppct_pct: Percentile (0-100) of completion percentage among passers clearing the leaderboard minimum of 14 dropbacks
+    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
+    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  comppct_rank: Rank of the passer's completion percentage among passers clearing the leaderboard minimum of 14 dropbacks
+    per team game, where 1 is best.
   detmer: Detmer rating -- the composite passing-efficiency measure this pipeline publishes, named for the college passing-efficiency
     tradition.
-  detmer_rank: National rank of the team's detmer rating -- the composite passing-efficiency measure this pipeline publishes,
-    named for the college passing-efficiency tradition, where 1 is best.
+  detmer_pct: Percentile (0-100) of detmer rating -- the composite passing-efficiency measure this pipeline publishes, named
+    for the college passing-efficiency tradition among passers clearing the leaderboard minimum of 14 dropbacks per team game,
+    where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100 at
+    its best. Null when the metric is null, and null rows are excluded from the denominator.
+  detmer_rank: Rank of the passer's detmer rating -- the composite passing-efficiency measure this pipeline publishes, named
+    for the college passing-efficiency tradition among passers clearing the leaderboard minimum of 14 dropbacks per team game,
+    where 1 is best.
   detmergame: Detmer rating expressed per game.
-  detmergame_rank: National rank of the team's detmer rating expressed per game, where 1 is best.
+  detmergame_pct: Percentile (0-100) of detmer rating expressed per game among passers clearing the leaderboard minimum of
+    14 dropbacks per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better
+    metric still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  detmergame_rank: Rank of the passer's detmer rating expressed per game among passers clearing the leaderboard minimum of
+    14 dropbacks per team game, where 1 is best.
   dropbacks: Dropbacks taken by the passer.
   fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
     membership. Null for teams outside FBS.'
@@ -5798,20 +5827,44 @@ load_cfb_passing:
   passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
   playsgame: Plays per game.
   sack_adj_yards: Passing yards adjusted for sack yardage lost.
-  sack_adj_yards_rank: National rank of the team's passing yards adjusted for sack yardage lost, where 1 is best.
+  sack_adj_yards_pct: Percentile (0-100) of passing yards adjusted for sack yardage lost among passers clearing the leaderboard
+    minimum of 14 dropbacks per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better
+    metric still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  sack_adj_yards_rank: Rank of the passer's passing yards adjusted for sack yardage lost among passers clearing the leaderboard
+    minimum of 14 dropbacks per team game, where 1 is best.
   sack_epa: EPA lost on the sacks the team's passers took -- the expected-points cost of those plays.
   sack_yds: Yards lost to sacks.
   sacked: Times the passer was sacked.
   success: Success rate across the team plays.
-  success_rank: National rank of the team's success rate across the team plays, where 1 is best.
+  success_pct: Percentile (0-100) of success rate across their plays among passers clearing the leaderboard minimum of 14
+    dropbacks per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric
+    still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  success_rank: Rank of the passer's success rate across their plays among passers clearing the leaderboard minimum of 14
+    dropbacks per team game, where 1 is best.
   team_games: Games the team played, used as the per-game denominator.
-  yards_rank: National rank of the team's total yards, where 1 is best.
+  yards_pct: Percentile (0-100) of total yards among passers clearing the leaderboard minimum of 14 dropbacks per team game,
+    where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100 at
+    its best. Null when the metric is null, and null rows are excluded from the denominator.
+  yards_rank: Rank of the passer's total yards among passers clearing the leaderboard minimum of 14 dropbacks per team game,
+    where 1 is best.
   yardsdropback: Yards per dropback.
-  yardsdropback_rank: National rank of the team's yards per dropback, where 1 is best.
+  yardsdropback_pct: Percentile (0-100) of yards per dropback among passers clearing the leaderboard minimum of 14 dropbacks
+    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
+    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  yardsdropback_rank: Rank of the passer's yards per dropback among passers clearing the leaderboard minimum of 14 dropbacks
+    per team game, where 1 is best.
   yardsgame: Yards per game.
-  yardsgame_rank: National rank of the team's yards per game, where 1 is best.
+  yardsgame_pct: Percentile (0-100) of yards per game among passers clearing the leaderboard minimum of 14 dropbacks per team
+    game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100
+    at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  yardsgame_rank: Rank of the passer's yards per game among passers clearing the leaderboard minimum of 14 dropbacks per team
+    game, where 1 is best.
   yardsplay: Yards per play.
-  yardsplay_rank: National rank of the team's yards per play, where 1 is best.
+  yardsplay_pct: Percentile (0-100) of yards per play among passers clearing the leaderboard minimum of 14 dropbacks per team
+    game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100
+    at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  yardsplay_rank: Rank of the passer's yards per play among passers clearing the leaderboard minimum of 14 dropbacks per team
+    game, where 1 is best.
 load_cfb_pbp:
   A_score_diff: Away team's score minus the home team's, from the away perspective.
   EPA_explosive: True when the play was explosive.
@@ -6429,11 +6482,23 @@ load_cfb_ratings_weekly:
     that week's final kickoff date.
 load_cfb_receiving:
   EPAgame: EPA generated per game.
-  EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
+  EPAgame_pct: Percentile (0-100) of EPA generated per game among receivers clearing the leaderboard minimum of 1.875 targets
+    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
+    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  EPAgame_rank: Rank of the receiver's EPA generated per game among receivers clearing the leaderboard minimum of 1.875 targets
+    per team game, where 1 is best.
   EPAplay: EPA generated per play.
-  EPAplay_rank: National rank of the team's EPA generated per play, where 1 is best.
+  EPAplay_pct: Percentile (0-100) of EPA generated per play among receivers clearing the leaderboard minimum of 1.875 targets
+    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
+    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  EPAplay_rank: Rank of the receiver's EPA generated per play among receivers clearing the leaderboard minimum of 1.875 targets
+    per team game, where 1 is best.
   TEPA: Total EPA summed over every play.
-  TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
+  TEPA_pct: Percentile (0-100) of total EPA summed over every play among receivers clearing the leaderboard minimum of 1.875
+    targets per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric
+    still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  TEPA_rank: Rank of the receiver's total EPA summed over every play among receivers clearing the leaderboard minimum of 1.875
+    targets per team game, where 1 is best.
   catchpct: Catch rate on a 0-to-1 scale, receptions divided by targets for the season.
   catchpct_rank: Season rank of catchpct with the best catch rate first, computed only for receivers clearing the leaderboard
     minimum of 1.875 targets per team game and using averaged ranks for ties.
@@ -6444,13 +6509,29 @@ load_cfb_receiving:
   playsgame: Plays per game.
   receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
   success: Success rate across the team plays.
-  success_rank: National rank of the team's success rate across the team plays, where 1 is best.
+  success_pct: Percentile (0-100) of success rate across their plays among receivers clearing the leaderboard minimum of 1.875
+    targets per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric
+    still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  success_rank: Rank of the receiver's success rate across their plays among receivers clearing the leaderboard minimum of
+    1.875 targets per team game, where 1 is best.
   team_games: Games the team played, used as the per-game denominator.
-  yards_rank: National rank of the team's total yards, where 1 is best.
+  yards_pct: Percentile (0-100) of total yards among receivers clearing the leaderboard minimum of 1.875 targets per team
+    game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100
+    at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  yards_rank: Rank of the receiver's total yards among receivers clearing the leaderboard minimum of 1.875 targets per team
+    game, where 1 is best.
   yardsgame: Yards per game.
-  yardsgame_rank: National rank of the team's yards per game, where 1 is best.
+  yardsgame_pct: Percentile (0-100) of yards per game among receivers clearing the leaderboard minimum of 1.875 targets per
+    team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores
+    100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  yardsgame_rank: Rank of the receiver's yards per game among receivers clearing the leaderboard minimum of 1.875 targets
+    per team game, where 1 is best.
   yardsplay: Yards per play.
-  yardsplay_rank: National rank of the team's yards per play, where 1 is best.
+  yardsplay_pct: Percentile (0-100) of yards per play among receivers clearing the leaderboard minimum of 1.875 targets per
+    team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores
+    100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  yardsplay_rank: Rank of the receiver's yards per play among receivers clearing the leaderboard minimum of 1.875 targets
+    per team game, where 1 is best.
 load_cfb_recruiting_proj:
   pred_margin: Ridge projection of the team's average per-game scoring margin, from the same preseason-known feature set as
     pred_wins.
@@ -6582,24 +6663,52 @@ load_cfb_rosters_cfbd:
     0 entry means no recruiting profile was matched.
 load_cfb_rushing:
   EPAgame: EPA generated per game.
-  EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
+  EPAgame_pct: Percentile (0-100) of EPA generated per game among rushers clearing the leaderboard minimum of 6.25 plays per
+    team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores
+    100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  EPAgame_rank: Rank of the rusher's EPA generated per game among rushers clearing the leaderboard minimum of 6.25 plays per
+    team game, where 1 is best.
   EPAplay: EPA generated per play.
-  EPAplay_rank: National rank of the team's EPA generated per play, where 1 is best.
+  EPAplay_pct: Percentile (0-100) of EPA generated per play among rushers clearing the leaderboard minimum of 6.25 plays per
+    team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores
+    100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  EPAplay_rank: Rank of the rusher's EPA generated per play among rushers clearing the leaderboard minimum of 6.25 plays per
+    team game, where 1 is best.
   TEPA: Total EPA summed over every play.
-  TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
+  TEPA_pct: Percentile (0-100) of total EPA summed over every play among rushers clearing the leaderboard minimum of 6.25
+    plays per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric
+    still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  TEPA_rank: Rank of the rusher's total EPA summed over every play among rushers clearing the leaderboard minimum of 6.25
+    plays per team game, where 1 is best.
   fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
     membership. Null for teams outside FBS.'
   fumbles: Count of the ball carrier's rush attempts across the season whose play text mentions a fumble by either team.
   playsgame: Plays per game.
   rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
   success: Success rate across the team plays.
-  success_rank: National rank of the team's success rate across the team plays, where 1 is best.
+  success_pct: Percentile (0-100) of success rate across their plays among rushers clearing the leaderboard minimum of 6.25
+    plays per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric
+    still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  success_rank: Rank of the rusher's success rate across their plays among rushers clearing the leaderboard minimum of 6.25
+    plays per team game, where 1 is best.
   team_games: Games the team played, used as the per-game denominator.
-  yards_rank: National rank of the team's total yards, where 1 is best.
+  yards_pct: Percentile (0-100) of total yards among rushers clearing the leaderboard minimum of 6.25 plays per team game,
+    where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100 at
+    its best. Null when the metric is null, and null rows are excluded from the denominator.
+  yards_rank: Rank of the rusher's total yards among rushers clearing the leaderboard minimum of 6.25 plays per team game,
+    where 1 is best.
   yardsgame: Yards per game.
-  yardsgame_rank: National rank of the team's yards per game, where 1 is best.
+  yardsgame_pct: Percentile (0-100) of yards per game among rushers clearing the leaderboard minimum of 6.25 plays per team
+    game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100
+    at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  yardsgame_rank: Rank of the rusher's yards per game among rushers clearing the leaderboard minimum of 6.25 plays per team
+    game, where 1 is best.
   yardsplay: Yards per play.
-  yardsplay_rank: National rank of the team's yards per play, where 1 is best.
+  yardsplay_pct: Percentile (0-100) of yards per play among rushers clearing the leaderboard minimum of 6.25 plays per team
+    game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100
+    at its best. Null when the metric is null, and null rows are excluded from the denominator.
+  yardsplay_rank: Rank of the rusher's yards per play among rushers clearing the leaderboard minimum of 6.25 plays per team
+    game, where 1 is best.
 load_cfb_schedule:
   attendance: Announced attendance for the game as reported to ESPN. Null for games with no announced figure and for closed-door
     2020 games; a null is unknown, not zero, so exclude it rather than filling it.
@@ -9286,6 +9395,18 @@ load_ncaa_mbb_possessions:
   poss_team_espn_team_id: ESPN team identifier of the team in possession, via the NCAA-to-ESPN crosswalk.
   poss_team_ncaa_team_id: stats.ncaa.org team identifier of the team in possession.
   start_event_type: Event type that opened the possession (e.g., a defensive rebound or a made-basket inbound).
+load_ncaa_mbb_rapm:
+  def_poss: Defensive possessions the player was on court for; the regression weight behind drapm.
+  drapm: 'Defensive regularized adjusted plus-minus: points prevented per 100 possessions on defense (higher is better defense),
+    adjusted for the other 9 players on the floor.'
+  estimand: 'Fit-scope tag for the RAPM model that produced this row (observed value: ''league'', a Division I-wide fit) --
+    one row per player-season, not per estimand.'
+  off_poss: Offensive possessions the player was on court for; the regression weight behind orapm.
+  orapm: 'Offensive regularized adjusted plus-minus: points contributed per 100 possessions on offense, adjusted for the other
+    9 players on the floor.'
+  rapm_net: 'Net RAPM (orapm plus drapm): overall point contribution per 100 possessions. Verified against live data: rapm_net
+    == orapm + drapm exactly.'
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_ncaa_mbb_rapm_within_team:
   num_players: Number of players in the team's RAPM design matrix.
   player_code: Short unique-within-team player code generated from the player's name (hoop-explorer convention).
@@ -9367,6 +9488,91 @@ load_ncaa_mbb_team_box:
 load_ncaa_mbb_team_rosters:
   clean_name: Normalized (diacritics- and punctuation-cleaned) player name used to join across the NCAA datasets.
   ht_inches: Player height converted to total inches from the stats.ncaa.org roster listing.
+load_ncaa_mfb_drives:
+  end_how: How the drive ended (e.g. 'Touchdown', 'Punt', 'Interception', 'Fumble', 'End of Half').
+  n_plays: Number of plays run during the drive.
+  quarter: Quarter in which the drive started (1-4 for regulation, 5+ for overtime periods).
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  start_how: How the drive began (e.g. 'Kickoff', 'Interception', 'Fumble', 'Downs', 'Punt').
+load_ncaa_mfb_linescore:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_ncaa_mfb_officials:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_ncaa_mfb_pbp:
+  drive_scored: Whether the possession containing this play ended in points for the offense.
+  fair_catch: Whether the returner called a fair catch on a kickoff or punt.
+  fg_distance: Distance in yards of a field goal attempt.
+  formation: Offensive formation or personnel grouping reported for the play (e.g. 'Shotgun', 'I-Formation'), when the source
+    narrative names it.
+  is_first_down: Whether the play resulted in a first down for the offense.
+  is_fumble: Whether a fumble occurred on the play, regardless of which team recovered it.
+  is_safety: Whether the play resulted in a safety.
+  is_touchdown: Whether the play resulted in a touchdown.
+  kick_yards: Yards traveled on a kickoff.
+  kicker: Name of the player who kicked off, punted, or attempted the field goal/PAT on this play.
+  no_play: Whether the play was negated (e.g. by a penalty on the preceding down) and is excluded from drive/stat totals.
+  pass_complete: Whether a pass attempt on this play was completed.
+  pass_depth: Depth classification of a pass attempt (e.g. 'short', 'deep'), when the narrative reports it.
+  pass_direction: Side of the field the pass was thrown to (e.g. 'left', 'middle', 'right'), when the narrative reports it.
+  penalty_player: Name of the player penalized on the play, when a penalty occurred.
+  punt_yards: Gross yards traveled on a punt, before any return.
+  punter: Name of the player who punted on this play.
+  returner: Name of the player who fielded or returned the kickoff or punt on this play.
+  run_direction: Hole or side the ball carrier ran through on a rush play (e.g. 'left end', 'right guard'), when the narrative
+    reports it.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  tackler_1: Name of the primary (first-listed) tackler on the play.
+  tackler_2: Name of the secondary (assisting) tackler on the play, when the narrative credits an assist.
+  turnover_type: Kind of turnover on the play, if any (e.g. 'interception', 'fumble lost'); null when no turnover occurred.
+  yard_line_number: Yard line at the snap (0-50); pairs with yard_line_side for absolute field position.
+  yard_line_side: Which team's territory the ball was on at the snap ('OFF' own side, 'DEF' opponent side); pairs with yard_line_number
+    for absolute field position.
+load_ncaa_mfb_pbp_cfbfastr:
+  clock.minutes: Minutes remaining on the game clock at the start of the play (cfbfastR schema column).
+  clock.seconds: Seconds remaining within the current minute on the game clock at the start of the play (cfbfastR schema column).
+  n_plays_in_game: Total number of plays in the game this row belongs to, repeated on every row for convenience.
+  ot_synthesized: Whether this row's overtime clock/period fields were synthesized rather than sourced directly -- stats.ncaa.org
+    reports no running clock in overtime, so OT plays are assigned a synthetic countdown.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_ncaa_mfb_player_stats:
+  long_pass: Longest completed pass of the game.
+  long_rec: Longest reception of the game.
+  pass_attempts: Pass attempts for the game. Populated only on this player-game's 'passing' category row (null on the 'rushing'/'receiving'
+    rows for the same player-game) -- the loader returns one row per player-game-category.
+  pass_eff: Passer efficiency rating for the game, per the NCAA passer-rating formula.
+  pass_tds: Passing touchdowns thrown for the game. Populated only on this player-game's 'passing' category row (null on the
+    'rushing'/'receiving' rows for the same player-game) -- the loader returns one row per player-game-category.
+  rec: Total receptions for the game.
+  rec_td: Receiving touchdowns.
+  rush_long: Longest single rush of the game.
+  rush_tds: Rushing touchdowns for the game. Populated only on this player-game's 'rushing' category row (null on the 'passing'/'receiving'
+    rows for the same player-game) -- the loader returns one row per player-game-category.
+  rush_yds_gained: Total positive rushing yards gained on carries, before subtracting yards lost to tackles for loss.
+  rush_yds_lost: Total rushing yards lost to tackles for loss on carries.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  yards_per_reception: Receiving yards divided by receptions.
+  yds_per_completion: Passing yards divided by completions.
+  yds_rush: Net rushing yards (rush_yds_gained minus rush_yds_lost).
+load_ncaa_mfb_rosters:
+  academic_year: Academic year the roster snapshot covers (the ENDING year of the fall/spring split) -- distinct from `season`,
+    which is the STARTING year.
+  player_class: Player's academic/eligibility class (e.g. 'FR', 'SO', 'JR', 'SR', 'GR').
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+  statcrew_jersey: Jersey number as recorded in the NCAA StatCrew roster feed; can differ from the number a player actually
+    wears on a given game day.
+load_ncaa_mfb_schedule:
+  academic_year: Academic year the game was played in (the ENDING year of the fall/spring split, e.g. 2025 for the 2024 fall
+    season) -- distinct from `season`, which is the STARTING year.
+  outcome: Result of the game from the home team's perspective (e.g. 'W', 'L', 'T').
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_ncaa_mfb_team_stats:
+  away_value: Team-stat value for the away team; each row is one stat category for one game, wide by side.
+  home_value: Team-stat value for the home team; each row is one stat category for one game, wide by side.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_ncaa_mfb_teams:
+  academic_year: Academic year the team record covers (the ENDING year of the fall/spring split) -- distinct from `season`,
+    which is the STARTING year.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_ncaa_wbb_lineups:
   drb: Defensive rebounds by the lineup during the stint.
   duration_mins: Length of the stint in minutes.
@@ -9674,6 +9880,18 @@ load_ncaa_wbb_possessions:
   poss_team_espn_team_id: ESPN team identifier of the team in possession, via the NCAA-to-ESPN crosswalk.
   poss_team_ncaa_team_id: stats.ncaa.org team identifier of the team in possession.
   start_event_type: Event type that opened the possession (e.g., a defensive rebound or a made-basket inbound).
+load_ncaa_wbb_rapm:
+  def_poss: Defensive possessions the player was on court for; the regression weight behind drapm.
+  drapm: 'Defensive regularized adjusted plus-minus: points prevented per 100 possessions on defense (higher is better defense),
+    adjusted for the other 9 players on the floor.'
+  estimand: 'Fit-scope tag for the RAPM model that produced this row (observed value: ''league'', a Division I-wide fit) --
+    one row per player-season, not per estimand.'
+  off_poss: Offensive possessions the player was on court for; the regression weight behind orapm.
+  orapm: 'Offensive regularized adjusted plus-minus: points contributed per 100 possessions on offense, adjusted for the other
+    9 players on the floor.'
+  rapm_net: 'Net RAPM (orapm plus drapm): overall point contribution per 100 possessions. Verified against live data: rapm_net
+    == orapm + drapm exactly.'
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_ncaa_wbb_rapm_within_team:
   num_players: Number of players in the team's RAPM design matrix.
   player_code: Short unique-within-team player code generated from the player's name (hoop-explorer convention).
@@ -9954,6 +10172,7 @@ load_nfl_pfr_weekly_def:
   def_air_yards_completed: Total air yards on completed passes allowed by the defender during the week.
   def_completion_pct: Completion percentage allowed by the defender on targets thrown in their coverage during the week.
   def_completions_allowed: Number of completions allowed by the defender on passes thrown into their coverage during the week.
+  def_ints: Interceptions for the week (this loader is per-player-per-week, not career).
   def_missed_tackle_pct: Percentage of the defender's tackle opportunities that resulted in a missed tackle during the week.
   def_missed_tackles: Number of missed tackles recorded against this defender during the week per Pro Football Reference.
   def_passer_rating_allowed: NFL passer rating of quarterbacks when targeting this defender in coverage during the week.
@@ -9971,7 +10190,6 @@ load_nfl_pfr_weekly_def:
   def_yards_allowed: Total receiving yards allowed by this defender in coverage during the week per Pro Football Reference.
   def_yards_allowed_per_cmp: Receiving yards allowed per completion by this defender in coverage during the week.
   def_yards_allowed_per_tgt: Receiving yards allowed per target thrown at this defender in coverage during the week.
-  def_ints: "Interceptions for the week (this loader is per-player-per-week, not career)."
 load_nfl_pfr_weekly_pass:
   def_times_blitzed: Number of pass plays on which the defense sent a blitz, as experienced by the quarterback in this weekly
     log.
@@ -10783,7 +11001,7 @@ load_teams:
 load_wbb_game_rosters:
   athlete_headshot: URL of the player's ESPN headshot image on a.espncdn.com, whose filename is the athlete_id; null when
     ESPN publishes no headshot for that player.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wbb_officials:
   official_display_name: ESPN's displayName for the official, which is identical to official_full_name in every published
     row of the released data.
@@ -10797,7 +11015,7 @@ load_wbb_officials:
     1 to 3 for the standard three-person crew.
   official_uid: ESPN's globally unique resource identifier for the official, read from the core-api items[] uid key; that
     payload never ships it, so the column is null for every published row.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wbb_pbp:
   athlete_name_1: Display name of the first athlete in the ESPN play participants (e.g., the shooter on a shot attempt).
   athlete_name_2: Display name of the second athlete in the ESPN play participants (e.g., the assisting player), when present.
@@ -10808,26 +11026,34 @@ load_wbb_pbp:
     the ESPN play type.
   score_value: Point value of the attempt (1 / 2 / 3), carried even on misses (a missed free throw still shows 1); use scoring_play
     to identify points actually scored.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   short_description: Shortened version of ESPN's play description text, without score context.
   type_text: Play type text, passed through verbatim from ESPN. ESPN labels the free-throw play type "MadeFreeThrow" for made
     AND missed free throws; filter makes vs. misses with scoring_play, not type_text.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wbb_player_boxscore:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_wbb_player_core:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_wbb_player_crosswalk:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wbb_player_season_stats:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   stat_description: ESPN's prose definition of the statistic named in stat_name, for example The average assists per game
     for avgAssists; combined made-attempted stats carry both definitions joined by a hyphen.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wbb_player_value:
   box_bpm: Total box plus/minus in points per 100 possessions above average, exactly box_obpm plus box_dbpm in every published
     row.
   box_dbpm: Box-score defensive plus/minus for the player, the defensive half of box BPM.
   box_obpm: Box-score offensive plus/minus for the player, the offensive half of box BPM.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wbb_ratings:
   adj_em_z: Within-season z-score of adj_em, computed as adj_em minus the season mean divided by the season standard deviation
     over every team in the frame, so it is mean 0 and standard deviation 1 per season.
   adj_tempo: Opponent-adjusted tempo in possessions per 40 minutes, produced by the same fixed-point adjustment as the efficiencies
     applied to game possessions under the additive model poss = tempo_i + tempo_j minus the league baseline.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_wbb_rosters:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wbb_schedule:
   away_current_rank: Poll ranking ESPN listed for the away team at game time (unranked teams carry a sentinel value).
   away_linescores: Period-by-period scores for the away team as a delimited string from ESPN's schedule feed.
@@ -10835,26 +11061,30 @@ load_wbb_schedule:
   home_current_rank: Poll ranking ESPN listed for the home team at game time (unranked teams carry a sentinel value).
   home_linescores: Period-by-period scores for the home team as a delimited string from ESPN's schedule feed.
   home_records: Record strings (overall and split records) for the home team from ESPN's schedule feed.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_wbb_schedule_crosswalk:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wbb_shots:
   athlete_name_1: Display name of the shooter credited on the attempt in ESPN's play participants.
   athlete_name_2: Display name of the second athlete tied to the attempt (typically the assister), when present.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   team_mascot: Mascot/nickname of the shooting team from ESPN's team record.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wbb_standings:
   group_short_name: Short display name of the conference or division grouping the row belongs to.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   stat_abbreviation: ESPN's abbreviation for the standings stat, such as GB, OPP PPG or VS CONF; always populated and matching
     stat_short_display_name for about 90 percent of rows.
   stat_description: ESPN's longer wording for the standings stat, for example Overall Record for the Team Season Record entry
     and Current Streak for Streak; null for stats ESPN ships without one, such as vs AP Top 25.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wbb_team_boxscore:
   lead_percentage: Share of game time the team held the lead, as reported in ESPN's team boxscore.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_wbb_team_crosswalk:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wbb_team_season_stats:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   stat_description: ESPN's prose definition of the team statistic named in stat_name, for example The average blocks per game
     for avgBlocks or the full sentence defining a blocked shot for blocks.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_draft:
   college_abbreviation: Short code for the drafted player's school, read from the athlete's ESPN college block; null throughout
     the published data because ESPN ships no college block on these picks.
@@ -10865,11 +11095,11 @@ load_wnba_draft:
   round_display_name: Human-readable label for the draft round, read from the ESPN round object's displayName falling back
     to its name; null whenever ESPN ships the modern flat picks array with no round objects, which is the case for every published
     season.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wnba_game_rosters:
   athlete_headshot: Direct link to the player's ESPN headshot image, always of the form https://a.espncdn.com/i/headshots/wnba/players/full/{athlete_id}.png,
     and null for the few players ESPN has no photo for.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wnba_officials:
   official_display_name: ESPN's display rendering of the official's name, which is byte-identical to official_full_name on
     every published row and therefore adds nothing.
@@ -10882,7 +11112,7 @@ load_wnba_officials:
     crew and 40 of 573 games in 2024-2025 add a fourth.
   official_uid: ESPN's global uid string for the official, carried straight through from the officials payload; the Core v2
     items ESPN serves omit it, so it is null in every published season.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wnba_pbp:
   athlete_name_1: Display name of the primary athlete on the play (e.g. the shooter, rebounder, or fouler), per ESPN participant
     order.
@@ -10893,16 +11123,20 @@ load_wnba_pbp:
   points_attempted: Point value at stake on the play's shot attempt (1, 2, or 3); 0 for non-shooting plays.
   score_value: Point value of the attempt (1 / 2 / 3), carried even on misses (a missed free throw still shows 1); use scoring_play
     to identify points actually scored.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   short_description: Abbreviated ESPN text description of the play.
   type_text: Play type text, passed through verbatim from ESPN. ESPN labels the free-throw play type "MadeFreeThrow" for made
     AND missed free throws; filter makes vs. misses with scoring_play, not type_text.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wnba_player_boxscore:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_wnba_player_core:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wnba_player_crosswalk:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   wnba_jersey_num: Jersey number listed on the stats.wnba.com side of the crosswalk.
   wnba_player_id: Player identifier on stats.wnba.com matched to the ESPN player.
   wnba_player_name: Player display name on the stats.wnba.com side of the crosswalk.
   wnba_position: Position listed on the stats.wnba.com side of the crosswalk.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_player_impact:
   adj_rapm: Total prior-informed RAPM (offense plus defense), in points per 100 possessions.
   d_adj_rapm: 'Defensive prior-informed RAPM: ridge shrunk toward a box-score prior, in points per 100 possessions.'
@@ -10917,40 +11151,42 @@ load_wnba_player_impact:
   off_poss: Offensive possessions the player was on the floor for in the RAPM sample.
   ospm: 'Offensive statistical plus-minus: box-score features regressed onto the offensive RAPM target, per 100 possessions.'
   rapm: 'Total RAPM: offensive plus defensive regularized on/off impact, in points per 100 possessions.'
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   spm: 'Statistical plus-minus: offensive plus defensive box-score estimate of the RAPM target, per 100 possessions.'
   war: Wins above replacement implied by the player's impact and playing time, calibrated from team points-per-win.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_player_season_stats:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   stat_description: ESPN's prose definition of the statistic on this row, for example The average number of points scored
     per game for avgPoints; combined made-attempted stats carry both halves joined by a hyphen.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+load_wnba_rosters:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wnba_schedule:
   away_linescores: Stringified list of the away team's period-by-period scores from the ESPN schedule feed.
   away_records: Stringified list of the away team's record summaries (overall/home/away) from the ESPN schedule feed.
   home_linescores: Stringified list of the home team's period-by-period scores from the ESPN schedule feed.
   home_records: Stringified list of the home team's record summaries (overall/home/away) from the ESPN schedule feed.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wnba_schedule_crosswalk:
   fox_away_team_id: Away team identifier on Fox Sports for the matched game.
   fox_home_team_id: Home team identifier on Fox Sports for the matched game.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   wnba_away_team_id: Away team identifier on stats.wnba.com for the matched game.
   wnba_game_code: stats.wnba.com game code (date/matchup slug) for the matched game.
   wnba_game_id: Game identifier on stats.wnba.com matched to the ESPN game.
   wnba_home_team_id: Home team identifier on stats.wnba.com for the matched game.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_shots:
   athlete_name_1: Display name of the shooter, per ESPN participant order.
   athlete_name_2: Display name of the secondary athlete on the shot (typically the assister), when present.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   team_mascot: ESPN mascot (nickname) of the shooting team.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_standings:
   group_short_name: Short label of the standings group node the team sits under, read from ESPN shortName; the WNBA conference
     nodes ship only name and abbreviation, so it is null on every published row.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   stat_abbreviation: ESPN's abbreviation for the standings stat, which can differ from stat_short_display_name (playoffSeed
     is SEED here but POS there) and is null on the record-split rows such as Home and vs. Conf.
   stat_description: ESPN's long-form explanation of the standings stat, such as Clinched Best League Record for clincher or
     Record last 10 games for lasttengames.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_stats_coaches:
   coach_name: Full name of the staff member as the feed renders it, exactly first_name plus a space plus last_name on every
     published row.
@@ -10958,15 +11194,15 @@ load_wnba_stats_coaches:
     data.
   is_assistant: 'Numeric staff-role code rather than a boolean flag: 1 head coach, 2 assistant coach, 3 trainer, 9 associate
     head coach, mapping one-to-one onto coach_type.'
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   sort_sequence: Ordering field passed through unchanged from the stats.wnba.com coaches result set; it arrives empty, so
     every published row is null.
   sub_sort_sequence: 'Secondary display-ordering rank that tracks coach_type exactly: 1 head coach, 2 associate head coach,
     5 assistant coach, 7 trainer.'
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_stats_draft:
   draft_type: 'CONSTANT in the published asset: every row reads ''Draft'', so it does not currently distinguish the main draft
     from any other selection event.'
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wnba_stats_game_lineups:
   away_player_1: stats.wnba.com identifier of away on-court player 1 of 5 for the lineup stint.
   away_player_2: stats.wnba.com identifier of away on-court player 2 of 5 for the lineup stint.
@@ -10978,7 +11214,11 @@ load_wnba_stats_game_lineups:
   home_player_3: stats.wnba.com identifier of home on-court player 3 of 5 for the lineup stint.
   home_player_4: stats.wnba.com identifier of home on-court player 4 of 5 for the lineup stint.
   home_player_5: stats.wnba.com identifier of home on-court player 5 of 5 for the lineup stint.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_wnba_stats_game_rosters:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_wnba_stats_officials:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wnba_stats_pbp:
   is_foul: True when the event is a foul.
   is_free_throw: True when the event is a free throw attempt.
@@ -10990,7 +11230,9 @@ load_wnba_stats_pbp:
   is_substitution: True when the event is a substitution.
   is_timeout: True when the event is a timeout.
   order_index: Stable ordering index of the event within the game's stats.wnba.com play-by-play.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_wnba_stats_player_boxscores:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wnba_stats_player_game_logs:
   ast: Assists credited.
   blk: Total shots blocked.
@@ -11012,9 +11254,9 @@ load_wnba_stats_player_game_logs:
   plus_minus: Plus-minus point differential.
   pts: Total points scored.
   reb: Total rebounds collected.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   stl: Steals recorded.
   tov: Turnovers committed.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_stats_possessions:
   count_as_possession: False only for a possession starting with 2 seconds or less left in the period and no made basket before
     the period ends.
@@ -11036,27 +11278,33 @@ load_wnba_stats_possessions:
   off_player_4: stats.wnba.com identifier of offensive on-court player 4 of 5 for the possession (unordered slot).
   off_player_5: stats.wnba.com identifier of offensive on-court player 5 of 5 for the possession (unordered slot).
   possession_start_type: 'How the possession began: OffDeadball, OffTimeout, OffMadeShot, OffMissedShot, or OffLiveBallTurnover.'
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   start_order_index: order_index of the first event in the possession; joins to the wnba_stats_pbp table.
   start_seconds_remaining: Seconds remaining in the period when the possession began.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_stats_rosters:
   exp: Years of WNBA playing experience entering the season ('R' = rookie).
   how_acquired: How the team acquired the player (draft, trade, free agency).
   num: Jersey number worn by the player.
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   supplemental_status: Numeric supplemental roster-status code from the stats.wnba.com roster feed.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 load_wnba_stats_schedules:
   away_pts: Final points scored by the away team.
   away_wl: Result for the away team ('W' or 'L'); null before the game is final.
   home_pts: Final points scored by the home team.
   home_wl: Result for the home team ('W' or 'L'); null before the game is final.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_wnba_stats_shots:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_wnba_stats_team_boxscores:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wnba_team_boxscore:
   lead_percentage: Share of game time the team spent in the lead, as reported by ESPN.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
+load_wnba_team_crosswalk:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
 load_wnba_team_season_stats:
+  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
   stat_description: Human-readable description of the statistic the row reports.
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
 matchupsrollup:
   def_player_id: Stats API identifier for defensive player identifier associated with this NBA or WNBA Stats row.
   def_player_name: Display name for defensive player name associated with this NBA or WNBA Stats row.
@@ -21622,127 +21870,3 @@ x_era:
   season: MLB season (4-digit start year).
   x_era: Parametric xERA converted from x_woba via the season's league baselines.
   x_woba: Mean estimated_woba_using_speedangle allowed on batted balls.
-load_ncaa_mbb_rapm:
-  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
-  def_poss: "Defensive possessions the player was on court for; the regression weight behind drapm."
-  drapm: "Defensive regularized adjusted plus-minus: points prevented per 100 possessions on defense (higher is better defense), adjusted for the other 9 players on the floor."
-  estimand: "Fit-scope tag for the RAPM model that produced this row (observed value: 'league', a Division I-wide fit) -- one row per player-season, not per estimand."
-  off_poss: "Offensive possessions the player was on court for; the regression weight behind orapm."
-  orapm: "Offensive regularized adjusted plus-minus: points contributed per 100 possessions on offense, adjusted for the other 9 players on the floor."
-  rapm_net: "Net RAPM (orapm plus drapm): overall point contribution per 100 possessions. Verified against live data: rapm_net == orapm + drapm exactly."
-load_ncaa_wbb_rapm:
-  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
-  def_poss: "Defensive possessions the player was on court for; the regression weight behind drapm."
-  drapm: "Defensive regularized adjusted plus-minus: points prevented per 100 possessions on defense (higher is better defense), adjusted for the other 9 players on the floor."
-  estimand: "Fit-scope tag for the RAPM model that produced this row (observed value: 'league', a Division I-wide fit) -- one row per player-season, not per estimand."
-  off_poss: "Offensive possessions the player was on court for; the regression weight behind orapm."
-  orapm: "Offensive regularized adjusted plus-minus: points contributed per 100 possessions on offense, adjusted for the other 9 players on the floor."
-  rapm_net: "Net RAPM (orapm plus drapm): overall point contribution per 100 possessions. Verified against live data: rapm_net == orapm + drapm exactly."
-load_ncaa_mfb_pbp:
-  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
-  drive_scored: "Whether the possession containing this play ended in points for the offense."
-  fair_catch: "Whether the returner called a fair catch on a kickoff or punt."
-  fg_distance: "Distance in yards of a field goal attempt."
-  formation: "Offensive formation or personnel grouping reported for the play (e.g. 'Shotgun', 'I-Formation'), when the source narrative names it."
-  is_first_down: "Whether the play resulted in a first down for the offense."
-  is_fumble: "Whether a fumble occurred on the play, regardless of which team recovered it."
-  is_safety: "Whether the play resulted in a safety."
-  is_touchdown: "Whether the play resulted in a touchdown."
-  kick_yards: "Yards traveled on a kickoff."
-  kicker: "Name of the player who kicked off, punted, or attempted the field goal/PAT on this play."
-  no_play: "Whether the play was negated (e.g. by a penalty on the preceding down) and is excluded from drive/stat totals."
-  pass_complete: "Whether a pass attempt on this play was completed."
-  pass_depth: "Depth classification of a pass attempt (e.g. 'short', 'deep'), when the narrative reports it."
-  pass_direction: "Side of the field the pass was thrown to (e.g. 'left', 'middle', 'right'), when the narrative reports it."
-  penalty_player: "Name of the player penalized on the play, when a penalty occurred."
-  punt_yards: "Gross yards traveled on a punt, before any return."
-  punter: "Name of the player who punted on this play."
-  returner: "Name of the player who fielded or returned the kickoff or punt on this play."
-  run_direction: "Hole or side the ball carrier ran through on a rush play (e.g. 'left end', 'right guard'), when the narrative reports it."
-  tackler_1: "Name of the primary (first-listed) tackler on the play."
-  tackler_2: "Name of the secondary (assisting) tackler on the play, when the narrative credits an assist."
-  turnover_type: "Kind of turnover on the play, if any (e.g. 'interception', 'fumble lost'); null when no turnover occurred."
-  yard_line_number: "Yard line at the snap (0-50); pairs with yard_line_side for absolute field position."
-  yard_line_side: "Which team's territory the ball was on at the snap ('OFF' own side, 'DEF' opponent side); pairs with yard_line_number for absolute field position."
-load_ncaa_mfb_pbp_cfbfastr:
-  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
-  clock.minutes: "Minutes remaining on the game clock at the start of the play (cfbfastR schema column)."
-  clock.seconds: "Seconds remaining within the current minute on the game clock at the start of the play (cfbfastR schema column)."
-  n_plays_in_game: "Total number of plays in the game this row belongs to, repeated on every row for convenience."
-  ot_synthesized: "Whether this row's overtime clock/period fields were synthesized rather than sourced directly -- stats.ncaa.org reports no running clock in overtime, so OT plays are assigned a synthetic countdown."
-load_ncaa_mfb_drives:
-  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
-  end_how: "How the drive ended (e.g. 'Touchdown', 'Punt', 'Interception', 'Fumble', 'End of Half')."
-  n_plays: "Number of plays run during the drive."
-  quarter: "Quarter in which the drive started (1-4 for regulation, 5+ for overtime periods)."
-  start_how: "How the drive began (e.g. 'Kickoff', 'Interception', 'Fumble', 'Downs', 'Punt')."
-load_ncaa_mfb_schedule:
-  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
-  academic_year: "Academic year the game was played in (the ENDING year of the fall/spring split, e.g. 2025 for the 2024 fall season) -- distinct from `season`, which is the STARTING year."
-  outcome: "Result of the game from the home team's perspective (e.g. 'W', 'L', 'T')."
-load_ncaa_mfb_rosters:
-  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
-  academic_year: "Academic year the roster snapshot covers (the ENDING year of the fall/spring split) -- distinct from `season`, which is the STARTING year."
-  player_class: "Player's academic/eligibility class (e.g. 'FR', 'SO', 'JR', 'SR', 'GR')."
-  statcrew_jersey: "Jersey number as recorded in the NCAA StatCrew roster feed; can differ from the number a player actually wears on a given game day."
-load_ncaa_mfb_teams:
-  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
-  academic_year: "Academic year the team record covers (the ENDING year of the fall/spring split) -- distinct from `season`, which is the STARTING year."
-load_ncaa_mfb_team_stats:
-  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
-  away_value: "Team-stat value for the away team; each row is one stat category for one game, wide by side."
-  home_value: "Team-stat value for the home team; each row is one stat category for one game, wide by side."
-load_ncaa_mfb_player_stats:
-  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
-  long_pass: "Longest completed pass of the game."
-  long_rec: "Longest reception of the game."
-  pass_eff: "Passer efficiency rating for the game, per the NCAA passer-rating formula."
-  rec: "Total receptions for the game."
-  rec_td: "Receiving touchdowns."
-  rush_long: "Longest single rush of the game."
-  rush_yds_gained: "Total positive rushing yards gained on carries, before subtracting yards lost to tackles for loss."
-  rush_yds_lost: "Total rushing yards lost to tackles for loss on carries."
-  yards_per_reception: "Receiving yards divided by receptions."
-  yds_per_completion: "Passing yards divided by completions."
-  yds_rush: "Net rushing yards (rush_yds_gained minus rush_yds_lost)."
-  pass_attempts: "Pass attempts for the game. Populated only on this player-game's 'passing' category row (null on the 'rushing'/'receiving' rows for the same player-game) -- the loader returns one row per player-game-category."
-  pass_tds: "Passing touchdowns thrown for the game. Populated only on this player-game's 'passing' category row (null on the 'rushing'/'receiving' rows for the same player-game) -- the loader returns one row per player-game-category."
-  rush_tds: "Rushing touchdowns for the game. Populated only on this player-game's 'rushing' category row (null on the 'passing'/'receiving' rows for the same player-game) -- the loader returns one row per player-game-category."
-load_ncaa_mfb_officials:
-  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
-load_ncaa_mfb_linescore:
-  season: Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted.
-espn_wbb_game_officials:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-espn_wnba_game_officials:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wbb_player_boxscore:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wbb_player_core:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wbb_player_crosswalk:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wbb_rosters:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wbb_schedule_crosswalk:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wbb_team_crosswalk:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wnba_player_boxscore:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wnba_player_core:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wnba_rosters:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wnba_stats_game_rosters:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wnba_stats_officials:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wnba_stats_player_boxscores:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wnba_stats_shots:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wnba_stats_team_boxscores:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."
-load_wnba_team_crosswalk:
-  season: "Season as a 4-digit starting year (integer). A 'YYYY-YY' string is not accepted."

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -5779,44 +5779,25 @@ load_cfb_model_pbp:
   wp_model_version: Version of the win-probability model that scored the play.
 load_cfb_passing:
   EPAgame: EPA generated per game.
-  EPAgame_pct: Percentile (0-100) of EPA generated per game among passers clearing the leaderboard minimum of 14 dropbacks
-    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
-    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   EPAgame_rank: Rank of the passer's EPA generated per game among passers clearing the leaderboard minimum of 14 dropbacks
     per team game, where 1 is best.
   EPAplay: EPA generated per play.
-  EPAplay_pct: Percentile (0-100) of EPA generated per play among passers clearing the leaderboard minimum of 14 dropbacks
-    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
-    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   EPAplay_rank: Rank of the passer's EPA generated per play among passers clearing the leaderboard minimum of 14 dropbacks
     per team game, where 1 is best.
   TEPA: Total EPA summed over every play.
-  TEPA_pct: Percentile (0-100) of total EPA summed over every play among passers clearing the leaderboard minimum of 14 dropbacks
-    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
-    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   TEPA_rank: Rank of the passer's total EPA summed over every play among passers clearing the leaderboard minimum of 14 dropbacks
     per team game, where 1 is best.
   att: Pass attempts thrown.
   comp: Completed passes.
   comppct: Completion percentage.
-  comppct_pct: Percentile (0-100) of completion percentage among passers clearing the leaderboard minimum of 14 dropbacks
-    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
-    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   comppct_rank: Rank of the passer's completion percentage among passers clearing the leaderboard minimum of 14 dropbacks
     per team game, where 1 is best.
   detmer: Detmer rating -- the composite passing-efficiency measure this pipeline publishes, named for the college passing-efficiency
     tradition.
-  detmer_pct: Percentile (0-100) of detmer rating -- the composite passing-efficiency measure this pipeline publishes, named
-    for the college passing-efficiency tradition among passers clearing the leaderboard minimum of 14 dropbacks per team game,
-    where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100 at
-    its best. Null when the metric is null, and null rows are excluded from the denominator.
   detmer_rank: Rank of the passer's detmer rating -- the composite passing-efficiency measure this pipeline publishes, named
     for the college passing-efficiency tradition among passers clearing the leaderboard minimum of 14 dropbacks per team game,
     where 1 is best.
   detmergame: Detmer rating expressed per game.
-  detmergame_pct: Percentile (0-100) of detmer rating expressed per game among passers clearing the leaderboard minimum of
-    14 dropbacks per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better
-    metric still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   detmergame_rank: Rank of the passer's detmer rating expressed per game among passers clearing the leaderboard minimum of
     14 dropbacks per team game, where 1 is best.
   dropbacks: Dropbacks taken by the passer.
@@ -5827,42 +5808,24 @@ load_cfb_passing:
   passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
   playsgame: Plays per game.
   sack_adj_yards: Passing yards adjusted for sack yardage lost.
-  sack_adj_yards_pct: Percentile (0-100) of passing yards adjusted for sack yardage lost among passers clearing the leaderboard
-    minimum of 14 dropbacks per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better
-    metric still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   sack_adj_yards_rank: Rank of the passer's passing yards adjusted for sack yardage lost among passers clearing the leaderboard
     minimum of 14 dropbacks per team game, where 1 is best.
   sack_epa: EPA lost on the sacks the team's passers took -- the expected-points cost of those plays.
   sack_yds: Yards lost to sacks.
   sacked: Times the passer was sacked.
   success: Success rate across the team plays.
-  success_pct: Percentile (0-100) of success rate across their plays among passers clearing the leaderboard minimum of 14
-    dropbacks per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric
-    still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   success_rank: Rank of the passer's success rate across their plays among passers clearing the leaderboard minimum of 14
     dropbacks per team game, where 1 is best.
   team_games: Games the team played, used as the per-game denominator.
-  yards_pct: Percentile (0-100) of total yards among passers clearing the leaderboard minimum of 14 dropbacks per team game,
-    where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100 at
-    its best. Null when the metric is null, and null rows are excluded from the denominator.
   yards_rank: Rank of the passer's total yards among passers clearing the leaderboard minimum of 14 dropbacks per team game,
     where 1 is best.
   yardsdropback: Yards per dropback.
-  yardsdropback_pct: Percentile (0-100) of yards per dropback among passers clearing the leaderboard minimum of 14 dropbacks
-    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
-    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   yardsdropback_rank: Rank of the passer's yards per dropback among passers clearing the leaderboard minimum of 14 dropbacks
     per team game, where 1 is best.
   yardsgame: Yards per game.
-  yardsgame_pct: Percentile (0-100) of yards per game among passers clearing the leaderboard minimum of 14 dropbacks per team
-    game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100
-    at its best. Null when the metric is null, and null rows are excluded from the denominator.
   yardsgame_rank: Rank of the passer's yards per game among passers clearing the leaderboard minimum of 14 dropbacks per team
     game, where 1 is best.
   yardsplay: Yards per play.
-  yardsplay_pct: Percentile (0-100) of yards per play among passers clearing the leaderboard minimum of 14 dropbacks per team
-    game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100
-    at its best. Null when the metric is null, and null rows are excluded from the denominator.
   yardsplay_rank: Rank of the passer's yards per play among passers clearing the leaderboard minimum of 14 dropbacks per team
     game, where 1 is best.
 load_cfb_pbp:
@@ -6482,21 +6445,12 @@ load_cfb_ratings_weekly:
     that week's final kickoff date.
 load_cfb_receiving:
   EPAgame: EPA generated per game.
-  EPAgame_pct: Percentile (0-100) of EPA generated per game among receivers clearing the leaderboard minimum of 1.875 targets
-    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
-    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   EPAgame_rank: Rank of the receiver's EPA generated per game among receivers clearing the leaderboard minimum of 1.875 targets
     per team game, where 1 is best.
   EPAplay: EPA generated per play.
-  EPAplay_pct: Percentile (0-100) of EPA generated per play among receivers clearing the leaderboard minimum of 1.875 targets
-    per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still
-    scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   EPAplay_rank: Rank of the receiver's EPA generated per play among receivers clearing the leaderboard minimum of 1.875 targets
     per team game, where 1 is best.
   TEPA: Total EPA summed over every play.
-  TEPA_pct: Percentile (0-100) of total EPA summed over every play among receivers clearing the leaderboard minimum of 1.875
-    targets per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric
-    still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   TEPA_rank: Rank of the receiver's total EPA summed over every play among receivers clearing the leaderboard minimum of 1.875
     targets per team game, where 1 is best.
   catchpct: Catch rate on a 0-to-1 scale, receptions divided by targets for the season.
@@ -6509,27 +6463,15 @@ load_cfb_receiving:
   playsgame: Plays per game.
   receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
   success: Success rate across the team plays.
-  success_pct: Percentile (0-100) of success rate across their plays among receivers clearing the leaderboard minimum of 1.875
-    targets per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric
-    still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   success_rank: Rank of the receiver's success rate across their plays among receivers clearing the leaderboard minimum of
     1.875 targets per team game, where 1 is best.
   team_games: Games the team played, used as the per-game denominator.
-  yards_pct: Percentile (0-100) of total yards among receivers clearing the leaderboard minimum of 1.875 targets per team
-    game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100
-    at its best. Null when the metric is null, and null rows are excluded from the denominator.
   yards_rank: Rank of the receiver's total yards among receivers clearing the leaderboard minimum of 1.875 targets per team
     game, where 1 is best.
   yardsgame: Yards per game.
-  yardsgame_pct: Percentile (0-100) of yards per game among receivers clearing the leaderboard minimum of 1.875 targets per
-    team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores
-    100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   yardsgame_rank: Rank of the receiver's yards per game among receivers clearing the leaderboard minimum of 1.875 targets
     per team game, where 1 is best.
   yardsplay: Yards per play.
-  yardsplay_pct: Percentile (0-100) of yards per play among receivers clearing the leaderboard minimum of 1.875 targets per
-    team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores
-    100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   yardsplay_rank: Rank of the receiver's yards per play among receivers clearing the leaderboard minimum of 1.875 targets
     per team game, where 1 is best.
 load_cfb_recruiting_proj:
@@ -6663,21 +6605,12 @@ load_cfb_rosters_cfbd:
     0 entry means no recruiting profile was matched.
 load_cfb_rushing:
   EPAgame: EPA generated per game.
-  EPAgame_pct: Percentile (0-100) of EPA generated per game among rushers clearing the leaderboard minimum of 6.25 plays per
-    team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores
-    100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   EPAgame_rank: Rank of the rusher's EPA generated per game among rushers clearing the leaderboard minimum of 6.25 plays per
     team game, where 1 is best.
   EPAplay: EPA generated per play.
-  EPAplay_pct: Percentile (0-100) of EPA generated per play among rushers clearing the leaderboard minimum of 6.25 plays per
-    team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores
-    100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   EPAplay_rank: Rank of the rusher's EPA generated per play among rushers clearing the leaderboard minimum of 6.25 plays per
     team game, where 1 is best.
   TEPA: Total EPA summed over every play.
-  TEPA_pct: Percentile (0-100) of total EPA summed over every play among rushers clearing the leaderboard minimum of 6.25
-    plays per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric
-    still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   TEPA_rank: Rank of the rusher's total EPA summed over every play among rushers clearing the leaderboard minimum of 6.25
     plays per team game, where 1 is best.
   fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
@@ -6686,27 +6619,15 @@ load_cfb_rushing:
   playsgame: Plays per game.
   rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
   success: Success rate across the team plays.
-  success_pct: Percentile (0-100) of success rate across their plays among rushers clearing the leaderboard minimum of 6.25
-    plays per team game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric
-    still scores 100 at its best. Null when the metric is null, and null rows are excluded from the denominator.
   success_rank: Rank of the rusher's success rate across their plays among rushers clearing the leaderboard minimum of 6.25
     plays per team game, where 1 is best.
   team_games: Games the team played, used as the per-game denominator.
-  yards_pct: Percentile (0-100) of total yards among rushers clearing the leaderboard minimum of 6.25 plays per team game,
-    where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100 at
-    its best. Null when the metric is null, and null rows are excluded from the denominator.
   yards_rank: Rank of the rusher's total yards among rushers clearing the leaderboard minimum of 6.25 plays per team game,
     where 1 is best.
   yardsgame: Yards per game.
-  yardsgame_pct: Percentile (0-100) of yards per game among rushers clearing the leaderboard minimum of 6.25 plays per team
-    game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100
-    at its best. Null when the metric is null, and null rows are excluded from the denominator.
   yardsgame_rank: Rank of the rusher's yards per game among rushers clearing the leaderboard minimum of 6.25 plays per team
     game, where 1 is best.
   yardsplay: Yards per play.
-  yardsplay_pct: Percentile (0-100) of yards per play among rushers clearing the leaderboard minimum of 6.25 plays per team
-    game, where 100 is best. Direction is already encoded in the matching rank, so a lower-is-better metric still scores 100
-    at its best. Null when the metric is null, and null rows are excluded from the denominator.
   yardsplay_rank: Rank of the rusher's yards per play among rushers clearing the leaderboard minimum of 6.25 plays per team
     game, where 1 is best.
 load_cfb_schedule:


### PR DESCRIPTION
## The bug

The `_rank` descriptions on `load_cfb_passing` / `load_cfb_rushing` / `load_cfb_receiving` read **"National rank of the TEAM's ..."**. They were copy-pasted from the team grid, and they're wrong — those loaders are player-grain.

Measured on the published `cfb_passing_2025` asset:

| | |
|---|--:|
| rows | 567 |
| distinct `player_id` | 566 |
| `EPAgame_rank` range | 1 – 137 |
| teams where `EPAgame_rank` varies across their passers | **128 of 136** |

They are ranks among qualified **players**. 26 descriptions across the three loaders.

## What changed

**26 corrected `_rank`**, plus **26 `_pct` siblings** for the percentile columns [cfbfastR-cfb-data#50](https://github.com/sportsdataverse/cfbfastR-cfb-data/pull/50) adds.

The `_pct` keys are **inert until that lands** — the lookup is `manual[schema][col]`, keyed on columns that exist, so an entry for a column not yet in `loader_schemas.yaml` is never read. Confirmed empirically: the regenerated docs moved by exactly **26 insertions / 26 deletions in one file** (`docs/docs/cfb/reference/loaders.md`), i.e. the rank corrections only. Landing them now means the returns tables populate automatically when the rebuilt assets carry the columns.

## Composed, not hand-written

`gen_cfb_player_percentile_descriptions.py` is the player-grain sibling of `gen_cfb_summary_descriptions.py`, whose `targets` tuple deliberately covers only the team grid — which is why these three loaders were never generated and drifted by hand in the first place. Same contract as the sibling: enumerate from `loader_schemas.yaml` (stable, so it's idempotent — verified byte-identical across runs), write a side file, report anything unparsed, never invent.

The point is durability: the next ranked metric gets correct text instead of another hand-copied line.

## The text names the real gate

Not "qualified" — the actual threshold, transcribed from the producer's three `min_expr` call sites:

> Rank of the passer's EPA generated per play among **passers clearing the leaderboard minimum of 14 dropbacks per team game**, where 1 is best.

That distinction is load-bearing. **137 of 567 passers cleared the gate in 2025**, so the median qualifier is nothing like the median passer, and a UI rendering 50 as "median passer" would state something false. The existing `catchpct_rank` text already did this (1.875 targets per team game); the rest now match it.

## Two guards keep "never invent" honest

1. **A `_rank` description that doesn't parse is reported and skipped.** One hit: `catchpct_rank` — whose wording is already correct and better than the pattern, so skipping it is the right outcome.
2. **A noun still mentioning the team after the one verified fixup is also skipped.** This caught a defect in my own first pass: six descriptions read *"the passer's success rate across the **team** plays"* — I'd fixed the subject and left "team" in the object. Corrected to "across their plays" per the producer, where `summarize_passer` groups by player and takes `success=pl.col("success").mean()`. Residual team phrasing: **6 → 0**.

## Verification

- `generate.py` → `exit 0`; `generate.py --check` → **"all generated files current"**, tree clean.
- Semantic merge check against `HEAD`: **26 changed, 26 added, 0 REMOVED**, no loaders lost.
- Generator is idempotent (two runs byte-identical).

## One caveat for the reviewer

`manual_column_descriptions.yaml` shows ~500 changed lines for 52 real changes. The file **isn't `safe_dump` output** — I tried widths 80/100/120/200/1000/4096 and none round-trips it — so any re-dump rewraps. I attempted a surgical line-level edit to keep the diff small and **it produced invalid YAML**, so I reverted to the full dump and verified it semantically instead. Most of that file's diff is formatting, not content; the 26/26 doc diff is the substantive part.

## Summary by Sourcery

Correct CFB player leaderboard rank documentation and establish schema-driven generation for future rank and percentile descriptions.

New Features:
- Add a generator for durable player-level CFB rank and percentile descriptions across passing, rushing, and receiving loaders.

Bug Fixes:
- Correct CFB player rank documentation to describe rankings among players meeting the appropriate leaderboard thresholds rather than among teams.

Enhancements:
- Generate percentile descriptions that document ranking direction, qualifier populations, and null handling.
- Add guardrails and validation for parsing, composing, and maintaining generated loader descriptions.

Documentation:
- Update CFB passing, rushing, and receiving loader documentation with corrected player-grain rank definitions and leaderboard minimums.

Tests:
- Verify generated documentation is current, semantically preserves loader descriptions, and remains idempotent across repeated generation.

Chores:
- Regenerate the manual column-description catalog, including associated schema-driven description entries and formatting changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that college football passing, receiving, and rushing ranks are player-level rankings.
  - Documented the qualifying thresholds used for passer, receiver, and rusher leaderboards.
  - Expanded dataset documentation with season fields and coverage for officials, RAPM statistics, rosters, schedules, team IDs, and additional college football data.
  - Updated percentile-field documentation to reflect the currently available fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->