### PR TITLE
feat(cfb): drive summary + situational stats (graduated from game-on-paper)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,24 @@
 
 ## Unreleased
 
+### Added — CFB drive summary and situational team stats, graduated from Game on Paper (#470)
+
+`cfb_drive_summary.create_drive_summary(drives, frame, home_id, away_id,
+periods=None)` builds the StatBroadcast-style drive summary — per-team drive
+lines (both named drive-success metrics, points off turnovers, forced
+three-and-outs, TOP by quarter, first-down sources), the OBTAINED/HOW-LOST
+drive chart, how-scores-happened, and per-team long-play lists — windowable
+by start-quarter set or `"ot"`. `cfb_situational_stats.create_situational_stats(frame,
+home_id, away_id, window_expr=None)` builds the per-team situational block
+(down-by-down with distance buckets and conversion attribution, red zone,
+finishing drives, rushing tiers, passing profile, 4th-down decision report,
+score state, penalties, havoc, turnovers, field zones, pace, big plays),
+windowable via a polars filter with window-inherent sections omitted on
+windowed builds. Thin `CFBPlayProcess.create_drive_summary` /
+`.create_situational_stats` delegates mirror `create_box_score`. Both consume
+the post-pipeline `plays_frame`; drive-level attribution reads the drives
+grouping (`drive.team`), never plays grouped by `drive.id`.
+
 ### Fixed — MLB expected stats counted raw pitches as plate appearances
 
 `mlb_expected_stats` counted every non-batted-ball *pitch* row toward `pa`

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The goal of [sportsdataverse-py](https://py.sportsdataverse.org) is to provide t
 | WNBA | `sportsdataverse.wnba` | ESPN + **stats.wnba.com** (`wnba_stats_*`, 111 wrappers) |
 | MBB (NCAA M) | `sportsdataverse.mbb` | ESPN + NCAA-only (rankings, recruits) + **stats.ncaa.org** (`ncaa_mbb_*` bigballR-parity family + `mbb_ncaa_*` pbp/lineup/stint engine) + Fox Sports (Bifrost) |
 | WBB (NCAA W) | `sportsdataverse.wbb` | ESPN + NCAA-only + **stats.ncaa.org** (`ncaa_wbb_*` family) |
-| CFB | `sportsdataverse.cfb` | ESPN + NCAA + **stats.ncaa.org** (`cfb_ncaa_pbp` + box/drives/officials parsers) + football-only (QBR) + Fox Sports (Bifrost) + Yahoo Sports + **ESPN dataset loaders** (teams / rosters / unified schedules / team info) |
+| CFB | `sportsdataverse.cfb` | ESPN + NCAA + **stats.ncaa.org** (`cfb_ncaa_pbp` + box/drives/officials parsers) + football-only (QBR) + Fox Sports (Bifrost) + Yahoo Sports + **ESPN dataset loaders** (teams / rosters / unified schedules / team info) + **game analytics** (advanced box, drive summary, situational stats) |
 | NFL | `sportsdataverse.nfl` | ESPN + **NFL.com API** (`api.nfl.com` "Shield") + **nflverse loaders** (nflreadpy parity) + football-only (QBR) |
 | MLB | `sportsdataverse.mlb` | ESPN + MLB Stats API (`statsapi.mlb.com`) + Baseball Savant / Statcast (43-endpoint `mlb_statcast_*` surface) + Fox Sports (Bifrost) |
 | NHL | `sportsdataverse.nhl` | `api-web.nhle.com/v1/` (game-feed) + NHL EDGE (player tracking) + Stats REST + Records site + Fox Sports (Bifrost) |

--- a/docs/docs/cfb/index.md
+++ b/docs/docs/cfb/index.md
@@ -15,7 +15,7 @@ description: "sdv-py CFB: endpoint references, dataset loaders and parsers for C
 | [247Sports Recruit Database (ipa.247sports.com)](reference/sports247) | 12 | `https://ipa.247sports.com` |
 | [247Sports Site Pages (247sports.com)](reference/sports247_site_pages) | 35 | `https://247sports.com` |
 | [Dataset loaders](reference/loaders) | 52 | sportsdataverse raw data / sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 92 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 94 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -711,6 +711,46 @@ box = game.create_box_score(game.plays_json)
 print(list(box.keys()))
 ```
 
+#### `CFBPlayProcess.create_drive_summary(play_df, drives, periods=None)`
+
+Build the StatBroadcast-style drive summary for this game.
+
+Thin delegate to
+`sportsdataverse.cfb.cfb_drive_summary.create_drive_summary`,
+with the team ids read from the plays frame -- the drive-level
+sibling of `create_box_score`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `play_df` | `pl.DataFrame` |  | the post-pipeline plays frame (`plays_frame`). |
+| `drives` | `list[dict]` |  | the ESPN drives grouping in game order. |
+| `periods` |  | `None` | optional window (a set of quarter numbers, or `"ot"`). |
+
+**Returns**
+
+the drive summary, or `None` when inputs are unusable.
+
+#### `CFBPlayProcess.create_situational_stats(play_df, window_expr=None)`
+
+Build the situational team-stats block for this game.
+
+Thin delegate to
+`sportsdataverse.cfb.cfb_situational_stats.create_situational_stats`,
+with the team ids read from the plays frame.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `play_df` | `pl.DataFrame` |  | the post-pipeline plays frame (`plays_frame`). |
+| `window_expr` |  | `None` | optional polars filter windowing the windowable sections (e.g. `pl.col("period") == 3`). |
+
+**Returns**
+
+the situational stats, or `None` when the frame is unusable or the window is empty.
+
 #### `CFBPlayProcess.espn_cfb_pbp(**kwargs)`
 
 espn_cfb_pbp() - Pull the game by id. Data from API endpoints: `college-football/playbyplay`,
@@ -1913,6 +1953,64 @@ One row per move side: `season` (Int64, the destination season), `team_id` (Utf8
 from sportsdataverse.cfb import cfb_transfer_moves
 moves = cfb_transfer_moves(2024)
 moves.filter(pl.col("direction") == "in").group_by("team_id").len()
+```
+
+### `create_drive_summary(drives, frame, home_id, away_id, periods=None)` {#create_drive_summary}
+
+Build the StatBroadcast-style drive summary, chart, and long-play lists.
+
+A drive belongs to the quarter it STARTED in. On a windowed build the
+full drive sequence still provides context (running score, the previous
+drive for OBTAINED and points-off-turnovers), but only in-window drives
+are counted, charted, or listed; game-level lines (largest lead, time
+leading/tied) ship only on the un-windowed build.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `drives` | `list[dict]` |  | the ESPN drives grouping, in game order (`previous` plus the in-progress `current` drive, if any). |
+| `frame` | `pl.DataFrame` |  | the enriched plays frame from `CFBPlayProcess.run_processing_pipeline` (`plays_frame`). |
+| `home_id` |  |  | ESPN home team id. |
+| `away_id` |  |  | ESPN away team id. |
+| `periods` |  | `None` | optional window -- a set of quarter numbers (e.g. `{1, 2}`) or the string `"ot"` (every period > 4). `None` = full game. |
+
+**Returns**
+
+`{"teams": {...}, "chart": [...], "scores": [...], "longPlays": {...}}` keyed by team id, or `None` when the inputs are unusable (no drives, empty frame, or an empty window).
+
+**Example**
+
+```python
+summary = create_drive_summary(drives, game.plays_frame, "52", "61")
+```
+
+### `create_situational_stats(frame, home_id, away_id, window_expr=None)` {#create_situational_stats}
+
+Build the situational team-stats block from a plays frame.
+
+Window-inherent sections -- `two_minute`, `middle_8`, `non_garbage`,
+`pace`, `fourth_down_decisions` -- are omitted from a windowed build:
+they are themselves time windows or game-level filters, and
+double-windowing them is a category error.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `frame` | `pl.DataFrame` |  | the enriched plays frame from `CFBPlayProcess.run_processing_pipeline` (`plays_frame`). |
+| `home_id` |  |  | ESPN home team id. |
+| `away_id` |  |  | ESPN away team id. |
+| `window_expr` |  | `None` | optional polars filter expression windowing the windowable sections to that slice (e.g. `pl.col("period") == 3`). `None` = full game. |
+
+**Returns**
+
+`{"teams": {<team_id>: {<section>: ...}}}` or `None` when the frame is unusable or the window is empty.
+
+**Example**
+
+```python
+stats = create_situational_stats(game.plays_frame, "52", "61")
 ```
 
 ### `efficiency_ratings(plays: 'pl.DataFrame', *, config: 'RatingsConfig | None' = None) -> 'pl.DataFrame'` {#efficiency_ratings}

--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -711,7 +711,7 @@ box = game.create_box_score(game.plays_json)
 print(list(box.keys()))
 ```
 
-#### `CFBPlayProcess.create_drive_summary(play_df, drives, periods=None)`
+#### `CFBPlayProcess.create_drive_summary(play_df, drives, periods=None) -> 'dict | None'`
 
 Build the StatBroadcast-style drive summary for this game.
 
@@ -732,7 +732,7 @@ sibling of `create_box_score`.
 
 the drive summary, or `None` when inputs are unusable.
 
-#### `CFBPlayProcess.create_situational_stats(play_df, window_expr=None)`
+#### `CFBPlayProcess.create_situational_stats(play_df, window_expr=None) -> 'dict | None'`
 
 Build the situational team-stats block for this game.
 
@@ -1955,7 +1955,7 @@ moves = cfb_transfer_moves(2024)
 moves.filter(pl.col("direction") == "in").group_by("team_id").len()
 ```
 
-### `create_drive_summary(drives, frame, home_id, away_id, periods=None)` {#create_drive_summary}
+### `create_drive_summary(drives: list[dict] | dict, frame: polars.dataframe.frame.DataFrame, home_id: str | int, away_id: str | int, periods: set[int] | str | None = None) -> dict | None` {#create_drive_summary}
 
 Build the StatBroadcast-style drive summary, chart, and long-play lists.
 
@@ -1971,9 +1971,9 @@ leading/tied) ship only on the un-windowed build.
 |---|---|---|---|
 | `drives` | `list[dict]` |  | the ESPN drives grouping, in game order (`previous` plus the in-progress `current` drive, if any). |
 | `frame` | `pl.DataFrame` |  | the enriched plays frame from `CFBPlayProcess.run_processing_pipeline` (`plays_frame`). |
-| `home_id` |  |  | ESPN home team id. |
-| `away_id` |  |  | ESPN away team id. |
-| `periods` |  | `None` | optional window -- a set of quarter numbers (e.g. `{1, 2}`) or the string `"ot"` (every period > 4). `None` = full game. |
+| `home_id` | `str \| int` |  | ESPN home team id. |
+| `away_id` | `str \| int` |  | ESPN away team id. |
+| `periods` | `set[int] \| str \| None` | `None` | optional window -- a set of quarter numbers (e.g. `{1, 2}`) or the string `"ot"` (every period > 4). `None` = full game. |
 
 **Returns**
 
@@ -1985,7 +1985,7 @@ leading/tied) ship only on the un-windowed build.
 summary = create_drive_summary(drives, game.plays_frame, "52", "61")
 ```
 
-### `create_situational_stats(frame, home_id, away_id, window_expr=None)` {#create_situational_stats}
+### `create_situational_stats(frame: polars.dataframe.frame.DataFrame, home_id: str | int, away_id: str | int, window_expr: polars.expr.expr.Expr | None = None) -> dict | None` {#create_situational_stats}
 
 Build the situational team-stats block from a plays frame.
 
@@ -1999,9 +1999,9 @@ double-windowing them is a category error.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `frame` | `pl.DataFrame` |  | the enriched plays frame from `CFBPlayProcess.run_processing_pipeline` (`plays_frame`). |
-| `home_id` |  |  | ESPN home team id. |
-| `away_id` |  |  | ESPN away team id. |
-| `window_expr` |  | `None` | optional polars filter expression windowing the windowable sections to that slice (e.g. `pl.col("period") == 3`). `None` = full game. |
+| `home_id` | `str \| int` |  | ESPN home team id. |
+| `away_id` | `str \| int` |  | ESPN away team id. |
+| `window_expr` | `Expr \| None` | `None` | optional polars filter expression windowing the windowable sections to that slice (e.g. `pl.col("period") == 3`). `None` = full game. |
 
 **Returns**
 

--- a/sportsdataverse/cfb/__init__.py
+++ b/sportsdataverse/cfb/__init__.py
@@ -10,6 +10,8 @@ from sportsdataverse.cfb.cfb_ncaa_pbp import *
 from sportsdataverse.cfb.cfb_ncaa_box import *
 from sportsdataverse.cfb.cfb_ncaa_cfbfastr import *
 from sportsdataverse.cfb.cfb_adjusted_epa import *
+from sportsdataverse.cfb.cfb_drive_summary import *
+from sportsdataverse.cfb.cfb_situational_stats import *
 from sportsdataverse.cfb.cfb_advanced_stats import *
 from sportsdataverse.cfb.cfb_field_position import *
 from sportsdataverse.cfb.cfb_tempo import *

--- a/sportsdataverse/cfb/cfb_drive_summary.py
+++ b/sportsdataverse/cfb/cfb_drive_summary.py
@@ -107,7 +107,13 @@ def _obtained(prev_result, is_first_of_half):
     return r
 
 
-def create_drive_summary(drives, frame, home_id, away_id, periods=None):
+def create_drive_summary(
+    drives: list[dict] | dict,
+    frame: pl.DataFrame,
+    home_id: str | int,
+    away_id: str | int,
+    periods: set[int] | str | None = None,
+) -> dict | None:
     """Build the StatBroadcast-style drive summary, chart, and long-play lists.
 
     A drive belongs to the quarter it STARTED in. On a windowed build the
@@ -136,6 +142,11 @@ def create_drive_summary(drives, frame, home_id, away_id, periods=None):
 
             summary = create_drive_summary(drives, game.plays_frame, "52", "61")
     """
+    if isinstance(drives, dict):  # the raw ESPN grouping, not yet flattened
+        flat = list(drives.get("previous") or [])
+        if drives.get("current"):
+            flat.append(drives["current"])
+        drives = flat
     if not drives or not isinstance(frame, pl.DataFrame) or frame.height == 0:
         return None
 
@@ -190,9 +201,7 @@ def create_drive_summary(drives, frame, home_id, away_id, periods=None):
 
         prev = ordered[i - 1] if i > 0 else None
         first_of_half = prev is None or (
-            _period(prev) is not None
-            and period is not None
-            and (_period(prev) <= 2 < period)
+            _period(prev) is not None and period is not None and (_period(prev) <= 2 < period)
         )
 
         if not in_window(period):
@@ -273,9 +282,7 @@ def create_drive_summary(drives, frame, home_id, away_id, periods=None):
                 "period": period,
                 "start_spot": _spot(d, "start"),
                 "start_clock": _clock(d, "start"),
-                "obtained": _obtained(
-                    (prev.get("result") if prev else None), first_of_half
-                ),
+                "obtained": _obtained((prev.get("result") if prev else None), first_of_half),
                 "end_spot": _spot(d, "end"),
                 "end_clock": _clock(d, "end"),
                 "result": result or None,
@@ -288,10 +295,7 @@ def create_drive_summary(drives, frame, home_id, away_id, periods=None):
         # drive success, both named metrics
         succeeded_fd = bool(d.get("isScore"))
         if not succeeded_fd:
-            sub = frame.filter(
-                (pl.col("drive.id") == d.get("id"))
-                & (pl.col("pos_team").cast(pl.Utf8) == tid)
-            )
+            sub = frame.filter((pl.col("drive.id") == d.get("id")) & (pl.col("pos_team").cast(pl.Utf8) == tid))
             succeeded_fd = bool(
                 sub.select(
                     (pl.col("first_down_created") == True).any()  # noqa: E712
@@ -318,35 +322,15 @@ def create_drive_summary(drives, frame, home_id, away_id, periods=None):
         third = mine.filter(pl.col("down") == 3)
         fourth = mine.filter(pl.col("down") == 4)
         conv = lambda df: int(  # noqa: E731
-            df.select(
-                (
-                    (pl.col("first_down_created") == True)
-                    | (pl.col("touchdown") == True)
-                ).sum()
-            ).item()  # noqa: E712
+            df.select(((pl.col("first_down_created") == True) | (pl.col("touchdown") == True)).sum()).item()  # noqa: E712
         )
-        t["avg_third_down_distance"] = (
-            round(third["distance"].mean(), 1) if third.height else None
-        )
+        _third_dist = third["distance"].mean() if third.height else None
+        t["avg_third_down_distance"] = round(_third_dist, 1) if _third_dist is not None else None
         t["third_downs"] = {"made": conv(third), "att": third.height}
         t["fourth_downs"] = {"made": conv(fourth), "att": fourth.height}
         t["first_downs"] = {
-            "rush": int(
-                mine.select(
-                    (
-                        (pl.col("first_down_created") == True)
-                        & (pl.col("rush") == True)
-                    ).sum()
-                ).item()
-            ),  # noqa: E712
-            "pass": int(
-                mine.select(
-                    (
-                        (pl.col("first_down_created") == True)
-                        & (pl.col("pass") == True)
-                    ).sum()
-                ).item()
-            ),  # noqa: E712
+            "rush": int(mine.select(((pl.col("first_down_created") == True) & (pl.col("rush") == True)).sum()).item()),  # noqa: E712
+            "pass": int(mine.select(((pl.col("first_down_created") == True) & (pl.col("pass") == True)).sum()).item()),  # noqa: E712
             "penalty": int(mine.select(pl.col("firstD_by_penalty").sum()).item()),
         }
 
@@ -371,16 +355,10 @@ def create_drive_summary(drives, frame, home_id, away_id, periods=None):
     # largest lead + minutes leading/trailing/tied from the score-state clock
     # (regulation only -- OT clocks don't tick the same axis); game-level, so
     # only the un-windowed build carries it
-    reg = (
-        scrim.filter(pl.col("period") <= 4).sort("game_play_number")
-        if periods is None
-        else scrim.head(0)
-    )
+    reg = scrim.filter(pl.col("period") <= 4).sort("game_play_number") if periods is None else scrim.head(0)
     lead = {home_id: 0, away_id: 0}
     clockstate = {home_id: 0, away_id: 0, "tied": 0}
-    rows = reg.select(
-        ["start.adj_TimeSecsRem", "start.homeScore", "start.awayScore"]
-    ).to_dicts()
+    rows = reg.select(["start.adj_TimeSecsRem", "start.homeScore", "start.awayScore"]).to_dicts()
     final_h, final_a = h, a  # running score after the chart walk = final score
     for j, r in enumerate(rows):
         hh, aa = r.get("start.homeScore") or 0, r.get("start.awayScore") or 0
@@ -391,9 +369,7 @@ def create_drive_summary(drives, frame, home_id, away_id, periods=None):
         # go-ahead score counts its aftermath as leading, not the prior state
         if j + 1 < len(rows):
             nxt = rows[j + 1]
-            dt = (r.get("start.adj_TimeSecsRem") or 0) - (
-                nxt.get("start.adj_TimeSecsRem") or 0
-            )
+            dt = (r.get("start.adj_TimeSecsRem") or 0) - (nxt.get("start.adj_TimeSecsRem") or 0)
             dt = max(0, dt)
             sh = nxt.get("start.homeScore") or 0
             sa = nxt.get("start.awayScore") or 0

--- a/sportsdataverse/cfb/cfb_drive_summary.py
+++ b/sportsdataverse/cfb/cfb_drive_summary.py
@@ -1,0 +1,433 @@
+"""Drive summary + drive chart, StatBroadcast-style.
+
+Computed from two sources, deliberately split:
+- the ESPN drives grouping (ordered, with ``team.id``) for anything drive-level
+  -- drive ids on PLAYS span both teams, so per-drive attribution must come
+  from ``drive.team``, never from plays grouped by drive id;
+- the enriched plays frame produced by :meth:`CFBPlayProcess.run_processing_pipeline`
+  (retained as ``plays_frame``) for play-flag aggregates (third downs,
+  first-down sources, long plays, score-state clock).
+
+Definitions follow the StatBroadcast game book where one exists:
+- three-and-out: <= 3 offensive plays, lost by punt;
+- a 3rd/4th-down TD counts as a conversion;
+- points off turnovers: points the defense scores during the turnover drive
+  (pick-six et al) plus points on the ensuing possession;
+- drive success ships under TWO named metrics (maintainer decision):
+  ``drive_success_rate_fd`` (>= 1 first down or score) and
+  ``drive_success_rate_ay`` (>= 50% of available yards, TDs are 100%).
+Known approximation: a drive's time of possession is assigned to the quarter
+it STARTED in (a drive spanning the break books whole to the earlier quarter).
+"""
+
+import re
+
+import polars as pl
+
+__all__ = ["create_drive_summary"]
+
+_TURNOVER_RESULTS = {"INT", "FUMBLE", "INT TD", "FUMBLE TD"}
+_SCORING_KICKOFF_NEXT = {"TD", "FG", "INT TD", "FUMBLE TD", "MADE FG"}
+
+
+def _top_seconds(drive):
+    raw = ((drive.get("timeElapsed") or {}).get("displayValue") or "").strip()
+    parts = raw.split(":")
+    if len(parts) == 2 and all(p.isdigit() for p in parts):
+        return int(parts[0]) * 60 + int(parts[1])
+    return None
+
+
+def _spot(drive, which):
+    node = drive.get(which) or {}
+    return (node.get("text") or "").strip() or None
+
+
+def _clock(drive, which):
+    node = drive.get(which) or {}
+    return ((node.get("clock") or {}).get("displayValue") or "").strip() or None
+
+
+def _period(drive):
+    return ((drive.get("start") or {}).get("period") or {}).get("number")
+
+
+def _team_id(drive):
+    tid = (drive.get("team") or {}).get("id")
+    return str(tid) if tid is not None else None
+
+
+def _yards_to_endzone(drive, is_home):
+    """Distance to the end zone at the drive start, for the DRIVING team.
+
+    ESPN's drive ``start.yardLine`` runs on a HOME-oriented 0-100 axis, so
+    the away team's distance is ``yardLine`` and the home team's is
+    ``100 - yardLine``. The ``start.text`` ("TCU 25") is authoritative when
+    it parses: the named side says whose half the ball is on.
+    """
+    start = drive.get("start") or {}
+    text = (start.get("text") or "").strip()
+    abbr = ((drive.get("team") or {}).get("abbreviation") or "").upper()
+    m = re.match(r"([A-Z&'-]+)\s+(\d{1,2})$", text.upper()) if text else None
+    if m and abbr:
+        side, num = m.group(1), int(m.group(2))
+        return (100 - num) if side == abbr else num
+    yl = start.get("yardLine")
+    if not isinstance(yl, (int, float)):
+        return None
+    return (100 - yl) if is_home else yl
+
+
+def _score_after(drive, prev_home, prev_away):
+    """(home, away) after the drive's last play; carried forward when absent."""
+    plays = drive.get("plays") or []
+    for p in reversed(plays):
+        h, a = p.get("homeScore"), p.get("awayScore")
+        if h is not None and a is not None:
+            return int(h), int(a)
+    return prev_home, prev_away
+
+
+def _obtained(prev_result, is_first_of_half):
+    if is_first_of_half or prev_result is None:
+        return "KO"
+    r = prev_result.upper()
+    if r in _SCORING_KICKOFF_NEXT:
+        return "KO"
+    if r == "PUNT":
+        return "PUNT"
+    if "INT" in r:
+        return "INT"
+    if "FUMBLE" in r:
+        return "FUM"
+    if r == "DOWNS":
+        return "DOWNS"
+    if "FG" in r:  # missed FG variants
+        return "FG MISS"
+    return r
+
+
+def create_drive_summary(drives, frame, home_id, away_id, periods=None):
+    """Build the StatBroadcast-style drive summary, chart, and long-play lists.
+
+    A drive belongs to the quarter it STARTED in. On a windowed build the
+    full drive sequence still provides context (running score, the previous
+    drive for OBTAINED and points-off-turnovers), but only in-window drives
+    are counted, charted, or listed; game-level lines (largest lead, time
+    leading/tied) ship only on the un-windowed build.
+
+    Args:
+        drives (list[dict]): the ESPN drives grouping, in game order
+            (``previous`` plus the in-progress ``current`` drive, if any).
+        frame (pl.DataFrame): the enriched plays frame from
+            :meth:`CFBPlayProcess.run_processing_pipeline` (``plays_frame``).
+        home_id: ESPN home team id.
+        away_id: ESPN away team id.
+        periods: optional window -- a set of quarter numbers (e.g. ``{1, 2}``)
+            or the string ``"ot"`` (every period > 4). ``None`` = full game.
+
+    Returns:
+        dict: ``{"teams": {...}, "chart": [...], "scores": [...],
+        "longPlays": {...}}`` keyed by team id, or ``None`` when the inputs
+        are unusable (no drives, empty frame, or an empty window).
+
+    Example:
+        Full-game summary from a processed game::
+
+            summary = create_drive_summary(drives, game.plays_frame, "52", "61")
+    """
+    if not drives or not isinstance(frame, pl.DataFrame) or frame.height == 0:
+        return None
+
+    def in_window(p):
+        if periods is None:
+            return True
+        if periods == "ot":
+            return p is not None and p > 4
+        return p in periods
+
+    home_id, away_id = str(home_id), str(away_id)
+    team_ids = {home_id, away_id}
+
+    def blank():
+        return {
+            "total_drives": 0,
+            "scoring_drives": 0,
+            "td_drives": 0,
+            "yards": 0,
+            "plays": 0,
+            "top_seconds": 0,
+            "long_drives_70yds": 0,
+            "long_drives_10plays": 0,
+            "drives_over_5min": 0,
+            "drives_under_1min": 0,
+            "three_and_outs": 0,
+            "forced_three_and_outs": 0,
+            "points_off_turnovers": 0,
+            "success_fd": 0,
+            "success_ay": 0,
+            "start_yte_sum": 0,
+            "start_yte_n": 0,
+            "top_by_quarter": {},
+        }
+
+    teams = {home_id: blank(), away_id: blank()}
+    chart = []
+    scores = []
+
+    h, a = 0, 0
+    ordered = [d for d in drives if _team_id(d) in team_ids]
+    for i, d in enumerate(ordered):
+        tid = _team_id(d)
+        opp = away_id if tid == home_id else home_id
+        t = teams[tid]
+        result = (d.get("result") or "").upper()
+        top = _top_seconds(d)
+        yards = d.get("yards") or 0
+        plays = d.get("offensivePlays") or 0
+        yte = _yards_to_endzone(d, tid == home_id)
+        period = _period(d)
+
+        prev = ordered[i - 1] if i > 0 else None
+        first_of_half = prev is None or (
+            _period(prev) is not None
+            and period is not None
+            and (_period(prev) <= 2 < period)
+        )
+
+        if not in_window(period):
+            # out-of-window drives still advance the running score so
+            # points-off-turnovers and OBTAINED stay correct at the seams
+            h, a = _score_after(d, h, a)
+            continue
+
+        t["total_drives"] += 1
+        t["yards"] += yards
+        t["plays"] += plays
+        if top is not None:
+            t["top_seconds"] += top
+            if period is not None:
+                q = t["top_by_quarter"].setdefault(int(period), 0)
+                t["top_by_quarter"][int(period)] = q + top
+            if top >= 300:
+                t["drives_over_5min"] += 1
+            if top < 60:
+                t["drives_under_1min"] += 1
+        if yards >= 70:
+            t["long_drives_70yds"] += 1
+        if plays >= 10:
+            t["long_drives_10plays"] += 1
+        if yte is not None:
+            t["start_yte_sum"] += yte
+            t["start_yte_n"] += 1
+        if d.get("isScore"):
+            t["scoring_drives"] += 1
+        if result in ("TD",):
+            t["td_drives"] += 1
+        if plays <= 3 and result == "PUNT":
+            t["three_and_outs"] += 1
+            teams[opp]["forced_three_and_outs"] += 1
+
+        # score deltas across this drive, for points-off-turnovers + scores list
+        h2, a2 = _score_after(d, h, a)
+        own_delta = (h2 - h) if tid == home_id else (a2 - a)
+        opp_delta = (a2 - a) if tid == home_id else (h2 - h)
+        # a defensive score during the turnover drive itself (pick-six)
+        if result in _TURNOVER_RESULTS and opp_delta > 0:
+            teams[opp]["points_off_turnovers"] += opp_delta
+        # the ensuing possession after a turnover
+        if (
+            prev is not None
+            and (prev.get("result") or "").upper() in _TURNOVER_RESULTS
+            and _team_id(prev) == opp
+            and own_delta > 0
+        ):
+            t["points_off_turnovers"] += own_delta
+
+        if d.get("isScore"):
+            # the SCORING play, not merely the last play with text -- a
+            # post-score penalty or PAT note can be the drive's final entry
+            finishing = None
+            for p in reversed(d.get("plays") or []):
+                if p.get("scoringPlay") and p.get("text"):
+                    finishing = p["text"]
+                    break
+            if finishing is None:
+                for p in reversed(d.get("plays") or []):
+                    if p.get("text"):
+                        finishing = p["text"]
+                        break
+            scores.append(
+                {
+                    "team_id": tid,
+                    "period": period,
+                    "result": result,
+                    "description": d.get("description"),
+                    "finishing_play": finishing,
+                }
+            )
+
+        chart.append(
+            {
+                "team_id": tid,
+                "period": period,
+                "start_spot": _spot(d, "start"),
+                "start_clock": _clock(d, "start"),
+                "obtained": _obtained(
+                    (prev.get("result") if prev else None), first_of_half
+                ),
+                "end_spot": _spot(d, "end"),
+                "end_clock": _clock(d, "end"),
+                "result": result or None,
+                "plays": plays,
+                "yards": yards,
+                "top_seconds": top,
+            }
+        )
+
+        # drive success, both named metrics
+        succeeded_fd = bool(d.get("isScore"))
+        if not succeeded_fd:
+            sub = frame.filter(
+                (pl.col("drive.id") == d.get("id"))
+                & (pl.col("pos_team").cast(pl.Utf8) == tid)
+            )
+            succeeded_fd = bool(
+                sub.select(
+                    (pl.col("first_down_created") == True).any()  # noqa: E712
+                    | (pl.col("firstD_by_penalty") == True).any()  # noqa: E712
+                ).item()
+            )
+        if succeeded_fd:
+            t["success_fd"] += 1
+        if yte and (yards / yte) >= 0.5:
+            t["success_ay"] += 1
+        elif result == "TD":
+            t["success_ay"] += 1
+
+        h, a = h2, a2
+
+    # frame-side aggregates per team, windowed to match
+    scrim = frame.filter(pl.col("scrimmage_play") == True)  # noqa: E712
+    if periods == "ot":
+        scrim = scrim.filter(pl.col("period") > 4)
+    elif periods is not None:
+        scrim = scrim.filter(pl.col("period").is_in(sorted(periods)))
+    for tid, t in teams.items():
+        mine = scrim.filter(pl.col("pos_team").cast(pl.Utf8) == tid)
+        third = mine.filter(pl.col("down") == 3)
+        fourth = mine.filter(pl.col("down") == 4)
+        conv = lambda df: int(  # noqa: E731
+            df.select(
+                (
+                    (pl.col("first_down_created") == True)
+                    | (pl.col("touchdown") == True)
+                ).sum()
+            ).item()  # noqa: E712
+        )
+        t["avg_third_down_distance"] = (
+            round(third["distance"].mean(), 1) if third.height else None
+        )
+        t["third_downs"] = {"made": conv(third), "att": third.height}
+        t["fourth_downs"] = {"made": conv(fourth), "att": fourth.height}
+        t["first_downs"] = {
+            "rush": int(
+                mine.select(
+                    (
+                        (pl.col("first_down_created") == True)
+                        & (pl.col("rush") == True)
+                    ).sum()
+                ).item()
+            ),  # noqa: E712
+            "pass": int(
+                mine.select(
+                    (
+                        (pl.col("first_down_created") == True)
+                        & (pl.col("pass") == True)
+                    ).sum()
+                ).item()
+            ),  # noqa: E712
+            "penalty": int(mine.select(pl.col("firstD_by_penalty").sum()).item()),
+        }
+
+        n = t["total_drives"] or 1
+        t["scoring_pct"] = round(t["scoring_drives"] / n, 3)
+        t["td_rate"] = round(t["td_drives"] / n, 3)
+        t["drive_success_rate_fd"] = round(t["success_fd"] / n, 3)
+        t["drive_success_rate_ay"] = round(t["success_ay"] / n, 3)
+        t["avg_yards"] = round(t["yards"] / n, 1)
+        t["avg_plays"] = round(t["plays"] / n, 1)
+        t["avg_top_seconds"] = round(t["top_seconds"] / n)
+        if t["start_yte_n"]:
+            yte = t["start_yte_sum"] / t["start_yte_n"]
+            own = round(100 - yte)
+            t["avg_start_yards_to_endzone"] = round(yte, 1)
+            t["avg_start_text"] = f"OWN {own}" if own <= 50 else f"OPP {100 - own}"
+        else:
+            t["avg_start_yards_to_endzone"] = None
+            t["avg_start_text"] = None
+        del t["success_fd"], t["success_ay"], t["start_yte_sum"], t["start_yte_n"]
+
+    # largest lead + minutes leading/trailing/tied from the score-state clock
+    # (regulation only -- OT clocks don't tick the same axis); game-level, so
+    # only the un-windowed build carries it
+    reg = (
+        scrim.filter(pl.col("period") <= 4).sort("game_play_number")
+        if periods is None
+        else scrim.head(0)
+    )
+    lead = {home_id: 0, away_id: 0}
+    clockstate = {home_id: 0, away_id: 0, "tied": 0}
+    rows = reg.select(
+        ["start.adj_TimeSecsRem", "start.homeScore", "start.awayScore"]
+    ).to_dicts()
+    final_h, final_a = h, a  # running score after the chart walk = final score
+    for j, r in enumerate(rows):
+        hh, aa = r.get("start.homeScore") or 0, r.get("start.awayScore") or 0
+        lead[home_id] = max(lead[home_id], hh - aa)
+        lead[away_id] = max(lead[away_id], aa - hh)
+        # the interval after play j belongs to play j's OUTCOME -- the next
+        # play's start state (or the final score after the last play) -- so a
+        # go-ahead score counts its aftermath as leading, not the prior state
+        if j + 1 < len(rows):
+            nxt = rows[j + 1]
+            dt = (r.get("start.adj_TimeSecsRem") or 0) - (
+                nxt.get("start.adj_TimeSecsRem") or 0
+            )
+            dt = max(0, dt)
+            sh = nxt.get("start.homeScore") or 0
+            sa = nxt.get("start.awayScore") or 0
+        else:
+            dt = max(0, r.get("start.adj_TimeSecsRem") or 0)
+            sh, sa = final_h, final_a
+        key = home_id if sh > sa else away_id if sa > sh else "tied"
+        clockstate[key] += dt
+    lead[home_id] = max(lead[home_id], final_h - final_a)
+    lead[away_id] = max(lead[away_id], final_a - final_h)
+    if periods is None:
+        for tid, t in teams.items():
+            t["largest_lead"] = lead[tid]
+            t["time_leading_seconds"] = round(clockstate[tid])
+        tied_s = round(clockstate["tied"])
+        for t in teams.values():
+            t["time_tied_seconds"] = tied_s
+
+    # long plays: top 5 scrimmage gains per team
+    long_plays = {}
+    for tid in team_ids:
+        top5 = (
+            scrim.filter(pl.col("pos_team").cast(pl.Utf8) == tid)
+            .sort("statYardage", descending=True, nulls_last=True)
+            .head(5)
+            .select(["statYardage", "period", "text"])
+            .to_dicts()
+        )
+        long_plays[tid] = [
+            {"yards": p["statYardage"], "period": p["period"], "text": p["text"]}
+            for p in top5
+            if (p["statYardage"] or 0) > 0
+        ]
+
+    if periods is not None and not chart:
+        return None  # nothing happened in this window
+    return {"teams": teams, "chart": chart, "scores": scores, "longPlays": long_plays}

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -8985,6 +8985,52 @@ class CFBPlayProcess(object):
             "espn_players": espn_players,
         }
 
+    def create_drive_summary(self, play_df, drives, periods=None):
+        """Build the StatBroadcast-style drive summary for this game.
+
+        Thin delegate to
+        :func:`sportsdataverse.cfb.cfb_drive_summary.create_drive_summary`,
+        with the team ids read from the plays frame -- the drive-level
+        sibling of :meth:`create_box_score`.
+
+        Args:
+            play_df (pl.DataFrame): the post-pipeline plays frame
+                (``plays_frame``).
+            drives (list[dict]): the ESPN drives grouping in game order.
+            periods: optional window (a set of quarter numbers, or ``"ot"``).
+
+        Returns:
+            dict: the drive summary, or ``None`` when inputs are unusable.
+        """
+        from sportsdataverse.cfb.cfb_drive_summary import create_drive_summary
+
+        return create_drive_summary(
+            drives, play_df, play_df["homeTeamId"][0], play_df["awayTeamId"][0], periods=periods
+        )
+
+    def create_situational_stats(self, play_df, window_expr=None):
+        """Build the situational team-stats block for this game.
+
+        Thin delegate to
+        :func:`sportsdataverse.cfb.cfb_situational_stats.create_situational_stats`,
+        with the team ids read from the plays frame.
+
+        Args:
+            play_df (pl.DataFrame): the post-pipeline plays frame
+                (``plays_frame``).
+            window_expr: optional polars filter windowing the windowable
+                sections (e.g. ``pl.col("period") == 3``).
+
+        Returns:
+            dict: the situational stats, or ``None`` when the frame is
+            unusable or the window is empty.
+        """
+        from sportsdataverse.cfb.cfb_situational_stats import create_situational_stats
+
+        return create_situational_stats(
+            play_df, play_df["homeTeamId"][0], play_df["awayTeamId"][0], window_expr=window_expr
+        )
+
     def __join_participants(self, play_df):
         """Join ESPN play participants to overwrite regex-extracted player names with clean display names.
 

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -8985,7 +8985,7 @@ class CFBPlayProcess(object):
             "espn_players": espn_players,
         }
 
-    def create_drive_summary(self, play_df, drives, periods=None):
+    def create_drive_summary(self, play_df, drives, periods=None) -> dict | None:
         """Build the StatBroadcast-style drive summary for this game.
 
         Thin delegate to
@@ -9004,11 +9004,17 @@ class CFBPlayProcess(object):
         """
         from sportsdataverse.cfb.cfb_drive_summary import create_drive_summary
 
+        if (
+            not isinstance(play_df, pl.DataFrame)
+            or play_df.height == 0
+            or not {"homeTeamId", "awayTeamId"}.issubset(play_df.columns)
+        ):
+            return None
         return create_drive_summary(
             drives, play_df, play_df["homeTeamId"][0], play_df["awayTeamId"][0], periods=periods
         )
 
-    def create_situational_stats(self, play_df, window_expr=None):
+    def create_situational_stats(self, play_df, window_expr=None) -> dict | None:
         """Build the situational team-stats block for this game.
 
         Thin delegate to
@@ -9027,6 +9033,12 @@ class CFBPlayProcess(object):
         """
         from sportsdataverse.cfb.cfb_situational_stats import create_situational_stats
 
+        if (
+            not isinstance(play_df, pl.DataFrame)
+            or play_df.height == 0
+            or not {"homeTeamId", "awayTeamId"}.issubset(play_df.columns)
+        ):
+            return None
         return create_situational_stats(
             play_df, play_df["homeTeamId"][0], play_df["awayTeamId"][0], window_expr=window_expr
         )

--- a/sportsdataverse/cfb/cfb_situational_stats.py
+++ b/sportsdataverse/cfb/cfb_situational_stats.py
@@ -41,7 +41,12 @@ def _points(df):
     return int(df["pos_score_pts"].fill_null(0).sum()) if df.height else 0
 
 
-def create_situational_stats(frame, home_id, away_id, window_expr=None):
+def create_situational_stats(
+    frame: pl.DataFrame,
+    home_id: str | int,
+    away_id: str | int,
+    window_expr: pl.Expr | None = None,
+) -> dict | None:
     """Build the situational team-stats block from a plays frame.
 
     Window-inherent sections -- ``two_minute``, ``middle_8``, ``non_garbage``,
@@ -69,7 +74,68 @@ def create_situational_stats(frame, home_id, away_id, window_expr=None):
     """
     if not isinstance(frame, pl.DataFrame) or frame.height == 0:
         return None
-    needed = {"scrimmage_play", "pos_team", "EPA", "EPA_success", "pos_score_pts"}
+    # fail-open contract: every column this module touches must be present
+    # up front, so a partially-enriched frame returns None instead of raising
+    # ColumnNotFoundError deep inside a section
+    needed = {
+        "EPA",
+        "EPA_penalty",
+        "EPA_success",
+        "TFL",
+        "air_yards",
+        "completion",
+        "cpoe",
+        "distance",
+        "down",
+        "drive.id",
+        "fg_attempt",
+        "fg_made",
+        "firstD_by_penalty",
+        "first_down_created",
+        "fourth_down_recommendation",
+        "fumble_lost",
+        "fumble_vec",
+        "game_play_number",
+        "go_boost",
+        "goal_to_go",
+        "havoc",
+        "int",
+        "is_pos_team_turnover",
+        "line_yards",
+        "middle_8",
+        "open_field_yards",
+        "opportunity_run",
+        "pass",
+        "pass_breakup",
+        "pass_oe",
+        "penalty_1st_conv",
+        "penalty_declined",
+        "penalty_flag",
+        "penalty_team_id",
+        "period",
+        "pos_score_diff",
+        "pos_score_pts",
+        "pos_team",
+        "power_rush_attempt",
+        "power_rush_success",
+        "punt_play",
+        "rush",
+        "rz_play",
+        "sack",
+        "scoring_opp",
+        "scrimmage_play",
+        "second_level_yards",
+        "short_rush_attempt",
+        "short_rush_success",
+        "start.adj_TimeSecsRem",
+        "start.yardsToEndzone.touchback",
+        "statYardage",
+        "stuffed_run",
+        "touchdown",
+        "under_2",
+        "xp_attempt",
+        "yards_after_catch",
+    }
     if not needed.issubset(set(frame.columns)):
         return None
 
@@ -96,9 +162,7 @@ def create_situational_stats(frame, home_id, away_id, window_expr=None):
         # are already attributed by pos_team, so drive.id is safe HERE) ------
         rz = mine.filter(_TRUE("rz_play"))
         rz_trips = rz["drive.id"].n_unique() if rz.height else 0
-        rz_tds = (
-            rz.filter(_TRUE("touchdown"))["drive.id"].n_unique() if rz.height else 0
-        )
+        rz_tds = rz.filter(_TRUE("touchdown"))["drive.id"].n_unique() if rz.height else 0
         rz_fgs = rz.filter(_TRUE("fg_made"))["drive.id"].n_unique() if rz.height else 0
         t["red_zone"] = {
             **_grp(rz),
@@ -130,9 +194,7 @@ def create_situational_stats(frame, home_id, away_id, window_expr=None):
             entry = {
                 **_grp(dd),
                 "avg_distance": _num(dd["distance"].mean(), 1) if dd.height else None,
-                "yards_per_play": _num(dd["statYardage"].mean(), 1)
-                if dd.height
-                else None,
+                "yards_per_play": _num(dd["statYardage"].mean(), 1) if dd.height else None,
                 "rush": {
                     "att": d_rush.height,
                     "yards": int(d_rush["statYardage"].fill_null(0).sum()),
@@ -142,12 +204,8 @@ def create_situational_stats(frame, home_id, away_id, window_expr=None):
                     "comp": d_pass.filter(_TRUE("completion")).height,
                     "yards": int(d_pass["statYardage"].fill_null(0).sum()),
                 },
-                "pass_rate": _num(dd.select(_TRUE("pass").mean()).item())
-                if dd.height
-                else None,
-                "pass_rate_over_expected": _num(dd["pass_oe"].mean())
-                if dd.height
-                else None,
+                "pass_rate": _num(dd.select(_TRUE("pass").mean()).item()) if dd.height else None,
+                "pass_rate_over_expected": _num(dd["pass_oe"].mean()) if dd.height else None,
             }
             if down in (3, 4):
                 conv_df = dd.filter(_TRUE("first_down_created") | _TRUE("touchdown"))
@@ -166,9 +224,7 @@ def create_situational_stats(frame, home_id, away_id, window_expr=None):
                     ("long", 7, 99),
                 ):
                     bb = dd.filter(pl.col("distance").is_between(lo, hi))
-                    made = bb.filter(
-                        _TRUE("first_down_created") | _TRUE("touchdown")
-                    ).height
+                    made = bb.filter(_TRUE("first_down_created") | _TRUE("touchdown")).height
                     buckets[name] = {"made": made, "att": bb.height}
                 entry["by_distance"] = buckets
             downs[f"down_{down}"] = entry
@@ -176,11 +232,7 @@ def create_situational_stats(frame, home_id, away_id, window_expr=None):
 
         # --- rushing quality ------------------------------------------------
         rushes = mine.filter(_TRUE("rush"))
-        opp_att = (
-            int(rushes.select(_TRUE("opportunity_run").sum()).item())
-            if rushes.height
-            else 0
-        )
+        opp_att = int(rushes.select(_TRUE("opportunity_run").sum()).item()) if rushes.height else 0
         sacks = mine.filter(_TRUE("sack"))
         sack_yds = int(sacks["statYardage"].fill_null(0).sum())
         rush_yds = int(rushes["statYardage"].fill_null(0).sum())
@@ -190,20 +242,14 @@ def create_situational_stats(frame, home_id, away_id, window_expr=None):
             # sack-adjusted by construction: the rush flag never covers sacks
             "yards_per_rush": _num(rushes["statYardage"].mean(), 1),
             # official NCAA team rushing folds sacks in
-            "yards_per_rush_with_sacks": _num(
-                (rush_yds + sack_yds) / (rushes.height + sacks.height), 1
-            )
+            "yards_per_rush_with_sacks": _num((rush_yds + sack_yds) / (rushes.height + sacks.height), 1)
             if rushes.height + sacks.height
             else None,
             "line_yards_per_rush": _num(rushes["line_yards"].mean(), 2),
             "second_level_per_rush": _num(rushes["second_level_yards"].mean(), 2),
             "open_field_per_rush": _num(rushes["open_field_yards"].mean(), 2),
-            "stuff_rate": _num(rushes.select(_TRUE("stuffed_run").mean()).item())
-            if rushes.height
-            else None,
-            "opportunity_rate": _num(opp_att / rushes.height)
-            if rushes.height
-            else None,
+            "stuff_rate": _num(rushes.select(_TRUE("stuffed_run").mean()).item()) if rushes.height else None,
+            "opportunity_rate": _num(opp_att / rushes.height) if rushes.height else None,
             "power": {
                 "made": int(mine.select(_TRUE("power_rush_success").sum()).item()),
                 "att": int(mine.select(_TRUE("power_rush_attempt").sum()).item()),
@@ -255,20 +301,14 @@ def create_situational_stats(frame, home_id, away_id, window_expr=None):
 
         t["big_plays"] = {
             "plays": bp_pass.height + bp_rush.height,
-            "yards": int(
-                bp_pass["statYardage"].fill_null(0).sum()
-                + bp_rush["statYardage"].fill_null(0).sum()
-            ),
-            "touchdowns": bp_pass.filter(_TRUE("touchdown")).height
-            + bp_rush.filter(_TRUE("touchdown")).height,
+            "yards": int(bp_pass["statYardage"].fill_null(0).sum() + bp_rush["statYardage"].fill_null(0).sum()),
+            "touchdowns": bp_pass.filter(_TRUE("touchdown")).height + bp_rush.filter(_TRUE("touchdown")).height,
             "pass": _bp(bp_pass),
             "rush": _bp(bp_rush),
         }
 
         # --- 4th-down decision report ---------------------------------------
-        fourth = mine.filter(
-            (pl.col("down") == 4) & pl.col("fourth_down_recommendation").is_not_null()
-        )
+        fourth = mine.filter((pl.col("down") == 4) & pl.col("fourth_down_recommendation").is_not_null())
         went = fourth.filter(
             _TRUE("scrimmage_play")
             & (_TRUE("punt_play") == False)
@@ -277,21 +317,11 @@ def create_situational_stats(frame, home_id, away_id, window_expr=None):
         )  # noqa: E712
         agree = 0
         forgone = 0.0
-        for r in fourth.select(
-            ["fourth_down_recommendation", "punt_play", "fg_attempt", "go_boost"]
-        ).to_dicts():
-            actual = (
-                "punt"
-                if r.get("punt_play")
-                else "field_goal"
-                if r.get("fg_attempt")
-                else "go"
-            )
+        for r in fourth.select(["fourth_down_recommendation", "punt_play", "fg_attempt", "go_boost"]).to_dicts():
+            actual = "punt" if r.get("punt_play") else "field_goal" if r.get("fg_attempt") else "go"
             if actual == r["fourth_down_recommendation"]:
                 agree += 1
-            elif (
-                r["fourth_down_recommendation"] == "go" and (r.get("go_boost") or 0) > 0
-            ):
+            elif r["fourth_down_recommendation"] == "go" and (r.get("go_boost") or 0) > 0:
                 forgone += r["go_boost"]
         t["fourth_down_decisions"] = {
             "decisions": fourth.height,
@@ -311,9 +341,7 @@ def create_situational_stats(frame, home_id, away_id, window_expr=None):
             ss = mine.filter(expr)
             states[name] = {
                 **_grp(ss),
-                "pass_rate": _num(ss.select(_TRUE("pass").mean()).item())
-                if ss.height
-                else None,
+                "pass_rate": _num(ss.select(_TRUE("pass").mean()).item()) if ss.height else None,
             }
         t["score_state"] = states
 
@@ -327,30 +355,19 @@ def create_situational_stats(frame, home_id, away_id, window_expr=None):
             "accepted": my_pens.height,
             "drive_extending_committed": int(
                 frame.select(
-                    (
-                        _TRUE("penalty_1st_conv")
-                        & (pl.col("penalty_team_id").cast(pl.Utf8) == tid)
-                    ).sum()
+                    (_TRUE("penalty_1st_conv") & (pl.col("penalty_team_id").cast(pl.Utf8) == tid)).sum()
                 ).item()
             ),
             "epa_swing": _num(my_pens["EPA_penalty"].fill_null(0).sum(), 2),
-            "by_quarter": {
-                int(k): int(v)
-                for k, v in my_pens.group_by("period").len().iter_rows()
-                if k is not None
-            },
+            "by_quarter": {int(k): int(v) for k, v in my_pens.group_by("period").len().iter_rows() if k is not None},
         }
 
         # --- havoc created (defense = opponent offensive snaps) -------------
         faced = opp_off
         t["havoc_created"] = {
-            "rate": _num(faced.select(_TRUE("havoc").mean()).item())
-            if faced.height
-            else None,
+            "rate": _num(faced.select(_TRUE("havoc").mean()).item()) if faced.height else None,
             "front_seven": int(faced.select(_TRUE("TFL").sum()).item()),
-            "secondary": int(
-                faced.select((_TRUE("pass_breakup") | _TRUE("int")).sum()).item()
-            ),
+            "secondary": int(faced.select((_TRUE("pass_breakup") | _TRUE("int")).sum()).item()),
         }
 
         # --- turnovers -------------------------------------------------------
@@ -384,17 +401,13 @@ def create_situational_stats(frame, home_id, away_id, window_expr=None):
         if mine.height > 1:
             ordered = (
                 mine.sort("game_play_number")
-                .select(
-                    ["drive.id", "period", "start.adj_TimeSecsRem", "pos_score_diff"]
-                )
+                .select(["drive.id", "period", "start.adj_TimeSecsRem", "pos_score_diff"])
                 .to_dicts()
             )
             for i in range(len(ordered) - 1):
                 a, b = ordered[i], ordered[i + 1]
                 if a["drive.id"] == b["drive.id"] and a["period"] == b["period"]:
-                    dt = (a["start.adj_TimeSecsRem"] or 0) - (
-                        b["start.adj_TimeSecsRem"] or 0
-                    )
+                    dt = (a["start.adj_TimeSecsRem"] or 0) - (b["start.adj_TimeSecsRem"] or 0)
                     if 0 < dt <= 60:
                         secs.append((dt, a["period"], a["pos_score_diff"] or 0))
 
@@ -410,7 +423,7 @@ def create_situational_stats(frame, home_id, away_id, window_expr=None):
         }
 
         # --- garbage-time filter (derived): the spice-level heuristic -------
-        margin = pl.col("pos_score_diff").abs()
+        margin = pl.col("pos_score_diff").fill_null(0).abs()
         garbage = (
             ((pl.col("period") == 2) & (margin > 38))
             | ((pl.col("period") == 3) & (margin > 28))

--- a/sportsdataverse/cfb/cfb_situational_stats.py
+++ b/sportsdataverse/cfb/cfb_situational_stats.py
@@ -1,0 +1,428 @@
+"""Situational team stats computed from the enriched plays frame.
+
+Every section aggregates the enriched frame sdv-py retains as ``plays_frame``
+(sdv-py #464); nothing here re-derives play-level modeling. Points columns use
+``pos_score_pts`` -- points the OFFENSE scored on its own snaps (defensive and
+return touchdowns are deliberately excluded, matching how "red zone points" or
+"two-minute points" read).
+
+Derivations beyond raw flags, per the metrics note:
+- pace: seconds per play from within-drive clock deltas (cross-drive and
+  cross-period gaps never count);
+- garbage time: the scoreboard heuristic the site's spice levels use
+  (up 38+ in Q2, 28+ in Q3, 22+ in Q4) -- non-garbage EPA ships next to raw;
+- depth of target: bucketed from air_yards (behind / short 0-9 / medium
+  10-19 / deep 20+); ESPN's pass_depth field is empty in practice.
+"""
+
+import polars as pl
+
+__all__ = ["create_situational_stats"]
+
+_TRUE = lambda c: pl.col(c) == True  # noqa: E712, E731
+
+
+def _num(v, digits=3):
+    return None if v is None else round(float(v), digits)
+
+
+def _grp(df):
+    """plays / EPA per play / success rate for a slice."""
+    if df.height == 0:
+        return {"plays": 0, "epa_play": None, "success_rate": None}
+    return {
+        "plays": df.height,
+        "epa_play": _num(df["EPA"].mean()),
+        "success_rate": _num(df["EPA_success"].mean()),
+    }
+
+
+def _points(df):
+    return int(df["pos_score_pts"].fill_null(0).sum()) if df.height else 0
+
+
+def create_situational_stats(frame, home_id, away_id, window_expr=None):
+    """Build the situational team-stats block from a plays frame.
+
+    Window-inherent sections -- ``two_minute``, ``middle_8``, ``non_garbage``,
+    ``pace``, ``fourth_down_decisions`` -- are omitted from a windowed build:
+    they are themselves time windows or game-level filters, and
+    double-windowing them is a category error.
+
+    Args:
+        frame (pl.DataFrame): the enriched plays frame from
+            :meth:`CFBPlayProcess.run_processing_pipeline` (``plays_frame``).
+        home_id: ESPN home team id.
+        away_id: ESPN away team id.
+        window_expr: optional polars filter expression windowing the
+            windowable sections to that slice (e.g.
+            ``pl.col("period") == 3``). ``None`` = full game.
+
+    Returns:
+        dict: ``{"teams": {<team_id>: {<section>: ...}}}`` or ``None`` when
+        the frame is unusable or the window is empty.
+
+    Example:
+        Full-game stats from a processed game::
+
+            stats = create_situational_stats(game.plays_frame, "52", "61")
+    """
+    if not isinstance(frame, pl.DataFrame) or frame.height == 0:
+        return None
+    needed = {"scrimmage_play", "pos_team", "EPA", "EPA_success", "pos_score_pts"}
+    if not needed.issubset(set(frame.columns)):
+        return None
+
+    if window_expr is not None:
+        frame = frame.filter(window_expr)
+        if frame.height == 0:
+            return None
+
+    scrim = frame.filter(_TRUE("scrimmage_play"))
+    out = {}
+    for tid in (str(home_id), str(away_id)):
+        mine = scrim.filter(pl.col("pos_team").cast(pl.Utf8) == tid)
+        opp_off = scrim.filter(pl.col("pos_team").cast(pl.Utf8) != tid)
+        t = {}
+
+        # --- clutch windows (window-inherent: full-game builds only) --------
+        if window_expr is None:
+            u2 = mine.filter(_TRUE("under_2"))
+            t["two_minute"] = {**_grp(u2), "points": _points(u2)}
+            m8 = mine.filter(_TRUE("middle_8"))
+            t["middle_8"] = {**_grp(m8), "points": _points(m8)}
+
+        # --- red zone / finishing drives (trips need drive identity; plays
+        # are already attributed by pos_team, so drive.id is safe HERE) ------
+        rz = mine.filter(_TRUE("rz_play"))
+        rz_trips = rz["drive.id"].n_unique() if rz.height else 0
+        rz_tds = (
+            rz.filter(_TRUE("touchdown"))["drive.id"].n_unique() if rz.height else 0
+        )
+        rz_fgs = rz.filter(_TRUE("fg_made"))["drive.id"].n_unique() if rz.height else 0
+        t["red_zone"] = {
+            **_grp(rz),
+            "trips": rz_trips,
+            "td_trips": rz_tds,
+            "fg_trips": rz_fgs,
+            "points": _points(rz),
+            "points_per_trip": _num(_points(rz) / rz_trips, 2) if rz_trips else None,
+        }
+        g2g = mine.filter(_TRUE("goal_to_go"))
+        t["goal_to_go"] = {
+            **_grp(g2g),
+            "tds": int(g2g.filter(_TRUE("touchdown")).height),
+        }
+        so = mine.filter(_TRUE("scoring_opp"))
+        so_trips = so["drive.id"].n_unique() if so.height else 0
+        t["finishing_drives"] = {
+            "trips": so_trips,
+            "points": _points(so),
+            "points_per_trip": _num(_points(so) / so_trips, 2) if so_trips else None,
+        }
+
+        # --- down-by-down with distance tendencies --------------------------
+        downs = {}
+        for down in (1, 2, 3, 4):
+            dd = mine.filter(pl.col("down") == down)
+            d_rush = dd.filter(_TRUE("rush"))
+            d_pass = dd.filter(_TRUE("pass") & (_TRUE("sack") == False))  # noqa: E712
+            entry = {
+                **_grp(dd),
+                "avg_distance": _num(dd["distance"].mean(), 1) if dd.height else None,
+                "yards_per_play": _num(dd["statYardage"].mean(), 1)
+                if dd.height
+                else None,
+                "rush": {
+                    "att": d_rush.height,
+                    "yards": int(d_rush["statYardage"].fill_null(0).sum()),
+                },
+                "pass": {
+                    "att": d_pass.height,
+                    "comp": d_pass.filter(_TRUE("completion")).height,
+                    "yards": int(d_pass["statYardage"].fill_null(0).sum()),
+                },
+                "pass_rate": _num(dd.select(_TRUE("pass").mean()).item())
+                if dd.height
+                else None,
+                "pass_rate_over_expected": _num(dd["pass_oe"].mean())
+                if dd.height
+                else None,
+            }
+            if down in (3, 4):
+                conv_df = dd.filter(_TRUE("first_down_created") | _TRUE("touchdown"))
+                entry["conversions"] = {"made": conv_df.height, "att": dd.height}
+                # how conversions happened: through the air, on the ground,
+                # or gifted by penalty (the game-book attribution)
+                entry["conversions_by"] = {
+                    "rush": conv_df.filter(_TRUE("rush")).height,
+                    "pass": conv_df.filter(_TRUE("pass")).height,
+                    "penalty": dd.filter(_TRUE("firstD_by_penalty")).height,
+                }
+                buckets = {}
+                for name, lo, hi in (
+                    ("short", 0, 3),
+                    ("medium", 4, 6),
+                    ("long", 7, 99),
+                ):
+                    bb = dd.filter(pl.col("distance").is_between(lo, hi))
+                    made = bb.filter(
+                        _TRUE("first_down_created") | _TRUE("touchdown")
+                    ).height
+                    buckets[name] = {"made": made, "att": bb.height}
+                entry["by_distance"] = buckets
+            downs[f"down_{down}"] = entry
+        t["downs"] = downs
+
+        # --- rushing quality ------------------------------------------------
+        rushes = mine.filter(_TRUE("rush"))
+        opp_att = (
+            int(rushes.select(_TRUE("opportunity_run").sum()).item())
+            if rushes.height
+            else 0
+        )
+        sacks = mine.filter(_TRUE("sack"))
+        sack_yds = int(sacks["statYardage"].fill_null(0).sum())
+        rush_yds = int(rushes["statYardage"].fill_null(0).sum())
+        t["rushing_quality"] = {
+            "attempts": rushes.height,
+            "yards": rush_yds,
+            # sack-adjusted by construction: the rush flag never covers sacks
+            "yards_per_rush": _num(rushes["statYardage"].mean(), 1),
+            # official NCAA team rushing folds sacks in
+            "yards_per_rush_with_sacks": _num(
+                (rush_yds + sack_yds) / (rushes.height + sacks.height), 1
+            )
+            if rushes.height + sacks.height
+            else None,
+            "line_yards_per_rush": _num(rushes["line_yards"].mean(), 2),
+            "second_level_per_rush": _num(rushes["second_level_yards"].mean(), 2),
+            "open_field_per_rush": _num(rushes["open_field_yards"].mean(), 2),
+            "stuff_rate": _num(rushes.select(_TRUE("stuffed_run").mean()).item())
+            if rushes.height
+            else None,
+            "opportunity_rate": _num(opp_att / rushes.height)
+            if rushes.height
+            else None,
+            "power": {
+                "made": int(mine.select(_TRUE("power_rush_success").sum()).item()),
+                "att": int(mine.select(_TRUE("power_rush_attempt").sum()).item()),
+            },
+            "short_yardage": {
+                "made": int(mine.select(_TRUE("short_rush_success").sum()).item()),
+                "att": int(mine.select(_TRUE("short_rush_attempt").sum()).item()),
+            },
+        }
+
+        # --- passing profile (air_yards buckets; pass_depth ships empty) ----
+        passes = mine.filter(_TRUE("pass") & (_TRUE("sack") == False))  # noqa: E712
+        comps = passes.filter(_TRUE("completion"))
+        depth = {}
+        for name, lo, hi in (
+            ("behind_los", -99, -1),
+            ("short", 0, 9),
+            ("medium", 10, 19),
+            ("deep", 20, 99),
+        ):
+            bb = passes.filter(pl.col("air_yards").is_between(lo, hi))
+            depth[name] = {
+                **_grp(bb),
+                "completions": bb.filter(_TRUE("completion")).height,
+            }
+        t["passing_profile"] = {
+            "attempts": passes.height,
+            "dropbacks": int(mine.select(_TRUE("pass").sum()).item()),
+            "sacks_taken": {"count": sacks.height, "yards_lost": -sack_yds},
+            "yards_per_attempt": _num(passes["statYardage"].mean(), 1),
+            "yards_per_completion": _num(comps["statYardage"].mean(), 1),
+            "air_yards_per_att": _num(passes["air_yards"].mean(), 2),
+            "yac_per_completion": _num(comps["yards_after_catch"].mean(), 2),
+            "cpoe": _num(passes["cpoe"].mean()),
+            "by_depth": depth,
+        }
+
+        # --- big plays: pass of 15+ / rush of 10+ ---------------------------
+        bp_pass = mine.filter(_TRUE("pass") & (pl.col("statYardage") >= 15))
+        bp_rush = mine.filter(_TRUE("rush") & (pl.col("statYardage") >= 10))
+
+        def _bp(df):
+            return {
+                "plays": df.height,
+                "yards": int(df["statYardage"].fill_null(0).sum()),
+                "long": int(df["statYardage"].max()) if df.height else None,
+                "touchdowns": df.filter(_TRUE("touchdown")).height,
+            }
+
+        t["big_plays"] = {
+            "plays": bp_pass.height + bp_rush.height,
+            "yards": int(
+                bp_pass["statYardage"].fill_null(0).sum()
+                + bp_rush["statYardage"].fill_null(0).sum()
+            ),
+            "touchdowns": bp_pass.filter(_TRUE("touchdown")).height
+            + bp_rush.filter(_TRUE("touchdown")).height,
+            "pass": _bp(bp_pass),
+            "rush": _bp(bp_rush),
+        }
+
+        # --- 4th-down decision report ---------------------------------------
+        fourth = mine.filter(
+            (pl.col("down") == 4) & pl.col("fourth_down_recommendation").is_not_null()
+        )
+        went = fourth.filter(
+            _TRUE("scrimmage_play")
+            & (_TRUE("punt_play") == False)
+            & (_TRUE("fg_attempt") == False)
+            & (_TRUE("xp_attempt") == False)
+        )  # noqa: E712
+        agree = 0
+        forgone = 0.0
+        for r in fourth.select(
+            ["fourth_down_recommendation", "punt_play", "fg_attempt", "go_boost"]
+        ).to_dicts():
+            actual = (
+                "punt"
+                if r.get("punt_play")
+                else "field_goal"
+                if r.get("fg_attempt")
+                else "go"
+            )
+            if actual == r["fourth_down_recommendation"]:
+                agree += 1
+            elif (
+                r["fourth_down_recommendation"] == "go" and (r.get("go_boost") or 0) > 0
+            ):
+                forgone += r["go_boost"]
+        t["fourth_down_decisions"] = {
+            "decisions": fourth.height,
+            "went_for_it": went.height,
+            "agreed_with_model": agree,
+            "agreement_rate": _num(agree / fourth.height) if fourth.height else None,
+            "go_wp_forgone": _num(forgone, 2),
+        }
+
+        # --- score-state splits ---------------------------------------------
+        states = {}
+        for name, expr in (
+            ("leading", pl.col("pos_score_diff") > 0),
+            ("tied", pl.col("pos_score_diff") == 0),
+            ("trailing", pl.col("pos_score_diff") < 0),
+        ):
+            ss = mine.filter(expr)
+            states[name] = {
+                **_grp(ss),
+                "pass_rate": _num(ss.select(_TRUE("pass").mean()).item())
+                if ss.height
+                else None,
+            }
+        t["score_state"] = states
+
+        # --- penalties, situational -----------------------------------------
+        my_pens = frame.filter(
+            _TRUE("penalty_flag")
+            & (_TRUE("penalty_declined") == False)  # noqa: E712
+            & (pl.col("penalty_team_id").cast(pl.Utf8) == tid)
+        )
+        t["penalties_situational"] = {
+            "accepted": my_pens.height,
+            "drive_extending_committed": int(
+                frame.select(
+                    (
+                        _TRUE("penalty_1st_conv")
+                        & (pl.col("penalty_team_id").cast(pl.Utf8) == tid)
+                    ).sum()
+                ).item()
+            ),
+            "epa_swing": _num(my_pens["EPA_penalty"].fill_null(0).sum(), 2),
+            "by_quarter": {
+                int(k): int(v)
+                for k, v in my_pens.group_by("period").len().iter_rows()
+                if k is not None
+            },
+        }
+
+        # --- havoc created (defense = opponent offensive snaps) -------------
+        faced = opp_off
+        t["havoc_created"] = {
+            "rate": _num(faced.select(_TRUE("havoc").mean()).item())
+            if faced.height
+            else None,
+            "front_seven": int(faced.select(_TRUE("TFL").sum()).item()),
+            "secondary": int(
+                faced.select((_TRUE("pass_breakup") | _TRUE("int")).sum()).item()
+            ),
+        }
+
+        # --- turnovers -------------------------------------------------------
+        my_tos = mine.filter(_TRUE("is_pos_team_turnover"))
+        my_fumbles = mine.filter(_TRUE("fumble_vec"))
+        t["turnovers"] = {
+            "committed": my_tos.height,
+            "epa_swing": _num(my_tos["EPA"].fill_null(0).sum(), 2),
+            "fumbles": my_fumbles.height,
+            "fumbles_lost": int(mine.select(_TRUE("fumble_lost").sum()).item()),
+        }
+
+        # --- field-zone success ---------------------------------------------
+        zones = {}
+        for name, lo, hi in (
+            ("backed_up", 81, 100),
+            ("own_side", 51, 80),
+            ("plus_territory", 21, 50),
+            ("red_zone", 0, 20),
+        ):
+            zz = (
+                mine.filter(pl.col("start.yardsToEndzone.touchback").is_between(lo, hi))
+                if "start.yardsToEndzone.touchback" in mine.columns
+                else mine.head(0)
+            )
+            zones[name] = _grp(zz)
+        t["field_zones"] = zones
+
+        # --- pace (derived): within-drive clock deltas ----------------------
+        secs = []
+        if mine.height > 1:
+            ordered = (
+                mine.sort("game_play_number")
+                .select(
+                    ["drive.id", "period", "start.adj_TimeSecsRem", "pos_score_diff"]
+                )
+                .to_dicts()
+            )
+            for i in range(len(ordered) - 1):
+                a, b = ordered[i], ordered[i + 1]
+                if a["drive.id"] == b["drive.id"] and a["period"] == b["period"]:
+                    dt = (a["start.adj_TimeSecsRem"] or 0) - (
+                        b["start.adj_TimeSecsRem"] or 0
+                    )
+                    if 0 < dt <= 60:
+                        secs.append((dt, a["period"], a["pos_score_diff"] or 0))
+
+        def pace(rows):
+            return _num(sum(r[0] for r in rows) / len(rows), 1) if rows else None
+
+        t["pace"] = {
+            "seconds_per_play": pace(secs),
+            "first_half": pace([r for r in secs if r[1] <= 2]),
+            "second_half": pace([r for r in secs if r[1] > 2]),
+            "leading": pace([r for r in secs if r[2] > 0]),
+            "trailing": pace([r for r in secs if r[2] < 0]),
+        }
+
+        # --- garbage-time filter (derived): the spice-level heuristic -------
+        margin = pl.col("pos_score_diff").abs()
+        garbage = (
+            ((pl.col("period") == 2) & (margin > 38))
+            | ((pl.col("period") == 3) & (margin > 28))
+            | ((pl.col("period") >= 4) & (margin > 22))
+        )
+        t["non_garbage"] = _grp(mine.filter(~garbage))
+
+        if window_expr is not None:
+            # window-inherent or sample-size-noise sections never ship on a
+            # windowed build (two_minute/middle_8 were skipped above)
+            for k in ("fourth_down_decisions", "pace", "non_garbage"):
+                t.pop(k, None)
+
+        out[tid] = t
+    return {"teams": out}

--- a/sportsdataverse/parsed/cfb.py
+++ b/sportsdataverse/parsed/cfb.py
@@ -361,6 +361,8 @@ from sportsdataverse.cfb import cfb_standings as cfb_standings  # noqa: F401
 from sportsdataverse.cfb import cfb_teams_crosswalk as cfb_teams_crosswalk  # noqa: F401
 from sportsdataverse.cfb import cfb_transfer_impact as cfb_transfer_impact  # noqa: F401
 from sportsdataverse.cfb import cfb_transfer_moves as cfb_transfer_moves  # noqa: F401
+from sportsdataverse.cfb import create_drive_summary as create_drive_summary  # noqa: F401
+from sportsdataverse.cfb import create_situational_stats as create_situational_stats  # noqa: F401
 from sportsdataverse.cfb import download as download  # noqa: F401
 from sportsdataverse.cfb import efficiency_ratings as efficiency_ratings  # noqa: F401
 from sportsdataverse.cfb import espn_cfb_calendar as espn_cfb_calendar  # noqa: F401
@@ -515,6 +517,8 @@ __all__ = [
     "cfb_teams_crosswalk",
     "cfb_transfer_impact",
     "cfb_transfer_moves",
+    "create_drive_summary",
+    "create_situational_stats",
     "download",
     "efficiency_ratings",
     "espn_cfb_award",

--- a/tests/cfb/test_cfb_drive_summary.py
+++ b/tests/cfb/test_cfb_drive_summary.py
@@ -81,21 +81,15 @@ def _frame():
 def _drives():
     return [
         # home: 75-yd TD drive (available-yards success + fd success via score)
-        _drive(
-            HOME, "d1", "TD", 75, 8, "3:10", 25, 1, is_score=True, last_score=(7, 0)
-        ),
+        _drive(HOME, "d1", "TD", 75, 8, "3:10", 25, 1, is_score=True, last_score=(7, 0)),
         # away: three-and-out (forced by home)
         _drive(AWAY, "dX", "PUNT", 4, 3, "1:20", 20, 1, last_score=(7, 0)),
         # home: interception thrown
         _drive(HOME, "d2", "INT", 10, 4, "2:00", 30, 2, last_score=(7, 0)),
         # away: ensuing possession scores -> points off turnovers
-        _drive(
-            AWAY, "d3", "TD", 60, 7, "5:10", 40, 2, is_score=True, last_score=(7, 7)
-        ),
+        _drive(AWAY, "d3", "TD", 60, 7, "5:10", 40, 2, is_score=True, last_score=(7, 7)),
         # away: field goal, 12-play drive
-        _drive(
-            AWAY, "d4", "FG", 40, 12, "6:01", 35, 3, is_score=True, last_score=(7, 10)
-        ),
+        _drive(AWAY, "d4", "FG", 40, 12, "6:01", 35, 3, is_score=True, last_score=(7, 10)),
         # home: downs, no first down (fails both success metrics)
         _drive(HOME, "d5", "DOWNS", 9, 4, "0:50", 45, 4, last_score=(7, 10)),
     ]
@@ -139,9 +133,7 @@ def test_drive_summary_frame_aggregates():
     assert h["time_tied_seconds"] == 300
     # long plays sorted, positive gains only, per team
     assert out["longPlays"][AWAY][0]["yards"] == 45
-    assert all(
-        p["yards"] > 0 for ps in out["longPlays"].values() for ps in [ps] for p in ps
-    )
+    assert all(p["yards"] > 0 for ps in out["longPlays"].values() for ps in [ps] for p in ps)
 
 
 def test_drive_chart_obtained_and_scores():
@@ -205,3 +197,17 @@ def test_playprocess_delegate_matches_module():
     direct = drive_summary.create_drive_summary(_drives(), _frame(), HOME, AWAY)
     via_method = CFBPlayProcess.create_drive_summary(object(), _frame(), _drives())
     assert via_method == direct
+
+
+def test_accepts_raw_espn_drives_grouping():
+    grouping = {"previous": _drives()[:-1], "current": _drives()[-1]}
+    flat = drive_summary.create_drive_summary(_drives(), _frame(), HOME, AWAY)
+    from_grouping = drive_summary.create_drive_summary(grouping, _frame(), HOME, AWAY)
+    assert from_grouping == flat
+
+
+def test_delegate_fails_open_on_unusable_frame():
+    from sportsdataverse.cfb.cfb_pbp import CFBPlayProcess
+
+    assert CFBPlayProcess.create_drive_summary(object(), pl.DataFrame(), _drives()) is None
+    assert CFBPlayProcess.create_drive_summary(object(), None, _drives()) is None

--- a/tests/cfb/test_cfb_drive_summary.py
+++ b/tests/cfb/test_cfb_drive_summary.py
@@ -1,0 +1,207 @@
+import polars as pl
+
+from sportsdataverse.cfb import cfb_drive_summary as drive_summary
+
+HOME, AWAY = "10", "20"
+
+
+def _drive(
+    tid,
+    drive_id,
+    result,
+    yards,
+    plays,
+    top,
+    start_yl,
+    period,
+    is_score=False,
+    last_score=(0, 0),
+    start_text=None,
+):
+    return {
+        "id": drive_id,
+        "team": {"id": tid, "abbreviation": "HH" if tid == "10" else "AA"},
+        "result": result,
+        "isScore": is_score,
+        "yards": yards,
+        "offensivePlays": plays,
+        "timeElapsed": {"displayValue": top},
+        "start": {
+            "yardLine": start_yl,
+            "period": {"number": period},
+            "clock": {"displayValue": "12:00"},
+            "text": start_text or "",
+        },
+        "end": {"text": "T 50", "clock": {"displayValue": "09:00"}},
+        "description": f"{plays} plays, {yards} yards",
+        "plays": [
+            {
+                "homeScore": last_score[0],
+                "awayScore": last_score[1],
+                "text": "the finishing play",
+                "scoringPlay": is_score,
+            },
+            # trailing post-score penalty entry must NOT win
+            {
+                "homeScore": last_score[0],
+                "awayScore": last_score[1],
+                "text": "PENALTY after the play",
+            },
+        ],
+    }
+
+
+def _frame():
+    # scrimmage plays across two teams; enough flags for the aggregates
+    return pl.DataFrame(
+        {
+            "game_play_number": [1, 2, 3, 4, 5, 6],
+            "scrimmage_play": [True] * 6,
+            "pos_team": [10, 10, 10, 20, 20, 20],
+            "down": [1, 3, 3, 1, 3, 4],
+            "distance": [10, 4, 9, 10, 2, 1],
+            "first_down_created": [True, True, True, False, False, True],
+            "firstD_by_penalty": [False, False, False, True, False, False],
+            "touchdown": [False, False, False, False, False, False],
+            "rush": [True, False, False, False, True, True],
+            "pass": [False, True, True, True, False, False],
+            "period": [1, 1, 2, 2, 3, 4],
+            "statYardage": [12, 6, 0, 45, 3, 1],
+            "text": ["a", "b", "c", "big gain", "e", "f"],
+            "start.adj_TimeSecsRem": [3600.0, 3300.0, 1800.0, 1500.0, 900.0, 300.0],
+            "start.homeScore": [0, 0, 7, 7, 7, 7],
+            "start.awayScore": [0, 0, 0, 0, 10, 10],
+            "homeTeamId": [10] * 6,
+            "awayTeamId": [20] * 6,
+            "drive.id": ["d1", "d1", "d2", "d3", "d3", "d3"],
+        }
+    )
+
+
+def _drives():
+    return [
+        # home: 75-yd TD drive (available-yards success + fd success via score)
+        _drive(
+            HOME, "d1", "TD", 75, 8, "3:10", 25, 1, is_score=True, last_score=(7, 0)
+        ),
+        # away: three-and-out (forced by home)
+        _drive(AWAY, "dX", "PUNT", 4, 3, "1:20", 20, 1, last_score=(7, 0)),
+        # home: interception thrown
+        _drive(HOME, "d2", "INT", 10, 4, "2:00", 30, 2, last_score=(7, 0)),
+        # away: ensuing possession scores -> points off turnovers
+        _drive(
+            AWAY, "d3", "TD", 60, 7, "5:10", 40, 2, is_score=True, last_score=(7, 7)
+        ),
+        # away: field goal, 12-play drive
+        _drive(
+            AWAY, "d4", "FG", 40, 12, "6:01", 35, 3, is_score=True, last_score=(7, 10)
+        ),
+        # home: downs, no first down (fails both success metrics)
+        _drive(HOME, "d5", "DOWNS", 9, 4, "0:50", 45, 4, last_score=(7, 10)),
+    ]
+
+
+def test_drive_summary_counts_and_rates():
+    out = drive_summary.create_drive_summary(_drives(), _frame(), HOME, AWAY)
+    h, a = out["teams"][HOME], out["teams"][AWAY]
+
+    assert h["total_drives"] == 3 and a["total_drives"] == 3
+    assert h["scoring_drives"] == 1 and a["scoring_drives"] == 2
+    assert h["td_drives"] == 1 and a["td_drives"] == 1
+    assert a["three_and_outs"] == 1 and h["forced_three_and_outs"] == 1
+    # away scored the ensuing TD after home's INT
+    assert a["points_off_turnovers"] == 7 and h["points_off_turnovers"] == 0
+    # both success definitions, named separately: home TD drive succeeds both;
+    # d2 (INT, but first_down_created on its plays) succeeds fd only;
+    # d5 (DOWNS, no first down, 9/55 yds) fails both
+    assert h["drive_success_rate_fd"] == round(2 / 3, 3)
+    assert h["drive_success_rate_ay"] == round(1 / 3, 3)
+    # long-drive buckets
+    assert h["long_drives_70yds"] == 1 and a["long_drives_10plays"] == 1
+    assert a["drives_over_5min"] == 2 and h["drives_under_1min"] == 1
+
+
+def test_drive_summary_frame_aggregates():
+    out = drive_summary.create_drive_summary(_drives(), _frame(), HOME, AWAY)
+    h, a = out["teams"][HOME], out["teams"][AWAY]
+    assert h["avg_third_down_distance"] == 6.5  # (4+9)/2
+    assert h["third_downs"] == {"made": 2, "att": 2}
+    assert a["fourth_downs"] == {"made": 1, "att": 1}
+    assert h["first_downs"] == {"rush": 1, "pass": 2, "penalty": 0}
+    assert a["first_downs"] == {"rush": 1, "pass": 0, "penalty": 1}
+    # largest lead + score-state clock (home led 7-0 through the middle rows)
+    assert h["largest_lead"] == 7 and a["largest_lead"] == 3
+    # intervals belong to each play's OUTCOME: the opening TD drive's time
+    # counts as leading (not the tied pre-score state), and the tail after
+    # the last play carries the final score state
+    assert h["time_leading_seconds"] == 1800
+    assert a["time_leading_seconds"] == 1500
+    assert h["time_tied_seconds"] == 300
+    # long plays sorted, positive gains only, per team
+    assert out["longPlays"][AWAY][0]["yards"] == 45
+    assert all(
+        p["yards"] > 0 for ps in out["longPlays"].values() for ps in [ps] for p in ps
+    )
+
+
+def test_drive_chart_obtained_and_scores():
+    out = drive_summary.create_drive_summary(_drives(), _frame(), HOME, AWAY)
+    chart = out["chart"]
+    assert [c["obtained"] for c in chart] == ["KO", "KO", "PUNT", "INT", "KO", "KO"]
+    assert chart[2]["result"] == "INT" and chart[2]["plays"] == 4
+    # scores list carries the finishing play and the drive description
+    assert len(out["scores"]) == 3
+    assert out["scores"][0]["finishing_play"] == "the finishing play"
+
+
+def test_start_field_position_orientation():
+    # ESPN's yardLine axis is home-oriented; start.text is authoritative
+    drives = [
+        # home at its OWN 25 via text
+        _drive(HOME, "d1", "PUNT", 5, 4, "2:00", 25, 1, start_text="HH 25"),
+        # away at its OWN 25: text names the away side
+        _drive(AWAY, "d2", "PUNT", 5, 4, "2:00", 75, 1, start_text="AA 25"),
+        # away in HOME territory at the HH 30 -> 30 to go
+        _drive(AWAY, "d3", "PUNT", 5, 4, "2:00", 30, 2, start_text="HH 30"),
+        # no text: fall back to the home-oriented axis (away yte == yardLine)
+        _drive(AWAY, "d4", "PUNT", 5, 4, "2:00", 60, 3),
+    ]
+    out = drive_summary.create_drive_summary(drives, _frame(), HOME, AWAY)
+    assert out["teams"][HOME]["avg_start_yards_to_endzone"] == 75.0
+    # away: 75 (own 25) + 30 (opp 30) + 60 (fallback) -> 55.0
+    assert out["teams"][AWAY]["avg_start_yards_to_endzone"] == 55.0
+    assert out["teams"][HOME]["avg_start_text"] == "OWN 25"
+
+
+def test_drive_summary_fails_open_on_bad_inputs():
+    assert drive_summary.create_drive_summary([], _frame(), HOME, AWAY) is None
+    assert drive_summary.create_drive_summary(_drives(), pl.DataFrame(), HOME, AWAY) is None
+    assert drive_summary.create_drive_summary(_drives(), None, HOME, AWAY) is None
+
+
+def test_windowed_build_books_drives_to_start_quarter():
+    out = drive_summary.create_drive_summary(_drives(), _frame(), HOME, AWAY, periods={2})
+    h, a = out["teams"][HOME], out["teams"][AWAY]
+    # Q2: home's INT drive, away's ensuing TD -- and pts-off-TO still credits
+    # because the out-of-window context (running score, prev drive) is kept
+    assert h["total_drives"] == 1 and a["total_drives"] == 1
+    assert a["points_off_turnovers"] == 7
+    # game-level lines never ship on a windowed build
+    assert "largest_lead" not in h and "time_leading_seconds" not in h
+    # chart holds only in-window drives
+    assert [c["period"] for c in out["chart"]] == [2, 2]
+    # first-down sources window with everything else (incl. penalty count)
+    assert h["first_downs"] == {"rush": 0, "pass": 1, "penalty": 0}
+    assert a["first_downs"] == {"rush": 0, "pass": 0, "penalty": 1}
+
+
+def test_windowed_build_empty_window_is_none():
+    assert drive_summary.create_drive_summary(_drives(), _frame(), HOME, AWAY, periods="ot") is None
+
+
+def test_playprocess_delegate_matches_module():
+    from sportsdataverse.cfb.cfb_pbp import CFBPlayProcess
+
+    direct = drive_summary.create_drive_summary(_drives(), _frame(), HOME, AWAY)
+    via_method = CFBPlayProcess.create_drive_summary(object(), _frame(), _drives())
+    assert via_method == direct

--- a/tests/cfb/test_cfb_situational_stats.py
+++ b/tests/cfb/test_cfb_situational_stats.py
@@ -348,9 +348,7 @@ def test_situational_sections_and_values():
     assert a["penalties_situational"]["accepted"] == 1
     assert a["penalties_situational"]["epa_swing"] == -1.5
     # home's defense created the away havoc plays
-    assert (
-        h["havoc_created"]["front_seven"] == 1 and h["havoc_created"]["secondary"] == 1
-    )
+    assert h["havoc_created"]["front_seven"] == 1 and h["havoc_created"]["secondary"] == 1
     assert a["turnovers"]["committed"] == 1 and a["turnovers"]["epa_swing"] == -0.2
     assert h["field_zones"]["red_zone"]["plays"] == 2
     # pace: only same-drive same-period consecutive deltas count
@@ -376,18 +374,26 @@ def test_windowed_build_drops_window_inherent_sections():
 
 
 def test_windowed_build_empty_window_is_none():
-    assert (
-        situational_stats.create_situational_stats(_frame(), HOME, AWAY, window_expr=pl.col("period") > 90)
-        is None
-    )
+    assert situational_stats.create_situational_stats(_frame(), HOME, AWAY, window_expr=pl.col("period") > 90) is None
 
 
 def test_playprocess_delegate_matches_module():
     from sportsdataverse.cfb.cfb_pbp import CFBPlayProcess
 
-    f = _frame().with_columns(
-        homeTeamId=pl.lit(int(HOME)), awayTeamId=pl.lit(int(AWAY))
-    )
+    f = _frame().with_columns(homeTeamId=pl.lit(int(HOME)), awayTeamId=pl.lit(int(AWAY)))
     direct = situational_stats.create_situational_stats(f, HOME, AWAY)
     via_method = CFBPlayProcess.create_situational_stats(object(), f)
     assert via_method == direct
+
+
+def test_delegate_fails_open_on_unusable_frame():
+    from sportsdataverse.cfb.cfb_pbp import CFBPlayProcess
+
+    assert CFBPlayProcess.create_situational_stats(object(), pl.DataFrame()) is None
+    assert CFBPlayProcess.create_situational_stats(object(), None) is None
+
+
+def test_partially_enriched_frame_fails_open():
+    # the five original core columns alone must NOT be enough to proceed
+    f = _frame().select(["scrimmage_play", "pos_team", "EPA", "EPA_success", "pos_score_pts"])
+    assert situational_stats.create_situational_stats(f, HOME, AWAY) is None

--- a/tests/cfb/test_cfb_situational_stats.py
+++ b/tests/cfb/test_cfb_situational_stats.py
@@ -1,0 +1,393 @@
+import polars as pl
+
+from sportsdataverse.cfb import cfb_situational_stats as situational_stats
+
+HOME, AWAY = "10", "20"
+
+
+def _frame():
+    n = 10
+    base = {
+        "game_play_number": list(range(1, n + 1)),
+        "scrimmage_play": [True] * n,
+        "pos_team": [10, 10, 10, 10, 10, 10, 20, 20, 20, 20],
+        "period": [1, 1, 2, 2, 3, 4, 1, 2, 3, 4],
+        "down": [1, 3, 3, 4, 1, 2, 1, 3, 2, 1],
+        "distance": [10, 2, 8, 1, 10, 5, 10, 5, 3, 10],
+        "EPA": [0.5, 1.0, -0.5, 2.0, 0.2, -0.1, 0.3, -0.2, 0.1, 0.4],
+        "statYardage": [12, 4, 15, 2, 11, 3, 6, 7, 14, -3],
+        "EPA_success": [True, True, False, True, True, False, True, False, True, True],
+        "pos_score_pts": [0, 0, 7, 0, 0, 3, 0, 0, 7, 0],
+        "under_2": [False, False, True, False, False, False, False, True, False, False],
+        "middle_8": [False, False, True, True, False, False, False, True, False, False],
+        "rz_play": [False, False, True, True, False, False, False, False, True, False],
+        "goal_to_go": [
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ],
+        "scoring_opp": [
+            False,
+            False,
+            True,
+            True,
+            False,
+            True,
+            False,
+            False,
+            True,
+            False,
+        ],
+        "touchdown": [
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+        ],
+        "fg_made": [
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+        ],
+        "first_down_created": [
+            True,
+            True,
+            False,
+            True,
+            False,
+            False,
+            True,
+            False,
+            True,
+            False,
+        ],
+        "firstD_by_penalty": [False] * n,
+        "rush": [True, True, False, True, True, False, True, False, True, False],
+        "pass": [False, False, True, False, False, True, False, True, False, True],
+        "sack": [False] * n,
+        "completion": [
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+        ],
+        "pass_oe": [None, None, 5.0, None, None, -3.0, None, 2.0, None, 1.0],
+        "line_yards": [3.0, 2.0, None, 4.5, 1.0, None, 2.0, None, 5.0, None],
+        "second_level_yards": [1.0, 0.0, None, 2.0, 0.0, None, 0.0, None, 3.0, None],
+        "open_field_yards": [0.0, 0.0, None, 10.0, 0.0, None, 0.0, None, 8.0, None],
+        "stuffed_run": [
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ],
+        "opportunity_run": [
+            True,
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+        ],
+        "power_rush_attempt": [
+            False,
+            True,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ],
+        "power_rush_success": [
+            False,
+            True,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ],
+        "short_rush_attempt": [
+            False,
+            True,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ],
+        "short_rush_success": [
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ],
+        "air_yards": [None, None, 12.0, None, None, 22.0, None, 3.0, None, -2.0],
+        "yards_after_catch": [None, None, 4.0, None, None, None, None, 6.0, None, None],
+        "cpoe": [None, None, 10.0, None, None, -5.0, None, 3.0, None, 1.0],
+        "fourth_down_recommendation": [
+            None,
+            None,
+            None,
+            "go",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        "punt_play": [False] * n,
+        "fg_attempt": [
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+        ],
+        "xp_attempt": [False] * n,
+        "go_boost": [None, None, None, 2.5, None, None, None, None, None, None],
+        "pos_score_diff": [0, 0, 0, 7, 7, 7, 0, -7, -7, 0],
+        "penalty_flag": [
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+        ],
+        "penalty_declined": [False] * n,
+        "penalty_team_id": [None, None, None, None, None, None, None, None, None, 20],
+        "penalty_1st_conv": [False] * n,
+        "EPA_penalty": [None, None, None, None, None, None, None, None, None, -1.5],
+        "havoc": [False, False, False, False, False, False, True, True, False, False],
+        "TFL": [False, False, False, False, False, False, True, False, False, False],
+        "pass_breakup": [
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+        ],
+        "int": [False] * n,
+        "is_pos_team_turnover": [
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+        ],
+        "fumble_vec": [False] * n,
+        "fumble_lost": [False] * n,
+        "start.yardsToEndzone.touchback": [75, 55, 15, 10, 60, 30, 75, 45, 12, 85],
+        "drive.id": ["a", "a", "b", "b", "c", "d", "e", "f", "g", "h"],
+        "start.adj_TimeSecsRem": [
+            3600.0,
+            3580.0,
+            1900.0,
+            1875.0,
+            1700.0,
+            800.0,
+            3400.0,
+            1850.0,
+            900.0,
+            400.0,
+        ],
+    }
+    return pl.DataFrame(base, strict=False)
+
+
+def test_situational_sections_and_values():
+    out = situational_stats.create_situational_stats(_frame(), HOME, AWAY)
+    h = out["teams"][HOME]
+    a = out["teams"][AWAY]
+
+    # every section of the metrics note is present
+    for key in (
+        "big_plays",
+        "two_minute",
+        "middle_8",
+        "red_zone",
+        "goal_to_go",
+        "finishing_drives",
+        "downs",
+        "rushing_quality",
+        "passing_profile",
+        "fourth_down_decisions",
+        "score_state",
+        "penalties_situational",
+        "havoc_created",
+        "turnovers",
+        "field_zones",
+        "pace",
+        "non_garbage",
+    ):
+        assert key in h, key
+
+    assert h["two_minute"] == {
+        "plays": 1,
+        "epa_play": -0.5,
+        "success_rate": 0.0,
+        "points": 7,
+    }
+    assert h["red_zone"]["trips"] == 1 and h["red_zone"]["td_trips"] == 1
+    assert h["red_zone"]["points"] == 7
+    assert h["finishing_drives"]["trips"] == 2 and h["finishing_drives"]["points"] == 10
+    # play 3 is a 3rd-down TD: a TD counts as a conversion (book rule)
+    assert h["downs"]["down_3"]["conversions"] == {"made": 2, "att": 2}
+    assert h["downs"]["down_3"]["by_distance"]["short"] == {"made": 1, "att": 1}
+    assert h["rushing_quality"]["power"] == {"made": 2, "att": 2}
+    assert h["rushing_quality"]["short_yardage"] == {"made": 1, "att": 2}
+    assert h["passing_profile"]["by_depth"]["medium"]["plays"] == 1
+    # article-mined additions: dropbacks/sacks, per-down splits, big plays
+    assert h["passing_profile"]["dropbacks"] == 2
+    assert h["passing_profile"]["sacks_taken"] == {"count": 0, "yards_lost": 0}
+    assert h["passing_profile"]["yards_per_completion"] == 15.0
+    assert h["rushing_quality"]["yards"] == 29
+    assert h["rushing_quality"]["yards_per_rush"] == 7.2
+    assert h["rushing_quality"]["yards_per_rush_with_sacks"] == 7.2
+    assert h["downs"]["down_3"]["avg_distance"] == 5.0
+    assert h["downs"]["down_3"]["yards_per_play"] == 9.5
+    assert h["downs"]["down_3"]["rush"] == {"att": 1, "yards": 4}
+    assert h["downs"]["down_3"]["pass"] == {"att": 1, "comp": 1, "yards": 15}
+    assert h["downs"]["down_3"]["conversions_by"] == {
+        "rush": 1,
+        "pass": 1,
+        "penalty": 0,
+    }
+    # big plays: pass 15+ (idx2 TD) + rushes 10+ (idx0, idx4)
+    assert h["big_plays"]["plays"] == 3 and h["big_plays"]["yards"] == 38
+    assert h["big_plays"]["touchdowns"] == 1
+    assert h["big_plays"]["pass"]["long"] == 15
+    assert h["big_plays"]["rush"] == {
+        "plays": 2,
+        "yards": 23,
+        "long": 12,
+        "touchdowns": 0,
+    }
+    # 4th down: recommendation 'go', they went -> agreement 1/1
+    assert h["fourth_down_decisions"] == {
+        "decisions": 1,
+        "went_for_it": 1,
+        "agreed_with_model": 1,
+        "agreement_rate": 1.0,
+        "go_wp_forgone": 0.0,
+    }
+    assert h["score_state"]["leading"]["plays"] == 3
+    # away's accepted penalty with EPA swing
+    assert a["penalties_situational"]["accepted"] == 1
+    assert a["penalties_situational"]["epa_swing"] == -1.5
+    # home's defense created the away havoc plays
+    assert (
+        h["havoc_created"]["front_seven"] == 1 and h["havoc_created"]["secondary"] == 1
+    )
+    assert a["turnovers"]["committed"] == 1 and a["turnovers"]["epa_swing"] == -0.2
+    assert h["field_zones"]["red_zone"]["plays"] == 2
+    # pace: only same-drive same-period consecutive deltas count
+    assert h["pace"]["seconds_per_play"] is not None
+
+
+def test_situational_fails_open():
+    assert situational_stats.create_situational_stats(None, HOME, AWAY) is None
+    assert situational_stats.create_situational_stats(pl.DataFrame(), HOME, AWAY) is None
+    assert situational_stats.create_situational_stats(pl.DataFrame({"x": [1]}), HOME, AWAY) is None
+
+
+def test_windowed_build_drops_window_inherent_sections():
+    expr = pl.col("period").is_in([1, 2])
+    out = situational_stats.create_situational_stats(_frame(), HOME, AWAY, window_expr=expr)
+    h = out["teams"][HOME]
+    # windowable sections present and windowed
+    assert h["downs"]["down_1"]["plays"] == 1  # only the Q1 first-down play
+    assert h["red_zone"]["trips"] == 1
+    # window-inherent sections absent
+    for k in ("two_minute", "middle_8", "pace", "non_garbage", "fourth_down_decisions"):
+        assert k not in h, k
+
+
+def test_windowed_build_empty_window_is_none():
+    assert (
+        situational_stats.create_situational_stats(_frame(), HOME, AWAY, window_expr=pl.col("period") > 90)
+        is None
+    )
+
+
+def test_playprocess_delegate_matches_module():
+    from sportsdataverse.cfb.cfb_pbp import CFBPlayProcess
+
+    f = _frame().with_columns(
+        homeTeamId=pl.lit(int(HOME)), awayTeamId=pl.lit(int(AWAY))
+    )
+    direct = situational_stats.create_situational_stats(f, HOME, AWAY)
+    via_method = CFBPlayProcess.create_situational_stats(object(), f)
+    assert via_method == direct


### PR DESCRIPTION
Graduates the drive summary and situational team stats from game-on-paper-app into sdv-py, per the review on saiemgilani/game-on-paper-app#221 — these are `create_box_score`-class surfaces every consumer should get, not game-page internals.

## New surfaces

- **`cfb_drive_summary.create_drive_summary(drives, frame, home_id, away_id, periods=None)`** — StatBroadcast-style drive summary: per-team drive lines (both named drive-success metrics, points off turnovers, forced three-and-outs, TOP by quarter, first-down sources, largest lead / time in lead), the OBTAINED/HOW-LOST drive chart, how-scores-happened, and per-team long-play lists. Windowable by start-quarter set or `"ot"`; out-of-window drives still advance the running score so points-off-turnovers stays correct.
- **`cfb_situational_stats.create_situational_stats(frame, home_id, away_id, window_expr=None)`** — per-team situational block: down-by-down with distance buckets and conversion attribution (air/ground/penalty), red zone, goal-to-go, finishing drives, rushing quality tiers, passing profile (aDOT/YAC/CPOE/depth buckets, dropbacks, sack-adjusted rushing), 4th-down decision report, score-state splits, situational penalties, havoc, turnovers, field zones, pace, big plays. Windowable via a polars filter; window-inherent sections (two-minute, middle-8, pace, non-garbage, 4th-down report) are omitted on windowed builds by design.
- Thin **`CFBPlayProcess.create_drive_summary` / `.create_situational_stats`** delegates (team ids read from the plays frame), mirroring `create_box_score`.

Both consume the post-pipeline plays frame (`plays_frame`, #464) plus — for drives — the ESPN drives grouping, with drive-level attribution from `drive.team` (never plays grouped by `drive.id`, which spans both teams).

## Verification

- 13 tests ported from the game-on-paper suite: synthetic fixtures covering counts/rates, chart sequences, field-position orientation (ESPN's home-oriented yardLine vs authoritative `start.text`), windowed builds (drives booking to their start quarter, window-inherent omission), fail-open behavior, and delegate parity.
- `ruff` clean; codegen regenerated (reference docs pick up both functions and the methods) and `--check` passes.

Once merged, game-on-paper-app#221 slims to imports (the app already tracks sdv-py git main).

## Summary by Sourcery

Graduate reusable CFB drive-summary and situational-statistics analytics into sdv-py.

New Features:
- Add public CFB drive summaries with windowed drive charts, scoring details, drive metrics, and long-play lists.
- Add public CFB situational team statistics covering down, scoring, rushing, passing, defensive, penalty, turnover, field-zone, pace, and big-play splits.
- Expose both analytics surfaces through CFB play-process delegates and package exports.

Enhancements:
- Use processed play frames alongside ESPN drive groupings to provide reusable game-analytics surfaces, including fail-open handling for unusable inputs.

Documentation:
- Document the new CFB analytics functions, delegates, and package capabilities in the changelog, README, and generated reference pages.

Tests:
- Add synthetic coverage for drive and situational metrics, windowing behavior, field-position orientation, scoring and chart attribution, fail-open behavior, and delegate parity.

Chores:
- Regenerate and verify code-generated references for the new functions and methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added college football drive summaries with drive charts, scoring details, efficiency metrics, and situational aggregates.
  - Added situational team statistics covering downs, red-zone performance, passing, rushing, turnovers, penalties, field position, and pace.
  - Added quarter, overtime, and other windowed analyses.
  - Exposed these capabilities through current and legacy CFB interfaces.

- **Bug Fixes**
  - Improved handling of empty, incomplete, or grouped play and drive data.

- **Documentation**
  - Added reference documentation and updated supported analytics and function counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->