### PR TITLE
fix(cfb): a TBD placeholder competitor no longer dies on KeyError: 'name'

### DIFF
--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -2564,6 +2564,18 @@ class CFBPlayProcess(object):
             raise NoDataError(
                 f"ESPN summary for game {self.gameId} has no header.competitions; cannot build play-by-play.",
             )
+        # ESPN emits a PLACEHOLDER competitor when a game has no settled opponent:
+        # a NEGATIVE team id, "TBD" location/abbreviation, and a stub key set that
+        # omits `name`, `color`, `logos` and `groups`. 2020 is full of these (COVID
+        # cancellations). There is no play-by-play to build, so short-circuit here
+        # -- catchable, and before the pickcenter odds hop -- rather than dying deep
+        # in __helper_cfb_game_data on a bare `KeyError: 'name'`.
+        _competitors = (pbp_txt["header"]["competitions"][0] or {}).get("competitors") or []
+        if any(str(((c or {}).get("team") or {}).get("id", "")).strip().startswith("-") for c in _competitors):
+            raise NoDataError(
+                f"ESPN summary for game {self.gameId} has a placeholder (TBD) competitor; "
+                "there is no play-by-play to build.",
+            )
         init = self.__helper_cfb_pickcenter(pbp_txt)
         return self.__helper_cfb_game_data(pbp_txt, init)
 
@@ -2707,7 +2719,7 @@ class CFBPlayProcess(object):
                 "team"
             ]
             homeTeamId = int(pbp_txt["header"]["competitions"][0]["competitors"][0]["team"]["id"])
-            homeTeamMascot = str(pbp_txt["header"]["competitions"][0]["competitors"][0]["team"]["name"])
+            homeTeamMascot = str(pbp_txt["header"]["competitions"][0]["competitors"][0]["team"].get("name", ""))
             homeTeamName = str(pbp_txt["header"]["competitions"][0]["competitors"][0]["team"]["location"])
             homeTeamAbbrev = str(pbp_txt["header"]["competitions"][0]["competitors"][0]["team"]["abbreviation"])
             homeTeamNameAlt = re.sub("Stat(.+)", "St", homeTeamName)
@@ -2715,7 +2727,7 @@ class CFBPlayProcess(object):
                 "team"
             ]
             awayTeamId = int(pbp_txt["header"]["competitions"][0]["competitors"][1]["team"]["id"])
-            awayTeamMascot = str(pbp_txt["header"]["competitions"][0]["competitors"][1]["team"]["name"])
+            awayTeamMascot = str(pbp_txt["header"]["competitions"][0]["competitors"][1]["team"].get("name", ""))
             awayTeamName = str(pbp_txt["header"]["competitions"][0]["competitors"][1]["team"]["location"])
             awayTeamAbbrev = str(pbp_txt["header"]["competitions"][0]["competitors"][1]["team"]["abbreviation"])
             awayTeamNameAlt = re.sub("Stat(.+)", "St", awayTeamName)
@@ -2724,7 +2736,7 @@ class CFBPlayProcess(object):
                 "team"
             ]
             awayTeamId = int(pbp_txt["header"]["competitions"][0]["competitors"][0]["team"]["id"])
-            awayTeamMascot = str(pbp_txt["header"]["competitions"][0]["competitors"][0]["team"]["name"])
+            awayTeamMascot = str(pbp_txt["header"]["competitions"][0]["competitors"][0]["team"].get("name", ""))
             awayTeamName = str(pbp_txt["header"]["competitions"][0]["competitors"][0]["team"]["location"])
             awayTeamAbbrev = str(pbp_txt["header"]["competitions"][0]["competitors"][0]["team"]["abbreviation"])
             awayTeamNameAlt = re.sub("Stat(.+)", "St", awayTeamName)
@@ -2732,7 +2744,7 @@ class CFBPlayProcess(object):
                 "team"
             ]
             homeTeamId = int(pbp_txt["header"]["competitions"][0]["competitors"][1]["team"]["id"])
-            homeTeamMascot = str(pbp_txt["header"]["competitions"][0]["competitors"][1]["team"]["name"])
+            homeTeamMascot = str(pbp_txt["header"]["competitions"][0]["competitors"][1]["team"].get("name", ""))
             homeTeamName = str(pbp_txt["header"]["competitions"][0]["competitors"][1]["team"]["location"])
             homeTeamAbbrev = str(pbp_txt["header"]["competitions"][0]["competitors"][1]["team"]["abbreviation"])
             homeTeamNameAlt = re.sub("Stat(.+)", "St", homeTeamName)

--- a/tests/cfb/test_cfb_pbp_offline.py
+++ b/tests/cfb/test_cfb_pbp_offline.py
@@ -76,3 +76,67 @@ def test_odds_override_validation():
         CFBPlayProcess(gameId=1, odds_override={"gameSpread": -3.5})  # missing keys
     with pytest.raises(ValueError):
         CFBPlayProcess(gameId=1, odds_override=[1, 2, 3])  # not a dict
+
+
+def _stub_competitor():
+    """ESPN's placeholder competitor, verbatim key set from game 401256142 (2020).
+
+    A negative team id with "TBD" location/abbreviation; note the ABSENT `name`,
+    `color`, `logos` and `groups` that a real team carries.
+    """
+    return {
+        "id": "-2",
+        "uid": "s:20~l:23~t:-2",
+        "location": "TBD",
+        "abbreviation": "TBD",
+        "displayName": "TBD",
+        "nickname": "TBD",
+        "links": [],
+    }
+
+
+def test_placeholder_competitor_raises_nodata(monkeypatch):
+    """A TBD opponent has no play-by-play; fail catchably, not on KeyError: 'name'.
+
+    2020 is full of these (COVID cancellations) -- 28 games in that season alone
+    died deep inside __helper_cfb_game_data before this guard existed.
+    """
+    from sportsdataverse.errors import NoDataError
+
+    summary = _load_summary()
+    summary["header"]["competitions"][0]["competitors"][1]["team"] = _stub_competitor()
+
+    class _Resp:
+        def json(self):
+            return summary
+
+    monkeypatch.setattr("sportsdataverse.cfb.cfb_pbp.download", lambda *a, **k: _Resp())
+
+    game = CFBPlayProcess(gameId=401256142)
+    with pytest.raises(NoDataError, match="placeholder"):
+        game.espn_cfb_pbp()
+        game.run_processing_pipeline()
+
+
+def test_missing_team_name_does_not_keyerror(monkeypatch):
+    """A real team (positive id) missing only `name` must not raise KeyError.
+
+    The stub guard above catches the TBD case; this pins the belt-and-braces
+    .get("name", "") so any other payload shape degrades instead of crashing.
+    """
+    summary = _load_summary()
+    team = summary["header"]["competitions"][0]["competitors"][1]["team"]
+    team.pop("name", None)
+
+    class _Resp:
+        def json(self):
+            return summary
+
+    monkeypatch.setattr("sportsdataverse.cfb.cfb_pbp.download", lambda *a, **k: _Resp())
+
+    game = CFBPlayProcess(gameId=401628455)
+    try:
+        game.espn_cfb_pbp()
+        game.run_processing_pipeline()
+    except KeyError as exc:  # pragma: no cover - the regression we are pinning
+        pytest.fail(f"missing team key should not raise KeyError: {exc}")


### PR DESCRIPTION
## Summary

ESPN emits a **placeholder competitor** when a game has no settled opponent: a negative team id (`-2`), `location`/`abbreviation` of `"TBD"`, and a stub key set that omits `name`, `color`, `logos` and `groups`. `__helper_cfb_game_data` read `["team"]["name"]` unguarded, so every such game died on a bare `KeyError: 'name'` deep in the pipeline.

Measured against the real payload for game `401256142` (2020): the away competitor is `id=-2`, `location='TBD'`, and `'name' in team` is `False` while `location` and `abbreviation` are both present — which is exactly why the sibling lookups survived and only `name` blew up.

This surfaced from a reprocess run in `cfbfastR-cfb-raw` that failed **28 games in 2020 and 2 in 2021**, every one with the same error and zero successes. 2020 is dense with these because of COVID cancellations.

Two changes, matching the file's existing conventions:

1. **Short-circuit in `__helper_cfb_pbp`** — extends the guard already there for a missing `header.competitions`, raising the same catchable `NoDataError`. Placed *before* `__helper_cfb_pickcenter`, so a game that cannot be built no longer makes a fallback odds network hop on its way to failing. A TBD opponent has no play-by-play, so this is a genuine no-data condition rather than something to paper over with a default.
2. **Defensive `.get("name", "")`** at all four `["team"]["name"]` sites (both arms of the home/away swap) — so any *other* payload missing only `name` degrades instead of crashing, rather than relying on a negative id being the sole marker of a stub.

## Verification

`uv run pytest tests/cfb/test_cfb_pbp_offline.py -q` → **7 passed**, and the codegen drift gate is clean (`generate.py` then `--check`: *all generated files current*).

Two regression tests were added, and both were confirmed to **fail without the fix** — reverting `cfb_pbp.py` to `HEAD` reproduces `KeyError: 'name'` at `cfb_pbp.py:2718`, the same line as the production traceback:

- `test_placeholder_competitor_raises_nodata` — pins the verbatim stub key set from `401256142` and asserts `NoDataError`.
- `test_missing_team_name_does_not_keyerror` — a real team (positive id) missing only `name` must not raise.

## Summary by Sourcery

Prevent college football play-by-play processing from crashing on ESPN competitor payloads with missing team names.

Bug Fixes:
- Handle ESPN placeholder competitors as catchable no-data games instead of failing with a missing team-name error.
- Allow game processing to continue when a team payload omits its name.

Tests:
- Add regression coverage for placeholder competitors and team payloads without names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of incomplete college football game data.
  - Placeholder competitors now return a clear no-data result instead of causing an error.
  - Games with teams missing a name can now be processed without failure.

- **Tests**
  - Added coverage for placeholder competitors and incomplete team information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->