### PR TITLE
fix(cfb): retain the enriched plays frame after run_processing_pipeline

### DIFF
--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -9566,6 +9566,11 @@ class CFBPlayProcess(object):
                     self.plays_json = self.__add_two_pt_probs(self.plays_json)
                 self.ran_pipeline = True
                 advBoxScore = self.plays_json.pipe(self.create_box_score)
+                # Keep the enriched polars frame: plays_json becomes a list of
+                # dicts below (and callers mutate it), so consumers that need
+                # to re-aggregate windows (Game on Paper's ?span= boxes filter
+                # the frame and re-run create_box_score) read plays_frame.
+                self.plays_frame = self.plays_json
                 self.plays_json = self.plays_json.to_dicts()
                 pbp_json = {
                     "gameId": int(self.gameId),

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -9658,6 +9658,7 @@ class CFBPlayProcess(object):
                 dtype = pl.Utf8 if c == "fourth_down_recommendation" else pl.Float64
                 plays = plays.with_columns(pl.lit(None, dtype=dtype).alias(c))
             plays = plays.drop("__fourth_row_idx")
+            self.plays_frame = plays
             self.plays_json = plays.to_dicts()
             self.json["plays"] = self.plays_json
             return plays
@@ -9667,6 +9668,9 @@ class CFBPlayProcess(object):
         scored_pl = pl.from_pandas(scored[keep]).with_columns(pl.col("__fourth_row_idx").cast(pl.UInt32))
 
         plays = plays.join(scored_pl, on="__fourth_row_idx", how="left").drop("__fourth_row_idx")
+        # keep the retained frame in sync -- consumers re-aggregating windows
+        # (see run_processing_pipeline) must see the added columns too
+        self.plays_frame = plays
         self.plays_json = plays.to_dicts()
         self.json["plays"] = self.plays_json
         return plays
@@ -9711,6 +9715,9 @@ class CFBPlayProcess(object):
             self.run_processing_pipeline()
 
         plays = self.__add_two_pt_probs(pl.DataFrame(self.plays_json, infer_schema_length=None))
+        # keep the retained frame in sync -- consumers re-aggregating windows
+        # (see run_processing_pipeline) must see the added columns too
+        self.plays_frame = plays
         self.plays_json = plays.to_dicts()
         self.json["plays"] = self.plays_json
         return plays

--- a/tests/cfb/test_espn_flag_tripwires.py
+++ b/tests/cfb/test_espn_flag_tripwires.py
@@ -123,7 +123,13 @@ def test_plays_frame_retained_for_window_reaggregation(monkeypatch):
     # the flat dotted schema create_box_score consumes, not the nested shape
     assert "start.down" in proc.plays_frame.columns
     # and it is actually re-aggregable: a windowed box computes without error
+    # (the fixture game must exercise this -- an empty window would let the
+    # test pass without ever calling create_box_score)
     q3 = proc.plays_frame.filter(pl.col("period") == 3)
-    if q3.height:
-        box = proc.create_box_score(q3)
-        assert box
+    assert q3.height > 0
+    box = proc.create_box_score(q3)
+    assert box
+    # the post-pipeline prob methods must not leave the frame stale
+    proc.add_fourth_down_probs()
+    assert proc.plays_frame.height == len(proc.plays_json)
+    assert "fourth_down_recommendation" in proc.plays_frame.columns

--- a/tests/cfb/test_espn_flag_tripwires.py
+++ b/tests/cfb/test_espn_flag_tripwires.py
@@ -94,3 +94,36 @@ def test_ispenalty_implies_penalty_flag(monkeypatch, gid):
         f"{gid}: {viol.height} play(s) ESPN flags isPenalty=True but penalty_flag is False: "
         f"{viol.select(['type.text', 'text']).to_dicts()}"
     )
+
+
+def test_plays_frame_retained_for_window_reaggregation(monkeypatch):
+    """The enriched polars frame must survive run_processing_pipeline.
+
+    plays_json becomes a list of dicts at the end of the pipeline (and Game on
+    Paper's Flask layer then mutates the records, nesting start/end and
+    deleting the flat dotted columns) -- so windowed re-aggregation (?span=
+    boxes: filter the frame, re-run create_box_score) needs the ORIGINAL frame
+    kept as plays_frame. Its silent absence broke every ?span= box request.
+    """
+    gid = GIDS[0]
+    summary = json.loads((FIX / f"summary_{gid}.json").read_text(encoding="utf-8"))
+
+    class _Resp:
+        def json(self):
+            return summary
+
+    monkeypatch.setattr("sportsdataverse.cfb.cfb_pbp.download", lambda *a, **k: _Resp())
+    proc = CFBPlayProcess(gameId=gid)
+    proc.join_participants = False
+    proc.espn_cfb_pbp()
+    proc.run_processing_pipeline()
+
+    assert isinstance(proc.plays_frame, pl.DataFrame)
+    assert proc.plays_frame.height == len(proc.plays_json)
+    # the flat dotted schema create_box_score consumes, not the nested shape
+    assert "start.down" in proc.plays_frame.columns
+    # and it is actually re-aggregable: a windowed box computes without error
+    q3 = proc.plays_frame.filter(pl.col("period") == 3)
+    if q3.height:
+        box = proc.create_box_score(q3)
+        assert box


### PR DESCRIPTION
`run_processing_pipeline` ends with `self.plays_json = self.plays_json.to_dicts()`, and downstream consumers (Game on Paper's Flask layer) then mutate those records — nesting `start`/`end` and deleting the flat dotted columns. So any consumer that needs to **re-aggregate a window** (GOP's `?span=` boxes: filter the enriched frame, re-run `create_box_score`) had nothing usable — `plays_json.filter` threw `'list' object has no attribute 'filter'` on every span request, swallowed by a fail-open except. The windowed advanced box silently never worked in production.

One-line fix: `self.plays_frame` keeps a zero-copy reference to the enriched polars frame immediately before the conversion.

Offline test (fixture summary, no network) pins the contract GOP depends on: `plays_frame` is a `pl.DataFrame`, same height as `plays_json`, carries the flat dotted schema (`start.down`), and a filtered window actually re-aggregates through `create_box_score`.

Companion GOP PR consumes `plays_frame` in `span_box` and adds `?spans=all` (all standard windows' boxes in one response, the data layer for in-place span switching per the metric-tables discussion on GOP #218). GOP tracks sdv-py main at image build, so merging this first makes the next GOP deploy carry it.

## Summary by Sourcery

Preserve the enriched play-by-play frame alongside serialized play records to restore reliable windowed box-score re-aggregation.

Bug Fixes:
- Retain the enriched play-by-play data frame so downstream consumers can filter windows and re-aggregate box scores after pipeline processing.

Tests:
- Add an offline regression test verifying the retained frame schema, windowed box-score aggregation, and synchronization after probability enrichment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CFB play processing now retains an enriched play-by-play data view for downstream analysis.
  * Filtered play windows can be re-aggregated to generate windowed box scores.
  * Retained play data now stays synchronized with exported results, including fourth-down and two-point recommendations.

* **Tests**
  * Added coverage confirming retained play data remains available, preserves recommendation columns, and supports filtering and re-aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->