### PR TITLE
fix(ci): the GoP deploy dispatch needs Contents WRITE, not read

### DIFF
--- a/.github/workflows/deploy-gop.yml
+++ b/.github/workflows/deploy-gop.yml
@@ -8,10 +8,18 @@ name: dispatch Game on Paper deploy (package pushes to main)
 #
 # Cross-repo dispatch needs a token with access to game-on-paper-app;
 # GITHUB_TOKEN is scoped to this repository only. Least privilege for the
-# repository_dispatch endpoint is a fine-grained PAT with `Contents: read` on
-# saiemgilani/game-on-paper-app -- not the classic `repo` scope. Until the
-# GOP_DEPLOY_TOKEN secret exists this job explains itself and exits green
-# rather than failing every push to main.
+# repository_dispatch endpoint is a fine-grained PAT with `Contents: WRITE` on
+# saiemgilani/game-on-paper-app -- not the classic `repo` scope, and NOT
+# `Contents: read`, which this comment claimed until 2026-09-07.
+#
+# That was not a harmless typo. POST /repos/{owner}/{repo}/dispatches is a
+# write endpoint; a read-scoped token gets 403 "Resource not accessible by
+# personal access token". The secret was scoped by following this comment, so
+# every run of this workflow has failed -- 60 for 60, no success on record --
+# and no push to main has ever actually redeployed Game on Paper.
+#
+# Until the GOP_DEPLOY_TOKEN secret exists this job explains itself and exits
+# green rather than failing every push to main.
 
 on:
   push:


### PR DESCRIPTION
Comment-only change. The operative fix is to a secret and can't be made in a commit — details below.

## What's broken

`deploy-gop.yml` has failed on **every run on record — 60 for 60, no success**. Every push to `main` that touches `sportsdataverse/**`, `pyproject.toml` or `uv.lock` returns:

```
curl: (22) The requested URL returned error: 403
{ "message": "Resource not accessible by personal access token" }
```

So no push to this repo has ever actually redeployed Game on Paper. The site has been serving an API image built against whatever `main` looked like the last time someone deployed it by hand.

## Why

This workflow's own comment told whoever created `GOP_DEPLOY_TOKEN` to scope it:

> Least privilege for the repository_dispatch endpoint is a fine-grained PAT with `Contents: read`

That's wrong. `POST /repos/{owner}/{repo}/dispatches` is a **write** endpoint — a fine-grained PAT needs **`Contents: write`** on `saiemgilani/game-on-paper-app`. A read-scoped token gets precisely the 403 above.

The token was scoped by following the comment, so the comment is the root cause rather than an incidental doc bug. It's corrected here, including a note recording that it misled, so the next person doesn't re-derive the wrong scope from it.

## What still needs doing (not in this PR)

Reissue `GOP_DEPLOY_TOKEN` as a fine-grained PAT with **Contents: write** on `saiemgilani/game-on-paper-app`, and update the repo secret. Nothing in the workflow logic needs to change — it's correct as written.

## How this surfaced

Checking whether the new air-yards CP model from #466 would actually reach Game on Paper. It won't, until the token is reissued: GoP resolves its `sportsdataverse` pin at image build time, and that image isn't being rebuilt.

## Summary by Sourcery

Enhancements:
- Correct the documented permission requirement for the Game on Paper deployment dispatch token and record the resulting deployment impact.