### PR TITLE
fix(mbb): do not rotate proxies on a missing-dependency ImportError

### DIFF
--- a/sportsdataverse/mbb/mbb_ncaa_fetch.py
+++ b/sportsdataverse/mbb/mbb_ncaa_fetch.py
@@ -899,6 +899,15 @@ class NcaaFetcher:
             proxies = {"http": proxy, "https": proxy} if proxy else {}
             try:
                 status, text = transport(url, proxies, headers)
+            except ImportError:
+                # A missing optional dependency is a SETUP error, not a transport
+                # error, and no amount of proxy rotation installs patchright.
+                # Rotating on it burned the whole pool (with backoff between each
+                # attempt) and then reported the real cause under a "failed after
+                # rotating proxies" headline -- which reads as a ban and sends the
+                # reader hunting for an IP problem that does not exist. Re-raise so
+                # the install instruction from _ensure_page is the error.
+                raise
             except Exception as exc:  # noqa: BLE001 - rotate on any transport failure
                 last_err = str(exc)
                 self._rotate("transport error")

--- a/sportsdataverse/mbb/mbb_ncaa_fetch.py
+++ b/sportsdataverse/mbb/mbb_ncaa_fetch.py
@@ -980,6 +980,11 @@ class NcaaFetcher:
             RuntimeError: No proxy is configured (the binding directive --
                 there is no direct-fetch mode), or every proxy in the pool
                 failed / looked banned.
+            ImportError: An optional dependency the selected transport needs is
+                not installed -- patchright for the browser transport. Raised
+                immediately rather than rotated on: no amount of proxy rotation
+                installs a package, and reporting it as a pool exhaustion reads
+                as a ban. Carries the install instruction.
         """
         cache_file = cached_path(path, cache_dir=self.config.cache_dir)
         if cache_file.exists() and not force:

--- a/tests/mbb/test_mbb_ncaa_fetch.py
+++ b/tests/mbb/test_mbb_ncaa_fetch.py
@@ -118,6 +118,38 @@ def test_all_proxies_banned_raises_a_clear_error(tmp_path: Path) -> None:
         fetcher.fetch_html("contests/1/play_by_play")
 
 
+def test_missing_patchright_is_not_treated_as_a_transport_failure(tmp_path: Path) -> None:
+    """A missing optional dependency must not be rotated on.
+
+    patchright is imported lazily inside the browser transport, so its
+    ImportError arrives through the same call as a 403. Rotating on it burned
+    the entire pool -- one backoff sleep per proxy -- and then reported the real
+    cause under "NCAA fetch failed after rotating proxies", which reads as a ban
+    and sends the reader hunting for an IP problem that does not exist. It cost a
+    live cron a night: the install error was invisible under a proxy headline.
+    """
+
+    class _NoPatchright:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self, url: str, proxies: dict, headers: dict) -> "tuple[int, str]":
+            self.calls += 1
+            raise ImportError("The NCAA browser transport requires patchright")
+
+    transport = _NoPatchright()
+    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, rotation_backoff=0.0)
+    fetcher = NcaaFetcher(cfg, proxy_pool=_POOL)
+
+    # The install instruction is the error -- not a RuntimeError about proxies.
+    with pytest.raises(ImportError, match="requires patchright"):
+        fetcher.fetch_html("contests/1/play_by_play")
+
+    # And the pool is untouched: rotation cannot install a package.
+    assert transport.calls == 1
+    assert fetcher._dead == set()
+
+
 def test_rotate_every_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     from sportsdataverse.mbb.mbb_ncaa_fetch import _from_env
 


### PR DESCRIPTION
patchright is imported lazily inside the NCAA browser transport, so its `ImportError` reaches `_get_with_rotation` through the same call as a 403. The bare `except Exception` treated it as a transport failure: it burned the entire proxy pool — one `rotation_backoff` sleep per proxy — and then reported the real cause under `NCAA fetch failed after rotating proxies`, which reads as a ban.

That headline is the whole cost. A missing optional dependency is a **setup** error and no amount of rotation installs a package, but the message sends the reader hunting for an IP problem that does not exist. It cost a live NCAA MFB cron a night, with `No module named 'patchright'` invisible beneath a proxy headline.

## Change

Re-raise `ImportError` so the install instruction `_ensure_page` already writes is the error the caller sees.

Fixed here rather than in each consumer's launcher: `ncaa-mfb-football-raw`, `ncaa-mbb-hoops-raw`, `ncaa-wbb-hoops-raw` and `baseballr-data` all reach this same function, and so does anyone calling the library directly.

## Test

`test_missing_patchright_is_not_treated_as_a_transport_failure` asserts both halves — the `ImportError` propagates, and the pool is untouched (one transport call, no proxies retired). Verified it fails on the unfixed source with exactly the misleading message:

```
RuntimeError: NCAA fetch failed after rotating proxies: ...: The NCAA browser transport requires patchright
```

`43 passed` in `tests/mbb/test_mbb_ncaa_fetch.py`; ruff clean; `generate.py --check` reports all generated files current.

## Summary by Sourcery

Prevent missing browser dependencies from triggering proxy rotation and misleading pool-exhaustion errors.

Bug Fixes:
- Propagate missing optional-dependency ImportErrors immediately instead of treating them as proxy transport failures and exhausting the proxy pool.

Enhancements:
- Document the fetcher's ImportError behavior so callers receive the actionable installation guidance.

Tests:
- Add coverage confirming missing patchright errors propagate after one transport attempt without retiring proxies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing optional dependencies now produce a clear installation error immediately.
  * Dependency-related failures no longer trigger unnecessary proxy rotation or misleading transport-failure messages.
  * Fetch requests stop after the dependency error, preserving the original installation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->