### PR TITLE
fix(mbb): recover KenPom's depth-chart table from its script tag

### DIFF
--- a/docs/docs/mbb/reference/kenpom.md
+++ b/docs/docs/mbb/reference/kenpom.md
@@ -239,7 +239,7 @@ _Last validated n/a._
 
 ## `kenpom_team`
 
-GET /team.php - a team's full season page. Returns EVERY table on it, so one call covers hoopR's kp_team_schedule(), kp_team_players(), kp_team_depth_chart() and kp_team_lineups(), which each fetch this same page separately.
+GET /team.php - a team's full season page. Returns EVERY table on it, so one call covers hoopR's kp_team_schedule(), kp_team_players() and kp_team_lineups(), which each fetch this same page separately -- plus kp_team_depth_chart(), recovered under a "depth_chart" key from an embedded script tag rather than a table (KenPom dropped the static depth-chart table; see kp_team_depth_chart()'s R source).
 
 **Endpoint URL:** `GET https://kenpom.com/team.php`
 

--- a/sportsdataverse/mbb/kenpom.py
+++ b/sportsdataverse/mbb/kenpom.py
@@ -572,7 +572,7 @@ def kenpom_team(
     return_as_pandas: bool = False,
     **kwargs,
 ) -> Union[pl.DataFrame, pd.DataFrame, str]:
-    """GET /team.php - a team's full season page. Returns EVERY table on it, so one call covers hoopR's kp_team_schedule(), kp_team_players(), kp_team_depth_chart() and kp_team_lineups(), which each fetch this same page separately.
+    """GET /team.php - a team's full season page. Returns EVERY table on it, so one call covers hoopR's kp_team_schedule(), kp_team_players() and kp_team_lineups(), which each fetch this same page separately -- plus kp_team_depth_chart(), recovered under a "depth_chart" key from an embedded script tag rather than a table (KenPom dropped the static depth-chart table; see kp_team_depth_chart()'s R source).
 
     Endpoint: ``GET https://kenpom.com/team.php``
     Example URL: https://kenpom.com/team.php?team=Duke&y=2025

--- a/sportsdataverse/mbb/kenpom_runtime.py
+++ b/sportsdataverse/mbb/kenpom_runtime.py
@@ -324,7 +324,7 @@ def parse_kenpom_page(
     tidied = {k: _cast_numerics(_split_ncaa_seed(_drop_repeated_headers(v))) for k, v in tables.items()}
     depth_chart = _depth_chart_table(raw)
     if depth_chart is not None:
-        tidied["depth_chart"] = depth_chart
+        tidied["depth_chart"] = _cast_numerics(depth_chart)
     if return_as_pandas:
         return {k: v.to_pandas() for k, v in tidied.items()}
     return tidied

--- a/sportsdataverse/mbb/kenpom_runtime.py
+++ b/sportsdataverse/mbb/kenpom_runtime.py
@@ -9,7 +9,7 @@ KenPom-specific description of it plus the two callables the generated wrappers
 import (``_get`` and ``parse_kenpom_page``).
 
 This is the Python port of hoopR's ``kp_*()`` family (``R/kp_*.R`` +
-``login()`` / ``.kp_get_page()`` in ``R/utils.R``), with two deliberate
+``login()`` / ``.kp_get_page()`` in ``R/utils.R``), with three deliberate
 divergences:
 
 * **One wrapper per URL, all tables returned.** hoopR ships four functions
@@ -25,6 +25,16 @@ divergences:
   :func:`sportsdataverse._subscription_http.html_tables` derives the same names
   from the ``MultiIndex`` ``pandas.read_html`` builds, so a KenPom column
   addition widens the frame instead of silently shifting every column.
+* **The depth chart is recovered from a ``<script>`` tag, not a ``<table>``.**
+  KenPom retired the static ``#dc-table`` depth-chart table (hoopR issue
+  sportsdataverse/hoopR#152); ``team.php`` now renders it client-side from a
+  ``const players = [...]`` JSON array. :func:`_depth_chart_table` extracts
+  that array directly, since :func:`~sportsdataverse._subscription_http.html_tables`
+  only ever sees ``<table>`` elements (``<script>`` contents are stripped
+  before parsing so they can't contaminate a real table's cell text). Mirrors
+  hoopR's ``kp_team_depth_chart()``, minus its hardcoded column list; the
+  result is merged into ``kenpom_team()``'s returned dict under the
+  ``"depth_chart"`` key.
 
 Credentials come from ``KENPOM_EMAIL`` / ``KENPOM_PW`` (hoopR's ``KP_USER`` /
 ``KP_PW`` are also accepted, so an existing R environment works unchanged), or
@@ -34,6 +44,8 @@ from ``email=`` / ``password=`` on any call. Proxy from ``proxy=``,
 
 from __future__ import annotations
 
+import json
+import re
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import polars as pl
@@ -45,6 +57,7 @@ from sportsdataverse._subscription_http import (
     html_tables,
 )
 from sportsdataverse._subscription_http import login as _login
+from sportsdataverse.dl_utils import underscore
 
 if TYPE_CHECKING:  # pragma: no cover -- annotation-only imports
     import pandas as pd
@@ -243,6 +256,40 @@ def _cast_numerics(frame: pl.DataFrame) -> pl.DataFrame:
     return out
 
 
+_DEPTH_CHART_RE = re.compile(r"const players\s*=\s*(\[.*?\]);", re.DOTALL)
+
+
+def _depth_chart_table(raw: str) -> Optional[pl.DataFrame]:
+    """Extract KenPom's client-rendered depth-chart table from ``team.php``.
+
+    See the module docstring's third divergence for why this can't just be
+    another entry in :func:`~sportsdataverse._subscription_http.html_tables`'s
+    output -- the data isn't in a ``<table>`` at all.
+
+    Args:
+        raw: The page HTML from :func:`_get`.
+
+    Returns:
+        A polars DataFrame (one row per rostered player), or ``None`` when the
+        page carries no matching script -- an unauthenticated page, a
+        page/parser this doesn't apply to, or a further site change.
+    """
+    import pandas as pd
+
+    match = _DEPTH_CHART_RE.search(raw or "")
+    if match is None:
+        return None
+    try:
+        records = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return None
+    if not records:
+        return pl.DataFrame()
+    frame = pd.json_normalize(records)
+    frame.columns = [underscore(c) for c in frame.columns]
+    return pl.from_pandas(frame)
+
+
 def parse_kenpom_page(
     raw: str,
     *,
@@ -253,7 +300,9 @@ def parse_kenpom_page(
     Keys are the table's HTML ``id`` (KenPom's real data tables all carry one --
     ``ratings_table``, ``player_table``, ``schedule_table``, ...), snake-cased.
     ``min_rows=2`` drops the small nav/legend tables KenPom renders alongside
-    the data.
+    the data. On ``team.php`` an additional ``"depth_chart"`` key is added when
+    present, recovered from an embedded script tag rather than a table -- see
+    :func:`_depth_chart_table`.
 
     Args:
         raw: The page HTML from :func:`_get`.
@@ -273,6 +322,9 @@ def parse_kenpom_page(
     """
     tables = html_tables(raw, min_rows=2)
     tidied = {k: _cast_numerics(_split_ncaa_seed(_drop_repeated_headers(v))) for k, v in tables.items()}
+    depth_chart = _depth_chart_table(raw)
+    if depth_chart is not None:
+        tidied["depth_chart"] = depth_chart
     if return_as_pandas:
         return {k: v.to_pandas() for k, v in tidied.items()}
     return tidied

--- a/tests/test_subscription_http.py
+++ b/tests/test_subscription_http.py
@@ -17,7 +17,7 @@ from sportsdataverse._subscription_http import (
     resolve_credentials,
     resolve_proxy,
 )
-from sportsdataverse.mbb.kenpom_runtime import KENPOM, parse_kenpom_page
+from sportsdataverse.mbb.kenpom_runtime import KENPOM, _depth_chart_table, parse_kenpom_page
 from sportsdataverse.wbb.herhoopstats import HERHOOPSTATS
 
 # A KenPom-shaped ratings table: grouped two-row header, and each metric followed
@@ -35,6 +35,26 @@ KENPOM_HTML = """
   </tbody>
 </table>
 <table id="nav"><tr><th>x</th></tr><tr><td>1</td></tr></table>
+</body></html>
+"""
+
+# team.php-shaped page: a real <table> plus the depth chart's replacement -- a
+# `const players = [...]` JSON array inside a <script> tag (KenPom dropped the
+# static #dc-table depth-chart table; see hoopR's kp_team_depth_chart() source).
+DEPTH_CHART_HTML = """
+<html><body>
+<table id="schedule-table">
+  <tr><th>Date</th><th>Opponent</th></tr>
+  <tr><td>11/4</td><td>Maine</td></tr>
+  <tr><td>11/7</td><td>Kentucky</td></tr>
+</table>
+<script>
+  var otherStuff = 1;
+  const players = [{"playerID":"123","Name":"Cooper Flagg","Year":"Fr","Height":"6-9",
+    "Weight":"205","PctPG":0,"PctSG":0,"PctSF":40,"PctPF":60,"PctC":0,"PctPoss":100,
+    "FTA":"120","FG2A":"200","FG3A":"80"}];
+  var moreStuff = 2;
+</script>
 </body></html>
 """
 
@@ -139,6 +159,34 @@ def test_parse_kenpom_page_returns_dict_of_frames():
 
 def test_html_tables_empty_page_is_empty_not_an_error():
     assert html_tables("<html><body>no tables</body></html>") == {}
+
+
+# --- depth chart: recovered from a <script> tag, not html_tables() -----------
+
+
+def test_parse_kenpom_page_extracts_depth_chart_from_script_tag():
+    frames = parse_kenpom_page(DEPTH_CHART_HTML)
+    assert set(frames) == {"schedule_table", "depth_chart"}
+    dc = frames["depth_chart"]
+    # underscore() derives names generically (no hoopR-style hardcoded rename map),
+    # so KenPom's raw "Name" JSON key stays "name", not hoopR's renamed "player_name".
+    assert dc["player_id"].to_list() == ["123"]
+    assert dc["name"].to_list() == ["Cooper Flagg"]
+    assert dc["pct_sf"].to_list() == [40]
+
+
+def test_depth_chart_table_absent_without_a_script_tag():
+    assert _depth_chart_table(KENPOM_HTML) is None
+
+
+def test_depth_chart_table_ignores_malformed_json():
+    assert _depth_chart_table("<script>const players = [not json};</script>") is None
+
+
+def test_depth_chart_table_empty_array_is_zero_row_not_none():
+    df = _depth_chart_table("<script>const players = [];</script>")
+    assert df is not None
+    assert df.shape == (0, 0)
 
 
 # --- credentials -------------------------------------------------------------

--- a/tests/test_subscription_http.py
+++ b/tests/test_subscription_http.py
@@ -8,6 +8,7 @@ is the whole reason hoopR carries ~44 hardcoded header vectors).
 
 from __future__ import annotations
 
+import polars as pl
 import pytest
 
 from sportsdataverse._html_tables import _clean_name, _dedupe_headers, html_tables
@@ -170,9 +171,16 @@ def test_parse_kenpom_page_extracts_depth_chart_from_script_tag():
     dc = frames["depth_chart"]
     # underscore() derives names generically (no hoopR-style hardcoded rename map),
     # so KenPom's raw "Name" JSON key stays "name", not hoopR's renamed "player_name".
-    assert dc["player_id"].to_list() == ["123"]
     assert dc["name"].to_list() == ["Cooper Flagg"]
     assert dc["pct_sf"].to_list() == [40]
+    # player_id / FTA / FG2A / FG3A arrive as quoted JSON strings on the real site
+    # (hoopR casts FTA/FG2A/FG3A explicitly with as.integer()) -- _cast_numerics must
+    # run on this frame too, same as every HTML-table column, or these stay Utf8 while
+    # everything else gets typed. No ID-column carve-out: _cast_numerics has never had
+    # one (it treats every fully-numeric text column alike), so player_id casts too.
+    assert dc["player_id"].to_list() == [123]
+    assert dc["fta"].to_list() == [120]
+    assert dc.schema["fta"] == pl.Int64
 
 
 def test_depth_chart_table_absent_without_a_script_tag():

--- a/tools/codegen/endpoints/kenpom.yaml
+++ b/tools/codegen/endpoints/kenpom.yaml
@@ -174,8 +174,10 @@ endpoints:
 - short: team
   summary: >-
     GET /team.php - a team's full season page. Returns EVERY table on it, so one call
-    covers hoopR's kp_team_schedule(), kp_team_players(), kp_team_depth_chart() and
-    kp_team_lineups(), which each fetch this same page separately.
+    covers hoopR's kp_team_schedule(), kp_team_players() and kp_team_lineups(), which
+    each fetch this same page separately -- plus kp_team_depth_chart(), recovered
+    under a "depth_chart" key from an embedded script tag rather than a table (KenPom
+    dropped the static depth-chart table; see kp_team_depth_chart()'s R source).
   path: /team.php
   extra_params:
   - name: team


### PR DESCRIPTION
## Summary

- KenPom retired the static `#dc-table` depth-chart table on `team.php` (hoopR issue sportsdataverse/hoopR#152) and now renders it client-side from a `const players = [...]` JSON array embedded in a `<script>` tag.
- `html_tables()` only ever reads `<table>` elements (script contents are stripped before parsing so a media/script fallback can't contaminate a real table's cell text), so `kenpom_team()` silently dropped the depth chart despite its docstring explicitly claiming it "covers hoopR's ... `kp_team_depth_chart()`."
- Found during a parity audit against hoopR's `kp_*` R source after re-syncing both repos from `origin/main`.
- Adds `_depth_chart_table()` to `kenpom_runtime.py`, which extracts and JSON-parses that script-tag array directly (mirroring hoopR's `kp_team_depth_chart()` minus its hardcoded column renames — column names are derived generically via `underscore()`, consistent with this module's existing "no hardcoded header vectors" design).
- Wires the result into `parse_kenpom_page()` under a new `"depth_chart"` key, so `kenpom_team()` now returns it automatically.
- Corrects the `kenpom_team()` docstring (via its codegen YAML source, `tools/codegen/endpoints/kenpom.yaml`) to describe the fix, and regenerates the derived `kenpom.py` + reference docs.

## Test plan

- [x] `uv run pytest tests/test_subscription_http.py -v` — new tests cover: extraction from a script tag, absence when no script is present, malformed-JSON tolerance (returns `None`, doesn't raise), and empty-array tolerance (zero-row frame, not `None`).
- [x] `uv run mypy sportsdataverse/mbb/kenpom_runtime.py` — clean.
- [x] `uv run ruff check` / `ruff format --check` on touched files — clean.
- [x] `uv run python tools/codegen/generate.py && uv run python tools/codegen/generate.py --check` — no drift.
- [x] `uv run pytest tests/test_subscription_http.py tests/codegen/ -q` — 193 passed, 11 pre-existing skips.

## Summary by Sourcery

Restore KenPom depth-chart support by parsing the client-rendered player data embedded in team pages.

New Features:
- Recover KenPom team depth-chart data from its embedded player JSON and expose it under the `depth_chart` result key.

Bug Fixes:
- Restore depth-chart data that was lost after KenPom removed the static depth-chart table.

Documentation:
- Update the generated `kenpom_team()` documentation to describe the embedded-script depth-chart data.

Tests:
- Add coverage for extraction, missing and malformed scripts, empty player arrays, and numeric type conversion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * KenPom team data now correctly includes depth-chart information from embedded page content after the static depth-chart table was removed.
  * Depth-chart results are available under the `depth_chart` field when present, with numeric values consistently interpreted.

* **Documentation**
  * Updated endpoint documentation to describe the revised depth-chart source and response behavior.

* **Tests**
  * Added coverage for valid, missing, malformed, and empty depth-chart data, including numeric value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->