### PR TITLE
feat(cfb): compute returning production for 2004 instead of raising

### DIFF
--- a/sportsdataverse/cfb/cfb_returning_production.py
+++ b/sportsdataverse/cfb/cfb_returning_production.py
@@ -46,6 +46,7 @@ from sportsdataverse.cfb.cfb_loaders import (
     load_cfb_team_info,
 )
 from sportsdataverse._codegen_runtime import _read_release_parquet
+from sportsdataverse.errors import SeasonNotFoundError
 from sportsdataverse.cfb.cfb_crosswalk import _norm_team
 from sportsdataverse.cfb.cfb_projection_constants import get_constants
 
@@ -57,6 +58,27 @@ _PLAYER_STATS_URL = (
     "https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/"
     "player_stats/parquet/player_stats_{season}.parquet"
 )
+
+#: Season-2003 offensive production, the one season ESPN's player box cannot
+#: supply. ESPN starts in 2004 (0 athlete rows across sampled 2003 games; team
+#: rosters likewise empty), so returning production for 2004 had no S-1 side and
+#: raised SeasonNotFoundError. CFBD's play-by-play DOES start in 2003 and its
+#: play text is name-tagged by team, so the offensive half is recoverable; the
+#: producer parses it and hosts the result, because THIS package is keyless by
+#: design and must not start requiring a CFBD API key to compute a season.
+#:
+#: Offense only, deliberately. 2003 play text carries no tacklers at all -- the
+#: volume term of `_DEFENSE_BOX_WEIGHTS` is unrecoverable -- and every shipped
+#: season through 2016 already carries a null `def_returning` anyway, so a
+#: splash-only defensive number would make 2004 the lone pre-2020 season with a
+#: defensive value, computed by a method no other season uses.
+_PRODUCTION_2003_URL = (
+    "https://raw.githubusercontent.com/sportsdataverse/cfbfastR-cfb-data/main/data/cfb_production_2003.parquet"
+)
+
+#: The first season ESPN's player box can describe. Below it, `_load_box` has
+#: nothing and the S-1 production side must come from `_PRODUCTION_2003_URL`.
+_ESPN_BOX_FLOOR = 2004
 
 #: Offensive production = attributed yardage. One row per athlete-game.
 _OFFENSE_BOX_COLS: tuple[str, ...] = ("passingYards", "rushingYards", "receivingYards")
@@ -96,6 +118,12 @@ _RETURNING_SCHEMA: dict[str, pl.PolarsDataType] = {
     "def_returning": pl.Float64,
     "overall_returning": pl.Float64,
     "n_returning": pl.Int64,
+    #: True only where the S-1 production came from parsed play text rather than
+    #: the ESPN box (2004 alone). Back-tested against 2005, where both sources
+    #: exist, the play-text route tracks the box route at r=0.73 with a -0.085
+    #: bias: it ranks teams well but reads systematically LOW, so a consumer
+    #: comparing 2004 against its neighbours on level must filter on this.
+    "is_estimated": pl.Boolean,
 }
 
 # (player-id column, weight expression source, unit, team-name column)
@@ -192,7 +220,13 @@ def _num(col: str) -> pl.Expr:
 
 def _load_box(season: int) -> pl.DataFrame:
     """One season of the ESPN player box (empty frame when unavailable)."""
-    box = load_cfb_player_box([season])
+    try:
+        box = load_cfb_player_box([season])
+    except SeasonNotFoundError:
+        # "empty frame when unavailable" is what this promised and what every
+        # caller assumes; below the ESPN floor the loader RAISES instead, which
+        # is how cfb_returning_production(2004) came to abort a whole build.
+        return pl.DataFrame()
     if isinstance(box, pd.DataFrame):
         box = pl.from_pandas(box)
     return box if box is not None else pl.DataFrame()
@@ -354,6 +388,19 @@ def _cfbd_roster_keys(season: int) -> pl.DataFrame:
 # ---------------------------------------------------------------------------
 
 
+def _load_production_2003() -> pl.DataFrame:
+    """Hosted season-2003 offensive production ({} when unreachable).
+
+    Already in `_production_from_box`'s output shape and keyed on ESPN athlete
+    ids, so it drops straight into `_returning_from_frames`. A 2003 producer who
+    is NOT on the 2004 roster carries a synthetic ``cfbd2003:`` id: they belong
+    in the DENOMINATOR -- production that did not return -- and must never
+    collide with a real athlete id.
+    """
+    df = _read_release_parquet(_PRODUCTION_2003_URL)
+    return df if df is not None else pl.DataFrame()
+
+
 def _load_player_stats(season: int) -> pl.DataFrame:
     """One season of the hosted per-play player-stats parquet ({} on 404)."""
     df = _read_release_parquet(_PLAYER_STATS_URL.format(season=season))
@@ -466,10 +513,19 @@ def cfb_returning_production(
     Returns:
         Per ``(season, team_id)``: ``off_returning``, ``def_returning``,
         ``overall_returning`` (Float64 fractions in [0, 1]), ``n_returning``
-        (Int64 count of returning contributors). ``team_id`` is the ESPN team
-        id as Utf8 -- BREAKING vs the previous release, which emitted a
-        normalized team NAME under ``team`` and joined at 57.7%. Zero-row
-        (typed) when the box data is unavailable.
+        (Int64 count of returning contributors), ``is_estimated`` (Boolean).
+        ``team_id`` is the ESPN team id as Utf8 -- BREAKING vs the previous
+        release, which emitted a normalized team NAME under ``team`` and joined
+        at 57.7%. Zero-row (typed) when the box data is unavailable.
+
+        ``is_estimated`` is True for **2004 only**, where season-2003 production
+        is parsed from CFBD play text because ESPN's player box starts in 2004.
+        Back-tested on 2005, where both sources exist, that route tracks the box
+        route at r=0.73 (MAE 0.11) but reads about 0.085 LOW. It ranks teams
+        well; it is not on the same level as its neighbours, so filter on this
+        flag before comparing 2004 against another season. 2004 also carries a
+        null ``def_returning`` -- 2003 play text has no tacklers, and every
+        season through 2016 is null there regardless.
 
     Raises:
         ValueError: If the season-S CFBD roster cannot be resolved to team ids
@@ -492,10 +548,17 @@ def cfb_returning_production(
     season_list = [seasons] if isinstance(seasons, int) else list(seasons)
     out_frames: list[pl.DataFrame] = []
     for season in season_list:
+        estimated = False
         box_prev = _load_box(season - 1)
-        if box_prev.height == 0:
+        if box_prev.height:
+            prod_prev = _production_from_box(box_prev, season - 1)
+        elif season - 1 == _ESPN_BOX_FLOOR - 1:
+            # The one season the box cannot describe. Parsed 2003 play text is a
+            # proxy, not the same measurement -- hence the flag on every row.
+            prod_prev = _load_production_2003()
+            estimated = prod_prev.height > 0
+        else:
             continue
-        prod_prev = _production_from_box(box_prev, season - 1)
         if prod_prev.height == 0:
             continue
         roster_curr = _roster_keys(season)
@@ -503,7 +566,7 @@ def cfb_returning_production(
             continue
         frame = _returning_from_frames(prod_prev, roster_curr, division=division)
         _warn_thin_defense(frame, season)
-        out_frames.append(frame)
+        out_frames.append(frame.with_columns(pl.lit(estimated).alias("is_estimated")))
     if not out_frames:
         empty = pl.DataFrame(schema=_RETURNING_SCHEMA)
         return empty.to_pandas() if return_as_pandas else empty

--- a/tests/cfb/test_cfb_returning_production.py
+++ b/tests/cfb/test_cfb_returning_production.py
@@ -140,3 +140,90 @@ def test_roster_keys_cfbd_match_floor_still_asserts(monkeypatch) -> None:
     )
     with pytest.raises(ValueError, match="resolved to a team id"):
         rp._roster_keys(2026)
+
+
+class TestSeason2004:
+    """2004: the one season whose S-1 production cannot come from the ESPN box.
+
+    `load_cfb_player_box([2003])` RAISES SeasonNotFoundError (ESPN's player box
+    starts in 2004), which propagated out of cfb_returning_production and killed
+    a whole cfbfastR-cfb-data build -- run 34142076600, `A creation step for
+    season 2004 exited with code 1`.
+    """
+
+    def test_load_box_below_the_floor_returns_empty_not_raises(self, monkeypatch):
+        """Its docstring promised an empty frame; it raised instead."""
+        from sportsdataverse.errors import SeasonNotFoundError
+
+        def boom(_seasons):
+            raise SeasonNotFoundError("Season 2003 not found, season cannot be less than 2004")
+
+        monkeypatch.setattr(rp, "load_cfb_player_box", boom)
+        assert rp._load_box(2003).height == 0
+
+    def test_2004_falls_back_to_hosted_2003_production(self, monkeypatch):
+        prod_2003 = pl.DataFrame(
+            {
+                "season": [2003, 2003, 2003],
+                "team_id": ["333", "333", "333"],
+                # two returned in 2004, one did not
+                "player_id": ["1", "2", "cfbd2003:Alabama:gone player"],
+                "player_name": ["a", "b", "gone player"],
+                "unit": ["offense"] * 3,
+                "prod_weight": [600.0, 300.0, 100.0],
+                "position": [None, None, None],
+            }
+        )
+        roster_2004 = pl.DataFrame(
+            {"season": [2004, 2004], "team_id": ["333", "333"], "player_id": ["1", "2"]}
+        )
+        monkeypatch.setattr(rp, "_load_box", lambda _s: pl.DataFrame())
+        monkeypatch.setattr(rp, "_load_production_2003", lambda: prod_2003)
+        monkeypatch.setattr(rp, "_roster_keys", lambda _s: roster_2004)
+
+        out = rp.cfb_returning_production(2004)
+        assert out.height == 1
+        row = out.row(0, named=True)
+        assert row["season"] == 2004
+        # 900 of 1000 yards returned
+        assert row["off_returning"] == pytest.approx(0.9)
+        assert row["is_estimated"] is True
+        # 2003 play text carries no tacklers, and every season through 2016 is
+        # null here anyway -- a splash-only number would make 2004 the lone
+        # pre-2020 season with a defensive value.
+        assert row["def_returning"] is None
+
+    def test_a_normal_season_is_not_flagged_estimated(self, monkeypatch):
+        """The flag must mark 2004 alone, not every row in the panel."""
+        box = pl.DataFrame(
+            {
+                "season": [2004, 2004],
+                "team_id": [333, 333],
+                "athlete_id": [1, 2],
+                "athlete_name": ["a", "b"],
+                "passingYards": ["100", "0"],
+                "rushingYards": ["0", "50"],
+                "receivingYards": ["0", "0"],
+            }
+        )
+        monkeypatch.setattr(rp, "_load_box", lambda _s: box)
+        monkeypatch.setattr(
+            rp,
+            "_roster_keys",
+            lambda _s: pl.DataFrame(
+                {"season": [2005], "team_id": ["333"], "player_id": ["1"]}
+            ),
+        )
+        called = []
+        monkeypatch.setattr(rp, "_load_production_2003", lambda: called.append(1) or pl.DataFrame())
+        out = rp.cfb_returning_production(2005)
+        assert not called, "the 2003 table must not be fetched for a normal season"
+        assert out["is_estimated"].to_list() == [False]
+
+    def test_2004_still_skipped_when_the_hosted_table_is_unreachable(self, monkeypatch):
+        """A 404 must skip the season, never emit a row flagged as estimated."""
+        monkeypatch.setattr(rp, "_load_box", lambda _s: pl.DataFrame())
+        monkeypatch.setattr(rp, "_load_production_2003", lambda: pl.DataFrame())
+        out = rp.cfb_returning_production(2004)
+        assert out.height == 0
+        assert out.schema["is_estimated"] == pl.Boolean

--- a/tests/cfb/test_cfb_returning_production.py
+++ b/tests/cfb/test_cfb_returning_production.py
@@ -174,9 +174,7 @@ class TestSeason2004:
                 "position": [None, None, None],
             }
         )
-        roster_2004 = pl.DataFrame(
-            {"season": [2004, 2004], "team_id": ["333", "333"], "player_id": ["1", "2"]}
-        )
+        roster_2004 = pl.DataFrame({"season": [2004, 2004], "team_id": ["333", "333"], "player_id": ["1", "2"]})
         monkeypatch.setattr(rp, "_load_box", lambda _s: pl.DataFrame())
         monkeypatch.setattr(rp, "_load_production_2003", lambda: prod_2003)
         monkeypatch.setattr(rp, "_roster_keys", lambda _s: roster_2004)
@@ -210,9 +208,7 @@ class TestSeason2004:
         monkeypatch.setattr(
             rp,
             "_roster_keys",
-            lambda _s: pl.DataFrame(
-                {"season": [2005], "team_id": ["333"], "player_id": ["1"]}
-            ),
+            lambda _s: pl.DataFrame({"season": [2005], "team_id": ["333"], "player_id": ["1"]}),
         )
         called = []
         monkeypatch.setattr(rp, "_load_production_2003", lambda: called.append(1) or pl.DataFrame())


### PR DESCRIPTION
`cfb_returning_production(2004)` needs season-2003 production, and ESPN's player box starts in 2004 — `load_cfb_player_box([2003])` raises `SeasonNotFoundError`. That raise propagated out and took down a whole producer build ([cfbfastR-cfb-data run 34142076600](https://github.com/sportsdataverse/cfbfastR-cfb-data/actions/runs/34142076600): `A creation step for season 2004 exited with code 1`). It was deterministic — every build of 2004 hit it.

## Where 2003 production actually lives

| source | 2003 offense | 2003 defense | evidence |
|---|---|---|---|
| ESPN player box | no | no | 0 athlete rows across 8 games / 2 weeks; 34-41 per game in 2004 |
| ESPN Core rosters | no | no | Oklahoma 2003 -> 0 players; 2004 -> 59; 2005 -> 53 |
| CFBD `/stats/player/season` | no | no | 2003 = 0 records; 2004 = 5; 2005 = 135; usable ~2008 |
| CFBD `/player/returning` | no | no | floor 2014 (0 records for 2004, 2010) |
| CFBD `/games/players` | no | no | 2003 = 0 games |
| **CFBD `/plays`** | **yes** | splash only | 2002 = 0 plays; 2003 wk5 = 7,787; 83.9% name-tagged |
| Sports Reference | yes | yes | 403 from this host **and** through a residential proxy; ToS bars redistribution |

CFBD play-by-play is the one source that reaches 2003, and its play text is name-tagged by team, so the offensive half is recoverable.

## Why the parse is not in this package

This package is **keyless by design** — every loader reads hosted parquet, and nothing here touches a CFBD API key. Making `cfb_returning_production` require a secret to compute one season would be a real regression, so the producer parses and hosts the table and the library reads it over `raw.githubusercontent`, the same shape as the existing `_PLAYER_STATS_URL`.

## Offense only, deliberately

2003 play text carries **no tacklers at all** (0 matches for "tackled by" or a trailing `(Tackler)`; only sacks, INTs, fumbles), so the volume term of `_DEFENSE_BOX_WEIGHTS` is unrecoverable. And every shipped season through 2016 already carries a null `def_returning`:

| season | teams | `def_returning` present |
|---|---|---|
| 2005 | 161 | 0 (0.0%) |
| 2012 | 197 | 0 (0.0%) |
| 2016 | 214 | 0 (0.0%) |
| 2020 | 223 | 46 (20.6%) |
| 2025 | 236 | 229 (97.0%) |

A splash-only number would have made 2004 the lone pre-2020 season with a defensive value, computed by a method no other season uses. Null is what is consistent with its neighbours.

## `is_estimated` marks it, and the numbers are published

Back-tested against 2005, where **both** sources exist (130 teams overlap):

| matcher | Pearson r | MAE | bias |
|---|---|---|---|
| exact normalized name | 0.737 | 0.114 | -0.098 |
| + first-initial/last-name fallback | 0.725 | 0.112 | -0.085 |

The looser matcher moved the bias only 1.3pp and **lowered** r — it admits about as many false positives as real recoveries. That localizes the gap to play-text-vs-box attribution rather than to the join. So the route ranks teams well (2004 sd 0.217 vs 2005 sd 0.256) but reads systematically low, and `is_estimated` is on the row with r and bias in the docstring so a consumer comparing 2004 against a neighbour on level knows to filter.

Schema gains `is_estimated` (Boolean), False everywhere except 2004.

## Also: `_load_box` now honours its own docstring

It promised "empty frame when unavailable" and raised instead. That specific mismatch is what turned a missing season into a failed build.

## Companion

Reads `data/cfb_production_2003.parquet` from [cfbfastR-cfb-data#76](https://github.com/sportsdataverse/cfbfastR-cfb-data/pull/76). **Merge that one first** — until it is on `main` the loader 404s, which skips 2004 rather than emitting a row falsely flagged as estimated (covered by a test). Safe to merge in either order; 2004 simply starts publishing once the companion lands.

## Testing

4 new tests: the below-floor empty-frame contract, the 2004 fallback producing `is_estimated=True` with null `def_returning`, a normal season **not** fetching the 2003 table or being flagged, and the 404 path skipping rather than emitting.

- `pytest tests/cfb/` — 823 passed, 55 skipped, 2 xfailed
- `ruff check` + `ruff format` — clean
- `tools/codegen/generate.py --check` — all generated files current

## Summary by Sourcery

Support returning-production calculations for 2004 without failing builds by using hosted season-2003 offensive data and clearly marking the resulting estimates.

New Features:
- Add estimated returning-production values for 2004 using hosted season-2003 offensive production, while leaving defensive production null.

Bug Fixes:
- Prevent unavailable ESPN seasons from raising and aborting returning-production builds.
- Skip 2004 cleanly when the hosted season-2003 production table is unavailable.

Enhancements:
- Add an `is_estimated` output flag to identify 2004 values derived from an alternate production source.
- Make the ESPN box loader honor its documented empty-frame behavior for unavailable seasons.

Documentation:
- Document the estimated 2004 methodology, limitations, and interpretation of the new flag.

Tests:
- Add coverage for unavailable-season handling, the 2004 fallback, normal-season behavior, and missing hosted-data behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving college football returning-production data for the 2004 season.
  - Added an `is_estimated` indicator to identify production derived from play-by-play data.
  - Defensive returning-production values are left blank when unavailable.

- **Bug Fixes**
  - Seasons without available player-box data no longer cause an error; they are skipped gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->