### PR TITLE
fix(cfb): score xpass with the era cuts the model was trained on

### DIFF
--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -7620,13 +7620,23 @@ class CFBPlayProcess(object):
                 pl.lit(None, dtype=pl.Float64).alias("pass_oe"),
             )
         try:
-            # Ordinal era from season (cuts: <=2006->0, <=2013->1, <=2017->2, else 3).
+            # Ordinal era from season, cuts FD_ERA_BOUNDS (<=2006->0, <=2013->1,
+            # <=2020->2, else 3). These MUST match the training construction in
+            # cfbfastR-cfb-data (`model_training/features.py::_era`, which reads
+            # the same `ERA_BOUNDS = (2006, 2013, 2020)` the one-hot dummies use).
+            # This was hard-coded to <=2017, so 2018-2020 scored as era 3 against
+            # a model that trained them as era 2 -- see cfbfastR-cfb-data#70.
+            # function-local: cfb_fourth_down imports the EP/WP boosters from
+            # this module, so a top-level import here would be circular
+            from sportsdataverse.cfb.cfb_fourth_down import FD_ERA_BOUNDS
+
+            _lo, _mid, _hi = FD_ERA_BOUNDS
             play_df = play_df.with_columns(
-                pl.when(pl.col("season") <= 2006)
+                pl.when(pl.col("season") <= _lo)
                 .then(0)
-                .when(pl.col("season") <= 2013)
+                .when(pl.col("season") <= _mid)
                 .then(1)
-                .when(pl.col("season") <= 2017)
+                .when(pl.col("season") <= _hi)
                 .then(2)
                 .otherwise(3)
                 .alias("era"),

--- a/sportsdataverse/cfb/cfb_two_point.py
+++ b/sportsdataverse/cfb/cfb_two_point.py
@@ -92,7 +92,9 @@ TWO_PT_MODEL_AVAILABLE: bool = two_pt_model is not None
 
 
 def _era(season: np.ndarray) -> np.ndarray:
-    """Ordinal CFB rule-era factor from season (<=2006->0, <=2013->1, <=2017->2, else 3)."""
+    """Ordinal CFB rule-era factor from season, cuts ``FD_ERA_BOUNDS``
+    (<=2006->0, <=2013->1, <=2020->2, else 3) -- the same cuts the one-hot
+    dummies use, matching the training construction in cfbfastR-cfb-data."""
     lo, mid, hi = FD_ERA_BOUNDS
     out = np.full(len(season), 3, dtype=np.int32)
     out = np.where(season <= hi, 2, out)


### PR DESCRIPTION
Fixes the sdv-py half of sportsdataverse/cfbfastR-cfb-data#70. Companion: sportsdataverse/cfbfastR#150.

## The bug

`CFBPlayProcess.__process_xpass` hard-coded the ordinal rule-era cut at `<= 2017`, so
seasons **2018–2020** were scored as era 3 against a model that trained them as era **2**.

```python
.when(pl.col("season") <= 2017)   # <- inline, not the shared bounds
.then(2)
```

## Which side is wrong

`cfbfastR-cfb-data/model_training/constants.py` defines a single
`ERA_BOUNDS = (2006, 2013, 2020)` that both `_era()` (ordinal) and `_era_onehot()` derive
from, and `git log -S 2017` over that file shows a 2017 cut has never existed there. The
trainer is confirmed as the artifact's source — its `XPASS_PARAMS`/`XPASS_NROUNDS` and
`TWO_PT_PARAMS`/`TWO_PT_NROUNDS` reproduce `xpass_model.card.json` and
`two_pt_model.card.json` exactly.

## Two separate defects here

1. **`cfb_pbp.py::__process_xpass`** — the inline `<= 2017` above. Now reads
   `FD_ERA_BOUNDS`, imported function-locally because `cfb_fourth_down` imports the EP/WP
   boosters from this module and a top-level import would be circular.
2. **`cfb_two_point.py::_era`** — the **code was already correct** (it reads
   `FD_ERA_BOUNDS`); only its **docstring** claimed `<=2017->2`. That docstring is where
   the wrong cut propagated from: cfbfastR's `.XPASS_ERA_CUTS` cited it as its source, so
   the docstring got ported instead of the code.

## Impact

`era` takes 251 splits and ~1.1% of gain in `xpass_model`. Across 630 realistic
situations the mismatch moves `xpass` by a **mean of 0.9 pp, max 2.9 pp**, inherited by
`pass_oe` as a step at the 2017/2018 boundary. `prob_2pt` is unaffected — that model never
splits on `era` (#457).

## Verification

`tests/cfb/test_cfb_2pt.py` 8 passed / 1 skipped; `tests/cfb/test_cfb_cpoe_xpass.py`
2 passed / 1 skipped; ruff clean. The era mapping now reads
`{2017: 2, 2018: 2, 2019: 2, 2020: 2, 2021: 3}`.

## Follow-up (not in this PR)

Published pbp assets carry `xpass`/`pass_oe` computed with the old cut — **2018–2020 need
a republish**.

## Summary by Sourcery

Align football probability scoring with the era boundaries used during model training to prevent xpass and pass efficiency errors for 2018–2020 seasons.

Bug Fixes:
- Correct xpass scoring for 2018–2020 seasons by aligning ordinal era assignments with the model-training era boundaries.

Enhancements:
- Document the shared era cutoffs consistently across two-point and xpass scoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated college football play-by-play era classification to apply the correct rule-era boundaries, improving consistency for seasons from 2018 through 2020 and later seasons.

- **Documentation**
  - Clarified the documented college football rule-era cutoffs used for two-point conversion analysis, aligning the documentation with the system’s training behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->