### PR TITLE
docs(codegen): pull curated Highlights out of the Additional bucket

### DIFF
--- a/docs/docs/cfb/index.md
+++ b/docs/docs/cfb/index.md
@@ -7,6 +7,7 @@ description: "sdv-py CFB: endpoint references, dataset loaders and parsers for C
 
 | Reference | Functions | Base URL |
 |---|---:|---|
+| [Highlights](reference/additional#highlights) | 8 | curated "start here" functions |
 | [ESPN site API (v2)](reference/site) | 25 | `https://site.api.espn.com/apis/site/v2/sports` |
 | [ESPN web API (v3)](reference/web) | 5 | `https://site.web.api.espn.com/apis/common/v3/sports` |
 | [ESPN core API (v2)](reference/core) | 89 | `https://sports.core.api.espn.com/v2/sports` |
@@ -15,7 +16,7 @@ description: "sdv-py CFB: endpoint references, dataset loaders and parsers for C
 | [247Sports Recruit Database (ipa.247sports.com)](reference/sports247) | 12 | `https://ipa.247sports.com` |
 | [247Sports Site Pages (247sports.com)](reference/sports247_site_pages) | 35 | `https://247sports.com` |
 | [Dataset loaders](reference/loaders) | 52 | sportsdataverse raw data / sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 94 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 86 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -9,507 +9,7 @@ sidebar_position: 50
 Hand-written wrappers, loaders, and helpers in `sportsdataverse.cfb`
 not covered by the generated API-endpoint reference above.
 
-## Play-by-play, schedule & rosters
-
-### `espn_cfb_player_stats(athlete_id: 'int', season: 'int', *, season_type: 'str' = 'regular', total: 'bool' = False, raw: 'bool' = False, return_as_pandas: 'bool' = False, **kwargs: 'Any') -> 'pl.DataFrame | pd.DataFrame | dict[str, Any]'` {#espn_cfb_player_stats}
-
-Pull a college-football athlete's ESPN **season** stat line.
-
-See `sportsdataverse.wbb.espn_wbb_player_stats` for full
-documentation of the wide return shape, the `{category}_{stat}` stat
-columns (for football: `passing_*`, `rushing_*`, `receiving_*`,
-`scoring_*`, ...), the athlete / team metadata blocks, and the
-`season_type` / `total` parameters. For the richer multi-category
-web-v3 payload use `sportsdataverse.cfb.espn_cfb_player_stats_v3`.
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `athlete_id` | `int` |  | ESPN college-football athlete identifier. |
-| `season` | `int` |  | Season year, used in the core-v2 path. |
-| `season_type` | `str` | `'regular'` | `"regular"` (type 2) or `"postseason"` (type 3). |
-| `total` | `bool` | `False` | Forward-compat totals passthrough. |
-| `raw` | `bool` | `False` | If True, returns the raw core-v2 statistics JSON dict. |
-| `return_as_pandas` | `bool` | `False` | If True, returns a pandas DataFrame; else polars. |
-
-**Returns**
-
-A single-row wide DataFrame (polars by default). When `raw=True` returns the raw statistics JSON `dict`.
-
-| col_name | type | description |
-|---|---|---|
-| `season` | integer | Season (4-digit year). |
-| `season_type` | character | ESPN season type (2 = regular, 3 = postseason). |
-| `total` | logical | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
-| `athlete_id` | integer | ESPN athlete id. |
-| `athlete_uid` | character | ESPN athlete UID (universal identifier). |
-| `athlete_guid` | character | ESPN athlete GUID. |
-| `athlete_type` | character | Athlete type / class. |
-| `first_name` | character | Athlete first name. |
-| `last_name` | character | Athlete last name. |
-| `full_name` | character | Venue full name (e.g. `Tenney Stadium`). |
-| `display_name` | character | Human-readable metric name. |
-| `short_name` | character | Ranking source short name (e.g. `AP Poll`). |
-| `weight` | double | Listed weight (lbs). |
-| `display_weight` | character | Human-readable weight (e.g. `205 lbs`). |
-| `height` | double | Listed height (inches). |
-| `display_height` | character | Human-readable height (e.g. `6' 1"`). |
-| `age` | integer | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
-| `date_of_birth` | character | Player date of birth (if published). |
-| `jersey` | character | Jersey number. |
-| `slug` | character | URL slug for the team. |
-| `active` | logical | `TRUE` if the player was active for the game. |
-| `position_id` | integer | ESPN position id. |
-| `position_name` | character | Position name (e.g. `Quarterback`); `position_detail = TRUE` only. |
-| `position_display_name` | character | Human-readable position name; `position_detail = TRUE` only. |
-| `position_abbreviation` | character | Position abbreviation (e.g. `QB`); `position_detail = TRUE` only. |
-| `college_name` | character | Official college (usually the last one attended) |
-| `status_id` | integer | ESPN commitment status id. |
-| `status_name` | character | Status-type key (e.g. `STATUS_FINAL`). |
-| `general_fumbles` | double | Total number of fumbles committed by the player across all offensive and special-teams plays. |
-| `general_fumbles_lost` | double | Number of fumbles the player committed that were recovered by the opposing team. |
-| `general_fumbles_touchdowns` | double | Total touchdowns scored by the player as a result of fumble recoveries, combining offensive and defensive occurrences. |
-| `general_games_played` | double | Games Played. |
-| `general_offensive_two_pt_returns` | double | Number of two-point conversions the player scored by returning a blocked or intercepted two-point attempt on the offensive side. |
-| `general_offensive_fumbles_touchdowns` | double | Number of touchdowns scored by the player on fumble recoveries credited to the offensive category. |
-| `general_defensive_fumbles_touchdowns` | double | Number of touchdowns scored by the player on fumble recoveries attributed to the defensive category. |
-| `passing_avg_gain` | double | Average yards gained per passing play attempt by the quarterback in the passing category. |
-| `passing_completion_pct` | double | Percentage of pass attempts thrown by the quarterback that were completed, calculated as completions divided by attempts. |
-| `passing_completions` | double | Pass completions (split from CFBD's `C/ATT` field). |
-| `passing_espnqb_rating` | double | ESPN's proprietary quarterback rating for the player's passing performance, factoring in efficiency metrics beyond traditional passer rating. |
-| `passing_interception_pct` | double | Percentage of pass attempts that resulted in an interception, calculated as interceptions divided by passing attempts. |
-| `passing_interceptions` | double | Total number of passes thrown by the quarterback that were intercepted by the defense. |
-| `passing_long_passing` | double | Longest single completed pass in yards recorded by the quarterback during the stat period. |
-| `passing_net_passing_yards` | double | Net passing yards gained by the quarterback after subtracting yardage lost on sacks from gross passing yards. |
-| `passing_net_passing_yards_per_game` | double | Net passing yards per game for the quarterback, computed as net passing yards divided by games played. |
-| `passing_net_total_yards` | double | Combined net yardage from passing and rushing for a quarterback, accounting for sack yardage lost in the passing category. |
-| `passing_net_yards_per_game` | double | Net total yards gained per game for the player as recorded in the passing category context. |
-| `passing_passing_attempts` | double | Total number of pass attempts thrown by the quarterback, including completions, incompletions, and interceptions. |
-| `passing_passing_big_plays` | double | Number of passing plays that gained 20 or more yards as recorded for the quarterback. |
-| `passing_passing_first_downs` | double | Number of first downs gained by the team on passing plays thrown by the quarterback. |
-| `passing_passing_fumbles` | double | Number of fumbles the quarterback committed during passing plays, including fumbled snaps and sack fumbles. |
-| `passing_passing_fumbles_lost` | double | Number of fumbles the quarterback committed on passing plays that were recovered by the opposing team. |
-| `passing_passing_touchdown_pct` | double | Percentage of pass attempts that resulted in a passing touchdown, calculated as touchdowns divided by attempts. |
-| `passing_passing_touchdowns` | double | Total number of touchdown passes thrown by the quarterback. |
-| `passing_passing_yards` | double | Gross passing yards gained by the quarterback on completed passes. |
-| `passing_passing_yards_after_catch` | double | Total yards gained by receivers after the catch on passes thrown by the quarterback. |
-| `passing_passing_yards_at_catch` | double | Total yards gained at the point of the catch (air yards) on passes thrown by the quarterback, before any yards after catch. |
-| `passing_passing_yards_per_game` | double | Gross passing yards per game for the quarterback, computed as passing yards divided by games played. |
-| `passing_qb_rating` | double | Traditional NCAA passer rating for the quarterback, calculated from completion percentage, yards per attempt, touchdown rate, and interception rate. |
-| `passing_sacks` | double | Total number of times the quarterback was sacked (tackled behind the line of scrimmage on a passing play). |
-| `passing_sack_yards_lost` | double | Total yards lost by the quarterback as a result of being sacked, subtracted when computing net passing yards. |
-| `passing_team_games_played` | double | Number of team games played during the stat period, used as the denominator for per-game passing rate statistics. |
-| `passing_total_offensive_plays` | double | Total number of offensive plays (pass attempts plus rushes) for the team during the stat period, recorded in the passing category context. |
-| `passing_total_points_per_game` | double | Average total points scored per game by the player's team as recorded alongside passing statistics. |
-| `passing_total_touchdowns` | double | Total touchdowns accounted for by the quarterback across passing and rushing in the passing category context. |
-| `passing_total_yards` | double | Total offensive yardage (passing plus rushing) accumulated by the quarterback as reported in the passing category. |
-| `passing_total_yards_from_scrimmage` | double | Total yards from scrimmage accumulated by the quarterback (passing plus rushing yards) in the passing category context. |
-| `passing_two_point_pass_convs` | double | Number of successful two-point conversions the quarterback converted via a passing play. |
-| `passing_two_pt_pass` | double | Indicator or count of two-point conversion passing attempts recorded for the quarterback. |
-| `passing_two_pt_pass_attempts` | double | Total number of two-point conversion attempts the quarterback made via a passing play. |
-| `passing_yards_from_scrimmage_per_game` | double | Average yards from scrimmage per game for the quarterback as reported in the passing category. |
-| `passing_yards_per_completion` | double | Average yards gained per completed pass by the quarterback, calculated as passing yards divided by completions. |
-| `passing_yards_per_game` | double | Average gross passing yards per game for the quarterback, equivalent to passing_passing_yards_per_game. |
-| `passing_yards_per_pass_attempt` | double | Average yards gained per pass attempt by the quarterback, calculated as passing yards divided by attempts. |
-| `passing_net_yards_per_pass_attempt` | double | Net passing yards divided by total pass attempts, including sack yardage lost in the denominator's context. |
-| `passing_qbr` | double | ESPN Quarterback Rating (QBR) for the player in this game. |
-| `passing_adj_qbr` | double | ESPN's adjusted Total Quarterback Rating (QBR) for the player's passing performance, controlling for opponent difficulty and game situation. |
-| `passing_quarterback_rating` | double | Traditional passer rating for the quarterback, equivalent to passing_qb_rating, using the standard NCAA formula. |
-| `rushing_avg_gain` | double | Average yards gained per rushing attempt for the player in the rushing category. |
-| `rushing_espnrb_rating` | double | ESPN's proprietary running back rating for the player's rushing performance. |
-| `rushing_long_rushing` | double | Longest single rushing carry in yards recorded by the player during the stat period. |
-| `rushing_net_total_yards` | double | Net total yardage accumulated by the player from rushing and any receiving contributions as reported in the rushing category. |
-| `rushing_net_yards_per_game` | double | Net total yards per game for the player as reported in the rushing category context. |
-| `rushing_rushing_attempts` | double | Total number of rushing attempts (carries) credited to the player. |
-| `rushing_rushing_big_plays` | double | Number of rushing plays that gained 10 or more yards for the player. |
-| `rushing_rushing_first_downs` | double | Number of first downs gained by the player via rushing plays. |
-| `rushing_rushing_fumbles` | double | Number of fumbles the player committed on rushing plays. |
-| `rushing_rushing_fumbles_lost` | double | Number of fumbles the player committed on rushing plays that were recovered by the opposing team. |
-| `rushing_rushing_touchdowns` | double | Total number of rushing touchdowns scored by the player. |
-| `rushing_rushing_yards` | double | Total yards gained by the player on rushing attempts. |
-| `rushing_rushing_yards_per_game` | double | Average rushing yards per game for the player, calculated as rushing yards divided by games played. |
-| `rushing_stuffs` | double | Number of rushing attempts in which the player was stopped at or behind the line of scrimmage. |
-| `rushing_stuff_yards_lost` | double | Total yards lost by the player on stuffed rushing plays (carries stopped at or behind the line of scrimmage). |
-| `rushing_team_games_played` | double | Number of team games played during the stat period, used as the denominator for per-game rushing rate statistics. |
-| `rushing_total_offensive_plays` | double | Total number of offensive plays for the team during the stat period, recorded in the rushing category context. |
-| `rushing_total_points_per_game` | double | Average total points scored per game by the player's team as recorded alongside rushing statistics. |
-| `rushing_total_touchdowns` | double | Total touchdowns scored by the player across all methods as reported in the rushing category context. |
-| `rushing_total_yards` | double | Total offensive yardage accumulated by the player as reported in the rushing category. |
-| `rushing_total_yards_from_scrimmage` | double | Total yards from scrimmage for the player (rushing plus receiving yards) as reported in the rushing category. |
-| `rushing_two_point_rush_convs` | double | Number of successful two-point conversions the player converted via a rushing play. |
-| `rushing_two_pt_rush` | double | Indicator or count of two-point conversion rushing attempts recorded for the player. |
-| `rushing_two_pt_rush_attempts` | double | Total number of two-point conversion attempts the player made via a rushing play. |
-| `rushing_yards_from_scrimmage_per_game` | double | Average yards from scrimmage per game for the player as reported in the rushing category. |
-| `rushing_yards_per_game` | double | Average rushing yards per game for the player, equivalent to rushing_rushing_yards_per_game. |
-| `rushing_yards_per_rush_attempt` | double | Average yards gained per rushing attempt for the player, calculated as rushing yards divided by attempts. |
-| `receiving_avg_gain` | double | Average yards gained per reception for the player in the receiving category. |
-| `receiving_espnwr_rating` | double | ESPN's proprietary wide receiver / pass-catcher rating for the player's receiving performance. |
-| `receiving_long_reception` | double | Longest single reception in yards recorded by the player during the stat period. |
-| `receiving_net_total_yards` | double | Net total yardage accumulated by the player from receiving and any rushing contributions as reported in the receiving category. |
-| `receiving_net_yards_per_game` | double | Net total yards per game for the player as reported in the receiving category context. |
-| `receiving_receiving_big_plays` | double | Number of receiving plays that gained 20 or more yards for the player. |
-| `receiving_receiving_first_downs` | double | Number of first downs gained by the player via receptions. |
-| `receiving_receiving_fumbles` | double | Number of fumbles the player committed after catching a pass. |
-| `receiving_receiving_fumbles_lost` | double | Number of fumbles the player committed on receiving plays that were recovered by the opposing team. |
-| `receiving_receiving_targets` | double | Total number of times the player was targeted as the intended receiver on a pass play. |
-| `receiving_receiving_touchdowns` | double | Total number of touchdown receptions scored by the player. |
-| `receiving_receiving_yards` | double | Total yards gained by the player on completed receptions. |
-| `receiving_receiving_yards_after_catch` | double | Total yards gained by the player after the catch on receiving plays. |
-| `receiving_receiving_yards_at_catch` | double | Total air yards gained at the point of the catch on receiving plays, before any yards after catch. |
-| `receiving_receiving_yards_per_game` | double | Average receiving yards per game for the player, calculated as receiving yards divided by games played. |
-| `receiving_receptions` | double | Total number of completed receptions (catches) recorded by the player. |
-| `receiving_team_games_played` | double | Number of team games played during the stat period, used as the denominator for per-game receiving rate statistics. |
-| `receiving_total_offensive_plays` | double | Total number of offensive plays for the team during the stat period, recorded in the receiving category context. |
-| `receiving_total_points_per_game` | double | Average total points scored per game by the player's team as recorded alongside receiving statistics. |
-| `receiving_total_touchdowns` | double | Total touchdowns scored by the player across all methods as reported in the receiving category context. |
-| `receiving_total_yards` | double | Total offensive yardage accumulated by the player as reported in the receiving category. |
-| `receiving_total_yards_from_scrimmage` | double | Total yards from scrimmage for the player (receiving plus rushing yards) as reported in the receiving category. |
-| `receiving_two_point_rec_convs` | double | Number of successful two-point conversions the player converted via a reception. |
-| `receiving_two_pt_reception` | double | Indicator or count of two-point conversion receptions recorded for the player. |
-| `receiving_two_pt_reception_attempts` | double | Total number of two-point conversion attempts the player made via a receiving play. |
-| `receiving_yards_from_scrimmage_per_game` | double | Average yards from scrimmage per game for the player as reported in the receiving category. |
-| `receiving_yards_per_game` | double | Average receiving yards per game for the player, equivalent to receiving_receiving_yards_per_game. |
-| `receiving_yards_per_reception` | double | Average yards gained per reception for the player, calculated as receiving yards divided by receptions. |
-| `scoring_defensive_points` | double | Total points scored by the player through defensive plays such as defensive touchdowns, safeties, or fumble-return scores. |
-| `scoring_field_goals` | double | Total number of field goals made by the player in the scoring category. |
-| `scoring_kick_extra_points` | double | Total number of extra point attempts kicked by the player. |
-| `scoring_kick_extra_points_made` | double | Total number of successful extra points (PATs) kicked by the player. |
-| `scoring_misc_points` | double | Points scored by the player through miscellaneous means not captured by standard scoring categories. |
-| `scoring_passing_touchdowns` | double | Total touchdown passes thrown by the player as counted in the scoring category. |
-| `scoring_receiving_touchdowns` | double | Total touchdown receptions scored by the player as counted in the scoring category. |
-| `scoring_return_touchdowns` | double | Total touchdowns scored by the player on kick or punt returns as counted in the scoring category. |
-| `scoring_rushing_touchdowns` | double | Total rushing touchdowns scored by the player as counted in the scoring category. |
-| `scoring_total_points` | double | Total points scored by the player across all scoring methods during the stat period. |
-| `scoring_total_points_per_game` | double | Average total points scored by the player per game during the stat period. |
-| `scoring_total_touchdowns` | double | Total touchdowns scored by the player across all methods (passing, rushing, receiving, and return) in the scoring category. |
-| `scoring_total_two_point_convs` | double | Total number of successful two-point conversions scored by the player across passing, rushing, and receiving attempts. |
-| `scoring_two_point_pass_convs` | double | Number of successful two-point conversions the player scored via a passing play, as counted in the scoring category. |
-| `scoring_two_point_rec_convs` | double | Number of successful two-point conversions the player scored via a reception, as counted in the scoring category. |
-| `scoring_two_point_rush_convs` | double | Number of successful two-point conversions the player scored via a rushing play, as counted in the scoring category. |
-| `scoring_one_pt_safeties_made` | double | Number of one-point safeties scored by the player's team, credited in the scoring category. |
-| `team_id` | integer | ESPN team id. |
-| `team_uid` | character | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
-| `team_guid` | character | ESPN team GUID. |
-| `team_slug` | character | Team slug for the stat row. |
-| `team_location` | character | Team location / school name; `team_detail = TRUE` only. |
-| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
-| `team_abbreviation` | character | Team abbreviation; `team_detail = TRUE` only. |
-| `team_display_name` | character | Full team display name; `team_detail = TRUE` only. |
-| `team_short_display_name` | character | Short team display name; `team_detail = TRUE` only. |
-| `team_color` | character | Primary team color; `team_detail = TRUE` only. |
-| `team_alternate_color` | character | Alternate team color; `team_detail = TRUE` only. |
-| `team_is_active` | logical | TRUE if the team is currently active. |
-| `team_logo_href` | character | Default team logo URL; `team_detail = TRUE` only. |
-
-**Example**
-
-```python
-from sportsdataverse.cfb import espn_cfb_player_stats
-df = espn_cfb_player_stats(athlete_id=4426338, season=2023)
-df.select(["full_name", "team_display_name", "passing_passing_yards"])
-```
-
-### `espn_cfb_schedule(dates=None, week=None, season_type=None, groups=None, limit=500, return_as_pandas=False, **kwargs) -> 'pl.DataFrame'` {#espn_cfb_schedule}
-
-espn_cfb_schedule - look up the college football schedule for a given season
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `dates` | `int` | `None` | Used to define different seasons. 2002 is the earliest available season. |
-| `week` | `int` | `None` | Week of the schedule. |
-| `season_type` | `int` | `None` | 2 for regular season, 3 for post-season, 4 for off-season. |
-| `groups` | `int` | `None` | Used to define different divisions. 80 is FBS, 81 is FCS. |
-| `limit` | `int` | `500` | number of records to return, default: 500. |
-| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
-
-**Returns**
-
-Polars dataframe containing schedule dates for the requested season. Returns None if no games
-
-| col_name | type | description |
-|---|---|---|
-| `id` | character | 247Sports referencing id for the recruit. |
-| `uid` | character | ESPN global unique identifier. |
-| `date` | character | Date of the poll release. |
-| `attendance` | integer | Reported attendance at the game. |
-| `time_valid` | logical | Whether the start time is confirmed. |
-| `date_valid` | logical | Boolean flag indicating whether the game's scheduled date is confirmed and valid. |
-| `neutral_site` | logical | TRUE/FALSE flag for if the game took place at a neutral site. |
-| `conference_competition` | logical | Conference competition. |
-| `play_by_play_available` | logical | Whether play-by-play data is available. |
-| `recent` | logical | Whether the game is recent. |
-| `start_date` | character | Season start timestamp (ISO 8601, UTC). |
-| `broadcast` | character | Broadcast network short name. |
-| `highlights` | character | Game highlight urls. |
-| `notes_type` | character | Notes type. |
-| `notes_headline` | character | Notes headline. |
-| `broadcast_market` | character | Broadcast market label (e.g. 'national', 'home'). |
-| `broadcast_name` | character | Broadcast name. |
-| `type_id` | character | Play-type id. |
-| `type_abbreviation` | character | Play-type abbreviation (e.g. `RUSH`, `TD`). |
-| `venue_id` | character | Referencing venue id. |
-| `venue_full_name` | character | Venue full name. |
-| `venue_address_city` | character | Venue address city. |
-| `venue_address_country` | character | Country in which the game venue is located, as provided by ESPN's venue data. |
-| `venue_indoor` | logical | Whether the home venue is indoors. |
-| `status_clock` | double | Game clock in seconds. |
-| `status_display_clock` | character | Status display clock. |
-| `status_period` | integer | Current period. |
-| `status_type_id` | character | Unique identifier for status type. |
-| `status_type_name` | character | Status type name. |
-| `status_type_state` | character | Status state (pre/in/post). |
-| `status_type_completed` | logical | Whether the game is complete. |
-| `status_type_description` | character | Status type description. |
-| `status_type_detail` | character | Status type detail. |
-| `status_type_short_detail` | character | Status type short detail. |
-| `format_regulation_periods` | integer | Format regulation periods. |
-| `home_id` | character | Home team referencing id. |
-| `home_uid` | character | Home team's uid. |
-| `home_location` | character | Home team's location. |
-| `home_name` | character | Home team display name. |
-| `home_abbreviation` | character | Home team's abbreviation. |
-| `home_display_name` | character | Home team display name. |
-| `home_short_display_name` | character | Home short display name. |
-| `home_color` | character | Home team primary color hex. |
-| `home_alternate_color` | character | Color code (hex) for home alternate. |
-| `home_is_active` | logical | Home team's is active. |
-| `home_venue_id` | character | Unique identifier for home venue. |
-| `home_logo` | character | Home team logo URL. |
-| `home_conference_id` | character | Unique identifier for home conference. |
-| `home_score` | character | Home-team score after the play. |
-| `home_current_rank` | integer | AP or Coaches Poll ranking of the home team at the time of the game (null if unranked). |
-| `home_linescores` | list | Per-period point totals for the home team, stored as an array of quarter/overtime scores. |
-| `home_records` | character | Win-loss record of the home team at the time of the game, as reported by ESPN (e.g., overall or conference record). |
-| `away_id` | character | Away team referencing id. |
-| `away_uid` | character | Away team's uid. |
-| `away_location` | character | Away team's location. |
-| `away_name` | character | Away team display name. |
-| `away_abbreviation` | character | Away team's abbreviation. |
-| `away_display_name` | character | Away team display name. |
-| `away_short_display_name` | character | Away short display name. |
-| `away_color` | character | Away team primary color hex. |
-| `away_alternate_color` | character | Color code (hex) for away alternate. |
-| `away_is_active` | logical | Away team's is active. |
-| `away_venue_id` | character | Unique identifier for away venue. |
-| `away_logo` | character | Away team logo URL. |
-| `away_conference_id` | character | Unique identifier for away conference. |
-| `away_score` | character | Away-team score after the play. |
-| `away_current_rank` | integer | AP or Coaches Poll ranking of the away team at the time of the game (null if unranked). |
-| `away_linescores` | list | Per-period point totals for the away team, stored as an array of quarter/overtime scores. |
-| `away_records` | character | Win-loss record of the away team at the time of the game, as reported by ESPN (e.g., overall or conference record). |
-| `game_id` | integer | ESPN game identifier. |
-| `season` | integer | Season (4-digit year). |
-| `season_type` | integer | ESPN season type (2 = regular, 3 = postseason). |
-| `week` | integer | Game week of the season. |
-| `venue_address_state` | character | Venue address state / region. |
-| `groups_id` | character | Unique identifier for groups. |
-| `groups_name` | character | Groups name. |
-| `groups_short_name` | character | Groups short name. |
-| `groups_is_conference` | logical | Groups is conference. |
-
-**Example**
-
-```python
-from sportsdataverse.cfb import espn_cfb_schedule
-slate = espn_cfb_schedule()
-print(slate.shape if slate is not None else "no games")
-
-# Pull a specific week of FBS games
-
-week5 = espn_cfb_schedule(dates=2023, week=5, season_type=2)
-
-# Pipeline next step (extract finals only)
-
-import polars as pl
-finals = espn_cfb_schedule(dates=2023, week=5).filter(
-    pl.col("status_type_completed") == True
-)
-```
-
-## Dataset loaders
-
-### `load_cfb_betting_lines(return_as_pandas=False) -> 'pl.DataFrame'` {#load_cfb_betting_lines}
-
-Load college football betting lines information
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
-
-**Returns**
-
-Polars dataframe containing betting lines available for the available seasons.
-
-| col_name | type | description |
-|---|---|---|
-| `id` | double | 247Sports referencing id for the recruit. |
-| `game_id` | integer | ESPN game identifier. |
-| `season` | double | Season (4-digit year). |
-| `game_desc` | character | Human-readable description of the game, typically including team names and context. |
-| `date_time` | character | Date and time of the game to which the betting line applies, as a string. |
-| `market_type` | character | Geographic market type (e.g. `National`). |
-| `abbr` | character | Selection/side this odds row applies to — a team abbreviation for spread and moneyline markets, or 'over'/'under' for total markets (the data is long-format, one row per book per selection per market_type). |
-| `lines` | double | Numeric line for this row's market — the per-side point spread for spread markets or the over/under total points for total markets; null for moneyline rows. |
-| `odds` | integer | American-odds price for this selection — the juice/vig on spread and total rows, or the moneyline price itself on moneyline rows. |
-| `opening_lines` | double | Opening numeric line for this row's market (per-side spread or over/under total points) before line movement; null for moneyline rows. |
-| `opening_odds` | integer | Opening American-odds price for this selection before line movement (vig on spread/total rows, moneyline price on moneyline rows). |
-| `book` | character | Name of the sportsbook or oddsmaker that provided the betting line. |
-| `season_type` | character | ESPN season type (2 = regular, 3 = postseason). |
-| `week` | integer | Game week of the season. |
-
-**Example**
-
-```python
-from sportsdataverse.cfb import load_cfb_betting_lines
-lines = load_cfb_betting_lines()
-print(lines.shape)
-
-# Pandas round-trip
-
-lines_pd = load_cfb_betting_lines(return_as_pandas=True)
-lines_pd.head()
-
-# Pipeline next step (filter to one provider in 2023)
-
-import polars as pl
-consensus_2023 = load_cfb_betting_lines().filter(
-    (pl.col("season") == 2023) & (pl.col("provider") == "consensus")
-)
-```
-
-### `load_cfb_rosters_crosswalk(return_as_pandas: 'bool' = False) -> 'pl.DataFrame'` {#load_cfb_rosters_crosswalk}
-
-Load the current ESPN x Fox CFB rosters crosswalk (single snapshot).
-
-Unlike the per-season `load_cfb_teams_crosswalk` / `load_cfb_schedule_crosswalk`
-loaders, this one is **season-less**: ESPN's and Fox's team-roster endpoints
-only expose the *current* roster, so the published artifact is a single
-snapshot rather than a historical per-season series. It is built by
-`cfbfastR-cfb-data`'s `scripts/build_cfb_crosswalk.py` (which fans the
-per-team `sportsdataverse.cfb.cfb_rosters_crosswalk` builder out over
-the current season's ESPN<->Fox team-id pairs) and refreshed on that repo's
-cadence.
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
-
-**Returns**
-
-one row per matched player, carrying `espn_team_id` / `fox_team_id` provenance plus each provider's athlete id, name, jersey, position, and the `match_method` / `matched_sources` flags.
-
-**Example**
-
-```python
-from sportsdataverse.cfb import load_cfb_rosters_crosswalk
-xwalk = load_cfb_rosters_crosswalk()
-print(xwalk.shape)
-
-# Pandas round-trip
-
-xwalk_pd = load_cfb_rosters_crosswalk(return_as_pandas=True)
-
-# Pipeline next step (one team's ESPN<->Fox athlete map)
-
-import polars as pl
-osu = load_cfb_rosters_crosswalk().filter(pl.col("espn_team_id") == 194)
-```
-
-### `load_draft_outcomes(years: 'int | list[int]', *, return_as_pandas: 'bool' = False) -> 'pl.DataFrame | pd.DataFrame'` {#load_draft_outcomes}
-
-NFL draft picks with the college of each pick, for the requested draft years.
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `years` | `int \| list[int]` |  | A draft year or list of draft years. |
-| `return_as_pandas` | `bool` | `False` | If True, return a pandas DataFrame; otherwise polars. |
-
-**Returns**
-
-One row per pick: `draft_year` (Int64), `college` (Utf8 PFR-style college name), `player_id` (Utf8 ESPN college athlete id; null for older drafts), `player_name` (Utf8), `round` / `pick` (Int64), `position` (Utf8). Zero-row (typed) when the source is unavailable.
-
-| col_name | type | description |
-|---|---|---|
-| `draft_year` | integer | NFL draft year of the pick. |
-| `college` | character | College of the pick (PFR-style name, e.g. "Ohio St."). |
-| `player_id` | character | ESPN college athlete id as a string (null for older drafts). |
-| `player_name` | character | Player name as listed on the pick record. |
-| `round` | integer | Round of the NFL draft the player was selected in (1-7 in the modern format). |
-| `pick` | integer | Overall pick number. |
-| `position` | character | Position drafted at (PFR abbreviation). |
-
-**Example**
-
-```python
-from sportsdataverse.cfb import load_draft_outcomes
-picks = load_draft_outcomes([2023, 2024])
-picks.group_by("college").len().sort("len", descending=True).head()
-```
-
-### `load_fp_curve() -> 'pl.DataFrame'` {#load_fp_curve}
-
-Load the bundled EP-by-yardline curve (no network, no first-use download).
-
-**Returns**
-
-`yardline_own: Int64 (1..99), ep: Float64`.
-
-| col_name | type | description |
-|---|---|---|
-| `yardline_own` | integer | Starting yard line from the offense's own goal (1-99). |
-| `ep` | double | Bundled expected points for a drive starting at this yard line (2018-2021 fit). |
-
-**Example**
-
-```python
-from sportsdataverse.cfb.cfb_field_position import load_fp_curve
-curve = load_fp_curve()
-```
-
-### `load_recruit_classes(seasons: 'int | list[int]', *, division: 'str' = 'fbs', return_as_pandas: 'bool' = False) -> 'pl.DataFrame | pd.DataFrame'` {#load_recruit_classes}
-
-Load recruiting classes as per-recruit rows from the 247 RDB feed.
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `seasons` | `int \| list[int]` |  | A single recruiting-class year or a list of them. |
-| `division` | `str` | `'fbs'` | Division slug (reserved for constant lookups downstream; the feed itself is queried for all of college football). |
-| `return_as_pandas` | `bool` | `False` | If True, return a pandas DataFrame; otherwise polars. |
-
-**Returns**
-
-One row per committed recruit: `season` (Int64), `team_id` (Utf8 — the 247 committed-team key), `team` (Utf8 full name — the downstream name-join key, since the 247 recruit-team key differs from the 247 talent-composite key), `recruit_id` (Utf8), `stars` (Int64), `grade` (Float64 247 composite rating), `position` (Utf8). Zero-row (typed) when no data is available.
-
-| col_name | type | description |
-|---|---|---|
-| `season` | integer | Recruiting-class year the recruit signed in. |
-| `team_id` | character | 247Sports signed-institution team key as a string (falls back to the committed institution when unsigned). |
-| `team` | character | Signed-institution full name (falls back to committed) - the downstream name-join key. |
-| `recruit_id` | character | 247Sports recruit key as a string (integer-origin). |
-| `stars` | integer | 247 composite star rating (1-5; null for unrated recruits). |
-| `grade` | double | 247 composite rating on the 0-100 scale. |
-| `position` | character | Primary position abbreviation from the 247 recruit record. |
-
-**Example**
-
-```python
-from sportsdataverse.cfb.cfb_roster_talent import load_recruit_classes
-rec = load_recruit_classes([2022, 2023])
-rec.group_by("team").len().sort("len", descending=True).head()
-```
-
-## Utilities & helpers
+## Highlights
 
 ### `CFBPlayProcess(gameId=0, raw=False, path_to_json='/', return_keys=None, odds_override=None, game_roster=None, participants=None, join_participants=True, **kwargs)` {#CFBPlayProcess}
 
@@ -842,6 +342,515 @@ game.espn_cfb_pbp()
 trimmed = game.run_processing_pipeline()
 ```
 
+### `cfb_advanced_stats(seasons: 'Union[int, list[int]]', *, adjust: 'bool' = True, exclude_garbage: 'bool' = True, as_of_date: 'Optional[datetime.date]' = None, config: 'Optional[AdjustConfig]' = None, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#cfb_advanced_stats}
+
+Team-season CFB advanced stats: efficiency, explosiveness, havoc.
+
+Loads play-by-play via `load_cfb_pbp`, builds the garbage-filtered
+per-play long frame, aggregates raw per-team offense/defense success
+rate, EPA/play, isoPPP (mean EPA on successful plays), explosive rate
+and havoc, and (default) opponent-adjusts each metric with the
+iterative solver.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `seasons` | `Union[int, list[int]]` |  | season or list of seasons (hosted pbp covers 2002-2021). |
+| `adjust` | `bool` | `True` | add `adj_*` opponent-adjusted columns + EPA ranks. |
+| `exclude_garbage` | `bool` | `True` | drop Connelly garbage-time plays. |
+| `as_of_date` | `Optional[date]` | `None` | leakage boundary -- only plays strictly before this date contribute. |
+| `config` | `Optional[AdjustConfig]` | `None` | `AdjustConfig` for the solver. |
+| `return_as_pandas` | `bool` | `False` | return a pandas `DataFrame` instead of polars. |
+
+**Returns**
+
+One row per (season, team_id) with the raw columns (and `adj_*` plus `off_epa_rank`/`def_epa_rank` when `adjust=True`). Empty input returns a zero-row frame with the documented schema.
+
+| col_name | type | description |
+|---|---|---|
+| `season` | integer | Season the stats cover. |
+| `team_id` | character | Team ESPN id (character join key). |
+| `plays` | integer | Situation-neutral offensive plays in the aggregate. |
+| `off_success_rate` | double | Offensive success rate (yards gained >= 50/70/100 percent of distance by down). |
+| `def_success_rate` | double | Success rate allowed (Connelly 50/70/100 yardage rule). |
+| `off_epa_play` | double | Raw offensive EPA per play on the garbage-filtered substrate (garbage time excluded by default; pass exclude_garbage=False to keep it). |
+| `def_epa_play` | double | Raw EPA allowed per play on the garbage-filtered substrate (garbage time excluded by default; pass exclude_garbage=False to keep it). |
+| `off_iso_ppp` | double | Mean EPA on successful offensive plays (Connelly isoPPP explosiveness). |
+| `def_iso_ppp` | double | Mean EPA allowed on successful plays faced (isoPPP against). |
+| `off_explosive_rate` | double | Share of offensive plays that were explosive (pass EPA >= 2.4, rush EPA >= 1.8). |
+| `def_explosive_rate` | double | Share of plays faced that were explosive (pass EPA >= 2.4, rush EPA >= 1.8). |
+| `def_havoc` | double | Share of plays faced with a havoc event (TFL, pass breakup, interception, forced fumble). |
+| `off_havoc_allowed` | double | Share of offensive plays on which the defense recorded a havoc event. |
+| `off_epa_success_rate` | double | Share of offensive plays with EPA > 0 (EPA-based success rate). |
+| `adj_off_epa_play` | double | Opponent-adjusted offensive EPA per play (higher is better). |
+| `adj_off_success_rate` | double | Opponent-adjusted offensive success rate. |
+| `adj_off_explosive_rate` | double | Opponent-adjusted offensive explosive-play rate. |
+| `adj_def_epa_play` | double | Opponent-adjusted EPA allowed per play (lower is better). |
+| `adj_def_success_rate` | double | Opponent-adjusted success rate allowed. |
+| `adj_def_explosive_rate` | double | Opponent-adjusted explosive-play rate allowed. |
+| `adj_def_havoc` | double | Opponent-adjusted havoc rate created by the defense. |
+| `adj_off_havoc_allowed` | double | Opponent-adjusted havoc rate the offense allows. |
+| `off_epa_rank` | integer | Dense rank on adj_off_epa_play descending (best offense = 1). |
+| `def_epa_rank` | integer | Dense rank on adj_def_epa_play ascending (fewest EPA allowed = 1). |
+
+**Example**
+
+```python
+from sportsdataverse.cfb import cfb_advanced_stats
+df = cfb_advanced_stats([2021])
+print(df.shape)
+
+# Raw only, garbage time kept
+
+df_raw = cfb_advanced_stats(2021, adjust=False, exclude_garbage=False)
+
+# Pipeline next step (one line)
+
+df.sort("adj_off_epa_play", descending=True).head()
+```
+
+### `cfb_standings(games: 'FrameLike', teams: 'FrameLike', *, tiebreaker_depth: 'str' = 'SOS', playoff_seeds: 'Optional[int]' = None, rankings: 'Optional[FrameLike]' = None, tiebreaker_data: 'Optional[Dict[str, FrameLike]]' = None, return_as_pandas: 'bool' = False, rng: 'Optional[np.random.Generator]' = None) -> 'Union[pl.DataFrame, Any]'` {#cfb_standings}
+
+Compute college football standings with conference ranks and champions.
+
+Engine design adapted from nflseedR (MIT, Sebastian Carl & Lee Sharpe);
+see the module docstring for the documented CFB simplifications, and its
+"Official per-conference tiebreakers (registry)" section for how
+`CONFERENCE_TIEBREAKERS` overrides the generic cascade for the SEC,
+Big Ten, Big 12, ACC and MAC.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `games` | `FrameLike` |  | Game results with columns `sim` (or `season`), `week`, `game_type` (`REG` \| `CONF_CHAMP` \| `POST`), `home_team`, `away_team`, `result` (home margin: home - away; null = unplayed), optional `neutral` (0/1), and optional `home_points`/`away_points` (per-game scores — feeds the SEC capped-scoring-margin rung; `cfb_games_from_schedule` emits both). Either optional input absent -> that rung is skipped, not an error. |
+| `teams` | `FrameLike` |  | Team table with columns `team` and `conference` (null or `"FBS Independents"` marks an independent), and an optional `division` column (`"FBS"`/`"FCS"` or similar — feeds the Big 12 `total_wins` FCS cap; absent -> the cap degrades to uncapped win totals, noted in `tiebreak_notes`). |
+| `tiebreaker_depth` | `str` | `'SOS'` | One of `"RANDOM"`, `"PRE-SOV"`, `"SOS"`, `"POINTS"` — the nflseedR depth ladder. Steps beyond the chosen depth are skipped and remaining ties are broken by coin flip. Gates ONLY the generic fallback cascade; registered official conference procedures (below) always run in full. |
+| `playoff_seeds` | `Optional[int]` | `None` | If set, adds a `seed` column via `cfb_playoff_seeds` with this field size. |
+| `rankings` | `Optional[FrameLike]` | `None` | Optional committee-style rankings frame (`team`, `rank`) forwarded to `cfb_playoff_seeds`. |
+| `tiebreaker_data` | `Optional[Dict[str, FrameLike]]` | `None` | Optional external inputs for the registry rungs, as a dict with key `"analytics_ratings"` -> a frame with columns `team` and `rating` (feeds the `analytics_rating` rung used by Big Ten/Big 12/ACC/MAC). A `"cfp_rankings"` key (`team`, `rank`) is accepted for forward compatibility but unused by the current registry (no registered conference has a `cfp_ranking` rung yet). Missing -> the rung is skipped, noted. |
+| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
+| `rng` | `Optional[Generator]` | `None` | Optional numpy Generator used only for coin-flip tiebreaks (simulations pass their seeded generator through here). |
+
+**Returns**
+
+A polars (or pandas) DataFrame with one row per (sim, team): overall record (`games`/`wins`/`losses`/`ties`/`win_pct`/ `pd`), conference record (`conf_*`), `sov`, `sos`, `conf_rank` (null for independents), `conf_champ` and, when `playoff_seeds` is set, `seed`. The result also carries a `tiebreak_notes` list of skipped-rung messages (see the module docstring): `result.tiebreak_notes` for a polars frame, `result.attrs["tiebreak_notes"]` for a pandas frame (pandas' own metadata mechanism — avoids its "new attribute" warning).
+
+| col_name | type | description |
+|---|---|---|
+| `sim` | integer | Season or simulation identifier the standings row belongs to. |
+| `team` | character | Team name (join key across the seedr engine frames). |
+| `conference` | character | Conference the team belongs to; null or "FBS Independents" marks an independent. |
+| `games` | integer | Total games played across all game types (regular season, conference championship and postseason). |
+| `wins` | integer | Wins across all played games (conference championship and postseason included). |
+| `losses` | integer | Losses across all played games. |
+| `ties` | integer | Ties across all played games. |
+| `win_pct` | double | Overall win percentage - (wins + 0.5 * ties) / games, 0.0 when no games have been played. |
+| `pd` | double | Point differential (points for minus points against, via game margins) summed over all played games. |
+| `conf_games` | integer | Number of conference regular-season games played (both teams in the same conference; CONF_CHAMP games excluded). |
+| `conf_wins` | integer | Wins in conference regular-season games. |
+| `conf_losses` | integer | Losses in conference regular-season games. |
+| `conf_ties` | integer | Ties in conference regular-season games. |
+| `conf_pct` | double | Conference win percentage - (conf_wins + 0.5 * conf_ties) / conf_games, 0.0 with no conference games; the primary sort key for conference ranks. |
+| `conf_pd` | double | Point differential summed over conference regular-season games only; the POINTS-depth tiebreaker rung. |
+| `sov` | double | Strength of victory, conference-REG-scoped (unlike nflseedR's overall games-weighted version) - mean of defeated conference opponents' conference win pct, one term per conference victory; 0.0 for independents or teams without conference wins. |
+| `sos` | double | Strength of schedule, conference-REG-scoped (unlike nflseedR's overall games-weighted version) - mean of conference opponents' conference win pct across all conference games played; 0.0 for independents. |
+| `conf_rank` | integer | Rank within the conference from the tiebreaker cascade (1 = best); null for independents. |
+| `conf_champ` | logical | Whether the team is its conference's champion - the CONF_CHAMP game winner when one was played, otherwise the conference's rank-1 team; always false for independents. |
+
+**Example**
+
+```python
+import polars as pl
+from sportsdataverse.cfb import cfb_standings
+
+games = pl.DataFrame({
+    "sim": [2024, 2024], "week": [1, 2],
+    "game_type": ["REG", "REG"],
+    "home_team": ["A", "B"], "away_team": ["B", "A"],
+    "result": [7.0, -3.0], "neutral": [0, 0],
+})
+teams = pl.DataFrame({"team": ["A", "B"], "conference": ["X", "X"]})
+print(cfb_standings(games, teams))
+
+# With CFP seeds from committee rankings
+
+st = cfb_standings(games, teams, playoff_seeds=12, rankings=ranks_df)
+
+# With an official-registry analytics rating input
+
+ratings = pl.DataFrame({"team": ["A", "B"], "rating": [92.1, 88.4]})
+st = cfb_standings(games, teams, tiebreaker_data={"analytics_ratings": ratings})
+print(st.tiebreak_notes)
+```
+
+### `espn_cfb_player_stats(athlete_id: 'int', season: 'int', *, season_type: 'str' = 'regular', total: 'bool' = False, raw: 'bool' = False, return_as_pandas: 'bool' = False, **kwargs: 'Any') -> 'pl.DataFrame | pd.DataFrame | dict[str, Any]'` {#espn_cfb_player_stats}
+
+Pull a college-football athlete's ESPN **season** stat line.
+
+See `sportsdataverse.wbb.espn_wbb_player_stats` for full
+documentation of the wide return shape, the `{category}_{stat}` stat
+columns (for football: `passing_*`, `rushing_*`, `receiving_*`,
+`scoring_*`, ...), the athlete / team metadata blocks, and the
+`season_type` / `total` parameters. For the richer multi-category
+web-v3 payload use `sportsdataverse.cfb.espn_cfb_player_stats_v3`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `athlete_id` | `int` |  | ESPN college-football athlete identifier. |
+| `season` | `int` |  | Season year, used in the core-v2 path. |
+| `season_type` | `str` | `'regular'` | `"regular"` (type 2) or `"postseason"` (type 3). |
+| `total` | `bool` | `False` | Forward-compat totals passthrough. |
+| `raw` | `bool` | `False` | If True, returns the raw core-v2 statistics JSON dict. |
+| `return_as_pandas` | `bool` | `False` | If True, returns a pandas DataFrame; else polars. |
+
+**Returns**
+
+A single-row wide DataFrame (polars by default). When `raw=True` returns the raw statistics JSON `dict`.
+
+| col_name | type | description |
+|---|---|---|
+| `season` | integer | Season (4-digit year). |
+| `season_type` | character | ESPN season type (2 = regular, 3 = postseason). |
+| `total` | logical | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
+| `athlete_id` | integer | ESPN athlete id. |
+| `athlete_uid` | character | ESPN athlete UID (universal identifier). |
+| `athlete_guid` | character | ESPN athlete GUID. |
+| `athlete_type` | character | Athlete type / class. |
+| `first_name` | character | Athlete first name. |
+| `last_name` | character | Athlete last name. |
+| `full_name` | character | Venue full name (e.g. `Tenney Stadium`). |
+| `display_name` | character | Human-readable metric name. |
+| `short_name` | character | Ranking source short name (e.g. `AP Poll`). |
+| `weight` | double | Listed weight (lbs). |
+| `display_weight` | character | Human-readable weight (e.g. `205 lbs`). |
+| `height` | double | Listed height (inches). |
+| `display_height` | character | Human-readable height (e.g. `6' 1"`). |
+| `age` | integer | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
+| `date_of_birth` | character | Player date of birth (if published). |
+| `jersey` | character | Jersey number. |
+| `slug` | character | URL slug for the team. |
+| `active` | logical | `TRUE` if the player was active for the game. |
+| `position_id` | integer | ESPN position id. |
+| `position_name` | character | Position name (e.g. `Quarterback`); `position_detail = TRUE` only. |
+| `position_display_name` | character | Human-readable position name; `position_detail = TRUE` only. |
+| `position_abbreviation` | character | Position abbreviation (e.g. `QB`); `position_detail = TRUE` only. |
+| `college_name` | character | Official college (usually the last one attended) |
+| `status_id` | integer | ESPN commitment status id. |
+| `status_name` | character | Status-type key (e.g. `STATUS_FINAL`). |
+| `general_fumbles` | double | Total number of fumbles committed by the player across all offensive and special-teams plays. |
+| `general_fumbles_lost` | double | Number of fumbles the player committed that were recovered by the opposing team. |
+| `general_fumbles_touchdowns` | double | Total touchdowns scored by the player as a result of fumble recoveries, combining offensive and defensive occurrences. |
+| `general_games_played` | double | Games Played. |
+| `general_offensive_two_pt_returns` | double | Number of two-point conversions the player scored by returning a blocked or intercepted two-point attempt on the offensive side. |
+| `general_offensive_fumbles_touchdowns` | double | Number of touchdowns scored by the player on fumble recoveries credited to the offensive category. |
+| `general_defensive_fumbles_touchdowns` | double | Number of touchdowns scored by the player on fumble recoveries attributed to the defensive category. |
+| `passing_avg_gain` | double | Average yards gained per passing play attempt by the quarterback in the passing category. |
+| `passing_completion_pct` | double | Percentage of pass attempts thrown by the quarterback that were completed, calculated as completions divided by attempts. |
+| `passing_completions` | double | Pass completions (split from CFBD's `C/ATT` field). |
+| `passing_espnqb_rating` | double | ESPN's proprietary quarterback rating for the player's passing performance, factoring in efficiency metrics beyond traditional passer rating. |
+| `passing_interception_pct` | double | Percentage of pass attempts that resulted in an interception, calculated as interceptions divided by passing attempts. |
+| `passing_interceptions` | double | Total number of passes thrown by the quarterback that were intercepted by the defense. |
+| `passing_long_passing` | double | Longest single completed pass in yards recorded by the quarterback during the stat period. |
+| `passing_net_passing_yards` | double | Net passing yards gained by the quarterback after subtracting yardage lost on sacks from gross passing yards. |
+| `passing_net_passing_yards_per_game` | double | Net passing yards per game for the quarterback, computed as net passing yards divided by games played. |
+| `passing_net_total_yards` | double | Combined net yardage from passing and rushing for a quarterback, accounting for sack yardage lost in the passing category. |
+| `passing_net_yards_per_game` | double | Net total yards gained per game for the player as recorded in the passing category context. |
+| `passing_passing_attempts` | double | Total number of pass attempts thrown by the quarterback, including completions, incompletions, and interceptions. |
+| `passing_passing_big_plays` | double | Number of passing plays that gained 20 or more yards as recorded for the quarterback. |
+| `passing_passing_first_downs` | double | Number of first downs gained by the team on passing plays thrown by the quarterback. |
+| `passing_passing_fumbles` | double | Number of fumbles the quarterback committed during passing plays, including fumbled snaps and sack fumbles. |
+| `passing_passing_fumbles_lost` | double | Number of fumbles the quarterback committed on passing plays that were recovered by the opposing team. |
+| `passing_passing_touchdown_pct` | double | Percentage of pass attempts that resulted in a passing touchdown, calculated as touchdowns divided by attempts. |
+| `passing_passing_touchdowns` | double | Total number of touchdown passes thrown by the quarterback. |
+| `passing_passing_yards` | double | Gross passing yards gained by the quarterback on completed passes. |
+| `passing_passing_yards_after_catch` | double | Total yards gained by receivers after the catch on passes thrown by the quarterback. |
+| `passing_passing_yards_at_catch` | double | Total yards gained at the point of the catch (air yards) on passes thrown by the quarterback, before any yards after catch. |
+| `passing_passing_yards_per_game` | double | Gross passing yards per game for the quarterback, computed as passing yards divided by games played. |
+| `passing_qb_rating` | double | Traditional NCAA passer rating for the quarterback, calculated from completion percentage, yards per attempt, touchdown rate, and interception rate. |
+| `passing_sacks` | double | Total number of times the quarterback was sacked (tackled behind the line of scrimmage on a passing play). |
+| `passing_sack_yards_lost` | double | Total yards lost by the quarterback as a result of being sacked, subtracted when computing net passing yards. |
+| `passing_team_games_played` | double | Number of team games played during the stat period, used as the denominator for per-game passing rate statistics. |
+| `passing_total_offensive_plays` | double | Total number of offensive plays (pass attempts plus rushes) for the team during the stat period, recorded in the passing category context. |
+| `passing_total_points_per_game` | double | Average total points scored per game by the player's team as recorded alongside passing statistics. |
+| `passing_total_touchdowns` | double | Total touchdowns accounted for by the quarterback across passing and rushing in the passing category context. |
+| `passing_total_yards` | double | Total offensive yardage (passing plus rushing) accumulated by the quarterback as reported in the passing category. |
+| `passing_total_yards_from_scrimmage` | double | Total yards from scrimmage accumulated by the quarterback (passing plus rushing yards) in the passing category context. |
+| `passing_two_point_pass_convs` | double | Number of successful two-point conversions the quarterback converted via a passing play. |
+| `passing_two_pt_pass` | double | Indicator or count of two-point conversion passing attempts recorded for the quarterback. |
+| `passing_two_pt_pass_attempts` | double | Total number of two-point conversion attempts the quarterback made via a passing play. |
+| `passing_yards_from_scrimmage_per_game` | double | Average yards from scrimmage per game for the quarterback as reported in the passing category. |
+| `passing_yards_per_completion` | double | Average yards gained per completed pass by the quarterback, calculated as passing yards divided by completions. |
+| `passing_yards_per_game` | double | Average gross passing yards per game for the quarterback, equivalent to passing_passing_yards_per_game. |
+| `passing_yards_per_pass_attempt` | double | Average yards gained per pass attempt by the quarterback, calculated as passing yards divided by attempts. |
+| `passing_net_yards_per_pass_attempt` | double | Net passing yards divided by total pass attempts, including sack yardage lost in the denominator's context. |
+| `passing_qbr` | double | ESPN Quarterback Rating (QBR) for the player in this game. |
+| `passing_adj_qbr` | double | ESPN's adjusted Total Quarterback Rating (QBR) for the player's passing performance, controlling for opponent difficulty and game situation. |
+| `passing_quarterback_rating` | double | Traditional passer rating for the quarterback, equivalent to passing_qb_rating, using the standard NCAA formula. |
+| `rushing_avg_gain` | double | Average yards gained per rushing attempt for the player in the rushing category. |
+| `rushing_espnrb_rating` | double | ESPN's proprietary running back rating for the player's rushing performance. |
+| `rushing_long_rushing` | double | Longest single rushing carry in yards recorded by the player during the stat period. |
+| `rushing_net_total_yards` | double | Net total yardage accumulated by the player from rushing and any receiving contributions as reported in the rushing category. |
+| `rushing_net_yards_per_game` | double | Net total yards per game for the player as reported in the rushing category context. |
+| `rushing_rushing_attempts` | double | Total number of rushing attempts (carries) credited to the player. |
+| `rushing_rushing_big_plays` | double | Number of rushing plays that gained 10 or more yards for the player. |
+| `rushing_rushing_first_downs` | double | Number of first downs gained by the player via rushing plays. |
+| `rushing_rushing_fumbles` | double | Number of fumbles the player committed on rushing plays. |
+| `rushing_rushing_fumbles_lost` | double | Number of fumbles the player committed on rushing plays that were recovered by the opposing team. |
+| `rushing_rushing_touchdowns` | double | Total number of rushing touchdowns scored by the player. |
+| `rushing_rushing_yards` | double | Total yards gained by the player on rushing attempts. |
+| `rushing_rushing_yards_per_game` | double | Average rushing yards per game for the player, calculated as rushing yards divided by games played. |
+| `rushing_stuffs` | double | Number of rushing attempts in which the player was stopped at or behind the line of scrimmage. |
+| `rushing_stuff_yards_lost` | double | Total yards lost by the player on stuffed rushing plays (carries stopped at or behind the line of scrimmage). |
+| `rushing_team_games_played` | double | Number of team games played during the stat period, used as the denominator for per-game rushing rate statistics. |
+| `rushing_total_offensive_plays` | double | Total number of offensive plays for the team during the stat period, recorded in the rushing category context. |
+| `rushing_total_points_per_game` | double | Average total points scored per game by the player's team as recorded alongside rushing statistics. |
+| `rushing_total_touchdowns` | double | Total touchdowns scored by the player across all methods as reported in the rushing category context. |
+| `rushing_total_yards` | double | Total offensive yardage accumulated by the player as reported in the rushing category. |
+| `rushing_total_yards_from_scrimmage` | double | Total yards from scrimmage for the player (rushing plus receiving yards) as reported in the rushing category. |
+| `rushing_two_point_rush_convs` | double | Number of successful two-point conversions the player converted via a rushing play. |
+| `rushing_two_pt_rush` | double | Indicator or count of two-point conversion rushing attempts recorded for the player. |
+| `rushing_two_pt_rush_attempts` | double | Total number of two-point conversion attempts the player made via a rushing play. |
+| `rushing_yards_from_scrimmage_per_game` | double | Average yards from scrimmage per game for the player as reported in the rushing category. |
+| `rushing_yards_per_game` | double | Average rushing yards per game for the player, equivalent to rushing_rushing_yards_per_game. |
+| `rushing_yards_per_rush_attempt` | double | Average yards gained per rushing attempt for the player, calculated as rushing yards divided by attempts. |
+| `receiving_avg_gain` | double | Average yards gained per reception for the player in the receiving category. |
+| `receiving_espnwr_rating` | double | ESPN's proprietary wide receiver / pass-catcher rating for the player's receiving performance. |
+| `receiving_long_reception` | double | Longest single reception in yards recorded by the player during the stat period. |
+| `receiving_net_total_yards` | double | Net total yardage accumulated by the player from receiving and any rushing contributions as reported in the receiving category. |
+| `receiving_net_yards_per_game` | double | Net total yards per game for the player as reported in the receiving category context. |
+| `receiving_receiving_big_plays` | double | Number of receiving plays that gained 20 or more yards for the player. |
+| `receiving_receiving_first_downs` | double | Number of first downs gained by the player via receptions. |
+| `receiving_receiving_fumbles` | double | Number of fumbles the player committed after catching a pass. |
+| `receiving_receiving_fumbles_lost` | double | Number of fumbles the player committed on receiving plays that were recovered by the opposing team. |
+| `receiving_receiving_targets` | double | Total number of times the player was targeted as the intended receiver on a pass play. |
+| `receiving_receiving_touchdowns` | double | Total number of touchdown receptions scored by the player. |
+| `receiving_receiving_yards` | double | Total yards gained by the player on completed receptions. |
+| `receiving_receiving_yards_after_catch` | double | Total yards gained by the player after the catch on receiving plays. |
+| `receiving_receiving_yards_at_catch` | double | Total air yards gained at the point of the catch on receiving plays, before any yards after catch. |
+| `receiving_receiving_yards_per_game` | double | Average receiving yards per game for the player, calculated as receiving yards divided by games played. |
+| `receiving_receptions` | double | Total number of completed receptions (catches) recorded by the player. |
+| `receiving_team_games_played` | double | Number of team games played during the stat period, used as the denominator for per-game receiving rate statistics. |
+| `receiving_total_offensive_plays` | double | Total number of offensive plays for the team during the stat period, recorded in the receiving category context. |
+| `receiving_total_points_per_game` | double | Average total points scored per game by the player's team as recorded alongside receiving statistics. |
+| `receiving_total_touchdowns` | double | Total touchdowns scored by the player across all methods as reported in the receiving category context. |
+| `receiving_total_yards` | double | Total offensive yardage accumulated by the player as reported in the receiving category. |
+| `receiving_total_yards_from_scrimmage` | double | Total yards from scrimmage for the player (receiving plus rushing yards) as reported in the receiving category. |
+| `receiving_two_point_rec_convs` | double | Number of successful two-point conversions the player converted via a reception. |
+| `receiving_two_pt_reception` | double | Indicator or count of two-point conversion receptions recorded for the player. |
+| `receiving_two_pt_reception_attempts` | double | Total number of two-point conversion attempts the player made via a receiving play. |
+| `receiving_yards_from_scrimmage_per_game` | double | Average yards from scrimmage per game for the player as reported in the receiving category. |
+| `receiving_yards_per_game` | double | Average receiving yards per game for the player, equivalent to receiving_receiving_yards_per_game. |
+| `receiving_yards_per_reception` | double | Average yards gained per reception for the player, calculated as receiving yards divided by receptions. |
+| `scoring_defensive_points` | double | Total points scored by the player through defensive plays such as defensive touchdowns, safeties, or fumble-return scores. |
+| `scoring_field_goals` | double | Total number of field goals made by the player in the scoring category. |
+| `scoring_kick_extra_points` | double | Total number of extra point attempts kicked by the player. |
+| `scoring_kick_extra_points_made` | double | Total number of successful extra points (PATs) kicked by the player. |
+| `scoring_misc_points` | double | Points scored by the player through miscellaneous means not captured by standard scoring categories. |
+| `scoring_passing_touchdowns` | double | Total touchdown passes thrown by the player as counted in the scoring category. |
+| `scoring_receiving_touchdowns` | double | Total touchdown receptions scored by the player as counted in the scoring category. |
+| `scoring_return_touchdowns` | double | Total touchdowns scored by the player on kick or punt returns as counted in the scoring category. |
+| `scoring_rushing_touchdowns` | double | Total rushing touchdowns scored by the player as counted in the scoring category. |
+| `scoring_total_points` | double | Total points scored by the player across all scoring methods during the stat period. |
+| `scoring_total_points_per_game` | double | Average total points scored by the player per game during the stat period. |
+| `scoring_total_touchdowns` | double | Total touchdowns scored by the player across all methods (passing, rushing, receiving, and return) in the scoring category. |
+| `scoring_total_two_point_convs` | double | Total number of successful two-point conversions scored by the player across passing, rushing, and receiving attempts. |
+| `scoring_two_point_pass_convs` | double | Number of successful two-point conversions the player scored via a passing play, as counted in the scoring category. |
+| `scoring_two_point_rec_convs` | double | Number of successful two-point conversions the player scored via a reception, as counted in the scoring category. |
+| `scoring_two_point_rush_convs` | double | Number of successful two-point conversions the player scored via a rushing play, as counted in the scoring category. |
+| `scoring_one_pt_safeties_made` | double | Number of one-point safeties scored by the player's team, credited in the scoring category. |
+| `team_id` | integer | ESPN team id. |
+| `team_uid` | character | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_guid` | character | ESPN team GUID. |
+| `team_slug` | character | Team slug for the stat row. |
+| `team_location` | character | Team location / school name; `team_detail = TRUE` only. |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
+| `team_abbreviation` | character | Team abbreviation; `team_detail = TRUE` only. |
+| `team_display_name` | character | Full team display name; `team_detail = TRUE` only. |
+| `team_short_display_name` | character | Short team display name; `team_detail = TRUE` only. |
+| `team_color` | character | Primary team color; `team_detail = TRUE` only. |
+| `team_alternate_color` | character | Alternate team color; `team_detail = TRUE` only. |
+| `team_is_active` | logical | TRUE if the team is currently active. |
+| `team_logo_href` | character | Default team logo URL; `team_detail = TRUE` only. |
+
+**Example**
+
+```python
+from sportsdataverse.cfb import espn_cfb_player_stats
+df = espn_cfb_player_stats(athlete_id=4426338, season=2023)
+df.select(["full_name", "team_display_name", "passing_passing_yards"])
+```
+
+### `espn_cfb_schedule(dates=None, week=None, season_type=None, groups=None, limit=500, return_as_pandas=False, **kwargs) -> 'pl.DataFrame'` {#espn_cfb_schedule}
+
+espn_cfb_schedule - look up the college football schedule for a given season
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `dates` | `int` | `None` | Used to define different seasons. 2002 is the earliest available season. |
+| `week` | `int` | `None` | Week of the schedule. |
+| `season_type` | `int` | `None` | 2 for regular season, 3 for post-season, 4 for off-season. |
+| `groups` | `int` | `None` | Used to define different divisions. 80 is FBS, 81 is FCS. |
+| `limit` | `int` | `500` | number of records to return, default: 500. |
+| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
+
+**Returns**
+
+Polars dataframe containing schedule dates for the requested season. Returns None if no games
+
+| col_name | type | description |
+|---|---|---|
+| `id` | character | 247Sports referencing id for the recruit. |
+| `uid` | character | ESPN global unique identifier. |
+| `date` | character | Date of the poll release. |
+| `attendance` | integer | Reported attendance at the game. |
+| `time_valid` | logical | Whether the start time is confirmed. |
+| `date_valid` | logical | Boolean flag indicating whether the game's scheduled date is confirmed and valid. |
+| `neutral_site` | logical | TRUE/FALSE flag for if the game took place at a neutral site. |
+| `conference_competition` | logical | Conference competition. |
+| `play_by_play_available` | logical | Whether play-by-play data is available. |
+| `recent` | logical | Whether the game is recent. |
+| `start_date` | character | Season start timestamp (ISO 8601, UTC). |
+| `broadcast` | character | Broadcast network short name. |
+| `highlights` | character | Game highlight urls. |
+| `notes_type` | character | Notes type. |
+| `notes_headline` | character | Notes headline. |
+| `broadcast_market` | character | Broadcast market label (e.g. 'national', 'home'). |
+| `broadcast_name` | character | Broadcast name. |
+| `type_id` | character | Play-type id. |
+| `type_abbreviation` | character | Play-type abbreviation (e.g. `RUSH`, `TD`). |
+| `venue_id` | character | Referencing venue id. |
+| `venue_full_name` | character | Venue full name. |
+| `venue_address_city` | character | Venue address city. |
+| `venue_address_country` | character | Country in which the game venue is located, as provided by ESPN's venue data. |
+| `venue_indoor` | logical | Whether the home venue is indoors. |
+| `status_clock` | double | Game clock in seconds. |
+| `status_display_clock` | character | Status display clock. |
+| `status_period` | integer | Current period. |
+| `status_type_id` | character | Unique identifier for status type. |
+| `status_type_name` | character | Status type name. |
+| `status_type_state` | character | Status state (pre/in/post). |
+| `status_type_completed` | logical | Whether the game is complete. |
+| `status_type_description` | character | Status type description. |
+| `status_type_detail` | character | Status type detail. |
+| `status_type_short_detail` | character | Status type short detail. |
+| `format_regulation_periods` | integer | Format regulation periods. |
+| `home_id` | character | Home team referencing id. |
+| `home_uid` | character | Home team's uid. |
+| `home_location` | character | Home team's location. |
+| `home_name` | character | Home team display name. |
+| `home_abbreviation` | character | Home team's abbreviation. |
+| `home_display_name` | character | Home team display name. |
+| `home_short_display_name` | character | Home short display name. |
+| `home_color` | character | Home team primary color hex. |
+| `home_alternate_color` | character | Color code (hex) for home alternate. |
+| `home_is_active` | logical | Home team's is active. |
+| `home_venue_id` | character | Unique identifier for home venue. |
+| `home_logo` | character | Home team logo URL. |
+| `home_conference_id` | character | Unique identifier for home conference. |
+| `home_score` | character | Home-team score after the play. |
+| `home_current_rank` | integer | AP or Coaches Poll ranking of the home team at the time of the game (null if unranked). |
+| `home_linescores` | list | Per-period point totals for the home team, stored as an array of quarter/overtime scores. |
+| `home_records` | character | Win-loss record of the home team at the time of the game, as reported by ESPN (e.g., overall or conference record). |
+| `away_id` | character | Away team referencing id. |
+| `away_uid` | character | Away team's uid. |
+| `away_location` | character | Away team's location. |
+| `away_name` | character | Away team display name. |
+| `away_abbreviation` | character | Away team's abbreviation. |
+| `away_display_name` | character | Away team display name. |
+| `away_short_display_name` | character | Away short display name. |
+| `away_color` | character | Away team primary color hex. |
+| `away_alternate_color` | character | Color code (hex) for away alternate. |
+| `away_is_active` | logical | Away team's is active. |
+| `away_venue_id` | character | Unique identifier for away venue. |
+| `away_logo` | character | Away team logo URL. |
+| `away_conference_id` | character | Unique identifier for away conference. |
+| `away_score` | character | Away-team score after the play. |
+| `away_current_rank` | integer | AP or Coaches Poll ranking of the away team at the time of the game (null if unranked). |
+| `away_linescores` | list | Per-period point totals for the away team, stored as an array of quarter/overtime scores. |
+| `away_records` | character | Win-loss record of the away team at the time of the game, as reported by ESPN (e.g., overall or conference record). |
+| `game_id` | integer | ESPN game identifier. |
+| `season` | integer | Season (4-digit year). |
+| `season_type` | integer | ESPN season type (2 = regular, 3 = postseason). |
+| `week` | integer | Game week of the season. |
+| `venue_address_state` | character | Venue address state / region. |
+| `groups_id` | character | Unique identifier for groups. |
+| `groups_name` | character | Groups name. |
+| `groups_short_name` | character | Groups short name. |
+| `groups_is_conference` | logical | Groups is conference. |
+
+**Example**
+
+```python
+from sportsdataverse.cfb import espn_cfb_schedule
+slate = espn_cfb_schedule()
+print(slate.shape if slate is not None else "no games")
+
+# Pull a specific week of FBS games
+
+week5 = espn_cfb_schedule(dates=2023, week=5, season_type=2)
+
+# Pipeline next step (extract finals only)
+
+import polars as pl
+finals = espn_cfb_schedule(dates=2023, week=5).filter(
+    pl.col("status_type_completed") == True
+)
+```
+
+### `get_cfb_teams(return_as_pandas=False) -> 'pl.DataFrame'` {#get_cfb_teams}
+
+Load college football team ID information and logos
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
+
+**Returns**
+
+Polars dataframe containing teams available.
+
+| col_name | type | description |
+|---|---|---|
+| `team_id` | integer | ESPN team id. |
+| `school` | character | Team name. |
+| `mascot` | character | Team mascot. |
+| `abbreviation` | character | Metric abbreviation. |
+| `alt_name1` | character | Team alternate name 1 (as it appears in `play_text`). |
+| `alt_name2` | character | Team alternate name 2 (as it appears in `play_text`). |
+| `alt_name3` | character | Team alternate name 3 (as it appears in `play_text`). |
+| `conference` | character | Conference of the team. |
+| `division` | character | Division in the conference for the team. |
+| `color` | character | Primary team color (hex, no `#`). |
+| `alt_color` | character | Team color (alternate). |
+| `logo` | character | Team or league logo URL. |
+| `logo_dark` | character | Dark-mode logo URL. |
+
+**Example**
+
+```python
+from sportsdataverse.cfb import get_cfb_teams
+teams = get_cfb_teams()
+print(teams.shape)
+
+# Pandas round-trip
+
+teams_pd = get_cfb_teams(return_as_pandas=True)
+teams_pd.head()
+
+# Pipeline next step (build a team_id to logo URL map)
+
+teams = get_cfb_teams()
+logo_map = dict(zip(teams["team_id"], teams["logo"]))
+```
+
 ### `most_recent_cfb_season()` {#most_recent_cfb_season}
 
 Return the most recent college football season year based on today's date.
@@ -865,6 +874,221 @@ print(year)
 
 from sportsdataverse.cfb import load_cfb_schedule, most_recent_cfb_season
 sched = load_cfb_schedule(seasons=[most_recent_cfb_season()])
+```
+
+### `to_cfbfastr(pbp: 'pl.DataFrame', *, season: "'Optional[int]'" = None, week: "'Optional[int]'" = None, drives: "'Optional[pl.DataFrame]'" = None, linescore: "'Optional[pl.DataFrame]'" = None, drive_titles: "'Optional[pl.DataFrame]'" = None, ot_drives: "'Optional[pl.DataFrame]'" = None, scoring_summary: "'Optional[pl.DataFrame]'" = None, return_as_pandas: 'bool' = False) -> "'Union[pl.DataFrame, pd.DataFrame]'"` {#to_cfbfastr}
+
+cfbfastR-named play frame from the NCAA structural pbp frame.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `pbp` | `DataFrame` |  | Output of `sportsdataverse.cfb.cfb_ncaa_pbp.parse_cfb_ncaa_pbp` (one game). |
+| `season` | `Optional[int]` | `None` | Season year (2025 = fall-2025), written to `season`/`year`. |
+| `week` | `Optional[int]` | `None` | Optional week number (from the schedule master). |
+| `drives` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_drives` frame -- refines `period` per drive when quarter markers are missing from the pbp page. |
+| `linescore` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_linescore` frame -- provides `home`/`away` team names and the official per-team finals. |
+| `drive_titles` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_pbp.parse_cfb_ncaa_drive_titles` frame -- authoritative per-drive team labels (fixes graduated-parser team truncation) and running-score checkpoints the play-level score snaps to at each drive boundary (self-heals OT scoring rules + missed events). |
+| `ot_drives` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_drives` frame for the OT-synthesis pass -- overtime rows (`period > 4`) are selected internally, so the full drives frame can be passed as-is. |
+| `scoring_summary` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_scoring_summary` frame -- running-score checkpoints for the synthesized OT rows and the final-drive snap. |
+| `return_as_pandas` | `bool` | `False` | Return a `pandas.DataFrame` instead of `polars`. |
+
+**Returns**
+
+A `polars.DataFrame` (or `pandas.DataFrame` when `return_as_pandas`) with one row per play (markers/furniture dropped) and the columns of `CFBFASTR_SCHEMA`. Empty input returns a **zero-row frame carrying the documented schema**.
+
+**Example**
+
+```python
+from sportsdataverse.cfb import parse_cfb_ncaa_pbp, to_cfbfastr
+pbp = parse_cfb_ncaa_pbp(open("play_by_play_5362431.html").read(), contest_id=5362431)
+df = to_cfbfastr(pbp, season=2024)
+print(df.shape)
+
+# Final score from the running-score columns
+
+df.select("pos_team", "pos_team_score", "def_pos_team", "def_pos_team_score").row(-1)
+```
+
+## Dataset loaders
+
+### `load_cfb_betting_lines(return_as_pandas=False) -> 'pl.DataFrame'` {#load_cfb_betting_lines}
+
+Load college football betting lines information
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
+
+**Returns**
+
+Polars dataframe containing betting lines available for the available seasons.
+
+| col_name | type | description |
+|---|---|---|
+| `id` | double | 247Sports referencing id for the recruit. |
+| `game_id` | integer | ESPN game identifier. |
+| `season` | double | Season (4-digit year). |
+| `game_desc` | character | Human-readable description of the game, typically including team names and context. |
+| `date_time` | character | Date and time of the game to which the betting line applies, as a string. |
+| `market_type` | character | Geographic market type (e.g. `National`). |
+| `abbr` | character | Selection/side this odds row applies to — a team abbreviation for spread and moneyline markets, or 'over'/'under' for total markets (the data is long-format, one row per book per selection per market_type). |
+| `lines` | double | Numeric line for this row's market — the per-side point spread for spread markets or the over/under total points for total markets; null for moneyline rows. |
+| `odds` | integer | American-odds price for this selection — the juice/vig on spread and total rows, or the moneyline price itself on moneyline rows. |
+| `opening_lines` | double | Opening numeric line for this row's market (per-side spread or over/under total points) before line movement; null for moneyline rows. |
+| `opening_odds` | integer | Opening American-odds price for this selection before line movement (vig on spread/total rows, moneyline price on moneyline rows). |
+| `book` | character | Name of the sportsbook or oddsmaker that provided the betting line. |
+| `season_type` | character | ESPN season type (2 = regular, 3 = postseason). |
+| `week` | integer | Game week of the season. |
+
+**Example**
+
+```python
+from sportsdataverse.cfb import load_cfb_betting_lines
+lines = load_cfb_betting_lines()
+print(lines.shape)
+
+# Pandas round-trip
+
+lines_pd = load_cfb_betting_lines(return_as_pandas=True)
+lines_pd.head()
+
+# Pipeline next step (filter to one provider in 2023)
+
+import polars as pl
+consensus_2023 = load_cfb_betting_lines().filter(
+    (pl.col("season") == 2023) & (pl.col("provider") == "consensus")
+)
+```
+
+### `load_cfb_rosters_crosswalk(return_as_pandas: 'bool' = False) -> 'pl.DataFrame'` {#load_cfb_rosters_crosswalk}
+
+Load the current ESPN x Fox CFB rosters crosswalk (single snapshot).
+
+Unlike the per-season `load_cfb_teams_crosswalk` / `load_cfb_schedule_crosswalk`
+loaders, this one is **season-less**: ESPN's and Fox's team-roster endpoints
+only expose the *current* roster, so the published artifact is a single
+snapshot rather than a historical per-season series. It is built by
+`cfbfastR-cfb-data`'s `scripts/build_cfb_crosswalk.py` (which fans the
+per-team `sportsdataverse.cfb.cfb_rosters_crosswalk` builder out over
+the current season's ESPN<->Fox team-id pairs) and refreshed on that repo's
+cadence.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
+
+**Returns**
+
+one row per matched player, carrying `espn_team_id` / `fox_team_id` provenance plus each provider's athlete id, name, jersey, position, and the `match_method` / `matched_sources` flags.
+
+**Example**
+
+```python
+from sportsdataverse.cfb import load_cfb_rosters_crosswalk
+xwalk = load_cfb_rosters_crosswalk()
+print(xwalk.shape)
+
+# Pandas round-trip
+
+xwalk_pd = load_cfb_rosters_crosswalk(return_as_pandas=True)
+
+# Pipeline next step (one team's ESPN<->Fox athlete map)
+
+import polars as pl
+osu = load_cfb_rosters_crosswalk().filter(pl.col("espn_team_id") == 194)
+```
+
+### `load_draft_outcomes(years: 'int | list[int]', *, return_as_pandas: 'bool' = False) -> 'pl.DataFrame | pd.DataFrame'` {#load_draft_outcomes}
+
+NFL draft picks with the college of each pick, for the requested draft years.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `years` | `int \| list[int]` |  | A draft year or list of draft years. |
+| `return_as_pandas` | `bool` | `False` | If True, return a pandas DataFrame; otherwise polars. |
+
+**Returns**
+
+One row per pick: `draft_year` (Int64), `college` (Utf8 PFR-style college name), `player_id` (Utf8 ESPN college athlete id; null for older drafts), `player_name` (Utf8), `round` / `pick` (Int64), `position` (Utf8). Zero-row (typed) when the source is unavailable.
+
+| col_name | type | description |
+|---|---|---|
+| `draft_year` | integer | NFL draft year of the pick. |
+| `college` | character | College of the pick (PFR-style name, e.g. "Ohio St."). |
+| `player_id` | character | ESPN college athlete id as a string (null for older drafts). |
+| `player_name` | character | Player name as listed on the pick record. |
+| `round` | integer | Round of the NFL draft the player was selected in (1-7 in the modern format). |
+| `pick` | integer | Overall pick number. |
+| `position` | character | Position drafted at (PFR abbreviation). |
+
+**Example**
+
+```python
+from sportsdataverse.cfb import load_draft_outcomes
+picks = load_draft_outcomes([2023, 2024])
+picks.group_by("college").len().sort("len", descending=True).head()
+```
+
+### `load_fp_curve() -> 'pl.DataFrame'` {#load_fp_curve}
+
+Load the bundled EP-by-yardline curve (no network, no first-use download).
+
+**Returns**
+
+`yardline_own: Int64 (1..99), ep: Float64`.
+
+| col_name | type | description |
+|---|---|---|
+| `yardline_own` | integer | Starting yard line from the offense's own goal (1-99). |
+| `ep` | double | Bundled expected points for a drive starting at this yard line (2018-2021 fit). |
+
+**Example**
+
+```python
+from sportsdataverse.cfb.cfb_field_position import load_fp_curve
+curve = load_fp_curve()
+```
+
+### `load_recruit_classes(seasons: 'int | list[int]', *, division: 'str' = 'fbs', return_as_pandas: 'bool' = False) -> 'pl.DataFrame | pd.DataFrame'` {#load_recruit_classes}
+
+Load recruiting classes as per-recruit rows from the 247 RDB feed.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `seasons` | `int \| list[int]` |  | A single recruiting-class year or a list of them. |
+| `division` | `str` | `'fbs'` | Division slug (reserved for constant lookups downstream; the feed itself is queried for all of college football). |
+| `return_as_pandas` | `bool` | `False` | If True, return a pandas DataFrame; otherwise polars. |
+
+**Returns**
+
+One row per committed recruit: `season` (Int64), `team_id` (Utf8 — the 247 committed-team key), `team` (Utf8 full name — the downstream name-join key, since the 247 recruit-team key differs from the 247 talent-composite key), `recruit_id` (Utf8), `stars` (Int64), `grade` (Float64 247 composite rating), `position` (Utf8). Zero-row (typed) when no data is available.
+
+| col_name | type | description |
+|---|---|---|
+| `season` | integer | Recruiting-class year the recruit signed in. |
+| `team_id` | character | 247Sports signed-institution team key as a string (falls back to the committed institution when unsigned). |
+| `team` | character | Signed-institution full name (falls back to committed) - the downstream name-join key. |
+| `recruit_id` | character | 247Sports recruit key as a string (integer-origin). |
+| `stars` | integer | 247 composite star rating (1-5; null for unrated recruits). |
+| `grade` | double | 247 composite rating on the 0-100 scale. |
+| `position` | character | Primary position abbreviation from the 247 recruit record. |
+
+**Example**
+
+```python
+from sportsdataverse.cfb.cfb_roster_talent import load_recruit_classes
+rec = load_recruit_classes([2022, 2023])
+rec.group_by("team").len().sort("len", descending=True).head()
 ```
 
 ## Other
@@ -1065,74 +1289,6 @@ print(df.shape)
 # Pipeline next step (one line)
 
 df.sort("pace_rank").head()
-```
-
-### `cfb_advanced_stats(seasons: 'Union[int, list[int]]', *, adjust: 'bool' = True, exclude_garbage: 'bool' = True, as_of_date: 'Optional[datetime.date]' = None, config: 'Optional[AdjustConfig]' = None, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#cfb_advanced_stats}
-
-Team-season CFB advanced stats: efficiency, explosiveness, havoc.
-
-Loads play-by-play via `load_cfb_pbp`, builds the garbage-filtered
-per-play long frame, aggregates raw per-team offense/defense success
-rate, EPA/play, isoPPP (mean EPA on successful plays), explosive rate
-and havoc, and (default) opponent-adjusts each metric with the
-iterative solver.
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `seasons` | `Union[int, list[int]]` |  | season or list of seasons (hosted pbp covers 2002-2021). |
-| `adjust` | `bool` | `True` | add `adj_*` opponent-adjusted columns + EPA ranks. |
-| `exclude_garbage` | `bool` | `True` | drop Connelly garbage-time plays. |
-| `as_of_date` | `Optional[date]` | `None` | leakage boundary -- only plays strictly before this date contribute. |
-| `config` | `Optional[AdjustConfig]` | `None` | `AdjustConfig` for the solver. |
-| `return_as_pandas` | `bool` | `False` | return a pandas `DataFrame` instead of polars. |
-
-**Returns**
-
-One row per (season, team_id) with the raw columns (and `adj_*` plus `off_epa_rank`/`def_epa_rank` when `adjust=True`). Empty input returns a zero-row frame with the documented schema.
-
-| col_name | type | description |
-|---|---|---|
-| `season` | integer | Season the stats cover. |
-| `team_id` | character | Team ESPN id (character join key). |
-| `plays` | integer | Situation-neutral offensive plays in the aggregate. |
-| `off_success_rate` | double | Offensive success rate (yards gained >= 50/70/100 percent of distance by down). |
-| `def_success_rate` | double | Success rate allowed (Connelly 50/70/100 yardage rule). |
-| `off_epa_play` | double | Raw offensive EPA per play on the garbage-filtered substrate (garbage time excluded by default; pass exclude_garbage=False to keep it). |
-| `def_epa_play` | double | Raw EPA allowed per play on the garbage-filtered substrate (garbage time excluded by default; pass exclude_garbage=False to keep it). |
-| `off_iso_ppp` | double | Mean EPA on successful offensive plays (Connelly isoPPP explosiveness). |
-| `def_iso_ppp` | double | Mean EPA allowed on successful plays faced (isoPPP against). |
-| `off_explosive_rate` | double | Share of offensive plays that were explosive (pass EPA >= 2.4, rush EPA >= 1.8). |
-| `def_explosive_rate` | double | Share of plays faced that were explosive (pass EPA >= 2.4, rush EPA >= 1.8). |
-| `def_havoc` | double | Share of plays faced with a havoc event (TFL, pass breakup, interception, forced fumble). |
-| `off_havoc_allowed` | double | Share of offensive plays on which the defense recorded a havoc event. |
-| `off_epa_success_rate` | double | Share of offensive plays with EPA > 0 (EPA-based success rate). |
-| `adj_off_epa_play` | double | Opponent-adjusted offensive EPA per play (higher is better). |
-| `adj_off_success_rate` | double | Opponent-adjusted offensive success rate. |
-| `adj_off_explosive_rate` | double | Opponent-adjusted offensive explosive-play rate. |
-| `adj_def_epa_play` | double | Opponent-adjusted EPA allowed per play (lower is better). |
-| `adj_def_success_rate` | double | Opponent-adjusted success rate allowed. |
-| `adj_def_explosive_rate` | double | Opponent-adjusted explosive-play rate allowed. |
-| `adj_def_havoc` | double | Opponent-adjusted havoc rate created by the defense. |
-| `adj_off_havoc_allowed` | double | Opponent-adjusted havoc rate the offense allows. |
-| `off_epa_rank` | integer | Dense rank on adj_off_epa_play descending (best offense = 1). |
-| `def_epa_rank` | integer | Dense rank on adj_def_epa_play ascending (fewest EPA allowed = 1). |
-
-**Example**
-
-```python
-from sportsdataverse.cfb import cfb_advanced_stats
-df = cfb_advanced_stats([2021])
-print(df.shape)
-
-# Raw only, garbage time kept
-
-df_raw = cfb_advanced_stats(2021, adjust=False, exclude_garbage=False)
-
-# Pipeline next step (one line)
-
-df.sort("adj_off_epa_play", descending=True).head()
 ```
 
 ### `cfb_compute_results(teams: 'pl.DataFrame', games: 'pl.DataFrame', week_num: 'int', *, rng: 'Optional[np.random.Generator]' = None, elo: 'Optional[Dict[str, float]]' = None, **kwargs: 'Any') -> 'Dict[str, pl.DataFrame]'` {#cfb_compute_results}
@@ -1775,81 +1931,6 @@ print(out["overall"].sort("won_cfp", descending=True).head())
 
 out = cfb_simulations(games, teams, simulations=100,
                       sim_include="REG", seed=1)
-```
-
-### `cfb_standings(games: 'FrameLike', teams: 'FrameLike', *, tiebreaker_depth: 'str' = 'SOS', playoff_seeds: 'Optional[int]' = None, rankings: 'Optional[FrameLike]' = None, tiebreaker_data: 'Optional[Dict[str, FrameLike]]' = None, return_as_pandas: 'bool' = False, rng: 'Optional[np.random.Generator]' = None) -> 'Union[pl.DataFrame, Any]'` {#cfb_standings}
-
-Compute college football standings with conference ranks and champions.
-
-Engine design adapted from nflseedR (MIT, Sebastian Carl & Lee Sharpe);
-see the module docstring for the documented CFB simplifications, and its
-"Official per-conference tiebreakers (registry)" section for how
-`CONFERENCE_TIEBREAKERS` overrides the generic cascade for the SEC,
-Big Ten, Big 12, ACC and MAC.
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `games` | `FrameLike` |  | Game results with columns `sim` (or `season`), `week`, `game_type` (`REG` \| `CONF_CHAMP` \| `POST`), `home_team`, `away_team`, `result` (home margin: home - away; null = unplayed), optional `neutral` (0/1), and optional `home_points`/`away_points` (per-game scores — feeds the SEC capped-scoring-margin rung; `cfb_games_from_schedule` emits both). Either optional input absent -> that rung is skipped, not an error. |
-| `teams` | `FrameLike` |  | Team table with columns `team` and `conference` (null or `"FBS Independents"` marks an independent), and an optional `division` column (`"FBS"`/`"FCS"` or similar — feeds the Big 12 `total_wins` FCS cap; absent -> the cap degrades to uncapped win totals, noted in `tiebreak_notes`). |
-| `tiebreaker_depth` | `str` | `'SOS'` | One of `"RANDOM"`, `"PRE-SOV"`, `"SOS"`, `"POINTS"` — the nflseedR depth ladder. Steps beyond the chosen depth are skipped and remaining ties are broken by coin flip. Gates ONLY the generic fallback cascade; registered official conference procedures (below) always run in full. |
-| `playoff_seeds` | `Optional[int]` | `None` | If set, adds a `seed` column via `cfb_playoff_seeds` with this field size. |
-| `rankings` | `Optional[FrameLike]` | `None` | Optional committee-style rankings frame (`team`, `rank`) forwarded to `cfb_playoff_seeds`. |
-| `tiebreaker_data` | `Optional[Dict[str, FrameLike]]` | `None` | Optional external inputs for the registry rungs, as a dict with key `"analytics_ratings"` -> a frame with columns `team` and `rating` (feeds the `analytics_rating` rung used by Big Ten/Big 12/ACC/MAC). A `"cfp_rankings"` key (`team`, `rank`) is accepted for forward compatibility but unused by the current registry (no registered conference has a `cfp_ranking` rung yet). Missing -> the rung is skipped, noted. |
-| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
-| `rng` | `Optional[Generator]` | `None` | Optional numpy Generator used only for coin-flip tiebreaks (simulations pass their seeded generator through here). |
-
-**Returns**
-
-A polars (or pandas) DataFrame with one row per (sim, team): overall record (`games`/`wins`/`losses`/`ties`/`win_pct`/ `pd`), conference record (`conf_*`), `sov`, `sos`, `conf_rank` (null for independents), `conf_champ` and, when `playoff_seeds` is set, `seed`. The result also carries a `tiebreak_notes` list of skipped-rung messages (see the module docstring): `result.tiebreak_notes` for a polars frame, `result.attrs["tiebreak_notes"]` for a pandas frame (pandas' own metadata mechanism — avoids its "new attribute" warning).
-
-| col_name | type | description |
-|---|---|---|
-| `sim` | integer | Season or simulation identifier the standings row belongs to. |
-| `team` | character | Team name (join key across the seedr engine frames). |
-| `conference` | character | Conference the team belongs to; null or "FBS Independents" marks an independent. |
-| `games` | integer | Total games played across all game types (regular season, conference championship and postseason). |
-| `wins` | integer | Wins across all played games (conference championship and postseason included). |
-| `losses` | integer | Losses across all played games. |
-| `ties` | integer | Ties across all played games. |
-| `win_pct` | double | Overall win percentage - (wins + 0.5 * ties) / games, 0.0 when no games have been played. |
-| `pd` | double | Point differential (points for minus points against, via game margins) summed over all played games. |
-| `conf_games` | integer | Number of conference regular-season games played (both teams in the same conference; CONF_CHAMP games excluded). |
-| `conf_wins` | integer | Wins in conference regular-season games. |
-| `conf_losses` | integer | Losses in conference regular-season games. |
-| `conf_ties` | integer | Ties in conference regular-season games. |
-| `conf_pct` | double | Conference win percentage - (conf_wins + 0.5 * conf_ties) / conf_games, 0.0 with no conference games; the primary sort key for conference ranks. |
-| `conf_pd` | double | Point differential summed over conference regular-season games only; the POINTS-depth tiebreaker rung. |
-| `sov` | double | Strength of victory, conference-REG-scoped (unlike nflseedR's overall games-weighted version) - mean of defeated conference opponents' conference win pct, one term per conference victory; 0.0 for independents or teams without conference wins. |
-| `sos` | double | Strength of schedule, conference-REG-scoped (unlike nflseedR's overall games-weighted version) - mean of conference opponents' conference win pct across all conference games played; 0.0 for independents. |
-| `conf_rank` | integer | Rank within the conference from the tiebreaker cascade (1 = best); null for independents. |
-| `conf_champ` | logical | Whether the team is its conference's champion - the CONF_CHAMP game winner when one was played, otherwise the conference's rank-1 team; always false for independents. |
-
-**Example**
-
-```python
-import polars as pl
-from sportsdataverse.cfb import cfb_standings
-
-games = pl.DataFrame({
-    "sim": [2024, 2024], "week": [1, 2],
-    "game_type": ["REG", "REG"],
-    "home_team": ["A", "B"], "away_team": ["B", "A"],
-    "result": [7.0, -3.0], "neutral": [0, 0],
-})
-teams = pl.DataFrame({"team": ["A", "B"], "conference": ["X", "X"]})
-print(cfb_standings(games, teams))
-
-# With CFP seeds from committee rankings
-
-st = cfb_standings(games, teams, playoff_seeds=12, rankings=ranks_df)
-
-# With an official-registry analytics rating input
-
-ratings = pl.DataFrame({"team": ["A", "B"], "rating": [92.1, 88.4]})
-st = cfb_standings(games, teams, tiebreaker_data={"analytics_ratings": ratings})
-print(st.tiebreak_notes)
 ```
 
 ### `cfb_teams_crosswalk(*, season: 'Optional[int]' = None, week: 'int' = 1, providers: 'Optional[Sequence[str]]' = None, return_as_pandas: 'bool' = False, **kwargs: 'Any') -> 'DataFrameT'` {#cfb_teams_crosswalk}
@@ -2836,54 +2917,6 @@ out = get_4th_down_probs(fourth_down_rows)
 print(out[["go_wp", "punt_wp", "fg_wp", "fourth_down_recommendation"]].head())
 ```
 
-### `get_cfb_teams(return_as_pandas=False) -> 'pl.DataFrame'` {#get_cfb_teams}
-
-Load college football team ID information and logos
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
-
-**Returns**
-
-Polars dataframe containing teams available.
-
-| col_name | type | description |
-|---|---|---|
-| `team_id` | integer | ESPN team id. |
-| `school` | character | Team name. |
-| `mascot` | character | Team mascot. |
-| `abbreviation` | character | Metric abbreviation. |
-| `alt_name1` | character | Team alternate name 1 (as it appears in `play_text`). |
-| `alt_name2` | character | Team alternate name 2 (as it appears in `play_text`). |
-| `alt_name3` | character | Team alternate name 3 (as it appears in `play_text`). |
-| `conference` | character | Conference of the team. |
-| `division` | character | Division in the conference for the team. |
-| `color` | character | Primary team color (hex, no `#`). |
-| `alt_color` | character | Team color (alternate). |
-| `logo` | character | Team or league logo URL. |
-| `logo_dark` | character | Dark-mode logo URL. |
-
-**Example**
-
-```python
-from sportsdataverse.cfb import get_cfb_teams
-teams = get_cfb_teams()
-print(teams.shape)
-
-# Pandas round-trip
-
-teams_pd = get_cfb_teams(return_as_pandas=True)
-teams_pd.head()
-
-# Pipeline next step (build a team_id to logo URL map)
-
-teams = get_cfb_teams()
-logo_map = dict(zip(teams["team_id"], teams["logo"]))
-```
-
 ### `get_fg_wp(pbp_df) -> 'pd.DataFrame'` {#get_fg_wp}
 
 Expected win probability of attempting a field goal (cfb4th `get_fg_wp`).
@@ -3377,41 +3410,6 @@ A `polars.DataFrame` with one row per `team_id` appearing anywhere in `plays`: `
 from sportsdataverse.cfb.cfb_ratings import special_teams_ratings
 st = special_teams_ratings(pbp)
 st.sort("adj_st_epa", descending=True).head()
-```
-
-### `to_cfbfastr(pbp: 'pl.DataFrame', *, season: "'Optional[int]'" = None, week: "'Optional[int]'" = None, drives: "'Optional[pl.DataFrame]'" = None, linescore: "'Optional[pl.DataFrame]'" = None, drive_titles: "'Optional[pl.DataFrame]'" = None, ot_drives: "'Optional[pl.DataFrame]'" = None, scoring_summary: "'Optional[pl.DataFrame]'" = None, return_as_pandas: 'bool' = False) -> "'Union[pl.DataFrame, pd.DataFrame]'"` {#to_cfbfastr}
-
-cfbfastR-named play frame from the NCAA structural pbp frame.
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `pbp` | `DataFrame` |  | Output of `sportsdataverse.cfb.cfb_ncaa_pbp.parse_cfb_ncaa_pbp` (one game). |
-| `season` | `Optional[int]` | `None` | Season year (2025 = fall-2025), written to `season`/`year`. |
-| `week` | `Optional[int]` | `None` | Optional week number (from the schedule master). |
-| `drives` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_drives` frame -- refines `period` per drive when quarter markers are missing from the pbp page. |
-| `linescore` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_linescore` frame -- provides `home`/`away` team names and the official per-team finals. |
-| `drive_titles` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_pbp.parse_cfb_ncaa_drive_titles` frame -- authoritative per-drive team labels (fixes graduated-parser team truncation) and running-score checkpoints the play-level score snaps to at each drive boundary (self-heals OT scoring rules + missed events). |
-| `ot_drives` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_drives` frame for the OT-synthesis pass -- overtime rows (`period > 4`) are selected internally, so the full drives frame can be passed as-is. |
-| `scoring_summary` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_scoring_summary` frame -- running-score checkpoints for the synthesized OT rows and the final-drive snap. |
-| `return_as_pandas` | `bool` | `False` | Return a `pandas.DataFrame` instead of `polars`. |
-
-**Returns**
-
-A `polars.DataFrame` (or `pandas.DataFrame` when `return_as_pandas`) with one row per play (markers/furniture dropped) and the columns of `CFBFASTR_SCHEMA`. Empty input returns a **zero-row frame carrying the documented schema**.
-
-**Example**
-
-```python
-from sportsdataverse.cfb import parse_cfb_ncaa_pbp, to_cfbfastr
-pbp = parse_cfb_ncaa_pbp(open("play_by_play_5362431.html").read(), contest_id=5362431)
-df = to_cfbfastr(pbp, season=2024)
-print(df.shape)
-
-# Final score from the running-score columns
-
-df.select("pos_team", "pos_team_score", "def_pos_team", "def_pos_team_score").row(-1)
 ```
 
 ### `win_prob_from_margin(exp_margin: 'float', *, era: 'str' = 'modern') -> 'float'` {#win_prob_from_margin}

--- a/docs/docs/mbb/index.md
+++ b/docs/docs/mbb/index.md
@@ -7,6 +7,7 @@ description: "sdv-py MBB: endpoint references, dataset loaders and parsers for M
 
 | Reference | Functions | Base URL |
 |---|---:|---|
+| [Highlights](reference/additional#highlights) | 9 | curated "start here" functions |
 | [ESPN site API (v2)](reference/site) | 25 | `https://site.api.espn.com/apis/site/v2/sports` |
 | [ESPN web API (v3)](reference/web) | 5 | `https://site.web.api.espn.com/apis/common/v3/sports` |
 | [ESPN core API (v2)](reference/core) | 87 | `https://sports.core.api.espn.com/v2/sports` |
@@ -14,7 +15,7 @@ description: "sdv-py MBB: endpoint references, dataset loaders and parsers for M
 | [Bart Torvik T-Rank (barttorvik.com)](reference/torvik) | 2 | `https://barttorvik.com` |
 | [KenPom (kenpom.com, subscription)](reference/kenpom) | 30 | `https://kenpom.com` |
 | [Dataset loaders](reference/loaders) | 30 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 326 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 317 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -604,6 +604,7 @@ One row per scheduled game -- see `parse_ncaa_bb_team_schedule` for the column c
 **Example**
 
 ```python
+import polars as pl
 from sportsdataverse.mbb import ncaa_mbb_team_schedule
 df = ncaa_mbb_team_schedule(team="Illinois", season="2025-26")
 print(df.shape)

--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -9,7 +9,7 @@ sidebar_position: 50
 Hand-written wrappers, loaders, and helpers in `sportsdataverse.mbb`
 not covered by the generated API-endpoint reference above.
 
-## Play-by-play, schedule & rosters
+## Highlights
 
 ### `espn_mbb_game_rosters(game_id: 'int', raw=False, return_as_pandas=False, **kwargs) -> 'pl.DataFrame'` {#espn_mbb_game_rosters}
 
@@ -446,6 +446,173 @@ season_pd = espn_mbb_schedule(dates=2024, return_as_pandas=True)
 season_pd.head()
 ```
 
+### `espn_mbb_teams(groups=None, return_as_pandas=False, **kwargs) -> 'pl.DataFrame'` {#espn_mbb_teams}
+
+espn_mbb_teams - look up the men's college basketball teams
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `groups` | `int` | `None` | Used to define different divisions. 50 is Division I, 51 is Division II/Division III. |
+| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
+
+**Returns**
+
+Polars dataframe containing teams for the requested league. This function caches by default, so if you want to refresh the data, use the command sportsdataverse.mbb.espn_mbb_teams.clear_cache().
+
+| col_name | type | description |
+|---|---|---|
+| `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
+| `team_alternate_color` | character | Team alternate color (hex without leading '#'). |
+| `team_color` | character | Team primary color (hex without leading '#'). |
+| `team_display_name` | character | Full team display name. |
+| `team_id` | character | Unique team identifier. |
+| `team_is_active` | logical | TRUE if the team is currently active. |
+| `team_is_all_star` | logical | TRUE if the row represents an All-Star team. |
+| `team_location` | character | Team city or location string. |
+| `team_logos` | integer | Team logo metadata. |
+| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_nickname` | character | Team nickname. |
+| `team_short_display_name` | character | Short team display name (e.g. 'Aces'). |
+| `team_slug` | character | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_uid` | character | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+
+**Example**
+
+```python
+from sportsdataverse.mbb import espn_mbb_teams
+teams = espn_mbb_teams()
+print(teams.shape)
+print(teams.columns[:8])
+
+# Walk every team-id (handy for batched scrapes)
+
+team_ids = teams["team_id"].to_list()
+print(len(team_ids), "D1 teams")
+
+# Pandas round-trip + Division II/III
+
+d2_d3 = espn_mbb_teams(groups=51, return_as_pandas=True)
+d2_d3.head()
+```
+
+### `most_recent_mbb_season()` {#most_recent_mbb_season}
+
+Return the most recent men's college basketball season year.
+
+The men's college basketball season spans early November through early
+April; for any month October-December the "current season" is the
+following calendar year (e.g. October 2025 returns `2026`).
+
+**Returns**
+
+The most recent / current season year.
+
+**Example**
+
+```python
+from sportsdataverse.mbb import most_recent_mbb_season, espn_mbb_schedule
+season = most_recent_mbb_season()
+sched = espn_mbb_schedule(dates=season)
+```
+
+### `ncaa_mbb_play_by_play(game_ids: "'Sequence[object]'", *, fetcher: 'Optional[_SupportsFetchGamePbp]' = None, return_as_pandas: 'bool' = False) -> "'Union[pl.DataFrame, Any]'"` {#ncaa_mbb_play_by_play}
+
+Scrape many MBB games' play-by-play (bigballR `get_play_by_play`).
+
+Ports `bigballR/R/all_functions.R:1857-1897`: drops missing ids, shares
+one fetcher session across games, retries each empty/failed game once,
+row-binds the survivors, and logs the removed ids.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_ids` | `Sequence[object]` |  | NCAA contest ids; `None`/NaN entries are dropped. |
+| `fetcher` | `Optional[_SupportsFetchGamePbp]` | `None` | Optional injected fetcher exposing `fetch_game_pbp`. Defaults to one shared `NcaaFetcher.with_browser()` context. |
+| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
+
+**Returns**
+
+Row-bound play-by-play for every game that scraped successfully (zero-row contract frame when none did).
+
+**Example**
+
+```python
+from sportsdataverse.mbb.mbb_ncaa_game_pbp import ncaa_mbb_play_by_play
+df = ncaa_mbb_play_by_play(["6470186", "6479639"])
+print(df.shape)
+
+# Pipeline next step (one line)
+
+df.group_by("game_id").len()
+```
+
+### `ncaa_mbb_team_roster(team_id: 'Optional[int]' = None, *, team: 'Optional[str]' = None, season: 'Optional[str]' = None, fetcher: "Optional['NcaaFetcher']" = None, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#ncaa_mbb_team_roster}
+
+Scrape a men's team roster from stats.ncaa.org.
+
+Port of bigballR `get_team_roster`. The `player` column is the
+normalized `FIRST.LAST` key that byte-matches the play-by-play name
+normalization, so roster<->pbp joins line up.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `Optional[int]` | `None` | stats.ncaa.org team id (changes every season). |
+| `team` | `Optional[str]` | `None` | School name, e.g. `"Illinois"`. |
+| `season` | `Optional[str]` | `None` | Season string, e.g. `"2025-26"`; required with `team`. |
+| `fetcher` | `Optional['NcaaFetcher']` | `None` | Injectable `~sportsdataverse.mbb.mbb_ncaa_fetch. NcaaFetcher`; defaults to a fresh browser-transport fetcher. |
+| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
+
+**Returns**
+
+One row per player -- see `parse_ncaa_bb_team_roster` for the column contract.
+
+**Example**
+
+```python
+from sportsdataverse.mbb import ncaa_mbb_team_roster
+df = ncaa_mbb_team_roster(team="Illinois", season="2025-26")
+print(df.select("jersey", "player", "ht_inches").head())
+```
+
+### `ncaa_mbb_team_schedule(team_id: 'Optional[int]' = None, *, team: 'Optional[str]' = None, season: 'Optional[str]' = None, fetcher: "Optional['NcaaFetcher']" = None, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#ncaa_mbb_team_schedule}
+
+Scrape a men's team's season schedule from stats.ncaa.org.
+
+Port of bigballR `get_team_schedule`. Give either the season-specific
+`team_id` or a `team` + `season` pair (resolved through the bundled
+men's crosswalk).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `Optional[int]` | `None` | stats.ncaa.org team id (changes every season) -- the number in the team page URL. |
+| `team` | `Optional[str]` | `None` | School name, e.g. `"Illinois"` (not the mascot form). |
+| `season` | `Optional[str]` | `None` | Season string, e.g. `"2025-26"`; required with `team`. |
+| `fetcher` | `Optional['NcaaFetcher']` | `None` | Injectable `~sportsdataverse.mbb.mbb_ncaa_fetch. NcaaFetcher`; defaults to a fresh browser-transport fetcher (stats.ncaa.org blocks plain HTTP clients). |
+| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
+
+**Returns**
+
+One row per scheduled game -- see `parse_ncaa_bb_team_schedule` for the column contract.
+
+**Example**
+
+```python
+from sportsdataverse.mbb import ncaa_mbb_team_schedule
+df = ncaa_mbb_team_schedule(team="Illinois", season="2025-26")
+print(df.shape)
+
+# Pipeline next step (one line)
+
+df.filter(pl.col("is_neutral") == True).head()
+```
+
 ## Dataset loaders
 
 ### `load_artifact(name: 'str') -> 'dict'` {#load_artifact}
@@ -497,28 +664,6 @@ One `http://login:password@ip:port` URL per IP in the package.
 def fake(url, headers):
     return 200, '{"data": {"login": "u", "password": "p", "ippacks": []}}'
 pool = load_proxybonanza_pool("key", "pkg", transport=fake)
-```
-
-## Utilities & helpers
-
-### `most_recent_mbb_season()` {#most_recent_mbb_season}
-
-Return the most recent men's college basketball season year.
-
-The men's college basketball season spans early November through early
-April; for any month October-December the "current season" is the
-following calendar year (e.g. October 2025 returns `2026`).
-
-**Returns**
-
-The most recent / current season year.
-
-**Example**
-
-```python
-from sportsdataverse.mbb import most_recent_mbb_season, espn_mbb_schedule
-season = most_recent_mbb_season()
-sched = espn_mbb_schedule(dates=season)
 ```
 
 ## Other
@@ -4803,57 +4948,6 @@ under `==` (`ensure_ev_uniqueness`, `LineupUtils.scala:105-111`).
 
 A new `~sportsdataverse.mbb.mbb_ncaa_possessions.ConcurrentClump` with each event's `min` incremented by `1e-6 * index`.
 
-### `espn_mbb_teams(groups=None, return_as_pandas=False, **kwargs) -> 'pl.DataFrame'` {#espn_mbb_teams}
-
-espn_mbb_teams - look up the men's college basketball teams
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `groups` | `int` | `None` | Used to define different divisions. 50 is Division I, 51 is Division II/Division III. |
-| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
-
-**Returns**
-
-Polars dataframe containing teams for the requested league. This function caches by default, so if you want to refresh the data, use the command sportsdataverse.mbb.espn_mbb_teams.clear_cache().
-
-| col_name | type | description |
-|---|---|---|
-| `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
-| `team_alternate_color` | character | Team alternate color (hex without leading '#'). |
-| `team_color` | character | Team primary color (hex without leading '#'). |
-| `team_display_name` | character | Full team display name. |
-| `team_id` | character | Unique team identifier. |
-| `team_is_active` | logical | TRUE if the team is currently active. |
-| `team_is_all_star` | logical | TRUE if the row represents an All-Star team. |
-| `team_location` | character | Team city or location string. |
-| `team_logos` | integer | Team logo metadata. |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
-| `team_nickname` | character | Team nickname. |
-| `team_short_display_name` | character | Short team display name (e.g. 'Aces'). |
-| `team_slug` | character | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
-| `team_uid` | character | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
-
-**Example**
-
-```python
-from sportsdataverse.mbb import espn_mbb_teams
-teams = espn_mbb_teams()
-print(teams.shape)
-print(teams.columns[:8])
-
-# Walk every team-id (handy for batched scrapes)
-
-team_ids = teams["team_id"].to_list()
-print(len(team_ids), "D1 teams")
-
-# Pandas round-trip + Division II/III
-
-d2_d3 = espn_mbb_teams(groups=51, return_as_pandas=True)
-d2_d3.head()
-```
-
 ### `espn_shots_to_canonical(espn: 'pl.DataFrame', *, league: 'str', season: 'int', scale: "'tuple[float, float, float] | None'" = None) -> 'pl.DataFrame'` {#espn_shots_to_canonical}
 
 ESPN `load_mbb_shots` frame -> the canonical shot frame.
@@ -7903,38 +7997,6 @@ duo = ncaa_mbb_on_off(["A.PLAYER", "B.PLAYER"], lineups)
 split.select("status", "netrtg")
 ```
 
-### `ncaa_mbb_play_by_play(game_ids: "'Sequence[object]'", *, fetcher: 'Optional[_SupportsFetchGamePbp]' = None, return_as_pandas: 'bool' = False) -> "'Union[pl.DataFrame, Any]'"` {#ncaa_mbb_play_by_play}
-
-Scrape many MBB games' play-by-play (bigballR `get_play_by_play`).
-
-Ports `bigballR/R/all_functions.R:1857-1897`: drops missing ids, shares
-one fetcher session across games, retries each empty/failed game once,
-row-binds the survivors, and logs the removed ids.
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `game_ids` | `Sequence[object]` |  | NCAA contest ids; `None`/NaN entries are dropped. |
-| `fetcher` | `Optional[_SupportsFetchGamePbp]` | `None` | Optional injected fetcher exposing `fetch_game_pbp`. Defaults to one shared `NcaaFetcher.with_browser()` context. |
-| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
-
-**Returns**
-
-Row-bound play-by-play for every game that scraped successfully (zero-row contract frame when none did).
-
-**Example**
-
-```python
-from sportsdataverse.mbb.mbb_ncaa_game_pbp import ncaa_mbb_play_by_play
-df = ncaa_mbb_play_by_play(["6470186", "6479639"])
-print(df.shape)
-
-# Pipeline next step (one line)
-
-df.group_by("game_id").len()
-```
-
 ### `ncaa_mbb_player_combos(lineups: 'pl.DataFrame', *, n: 'int' = 2, min_mins: 'float' = 0, included: 'Union[str, Sequence[str], None]' = None, excluded: 'Union[str, Sequence[str], None]' = None, include_transition: 'bool' = False, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#ncaa_mbb_player_combos}
 
 Team stats for every n-player combination on the court together.
@@ -8106,70 +8168,6 @@ df = ncaa_mbb_shot_locations(["6470186"], fetcher=my_fetcher)
 # Pipeline next step (one line)
 
 df.group_by("team").agg(pl.col("shot_dist").mean()).head()
-```
-
-### `ncaa_mbb_team_roster(team_id: 'Optional[int]' = None, *, team: 'Optional[str]' = None, season: 'Optional[str]' = None, fetcher: "Optional['NcaaFetcher']" = None, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#ncaa_mbb_team_roster}
-
-Scrape a men's team roster from stats.ncaa.org.
-
-Port of bigballR `get_team_roster`. The `player` column is the
-normalized `FIRST.LAST` key that byte-matches the play-by-play name
-normalization, so roster<->pbp joins line up.
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `team_id` | `Optional[int]` | `None` | stats.ncaa.org team id (changes every season). |
-| `team` | `Optional[str]` | `None` | School name, e.g. `"Illinois"`. |
-| `season` | `Optional[str]` | `None` | Season string, e.g. `"2025-26"`; required with `team`. |
-| `fetcher` | `Optional['NcaaFetcher']` | `None` | Injectable `~sportsdataverse.mbb.mbb_ncaa_fetch. NcaaFetcher`; defaults to a fresh browser-transport fetcher. |
-| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
-
-**Returns**
-
-One row per player -- see `parse_ncaa_bb_team_roster` for the column contract.
-
-**Example**
-
-```python
-from sportsdataverse.mbb import ncaa_mbb_team_roster
-df = ncaa_mbb_team_roster(team="Illinois", season="2025-26")
-print(df.select("jersey", "player", "ht_inches").head())
-```
-
-### `ncaa_mbb_team_schedule(team_id: 'Optional[int]' = None, *, team: 'Optional[str]' = None, season: 'Optional[str]' = None, fetcher: "Optional['NcaaFetcher']" = None, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#ncaa_mbb_team_schedule}
-
-Scrape a men's team's season schedule from stats.ncaa.org.
-
-Port of bigballR `get_team_schedule`. Give either the season-specific
-`team_id` or a `team` + `season` pair (resolved through the bundled
-men's crosswalk).
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `team_id` | `Optional[int]` | `None` | stats.ncaa.org team id (changes every season) -- the number in the team page URL. |
-| `team` | `Optional[str]` | `None` | School name, e.g. `"Illinois"` (not the mascot form). |
-| `season` | `Optional[str]` | `None` | Season string, e.g. `"2025-26"`; required with `team`. |
-| `fetcher` | `Optional['NcaaFetcher']` | `None` | Injectable `~sportsdataverse.mbb.mbb_ncaa_fetch. NcaaFetcher`; defaults to a fresh browser-transport fetcher (stats.ncaa.org blocks plain HTTP clients). |
-| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
-
-**Returns**
-
-One row per scheduled game -- see `parse_ncaa_bb_team_schedule` for the column contract.
-
-**Example**
-
-```python
-from sportsdataverse.mbb import ncaa_mbb_team_schedule
-df = ncaa_mbb_team_schedule(team="Illinois", season="2025-26")
-print(df.shape)
-
-# Pipeline next step (one line)
-
-df.filter(pl.col("is_neutral") == True).head()
 ```
 
 ### `ncaa_mbb_team_stats(pbp: 'pl.DataFrame', *, include_transition: 'bool' = False, fix_tip_in: 'bool' = True, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#ncaa_mbb_team_stats}

--- a/docs/docs/nba/index.md
+++ b/docs/docs/nba/index.md
@@ -7,13 +7,14 @@ description: "sdv-py NBA: endpoint references, dataset loaders and parsers for N
 
 | Reference | Functions | Base URL |
 |---|---:|---|
+| [Highlights](reference/additional#highlights) | 8 | curated "start here" functions |
 | [ESPN site API (v2)](reference/site) | 24 | `https://site.api.espn.com/apis/site/v2/sports` |
 | [ESPN web API (v3)](reference/web) | 5 | `https://site.web.api.espn.com/apis/common/v3/sports` |
 | [ESPN core API (v2)](reference/core) | 82 | `https://sports.core.api.espn.com/v2/sports` |
 | [ESPN FPI API (fitt v3)](reference/fitt) | 1 | `https://site.web.api.espn.com/apis/fitt/v3/sports` |
 | [NBA Stats API (stats.nba.com)](reference/nba_stats) | 128 | `https://stats.nba.com` |
 | [Dataset loaders](reference/loaders) | 36 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 181 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 173 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -36,6 +36,7 @@ One row per player: `ranker`, `player`, `age`, `team`, `pos`, `g`, `gs` plus the
 **Example**
 
 ```python
+import polars as pl
 from sportsdataverse.nba.bref import bref_players_stats
 
 df = bref_players_stats(season=2024)
@@ -74,6 +75,7 @@ One row per team: `conference` (`"E"` / `"W"` for **both** leagues -- wehoop emi
 **Example**
 
 ```python
+import polars as pl
 from sportsdataverse.nba.bref import bref_standings
 
 df = bref_standings(season=2024)

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -9,7 +9,178 @@ sidebar_position: 50
 Hand-written wrappers, loaders, and helpers in `sportsdataverse.nba`
 not covered by the generated API-endpoint reference above.
 
-## Play-by-play, schedule & rosters
+## Highlights
+
+### `bref_players_stats(season: 'Optional[int]' = None, table: 'str' = 'per_game', league: 'str' = 'nba', *, return_as_pandas: 'bool' = False, proxy: 'Any' = None, **kwargs: 'Any') -> 'pl.DataFrame | pd.DataFrame'` {#bref_players_stats}
+
+Player season statistics for an entire league season.
+
+Port of hoopR's `bref_players_stats()` (NBA) and wehoop's
+`bref_wnba_player_stats()` (WNBA). One row per player, with columns named
+by Basketball-Reference `data-stat` keys.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` | Season in 4-digit ending-year format (`2024` = 2023-24). The WNBA season is a plain calendar year. Defaults to the current season. |
+| `table` | `str` | `'per_game'` | Which stat table. NBA accepts `per_game` (default), `totals`, `advanced`, `per_minute` (per 36) and `per_poss` (per 100 possessions); WNBA accepts `per_game`, `totals` and `advanced`. |
+| `league` | `str` | `'nba'` | `"nba"` (default) or `"wnba"`. |
+| `return_as_pandas` | `bool` | `False` | Return a `pandas.DataFrame` instead of polars. |
+| `proxy` | `Any` | `None` | Proxy configuration in the `requests` `proxies=` shape. |
+
+**Returns**
+
+One row per player: `ranker`, `player`, `age`, `team`, `pos`, `g`, `gs` plus the box columns scaled to `table` (the `advanced` table adds `per`, `ts_pct`, `usg_pct`, `ws`, `bpm`, `vorp` …), and echoed `season` / `table` / `league` columns. A zero-row frame when the page carries no player table.
+
+**Example**
+
+```python
+from sportsdataverse.nba.bref import bref_players_stats
+
+df = bref_players_stats(season=2024)
+print(df.shape)
+
+# Advanced metrics, and the WNBA page
+
+adv = bref_players_stats(season=2024, table="advanced")
+wnba = bref_players_stats(season=2024, league="wnba")
+
+# Pipeline next step (one line)
+
+adv.filter(pl.col("vorp") > 3.0).sort("vorp", descending=True).head()
+```
+
+### `bref_standings(season: 'Optional[int]' = None, league: 'str' = 'nba', *, return_as_pandas: 'bool' = False, proxy: 'Any' = None, **kwargs: 'Any') -> 'pl.DataFrame | pd.DataFrame'` {#bref_standings}
+
+Conference standings for a season, both conferences stacked.
+
+Port of hoopR's `bref_standings()` (NBA) and wehoop's
+`bref_wnba_standings()` (WNBA).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` | Season in 4-digit ending-year format. Defaults to the current season. |
+| `league` | `str` | `'nba'` | `"nba"` (default) or `"wnba"`. |
+| `return_as_pandas` | `bool` | `False` | Return a `pandas.DataFrame` instead of polars. |
+| `proxy` | `Any` | `None` | Proxy configuration in the `requests` `proxies=` shape. |
+
+**Returns**
+
+One row per team: `conference` (`"E"` / `"W"` for **both** leagues -- wehoop emits `"Eastern"`/`"Western"`), `team` (playoff `*` marker stripped), `playoffs` (bool, from that marker), `wins`, `losses`, `win_loss_pct`, `gb`, `pts_per_g`, `opp_pts_per_g`, `srs`, plus echoed `season` / `league`. Zero rows when neither conference table is present.
+
+**Example**
+
+```python
+from sportsdataverse.nba.bref import bref_standings
+
+df = bref_standings(season=2024)
+print(df.shape)
+
+# The WNBA page
+
+wnba = bref_standings(season=2024, league="wnba")
+
+# Pipeline next step (one line)
+
+df.filter(pl.col("playoffs") == True).sort("srs", descending=True).head()
+```
+
+### `bref_teams_stats(season: 'Optional[int]' = None, table: 'str' = 'per_game', league: 'str' = 'nba', *, return_as_pandas: 'bool' = False, proxy: 'Any' = None, **kwargs: 'Any') -> 'pl.DataFrame | pd.DataFrame'` {#bref_teams_stats}
+
+Team season statistics from the league season page.
+
+Port of hoopR's `bref_teams_stats()` (NBA) and wehoop's
+`bref_wnba_team_stats()` (WNBA). Every team table lives on the one season
+page and all but the first are comment-hidden, which is why the table `id`
+selection in bref_table` matters here.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` | Season in 4-digit ending-year format (`2024` = 2023-24). Defaults to the current season. |
+| `table` | `str` | `'per_game'` | NBA accepts `per_game` (default), `totals`, `per_poss`, `advanced` and `opponent` (opponent per-game); WNBA accepts the same set minus `opponent`. |
+| `league` | `str` | `'nba'` | `"nba"` (default) or `"wnba"`. |
+| `return_as_pandas` | `bool` | `False` | Return a `pandas.DataFrame` instead of polars. |
+| `proxy` | `Any` | `None` | Proxy configuration in the `requests` `proxies=` shape. |
+
+**Returns**
+
+One row per team: `ranker`, `team`, `g`, `mp` and the box categories scaled to `table`, plus echoed `season` / `table` / `league`. The WNBA path drops the `League Average` footer row, as wehoop does. A zero-row frame when the table id is absent.
+
+**Example**
+
+```python
+from sportsdataverse.nba.bref import bref_teams_stats
+
+df = bref_teams_stats(season=2024)
+print(df.shape)
+
+# Opponent per-game, and pandas output
+
+opp = bref_teams_stats(season=2024, table="opponent")
+df_pd = bref_teams_stats(season=2024, return_as_pandas=True)
+
+# Pipeline next step (one line)
+
+df.sort("pts_per_g", descending=True).head()
+```
+
+### `compile_nba_season(season: 'int', season_type: 'str' = 'Regular Season', *, resume: 'bool' = True, cache_dir: 'Optional[str]' = None, delay_s: 'float' = 0.6, lineup_source: 'str' = 'auto', proxy_provider: 'Optional[Callable[[], Optional[str]]]' = None, raw_store_dir: 'RawStoreDir' = None, raw_store_readonly: 'Optional[bool]' = None, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#compile_nba_season}
+
+Compile a full season's possession stint matrix (cached + resumable + throttled).
+
+Discovers game ids, dedupes, then per game loads the cached parquet if present
+(`resume`), else fetches via fetch_possessions`, caches it, and sleeps
+`delay_s` (throttle; only on live fetches). A game that errors or returns no
+possessions is logged and skipped (best-effort — a per-game failure never
+raises; see `Raises` for the game_date integrity error). The assembled
+frame is tagged with a `season` column.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `int` |  | Season END year (e.g. 2024 for 2023-24). |
+| `season_type` | `str` | `'Regular Season'` | `"Regular Season"` (default) or `"Playoffs"`. |
+| `resume` | `bool` | `True` | Reuse per-game cached parquet when present. |
+| `cache_dir` | `Optional[str]` | `None` | Cache root; defaults to `SDV_PY_NBA_CACHE_DIR` or `~/.sdv_py_nba_cache/possessions`. |
+| `delay_s` | `float` | `0.6` | Seconds to sleep after each live fetch (rate-limit throttle). |
+| `lineup_source` | `str` | `'auto'` | Which on-court lineup producer to use — `"auto"` (default; tries rotation then falls back to pbp), `"rotation"` (gamerotation endpoint only), or `"pbp"` (pbp-derived, no gamerotation fetch — useful when the gamerotation endpoint is throttled or unavailable). |
+| `proxy_provider` | `Optional[Callable[[], Optional[str]]]` | `None` | Optional zero-arg callable returning a proxy URL (or `None`). **Called once for game discovery, then once per game** (`N + 1` calls for an `N`-game season), so a rotating pool spreads a season's fetches across many exit IPs rather than hammering `stats.nba.com` from one address. `stats.nba.com` rejects or hangs on datacenter/cloud IPs, so an unattended host (CI, a droplet) MUST supply one — a proxied request is judged on the proxy's exit IP, which is what makes such a host viable at all. Note discovery is proxied too: an unproxied index call returns no rows there, compiling the season to zero games without an error. Any `() -> str \| None` works; a round-robin pool's `.next` matches the signature directly:: compile_nba_season(2024, proxy_provider=round_robin.next) |
+| `raw_store_dir` | `RawStoreDir` | `None` | Explicit raw JSON store root forwarded to every per-game fetch — a single path, or a per-endpoint mapping (`"*"` default key) so payload families can live in independent trees. `None` -> env vars (per-endpoint `SDV_PY_NBA_RAW_JSON_DIR_{ENDPOINT}`, then the generic `SDV_PY_NBA_RAW_JSON_DIR`); `""` force-disables. Same spirit as `cache_dir`'s arg-over-env precedence. |
+| `raw_store_readonly` | `Optional[bool]` | `None` | If `True`, per-game fetches are fully offline — the store is the only source, and a game with no capture raises `~sportsdataverse.errors.RawStoreMissError`, which this loop's per-game handler logs and skips (so an uncaptured game is visibly skipped instead of silently completed from the live API). `None` defers to `SDV_PY_NBA_RAW_JSON_READONLY`. |
+| `return_as_pandas` | `bool` | `False` | Return pandas instead of polars. |
+
+**Returns**
+
+The season possession frame (+ `season` and `game_date` cols). Empty typed frame if no games.
+
+**Example**
+
+```python
+from sportsdataverse.nba.nba_season_compile import compile_nba_season
+
+poss = compile_nba_season(2024)
+print(poss.shape)          # (n_possessions, n_cols)
+print(poss["season"][0])   # 2024
+
+# Resume a partially completed run and return as pandas
+
+poss_pd = compile_nba_season(2024, resume=True, return_as_pandas=True)
+print(type(poss_pd))       # <class 'pandas.core.frame.DataFrame'>
+
+# Compile Playoffs with a custom cache directory
+
+poss = compile_nba_season(
+    2024,
+    season_type="Playoffs",
+    cache_dir="/tmp/nba_cache",
+)
+```
 
 ### `espn_nba_player_stats(athlete_id: 'int', season: 'int', *, season_type: 'str' = 'regular', total: 'bool' = False, raw: 'bool' = False, return_as_pandas: 'bool' = False, **kwargs: 'Any') -> 'pl.DataFrame | pd.DataFrame | dict[str, Any]'` {#espn_nba_player_stats}
 
@@ -308,6 +479,80 @@ finals = espn_nba_schedule(dates=20230102).filter(
 )
 ```
 
+### `espn_nba_teams(return_as_pandas=False, **kwargs) -> 'pl.DataFrame'` {#espn_nba_teams}
+
+espn_nba_teams - look up NBA teams
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
+
+**Returns**
+
+Polars dataframe containing teams for the requested league. This function caches by default, so if you want to refresh the data, use the command sportsdataverse.nba.espn_nba_teams.clear_cache().
+
+| col_name | type | description |
+|---|---|---|
+| `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
+| `team_alternate_color` | character | Team alternate color (hex without leading '#'). |
+| `team_color` | character | Team primary color (hex without leading '#'). |
+| `team_display_name` | character | Full team display name. |
+| `team_id` | character | Unique team identifier. |
+| `team_is_active` | logical | TRUE if the team is currently active. |
+| `team_is_all_star` | logical | TRUE if the row represents an All-Star team. |
+| `team_location` | character | Team city or location string. |
+| `team_logos` | integer | Team logo metadata. |
+| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_nickname` | character | Team nickname. |
+| `team_short_display_name` | character | Short team display name (e.g. 'Aces'). |
+| `team_slug` | character | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_uid` | character | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+
+**Example**
+
+```python
+from sportsdataverse.nba import espn_nba_teams
+teams = espn_nba_teams()
+print(teams.shape)
+
+# Pandas round-trip
+
+teams_pd = espn_nba_teams(return_as_pandas=True)
+teams_pd.head()
+
+# Pipeline next step (build a team_id to abbreviation map)
+
+teams = espn_nba_teams()
+abbr_map = dict(zip(teams["team_id"], teams["team_abbreviation"]))
+```
+
+### `most_recent_nba_season()` {#most_recent_nba_season}
+
+Return the most recent NBA season year based on today's date.
+
+The NBA season crosses calendar years -- a season started in October of
+year Y is reported as season Y+1. If today is in October or later, this
+returns next calendar year; otherwise it returns the current calendar year.
+
+**Returns**
+
+The most recent NBA season year (e.g. 2024 for the 2023-24 season).
+
+**Example**
+
+```python
+from sportsdataverse.nba import most_recent_nba_season
+year = most_recent_nba_season()
+print(year)
+
+# Combine with the loaders for a "current season" pull
+
+from sportsdataverse.nba import load_nba_schedule, most_recent_nba_season
+sched = load_nba_schedule(seasons=[most_recent_nba_season()])
+```
+
 ## Dataset loaders
 
 ### `load_darko_dpm(path: 'str') -> 'pl.DataFrame'` {#load_darko_dpm}
@@ -517,31 +762,6 @@ season = oracle.filter(pl.col("season") == "2022-23")
 ```
 
 ## Utilities & helpers
-
-### `most_recent_nba_season()` {#most_recent_nba_season}
-
-Return the most recent NBA season year based on today's date.
-
-The NBA season crosses calendar years -- a season started in October of
-year Y is reported as season Y+1. If today is in October or later, this
-returns next calendar year; otherwise it returns the current calendar year.
-
-**Returns**
-
-The most recent NBA season year (e.g. 2024 for the 2023-24 season).
-
-**Example**
-
-```python
-from sportsdataverse.nba import most_recent_nba_season
-year = most_recent_nba_season()
-print(year)
-
-# Combine with the loaders for a "current season" pull
-
-from sportsdataverse.nba import load_nba_schedule, most_recent_nba_season
-sched = load_nba_schedule(seasons=[most_recent_nba_season()])
-```
 
 ### `year_to_season(year)` {#year_to_season}
 
@@ -1351,83 +1571,6 @@ df_pd = bref_player_game_log("jamesle01", 2024, return_as_pandas=True)
 df.select(["date", "opp", "pts", "trb", "ast"]).head()
 ```
 
-### `bref_players_stats(season: 'Optional[int]' = None, table: 'str' = 'per_game', league: 'str' = 'nba', *, return_as_pandas: 'bool' = False, proxy: 'Any' = None, **kwargs: 'Any') -> 'pl.DataFrame | pd.DataFrame'` {#bref_players_stats}
-
-Player season statistics for an entire league season.
-
-Port of hoopR's `bref_players_stats()` (NBA) and wehoop's
-`bref_wnba_player_stats()` (WNBA). One row per player, with columns named
-by Basketball-Reference `data-stat` keys.
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `season` | `Optional[int]` | `None` | Season in 4-digit ending-year format (`2024` = 2023-24). The WNBA season is a plain calendar year. Defaults to the current season. |
-| `table` | `str` | `'per_game'` | Which stat table. NBA accepts `per_game` (default), `totals`, `advanced`, `per_minute` (per 36) and `per_poss` (per 100 possessions); WNBA accepts `per_game`, `totals` and `advanced`. |
-| `league` | `str` | `'nba'` | `"nba"` (default) or `"wnba"`. |
-| `return_as_pandas` | `bool` | `False` | Return a `pandas.DataFrame` instead of polars. |
-| `proxy` | `Any` | `None` | Proxy configuration in the `requests` `proxies=` shape. |
-
-**Returns**
-
-One row per player: `ranker`, `player`, `age`, `team`, `pos`, `g`, `gs` plus the box columns scaled to `table` (the `advanced` table adds `per`, `ts_pct`, `usg_pct`, `ws`, `bpm`, `vorp` …), and echoed `season` / `table` / `league` columns. A zero-row frame when the page carries no player table.
-
-**Example**
-
-```python
-from sportsdataverse.nba.bref import bref_players_stats
-
-df = bref_players_stats(season=2024)
-print(df.shape)
-
-# Advanced metrics, and the WNBA page
-
-adv = bref_players_stats(season=2024, table="advanced")
-wnba = bref_players_stats(season=2024, league="wnba")
-
-# Pipeline next step (one line)
-
-adv.filter(pl.col("vorp") > 3.0).sort("vorp", descending=True).head()
-```
-
-### `bref_standings(season: 'Optional[int]' = None, league: 'str' = 'nba', *, return_as_pandas: 'bool' = False, proxy: 'Any' = None, **kwargs: 'Any') -> 'pl.DataFrame | pd.DataFrame'` {#bref_standings}
-
-Conference standings for a season, both conferences stacked.
-
-Port of hoopR's `bref_standings()` (NBA) and wehoop's
-`bref_wnba_standings()` (WNBA).
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `season` | `Optional[int]` | `None` | Season in 4-digit ending-year format. Defaults to the current season. |
-| `league` | `str` | `'nba'` | `"nba"` (default) or `"wnba"`. |
-| `return_as_pandas` | `bool` | `False` | Return a `pandas.DataFrame` instead of polars. |
-| `proxy` | `Any` | `None` | Proxy configuration in the `requests` `proxies=` shape. |
-
-**Returns**
-
-One row per team: `conference` (`"E"` / `"W"` for **both** leagues -- wehoop emits `"Eastern"`/`"Western"`), `team` (playoff `*` marker stripped), `playoffs` (bool, from that marker), `wins`, `losses`, `win_loss_pct`, `gb`, `pts_per_g`, `opp_pts_per_g`, `srs`, plus echoed `season` / `league`. Zero rows when neither conference table is present.
-
-**Example**
-
-```python
-from sportsdataverse.nba.bref import bref_standings
-
-df = bref_standings(season=2024)
-print(df.shape)
-
-# The WNBA page
-
-wnba = bref_standings(season=2024, league="wnba")
-
-# Pipeline next step (one line)
-
-df.filter(pl.col("playoffs") == True).sort("srs", descending=True).head()
-```
-
 ### `bref_team_roster(team: 'str', season: 'Optional[int]' = None, *, return_as_pandas: 'bool' = False, proxy: 'Any' = None, **kwargs: 'Any') -> 'pl.DataFrame | pd.DataFrame'` {#bref_team_roster}
 
 A team's roster for one season.
@@ -1462,47 +1605,6 @@ sonics = bref_team_roster(team="SEA", season=1996)
 # Pipeline next step (one line)
 
 df.select(["player", "pos", "height", "college"]).head()
-```
-
-### `bref_teams_stats(season: 'Optional[int]' = None, table: 'str' = 'per_game', league: 'str' = 'nba', *, return_as_pandas: 'bool' = False, proxy: 'Any' = None, **kwargs: 'Any') -> 'pl.DataFrame | pd.DataFrame'` {#bref_teams_stats}
-
-Team season statistics from the league season page.
-
-Port of hoopR's `bref_teams_stats()` (NBA) and wehoop's
-`bref_wnba_team_stats()` (WNBA). Every team table lives on the one season
-page and all but the first are comment-hidden, which is why the table `id`
-selection in bref_table` matters here.
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `season` | `Optional[int]` | `None` | Season in 4-digit ending-year format (`2024` = 2023-24). Defaults to the current season. |
-| `table` | `str` | `'per_game'` | NBA accepts `per_game` (default), `totals`, `per_poss`, `advanced` and `opponent` (opponent per-game); WNBA accepts the same set minus `opponent`. |
-| `league` | `str` | `'nba'` | `"nba"` (default) or `"wnba"`. |
-| `return_as_pandas` | `bool` | `False` | Return a `pandas.DataFrame` instead of polars. |
-| `proxy` | `Any` | `None` | Proxy configuration in the `requests` `proxies=` shape. |
-
-**Returns**
-
-One row per team: `ranker`, `team`, `g`, `mp` and the box categories scaled to `table`, plus echoed `season` / `table` / `league`. The WNBA path drops the `League Average` footer row, as wehoop does. A zero-row frame when the table id is absent.
-
-**Example**
-
-```python
-from sportsdataverse.nba.bref import bref_teams_stats
-
-df = bref_teams_stats(season=2024)
-print(df.shape)
-
-# Opponent per-game, and pandas output
-
-opp = bref_teams_stats(season=2024, table="opponent")
-df_pd = bref_teams_stats(season=2024, return_as_pandas=True)
-
-# Pipeline next step (one line)
-
-df.sort("pts_per_g", descending=True).head()
 ```
 
 ### `build_athlete_identity_lookup(rosters: 'dict[int | str, dict]') -> 'dict[str, dict[str, Any]]'` {#build_athlete_identity_lookup}
@@ -1709,59 +1811,6 @@ from sportsdataverse.nba.nba_clutch import clutch_delta
 d = clutch_delta(clutch_frame, baseline_frame)
 ```
 
-### `compile_nba_season(season: 'int', season_type: 'str' = 'Regular Season', *, resume: 'bool' = True, cache_dir: 'Optional[str]' = None, delay_s: 'float' = 0.6, lineup_source: 'str' = 'auto', proxy_provider: 'Optional[Callable[[], Optional[str]]]' = None, raw_store_dir: 'RawStoreDir' = None, raw_store_readonly: 'Optional[bool]' = None, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#compile_nba_season}
-
-Compile a full season's possession stint matrix (cached + resumable + throttled).
-
-Discovers game ids, dedupes, then per game loads the cached parquet if present
-(`resume`), else fetches via fetch_possessions`, caches it, and sleeps
-`delay_s` (throttle; only on live fetches). A game that errors or returns no
-possessions is logged and skipped (best-effort — a per-game failure never
-raises; see `Raises` for the game_date integrity error). The assembled
-frame is tagged with a `season` column.
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `season` | `int` |  | Season END year (e.g. 2024 for 2023-24). |
-| `season_type` | `str` | `'Regular Season'` | `"Regular Season"` (default) or `"Playoffs"`. |
-| `resume` | `bool` | `True` | Reuse per-game cached parquet when present. |
-| `cache_dir` | `Optional[str]` | `None` | Cache root; defaults to `SDV_PY_NBA_CACHE_DIR` or `~/.sdv_py_nba_cache/possessions`. |
-| `delay_s` | `float` | `0.6` | Seconds to sleep after each live fetch (rate-limit throttle). |
-| `lineup_source` | `str` | `'auto'` | Which on-court lineup producer to use — `"auto"` (default; tries rotation then falls back to pbp), `"rotation"` (gamerotation endpoint only), or `"pbp"` (pbp-derived, no gamerotation fetch — useful when the gamerotation endpoint is throttled or unavailable). |
-| `proxy_provider` | `Optional[Callable[[], Optional[str]]]` | `None` | Optional zero-arg callable returning a proxy URL (or `None`). **Called once for game discovery, then once per game** (`N + 1` calls for an `N`-game season), so a rotating pool spreads a season's fetches across many exit IPs rather than hammering `stats.nba.com` from one address. `stats.nba.com` rejects or hangs on datacenter/cloud IPs, so an unattended host (CI, a droplet) MUST supply one — a proxied request is judged on the proxy's exit IP, which is what makes such a host viable at all. Note discovery is proxied too: an unproxied index call returns no rows there, compiling the season to zero games without an error. Any `() -> str \| None` works; a round-robin pool's `.next` matches the signature directly:: compile_nba_season(2024, proxy_provider=round_robin.next) |
-| `raw_store_dir` | `RawStoreDir` | `None` | Explicit raw JSON store root forwarded to every per-game fetch — a single path, or a per-endpoint mapping (`"*"` default key) so payload families can live in independent trees. `None` -> env vars (per-endpoint `SDV_PY_NBA_RAW_JSON_DIR_{ENDPOINT}`, then the generic `SDV_PY_NBA_RAW_JSON_DIR`); `""` force-disables. Same spirit as `cache_dir`'s arg-over-env precedence. |
-| `raw_store_readonly` | `Optional[bool]` | `None` | If `True`, per-game fetches are fully offline — the store is the only source, and a game with no capture raises `~sportsdataverse.errors.RawStoreMissError`, which this loop's per-game handler logs and skips (so an uncaptured game is visibly skipped instead of silently completed from the live API). `None` defers to `SDV_PY_NBA_RAW_JSON_READONLY`. |
-| `return_as_pandas` | `bool` | `False` | Return pandas instead of polars. |
-
-**Returns**
-
-The season possession frame (+ `season` and `game_date` cols). Empty typed frame if no games.
-
-**Example**
-
-```python
-from sportsdataverse.nba.nba_season_compile import compile_nba_season
-
-poss = compile_nba_season(2024)
-print(poss.shape)          # (n_possessions, n_cols)
-print(poss["season"][0])   # 2024
-
-# Resume a partially completed run and return as pandas
-
-poss_pd = compile_nba_season(2024, resume=True, return_as_pandas=True)
-print(type(poss_pd))       # <class 'pandas.core.frame.DataFrame'>
-
-# Compile Playoffs with a custom cache directory
-
-poss = compile_nba_season(
-    2024,
-    season_type="Playoffs",
-    cache_dir="/tmp/nba_cache",
-)
-```
-
 ### `darko_forecast_accuracy(panel: 'pl.DataFrame', ages: 'pl.DataFrame', *, aging_curve: "'AgingCurve | None'" = None, process_var: "'float | None'" = None, obs_base: "'float | None'" = None, min_history: 'int' = 1) -> 'ForecastResult'` {#darko_forecast_accuracy}
 
 Holdout forecast accuracy: for each transition, forecast N+1 from history <= N vs actual.
@@ -1828,55 +1877,6 @@ from sportsdataverse.nba.nba_rapm_variants import decay_weights
 dates = pl.Series("game_date", [datetime.date(2023, 1, 1)])
 w = decay_weights(dates, datetime.date(2023, 1, 31), half_life_days=30.0)
 print(round(float(w[0]), 3))  # 0.5
-```
-
-### `espn_nba_teams(return_as_pandas=False, **kwargs) -> 'pl.DataFrame'` {#espn_nba_teams}
-
-espn_nba_teams - look up NBA teams
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
-
-**Returns**
-
-Polars dataframe containing teams for the requested league. This function caches by default, so if you want to refresh the data, use the command sportsdataverse.nba.espn_nba_teams.clear_cache().
-
-| col_name | type | description |
-|---|---|---|
-| `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
-| `team_alternate_color` | character | Team alternate color (hex without leading '#'). |
-| `team_color` | character | Team primary color (hex without leading '#'). |
-| `team_display_name` | character | Full team display name. |
-| `team_id` | character | Unique team identifier. |
-| `team_is_active` | logical | TRUE if the team is currently active. |
-| `team_is_all_star` | logical | TRUE if the row represents an All-Star team. |
-| `team_location` | character | Team city or location string. |
-| `team_logos` | integer | Team logo metadata. |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
-| `team_nickname` | character | Team nickname. |
-| `team_short_display_name` | character | Short team display name (e.g. 'Aces'). |
-| `team_slug` | character | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
-| `team_uid` | character | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
-
-**Example**
-
-```python
-from sportsdataverse.nba import espn_nba_teams
-teams = espn_nba_teams()
-print(teams.shape)
-
-# Pandas round-trip
-
-teams_pd = espn_nba_teams(return_as_pandas=True)
-teams_pd.head()
-
-# Pipeline next step (build a team_id to abbreviation map)
-
-teams = espn_nba_teams()
-abbr_map = dict(zip(teams["team_id"], teams["team_abbreviation"]))
 ```
 
 ### `expected_possessions(home_pace: 'float', away_pace: 'float', *, league_id: 'str' = '00') -> 'float'` {#expected_possessions}

--- a/sportsdataverse/mbb/mbb_ncaa_schedule.py
+++ b/sportsdataverse/mbb/mbb_ncaa_schedule.py
@@ -457,6 +457,7 @@ def ncaa_mbb_team_schedule(
     Example:
         Quick start::
 
+            import polars as pl
             from sportsdataverse.mbb import ncaa_mbb_team_schedule
             df = ncaa_mbb_team_schedule(team="Illinois", season="2025-26")
             print(df.shape)

--- a/sportsdataverse/nba/bref.py
+++ b/sportsdataverse/nba/bref.py
@@ -374,6 +374,7 @@ def bref_players_stats(
     Example:
         Quick start::
 
+            import polars as pl
             from sportsdataverse.nba.bref import bref_players_stats
 
             df = bref_players_stats(season=2024)
@@ -537,6 +538,7 @@ def bref_standings(
     Example:
         Quick start::
 
+            import polars as pl
             from sportsdataverse.nba.bref import bref_standings
 
             df = bref_standings(season=2024)

--- a/tests/codegen/test_docs.py
+++ b/tests/codegen/test_docs.py
@@ -60,6 +60,49 @@ def test_league_index_lists_api_rows_and_loaders():
     assert "[Dataset loaders](reference/loaders)" in md
 
 
+# --- Highlights: curated functions pulled out of the Additional bucket ------
+
+
+def test_highlighted_names_intersects_against_the_real_autodoc_set():
+    # A curated name that doesn't actually exist in this call's autodoc set (typo,
+    # or since moved to a generated page) is silently dropped, not surfaced.
+    highlighted = generate._highlighted_names("mbb", ["espn_mbb_schedule", "not_a_real_function"])
+    assert highlighted == {"espn_mbb_schedule"}
+
+
+def test_highlighted_names_is_always_empty_for_the_global_scope():
+    assert generate._highlighted_names(None, ["espn_mbb_schedule"]) == set()
+
+
+def test_autodoc_family_checks_highlighted_before_the_keyword_rules():
+    # espn_mbb_schedule would otherwise classify as "Play-by-play, schedule & rosters"
+    # (it matches the _ESPN_PBP_FAMILY_TOKENS "_schedule" token) -- Highlights wins.
+    assert generate._autodoc_family("espn_mbb_schedule") == "Play-by-play, schedule & rosters"
+    assert generate._autodoc_family("espn_mbb_schedule", frozenset({"espn_mbb_schedule"})) == "Highlights"
+
+
+def test_render_league_index_highlights_row_and_additional_count_do_not_overlap():
+    md = generate.render_league_index(
+        "mbb", has_additional=True, additional_count=317, has_highlights=True, highlights_count=9
+    )
+    assert "| [Highlights](reference/additional#highlights) | 9 |" in md
+    assert "| [Additional functions](reference/additional) | 317 |" in md
+
+
+def test_render_league_index_omits_highlights_row_by_default():
+    md = generate.render_league_index("nba")
+    assert "Highlights" not in md
+
+
+def test_mbb_additional_page_has_a_highlights_group_first():
+    names = generate._autodoc_names("mbb", "")
+    groups = generate._autodoc_groups("mbb", names)
+    assert groups[0]["family"] == "Highlights"
+    highlighted_fns = {fn["name"] for fn in groups[0]["functions"]}
+    assert "espn_mbb_pbp" in highlighted_fns
+    assert "espn_mbb_schedule" in highlighted_fns
+
+
 def test_loaders_page_has_mermaid_and_per_loader_blocks():
     md = generate.render_loaders_page("nhl")
     assert "```mermaid" in md

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -444,6 +444,7 @@ def _table_cell_desc(stored: str, league: str | None, col: str, schema: str | No
 
 _R_EXPORTS_FILE = ROOT / "tools" / "codegen" / "r_exports.yaml"
 _R_PARITY_ALIASES_FILE = ROOT / "tools" / "codegen" / "r_parity_aliases.yaml"
+_HIGHLIGHTS_FILE = ROOT / "tools" / "codegen" / "highlights.yaml"
 
 # League prefix -> R package for parity (pwhl is also fastRhockey; otherwise the
 # same mapping used for column descriptions).
@@ -475,6 +476,34 @@ def _r_exports() -> dict:
     import yaml
 
     return yaml.safe_load(_R_EXPORTS_FILE.read_text(encoding="utf-8")) or {}
+
+
+@functools.lru_cache(maxsize=1)
+def _highlights_map() -> dict:
+    """``{league_prefix: [curated function names]}`` from the committed ``highlights.yaml``.
+
+    Hand-maintained "start here" picks pulled out of a league's Additional bucket
+    into their own top-billed Highlights section -- see the file's own header
+    comment and :func:`_autodoc_family`. Empty dict if absent/for an unlisted
+    league, so a league with no curated list just keeps today's behavior."""
+    if not _HIGHLIGHTS_FILE.exists():
+        return {}
+    import yaml
+
+    return yaml.safe_load(_HIGHLIGHTS_FILE.read_text(encoding="utf-8")) or {}
+
+
+def _highlighted_names(league: str | None, names: list[str]) -> set[str]:
+    """Curated names from :func:`_highlights_map` that are actually in *names*.
+
+    ``None`` (the package-level global scope) always yields an empty set -- the
+    pilot is per-league only. Intersecting against *names* means a stale or
+    misspelled entry in ``highlights.yaml`` is silently inert rather than
+    surfacing a name that doesn't exist / already moved to a generated page.
+    """
+    if league is None:
+        return set()
+    return set(_highlights_map().get(league, [])) & set(names)
 
 
 @functools.lru_cache(maxsize=1)
@@ -2495,6 +2524,8 @@ def render_league_index(
     *,
     has_additional: bool = False,
     additional_count: int = 0,
+    has_highlights: bool = False,
+    highlights_count: int = 0,
     r_parity: list[dict] | None = None,
     r_pkg: str | None = None,
 ) -> str:
@@ -2503,8 +2534,11 @@ def render_league_index(
     ``has_additional`` / ``additional_count`` are supplied by :func:`_render_docs_all`
     (and :func:`_autodoc_names_by_scope`) after they compute the autodoc set for this
     league, so the index table can link the ``reference/additional`` page with an
-    accurate function count. ``r_parity`` / ``r_pkg`` (also from
-    :func:`_render_docs_all`) drive the Python<->R parity table."""
+    accurate function count. ``has_highlights`` / ``highlights_count`` are the curated
+    subset of that same autodoc set (see :func:`_highlighted_names`) -- when non-zero,
+    ``additional_count`` reports the REST (the autodoc set minus the highlighted names)
+    so the two rows never double-count the same functions. ``r_parity`` / ``r_pkg``
+    (also from :func:`_render_docs_all`) drive the Python<->R parity table."""
     loaders = _loader_doc_views(prefix)
     template = render.ENV.get_template("league_index.md.jinja")
     return template.render(
@@ -2515,6 +2549,8 @@ def render_league_index(
         loader_base=_loader_base_label(prefix),
         has_additional=has_additional,
         additional_count=additional_count,
+        has_highlights=has_highlights,
+        highlights_count=highlights_count,
         notebooks=_notebooks_for(prefix),
         r_parity=r_parity or [],
         r_pkg=r_pkg,
@@ -2623,6 +2659,7 @@ def _is_shared_leak(module: str) -> bool:
 # Deterministic family order for the autodoc page (families not listed sort last,
 # alphabetically). Functions within a family are always sorted alphabetically.
 _AUTODOC_FAMILY_ORDER = [
+    "Highlights",
     "Statcast",
     "MLB Stats API",
     "Play-by-play, schedule & rosters",
@@ -2643,8 +2680,15 @@ _ESPN_PBP_FAMILY_TOKENS = (
 )
 
 
-def _autodoc_family(name: str) -> str:
-    """Group key for an autodoc function name (see the family rules in Task D2)."""
+def _autodoc_family(name: str, highlighted: frozenset[str] = frozenset()) -> str:
+    """Group key for an autodoc function name (see the family rules in Task D2).
+
+    ``highlighted`` (the per-league curated set from :func:`_highlighted_names`)
+    is checked FIRST, so a hand-picked "start here" function is pulled out of
+    whichever family it would otherwise land in (Utilities & helpers, Other,
+    Play-by-play, ...) into its own top-billed Highlights section instead."""
+    if name in highlighted:
+        return "Highlights"
     if name.startswith("statcast") or name == "mlb_statcast":
         return "Statcast"
     if name.startswith("load_"):
@@ -3275,6 +3319,7 @@ def _autodoc_groups(league: str | None, names: list[str]) -> list[dict]:
     _mod_path = _LEAGUE_MODULE.get(league, league) if league is not None else None
     mod = importlib.import_module("sportsdataverse" if _mod_path is None else f"sportsdataverse.{_mod_path}")
     scope = "global" if league is None else league
+    highlighted = frozenset(_highlighted_names(league, names))
     by_family: dict[str, list[dict]] = {}
     for n in names:
         obj = getattr(mod, n)
@@ -3299,7 +3344,7 @@ def _autodoc_groups(league: str | None, names: list[str]) -> list[dict]:
             c["description"] = _table_cell_desc(str(c.get("description", "")), league, raw_name, n)
             c["name"] = raw_name.replace("|", "\\|")
             c["type"] = str(c.get("type", "")).replace("|", "\\|")
-        by_family.setdefault(_autodoc_family(n), []).append(
+        by_family.setdefault(_autodoc_family(n, highlighted), []).append(
             {"name": n, "signature": _autodoc_signature(obj), "return_columns": return_columns, **view},
         )
 
@@ -3548,10 +3593,14 @@ def _render_docs_all() -> dict[str, str]:
         ref_pages = {
             rel[len(ref_prefix) : -3]: c for rel, c in out.items() if rel.startswith(ref_prefix) and rel.endswith(".md")
         }
+        highlights_count = len(_highlighted_names(prefix, autodoc_names_list))
+        remaining_count = len(autodoc_names_list) - highlights_count
         out[f"{prefix}/index.md"] = render_league_index(
             prefix,
-            has_additional=bool(autodoc_names_list),
-            additional_count=len(autodoc_names_list),
+            has_additional=bool(remaining_count),
+            additional_count=remaining_count,
+            has_highlights=bool(highlights_count),
+            highlights_count=highlights_count,
             r_parity=_r_parity_rows(prefix, ref_pages, autodoc_names_list),
             r_pkg=_R_PARITY_PACKAGE.get(prefix),
         )

--- a/tools/codegen/highlights.yaml
+++ b/tools/codegen/highlights.yaml
@@ -1,0 +1,51 @@
+# Hand-maintained, per-league "start here" function picks.
+#
+# A league's `Additional functions` page (reference/additional.md) is a residual
+# bucket -- whatever public function isn't already covered by a generated
+# API-endpoint reference page, listed alphabetically. That mixes genuinely
+# important entry points (schedule/roster/pbp/player-stats wrappers) in with
+# hundreds of internal engine helpers (RAPM/lineup/possession plumbing classes
+# and functions never meant to be a user's first stop).
+#
+# Names listed here for a league are pulled into a dedicated "Highlights"
+# section: its own row at the TOP of that league's index.md table, and its own
+# `## Highlights` group at the TOP of reference/additional.md (see
+# generate.py's `_autodoc_family` / `_AUTODOC_FAMILY_ORDER`).
+#
+# A name here that isn't actually in that league's autodoc (Additional) set --
+# e.g. a typo, or a function that later moved to a generated API family -- is
+# silently ignored, not an error (`_highlighted_names` intersects against the
+# real autodoc name list).
+#
+# Pilot: mbb, nba, cfb. Add more leagues by adding a key here; no other wiring
+# is needed.
+mbb:
+  - espn_mbb_schedule
+  - espn_mbb_pbp
+  - espn_mbb_teams
+  - espn_mbb_player_stats
+  - espn_mbb_game_rosters
+  - most_recent_mbb_season
+  - ncaa_mbb_team_schedule
+  - ncaa_mbb_play_by_play
+  - ncaa_mbb_team_roster
+
+nba:
+  - espn_nba_schedule
+  - espn_nba_player_stats
+  - espn_nba_teams
+  - most_recent_nba_season
+  - bref_players_stats
+  - bref_teams_stats
+  - bref_standings
+  - compile_nba_season
+
+cfb:
+  - espn_cfb_schedule
+  - espn_cfb_player_stats
+  - most_recent_cfb_season
+  - cfb_standings
+  - cfb_advanced_stats
+  - get_cfb_teams
+  - to_cfbfastr
+  - CFBPlayProcess

--- a/tools/codegen/templates/league_index.md.jinja
+++ b/tools/codegen/templates/league_index.md.jinja
@@ -7,7 +7,8 @@ description: "sdv-py {{ prefix|upper }}: endpoint references, dataset loaders an
 
 | Reference | Functions | Base URL |
 |---|---:|---|
-{% for a in api_rows %}| [{{ a.label }}](reference/{{ a.slug }}) | {{ a.count }} | `{{ a.base }}` |
+{% if has_highlights %}| [Highlights](reference/additional#highlights) | {{ highlights_count }} | curated "start here" functions |
+{% endif %}{% for a in api_rows %}| [{{ a.label }}](reference/{{ a.slug }}) | {{ a.count }} | `{{ a.base }}` |
 {% endfor %}
 {% if has_loaders %}| [Dataset loaders](reference/loaders) | {{ loader_count }} | {{ loader_base }} |
 {% endif %}{% if has_additional %}| [Additional functions](reference/additional) | {{ additional_count }} | hand-written wrappers, loaders & helpers |


### PR DESCRIPTION
## Summary

Every league's index page (`docs/docs/<league>/index.md`) renders its reference-table rows in a fixed order: generated API-family groupings → Dataset loaders → **Additional functions**, always last. "Additional" isn't curated by importance — it's a mechanical residual: whatever public function isn't already claimed by a registered per-family reference page, listed alphabetically. For MBB that bucket is 326 functions and quietly buries `espn_mbb_pbp`, `espn_mbb_teams`, `espn_mbb_player_stats`, and `most_recent_mbb_season` under things like the Bart Torvik reference table.

Per discussion, the fix piloted here:
- **Priority scheme:** a curated "Highlights" allowlist (not blanket-promoting every hand-written function, since most of the residual bucket is internal engine plumbing — RAPM/lineup/possession helpers never meant to be a user's first stop).
- **Curation source:** a new hand-maintained `tools/codegen/highlights.yaml`, one list of function names per league.
- **Rollout:** piloted on the 3 leagues with the largest residual buckets — MBB (326), NBA (181), CFB (94).
- **Scope:** both the top-level index table AND `reference/additional.md`'s internal grouping — a curated function now gets its own `## Highlights` section at the top of `additional.md`, not just a link from the index.

## How it works

`_autodoc_family()` checks the per-league highlighted-name set FIRST (before its existing keyword-based classification), so a curated name is pulled into a new `"Highlights"` family — first in `_AUTODOC_FAMILY_ORDER`, so it renders first in both the index table (a new row, above every API-family row) and `additional.md` (a new `## Highlights` group, above everything else). The plain `Additional functions` count is adjusted to exclude highlighted names, so the two rows never double-count. A name in `highlights.yaml` that isn't actually in a league's autodoc set (typo, or since moved to a generated reference page) is silently ignored, not an error.

Extending to another league is just adding a key to `highlights.yaml` — no other wiring needed.

## Test plan

- [x] New tests in `tests/codegen/test_docs.py`: highlight/autodoc-set intersection, global-scope is always empty, family classification precedence, index-table row rendering (count non-overlap), default omission when no highlights are configured, and that MBB's `additional.md` groups render Highlights first with the right members.
- [x] `uv run python tools/codegen/generate.py` — regenerated exactly the 6 expected files (index.md + additional.md for mbb/nba/cfb), nothing else touched.
- [x] `uv run python tools/codegen/generate.py --check` — no drift.
- [x] `uv run pytest tests/codegen/ -q` — 180 passed, 11 pre-existing skips.
- [x] `uv run ruff check` / `ruff format --check` on touched files — clean.
- [x] `uv run mypy tools/codegen/generate.py` — same 24 pre-existing errors before and after (confirmed via stash-diff); the file isn't in the `[tool.mypy] files` strict ratchet.
- [x] `cd docs && yarn build` — succeeds; no new broken-anchor warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added curated “Highlights” sections to the CFB, MBB, and NBA reference documentation.
  - Added “Highlights” rows to league indexes with links and function counts.
  - Reorganized MBB and NBA reference entries to group recommended functions together.

- **Tests**
  - Added coverage for highlight selection, documentation grouping, and index rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->