### PR TITLE
fix(cfb): window pace, non-garbage and the score-state clock

### DIFF
--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -2348,8 +2348,11 @@ Build the StatBroadcast-style drive summary, chart, and long-play lists.
 A drive belongs to the quarter it STARTED in. On a windowed build the
 full drive sequence still provides context (running score, the previous
 drive for OBTAINED and points-off-turnovers), but only in-window drives
-are counted, charted, or listed; game-level lines (largest lead, time
-leading/tied) ship only on the un-windowed build.
+are counted, charted, or listed. `largest_lead` and the time-leading /
+time-tied split are measured against the window's own clock bounds and its
+own opening and closing score, so they window too -- except under `"ot"`,
+where the OT clock has no axis to integrate over and only `largest_lead`
+ships.
 
 **Parameters**
 
@@ -2375,10 +2378,11 @@ summary = create_drive_summary(drives, game.plays_frame, "52", "61")
 
 Build the situational team-stats block from a plays frame.
 
-Window-inherent sections -- `two_minute`, `middle_8`, `non_garbage`,
-`pace`, `fourth_down_decisions` -- are omitted from a windowed build:
-they are themselves time windows or game-level filters, and
-double-windowing them is a category error.
+`two_minute` and `middle_8` are omitted from a windowed build: both name
+a clock window of their own, so intersecting them with another window
+describes neither (middle-8 inside Q1 is empty). Every other section,
+`pace` and `non_garbage` included, is computed on the windowed slice and
+ships with it.
 
 **Parameters**
 

--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -2349,10 +2349,11 @@ A drive belongs to the quarter it STARTED in. On a windowed build the
 full drive sequence still provides context (running score, the previous
 drive for OBTAINED and points-off-turnovers), but only in-window drives
 are counted, charted, or listed. `largest_lead` and the time-leading /
-time-tied split are measured against the window's own clock bounds and its
-own opening and closing score, so they window too -- except under `"ot"`,
-where the OT clock has no axis to integrate over and only `largest_lead`
-ships.
+time-tied split window too: the score state is read from the whole
+regulation play sequence and then clipped to the window's clock intervals
+(one per contiguous run of quarters, so a gapped set never charges the
+quarter it skipped). Under `"ot"` the clock has no axis to integrate over
+and only `largest_lead` ships.
 
 **Parameters**
 

--- a/sportsdataverse/cfb/cfb_drive_summary.py
+++ b/sportsdataverse/cfb/cfb_drive_summary.py
@@ -107,6 +107,34 @@ def _obtained(prev_result, is_first_of_half):
     return r
 
 
+# Regulation runs 3600 game-seconds down to 0, so quarter q spans
+# 3600 - 900*(q-1) down to 3600 - 900*q. `middle_8` is defined against the same
+# axis in cfb_pbp (1560 <= t <= 2040, i.e. halftime +/- 4:00).
+_REG_SECONDS = 3600
+_QUARTER_SECONDS = 900
+
+
+def _clock_bounds(periods: set[int] | str | None) -> tuple[int, int] | None:
+    """The window's start and end in ``adj_TimeSecsRem``, or None with no clock.
+
+    Returns None for overtime: from 2023 ESPN files every OT play under one
+    ``period.number`` and the clock-derived ``adj_TimeSecsRem`` collapses (see
+    the sort note in ``cfb_pbp``), so there is no axis to integrate time over.
+    A window of only OT therefore reports ``largest_lead`` but no time split.
+    """
+    if periods is None:
+        return _REG_SECONDS, 0
+    if periods == "ot":
+        return None
+    reg = sorted(p for p in periods if p <= 4)
+    if not reg:
+        return None
+    return (
+        _REG_SECONDS - _QUARTER_SECONDS * (reg[0] - 1),
+        _REG_SECONDS - _QUARTER_SECONDS * reg[-1],
+    )
+
+
 def create_drive_summary(
     drives: list[dict] | dict,
     frame: pl.DataFrame,
@@ -119,8 +147,11 @@ def create_drive_summary(
     A drive belongs to the quarter it STARTED in. On a windowed build the
     full drive sequence still provides context (running score, the previous
     drive for OBTAINED and points-off-turnovers), but only in-window drives
-    are counted, charted, or listed; game-level lines (largest lead, time
-    leading/tied) ship only on the un-windowed build.
+    are counted, charted, or listed. ``largest_lead`` and the time-leading /
+    time-tied split are measured against the window's own clock bounds and its
+    own opening and closing score, so they window too -- except under ``"ot"``,
+    where the OT clock has no axis to integrate over and only ``largest_lead``
+    ships.
 
     Args:
         drives (list[dict]): the ESPN drives grouping, in game order
@@ -187,6 +218,10 @@ def create_drive_summary(
     scores = []
 
     h, a = 0, 0
+    # score entering and leaving the window, for the score-state clock below.
+    # On a full-game build these collapse to 0-0 and the final score.
+    win_open: tuple[int, int] | None = None
+    win_close = (0, 0)
     ordered = [d for d in drives if _team_id(d) in team_ids]
     for i, d in enumerate(ordered):
         tid = _team_id(d)
@@ -209,6 +244,9 @@ def create_drive_summary(
             # points-off-turnovers and OBTAINED stay correct at the seams
             h, a = _score_after(d, h, a)
             continue
+
+        if win_open is None:
+            win_open = (h, a)
 
         t["total_drives"] += 1
         t["yards"] += yards
@@ -310,6 +348,7 @@ def create_drive_summary(
             t["success_ay"] += 1
 
         h, a = h2, a2
+        win_close = (h, a)
 
     # frame-side aggregates per team, windowed to match
     scrim = frame.filter(pl.col("scrimmage_play") == True)  # noqa: E712
@@ -352,37 +391,55 @@ def create_drive_summary(
             t["avg_start_text"] = None
         del t["success_fd"], t["success_ay"], t["start_yte_sum"], t["start_yte_n"]
 
-    # largest lead + minutes leading/trailing/tied from the score-state clock
-    # (regulation only -- OT clocks don't tick the same axis); game-level, so
-    # only the un-windowed build carries it
-    reg = scrim.filter(pl.col("period") <= 4).sort("game_play_number") if periods is None else scrim.head(0)
+    # largest lead + seconds leading/trailing/tied from the score-state clock.
+    # `scrim` is already windowed above, so this integrates over the window --
+    # but only against the window's own clock bounds and its own opening and
+    # closing score, never the game's.
+    reg = scrim.filter(pl.col("period") <= 4).sort("game_play_number")
     lead = {home_id: 0, away_id: 0}
     clockstate = {home_id: 0, away_id: 0, "tied": 0}
     rows = reg.select(["start.adj_TimeSecsRem", "start.homeScore", "start.awayScore"]).to_dicts()
     final_h, final_a = h, a  # running score after the chart walk = final score
-    for j, r in enumerate(rows):
-        hh, aa = r.get("start.homeScore") or 0, r.get("start.awayScore") or 0
-        lead[home_id] = max(lead[home_id], hh - aa)
-        lead[away_id] = max(lead[away_id], aa - hh)
-        # the interval after play j belongs to play j's OUTCOME -- the next
-        # play's start state (or the final score after the last play) -- so a
-        # go-ahead score counts its aftermath as leading, not the prior state
-        if j + 1 < len(rows):
-            nxt = rows[j + 1]
-            dt = (r.get("start.adj_TimeSecsRem") or 0) - (nxt.get("start.adj_TimeSecsRem") or 0)
-            dt = max(0, dt)
-            sh = nxt.get("start.homeScore") or 0
-            sa = nxt.get("start.awayScore") or 0
-        else:
-            dt = max(0, r.get("start.adj_TimeSecsRem") or 0)
-            sh, sa = final_h, final_a
-        key = home_id if sh > sa else away_id if sa > sh else "tied"
+    open_h, open_a = win_open if win_open is not None else (0, 0)
+    close_h, close_a = win_close if periods is not None else (final_h, final_a)
+    bounds = _clock_bounds(periods)
+    # the window's own edges bound the lead too: a team can enter a window
+    # already ahead by more than any in-window snap shows
+    for ph, pa in ((open_h, open_a), (close_h, close_a)):
+        lead[home_id] = max(lead[home_id], ph - pa)
+        lead[away_id] = max(lead[away_id], pa - ph)
+    if bounds is not None and rows:
+        start_rem, end_rem = bounds
+        # the stretch from the window's opening whistle to its first snap
+        first_rem = rows[0].get("start.adj_TimeSecsRem")
+        dt = max(0, start_rem - (first_rem if first_rem is not None else start_rem))
+        key = home_id if open_h > open_a else away_id if open_a > open_h else "tied"
         clockstate[key] += dt
-    lead[home_id] = max(lead[home_id], final_h - final_a)
-    lead[away_id] = max(lead[away_id], final_a - final_h)
-    if periods is None:
+        for j, r in enumerate(rows):
+            hh, aa = r.get("start.homeScore") or 0, r.get("start.awayScore") or 0
+            lead[home_id] = max(lead[home_id], hh - aa)
+            lead[away_id] = max(lead[away_id], aa - hh)
+            # the interval after play j belongs to play j's OUTCOME -- the next
+            # play's start state (or the score at the window's end after the
+            # last one) -- so a go-ahead score counts its aftermath as leading,
+            # not the prior state
+            if j + 1 < len(rows):
+                nxt = rows[j + 1]
+                dt = (r.get("start.adj_TimeSecsRem") or 0) - (nxt.get("start.adj_TimeSecsRem") or 0)
+                dt = max(0, dt)
+                sh = nxt.get("start.homeScore") or 0
+                sa = nxt.get("start.awayScore") or 0
+            else:
+                # to the END OF THE WINDOW, not the end of the game: on a Q3
+                # build an unclamped remainder would swallow the fourth quarter
+                dt = max(0, (r.get("start.adj_TimeSecsRem") or 0) - end_rem)
+                sh, sa = close_h, close_a
+            key = home_id if sh > sa else away_id if sa > sh else "tied"
+            clockstate[key] += dt
+    for tid, t in teams.items():
+        t["largest_lead"] = lead[tid]
+    if bounds is not None:
         for tid, t in teams.items():
-            t["largest_lead"] = lead[tid]
             t["time_leading_seconds"] = round(clockstate[tid])
         tied_s = round(clockstate["tied"])
         for t in teams.values():

--- a/sportsdataverse/cfb/cfb_drive_summary.py
+++ b/sportsdataverse/cfb/cfb_drive_summary.py
@@ -114,8 +114,12 @@ _REG_SECONDS = 3600
 _QUARTER_SECONDS = 900
 
 
-def _clock_bounds(periods: set[int] | str | None) -> tuple[int, int] | None:
-    """The window's start and end in ``adj_TimeSecsRem``, or None with no clock.
+def _clock_intervals(periods: set[int] | str | None) -> list[tuple[int, int]] | None:
+    """The window's ``adj_TimeSecsRem`` intervals, or None when it has no clock.
+
+    One ``(high, low)`` interval per CONTIGUOUS run of selected quarters, so a
+    gapped set like ``{1, 3}`` yields two intervals and never charges the second
+    quarter it did not ask for.
 
     Returns None for overtime: from 2023 ESPN files every OT play under one
     ``period.number`` and the clock-derived ``adj_TimeSecsRem`` collapses (see
@@ -123,16 +127,23 @@ def _clock_bounds(periods: set[int] | str | None) -> tuple[int, int] | None:
     A window of only OT therefore reports ``largest_lead`` but no time split.
     """
     if periods is None:
-        return _REG_SECONDS, 0
-    if periods == "ot":
+        return [(_REG_SECONDS, 0)]
+    if isinstance(periods, str):  # the "ot" sentinel, and any other string
         return None
-    reg = sorted(p for p in periods if p <= 4)
+    reg = sorted(p for p in periods if 1 <= p <= 4)
     if not reg:
         return None
-    return (
-        _REG_SECONDS - _QUARTER_SECONDS * (reg[0] - 1),
-        _REG_SECONDS - _QUARTER_SECONDS * reg[-1],
-    )
+    runs: list[tuple[int, int]] = []
+    first = prev = reg[0]
+    for q in reg[1:]:
+        if q != prev + 1:
+            runs.append((first, prev))
+            first = q
+        prev = q
+    runs.append((first, prev))
+    return [
+        (_REG_SECONDS - _QUARTER_SECONDS * (lo_q - 1), _REG_SECONDS - _QUARTER_SECONDS * hi_q) for lo_q, hi_q in runs
+    ]
 
 
 def create_drive_summary(
@@ -148,10 +159,11 @@ def create_drive_summary(
     full drive sequence still provides context (running score, the previous
     drive for OBTAINED and points-off-turnovers), but only in-window drives
     are counted, charted, or listed. ``largest_lead`` and the time-leading /
-    time-tied split are measured against the window's own clock bounds and its
-    own opening and closing score, so they window too -- except under ``"ot"``,
-    where the OT clock has no axis to integrate over and only ``largest_lead``
-    ships.
+    time-tied split window too: the score state is read from the whole
+    regulation play sequence and then clipped to the window's clock intervals
+    (one per contiguous run of quarters, so a gapped set never charges the
+    quarter it skipped). Under ``"ot"`` the clock has no axis to integrate over
+    and only ``largest_lead`` ships.
 
     Args:
         drives (list[dict]): the ESPN drives grouping, in game order
@@ -392,53 +404,68 @@ def create_drive_summary(
         del t["success_fd"], t["success_ay"], t["start_yte_sum"], t["start_yte_n"]
 
     # largest lead + seconds leading/trailing/tied from the score-state clock.
-    # `scrim` is already windowed above, so this integrates over the window --
-    # but only against the window's own clock bounds and its own opening and
-    # closing score, never the game's.
-    reg = scrim.filter(pl.col("period") <= 4).sort("game_play_number")
-    lead = {home_id: 0, away_id: 0}
-    clockstate = {home_id: 0, away_id: 0, "tied": 0}
-    rows = reg.select(["start.adj_TimeSecsRem", "start.homeScore", "start.awayScore"]).to_dicts()
+    #
+    # Built from the WHOLE regulation sequence, not the windowed one. A drive
+    # books to the quarter it started in, so a drive that starts in Q2 and
+    # scores in Q3 is out of a Q3 window while its points land inside it --
+    # taking the boundary score from drive outcomes would credit those points
+    # to the wrong side of the edge. Play start scores do not have that problem.
+    #
+    # Each consecutive pair of plays defines an interval whose score state is
+    # the LATER play's start score: the stretch after a play belongs to that
+    # play's outcome, so a go-ahead score counts its own aftermath as leading.
+    # The window then just clips those intervals.
+    reg_all = (
+        frame.filter((pl.col("scrimmage_play") == True) & (pl.col("period") <= 4))  # noqa: E712
+        .sort("game_play_number")
+        .select(["start.adj_TimeSecsRem", "start.homeScore", "start.awayScore"])
+        .to_dicts()
+    )
     final_h, final_a = h, a  # running score after the chart walk = final score
-    open_h, open_a = win_open if win_open is not None else (0, 0)
-    close_h, close_a = win_close if periods is not None else (final_h, final_a)
-    bounds = _clock_bounds(periods)
-    # the window's own edges bound the lead too: a team can enter a window
-    # already ahead by more than any in-window snap shows
-    for ph, pa in ((open_h, open_a), (close_h, close_a)):
-        lead[home_id] = max(lead[home_id], ph - pa)
-        lead[away_id] = max(lead[away_id], pa - ph)
-    if bounds is not None and rows:
-        start_rem, end_rem = bounds
-        # the stretch from the window's opening whistle to its first snap
-        first_rem = rows[0].get("start.adj_TimeSecsRem")
-        dt = max(0, start_rem - (first_rem if first_rem is not None else start_rem))
-        key = home_id if open_h > open_a else away_id if open_a > open_h else "tied"
-        clockstate[key] += dt
-        for j, r in enumerate(rows):
-            hh, aa = r.get("start.homeScore") or 0, r.get("start.awayScore") or 0
-            lead[home_id] = max(lead[home_id], hh - aa)
-            lead[away_id] = max(lead[away_id], aa - hh)
-            # the interval after play j belongs to play j's OUTCOME -- the next
-            # play's start state (or the score at the window's end after the
-            # last one) -- so a go-ahead score counts its aftermath as leading,
-            # not the prior state
-            if j + 1 < len(rows):
-                nxt = rows[j + 1]
-                dt = (r.get("start.adj_TimeSecsRem") or 0) - (nxt.get("start.adj_TimeSecsRem") or 0)
-                dt = max(0, dt)
+    segments: list[tuple[float, float, int, int]] = []
+    if reg_all:
+        first_rem = reg_all[0].get("start.adj_TimeSecsRem")
+        if first_rem is not None and first_rem < _REG_SECONDS:
+            # kickoff to the first snap, at 0-0
+            segments.append((_REG_SECONDS, first_rem, 0, 0))
+        for j, r in enumerate(reg_all):
+            t0 = r.get("start.adj_TimeSecsRem")
+            if t0 is None:
+                continue
+            if j + 1 < len(reg_all):
+                nxt = reg_all[j + 1]
+                t1 = nxt.get("start.adj_TimeSecsRem")
                 sh = nxt.get("start.homeScore") or 0
                 sa = nxt.get("start.awayScore") or 0
             else:
-                # to the END OF THE WINDOW, not the end of the game: on a Q3
-                # build an unclamped remainder would swallow the fourth quarter
-                dt = max(0, (r.get("start.adj_TimeSecsRem") or 0) - end_rem)
-                sh, sa = close_h, close_a
-            key = home_id if sh > sa else away_id if sa > sh else "tied"
-            clockstate[key] += dt
+                t1, sh, sa = 0, final_h, final_a
+            if t1 is not None and t0 > t1:
+                segments.append((t0, t1, sh, sa))
+
+    lead = {home_id: 0, away_id: 0}
+    clockstate = {home_id: 0.0, away_id: 0.0, "tied": 0.0}
+    intervals = _clock_intervals(periods)
+    if intervals is not None:
+        for hi, lo in intervals:
+            for t0, t1, sh, sa in segments:
+                overlap = min(t0, hi) - max(t1, lo)
+                if overlap <= 0:
+                    continue
+                key = home_id if sh > sa else away_id if sa > sh else "tied"
+                clockstate[key] += overlap
+                # only states the window actually saw can set its largest lead
+                lead[home_id] = max(lead[home_id], sh - sa)
+                lead[away_id] = max(lead[away_id], sa - sh)
+    else:
+        # overtime: no clock axis, so the lead comes from the drive boundaries
+        open_h, open_a = win_open if win_open is not None else (0, 0)
+        for ph, pa in ((open_h, open_a), win_close):
+            lead[home_id] = max(lead[home_id], ph - pa)
+            lead[away_id] = max(lead[away_id], pa - ph)
+
     for tid, t in teams.items():
         t["largest_lead"] = lead[tid]
-    if bounds is not None:
+    if intervals is not None:
         for tid, t in teams.items():
             t["time_leading_seconds"] = round(clockstate[tid])
         tied_s = round(clockstate["tied"])

--- a/sportsdataverse/cfb/cfb_situational_stats.py
+++ b/sportsdataverse/cfb/cfb_situational_stats.py
@@ -146,6 +146,12 @@ def create_situational_stats(
             return None
 
     scrim = frame.filter(_TRUE("scrimmage_play"))
+    # Whether the SELECTED WINDOW straddles halftime, decided once from the
+    # frame so both teams get the same shape -- a per-team test on qualifying
+    # pace intervals would drop the half split for one team and keep it for the
+    # other inside the same response.
+    _periods = set(frame["period"].drop_nulls().to_list()) if "period" in frame.columns else set()
+    _spans_halves = any(p <= 2 for p in _periods) and any(p > 2 for p in _periods)
     out = {}
     for tid in (str(home_id), str(away_id)):
         mine = scrim.filter(pl.col("pos_team").cast(pl.Utf8) == tid)
@@ -426,7 +432,7 @@ def create_situational_stats(
         # a single-quarter window one side IS the window and the other is empty,
         # so drop both rather than ship a permanently-null pair. The full-game
         # build keeps both keys whatever the data, so its shape never moves.
-        if window_expr is not None and not (any(r[1] <= 2 for r in secs) and any(r[1] > 2 for r in secs)):
+        if window_expr is not None and not _spans_halves:
             t["pace"].pop("first_half", None)
             t["pace"].pop("second_half", None)
 

--- a/sportsdataverse/cfb/cfb_situational_stats.py
+++ b/sportsdataverse/cfb/cfb_situational_stats.py
@@ -49,10 +49,11 @@ def create_situational_stats(
 ) -> dict | None:
     """Build the situational team-stats block from a plays frame.
 
-    Window-inherent sections -- ``two_minute``, ``middle_8``, ``non_garbage``,
-    ``pace``, ``fourth_down_decisions`` -- are omitted from a windowed build:
-    they are themselves time windows or game-level filters, and
-    double-windowing them is a category error.
+    ``two_minute`` and ``middle_8`` are omitted from a windowed build: both name
+    a clock window of their own, so intersecting them with another window
+    describes neither (middle-8 inside Q1 is empty). Every other section,
+    ``pace`` and ``non_garbage`` included, is computed on the windowed slice and
+    ships with it.
 
     Args:
         frame (pl.DataFrame): the enriched plays frame from
@@ -421,6 +422,13 @@ def create_situational_stats(
             "leading": pace([r for r in secs if r[2] > 0]),
             "trailing": pace([r for r in secs if r[2] < 0]),
         }
+        # The half split is only a split when the window straddles halftime. On
+        # a single-quarter window one side IS the window and the other is empty,
+        # so drop both rather than ship a permanently-null pair. The full-game
+        # build keeps both keys whatever the data, so its shape never moves.
+        if window_expr is not None and not (any(r[1] <= 2 for r in secs) and any(r[1] > 2 for r in secs)):
+            t["pace"].pop("first_half", None)
+            t["pace"].pop("second_half", None)
 
         # --- garbage-time filter (derived): the spice-level heuristic -------
         margin = pl.col("pos_score_diff").fill_null(0).abs()
@@ -431,11 +439,14 @@ def create_situational_stats(
         )
         t["non_garbage"] = _grp(mine.filter(~garbage))
 
-        if window_expr is not None:
-            # window-inherent or sample-size-noise sections never ship on a
-            # windowed build (two_minute/middle_8 were skipped above)
-            for k in ("fourth_down_decisions", "pace", "non_garbage"):
-                t.pop(k, None)
+        # pace, non_garbage and fourth_down_decisions all read `mine`, which the
+        # window already filtered at the top of this function, and none of them
+        # reaches outside the slice: pace only measures deltas WITHIN a drive and
+        # period, the garbage mask is a per-play test on period and margin, and
+        # the fourth-down columns are per-play model output. They are therefore
+        # correct per window and ship on a windowed build too. Only two_minute
+        # and middle_8 stay full-game-only (skipped above): both intersect a
+        # window rather than describing one, and middle-8-inside-Q1 is empty.
 
         out[tid] = t
     return {"teams": out}

--- a/tests/cfb/test_cfb_drive_summary.py
+++ b/tests/cfb/test_cfb_drive_summary.py
@@ -281,6 +281,9 @@ def test_windowed_clock_accounts_for_exactly_the_window():
         ({4}, 900),
         ({1, 2}, 1800),
         ({3, 4}, 1800),
+        # gapped: two quarters, and none of the one between them
+        ({1, 3}, 1800),
+        ({1, 2, 4}, 2700),
         (None, 3600),
     ):
         out = drive_summary.create_drive_summary(_clock_drives(), _clock_frame(), HOME, AWAY, periods=periods)
@@ -333,11 +336,54 @@ def test_ot_window_reports_lead_but_no_clock():
     assert "time_leading_seconds" not in h and "time_tied_seconds" not in h
 
 
-def test_clock_bounds_table():
-    assert drive_summary._clock_bounds(None) == (3600, 0)
-    assert drive_summary._clock_bounds({1}) == (3600, 2700)
-    assert drive_summary._clock_bounds({3}) == (1800, 900)
-    assert drive_summary._clock_bounds({1, 2}) == (3600, 1800)
-    assert drive_summary._clock_bounds({4}) == (900, 0)
-    assert drive_summary._clock_bounds("ot") is None
-    assert drive_summary._clock_bounds({5, 6}) is None
+def test_clock_intervals_table():
+    assert drive_summary._clock_intervals(None) == [(3600, 0)]
+    assert drive_summary._clock_intervals({1}) == [(3600, 2700)]
+    assert drive_summary._clock_intervals({3}) == [(1800, 900)]
+    assert drive_summary._clock_intervals({1, 2}) == [(3600, 1800)]
+    assert drive_summary._clock_intervals({4}) == [(900, 0)]
+    assert drive_summary._clock_intervals("ot") is None
+    assert drive_summary._clock_intervals({5, 6}) is None
+    # a gapped set is two runs, never one span across the quarter it skipped
+    assert drive_summary._clock_intervals({1, 3}) == [(3600, 2700), (1800, 900)]
+    assert drive_summary._clock_intervals({1, 2, 4}) == [(3600, 1800), (900, 0)]
+
+
+def test_boundary_score_comes_from_plays_not_drive_outcomes():
+    """A drive that starts in Q2 and scores in Q3 must not colour Q2's clock.
+
+    The drive books to Q2, so a Q3 window excludes it -- but its points land
+    inside Q3. Taking the window's opening score from drive outcomes would put
+    those seven points on the wrong side of the boundary in both directions.
+    """
+    frame = _clock_frame().with_columns(
+        # home's go-ahead score now happens just INSIDE Q3, on a drive that
+        # started in Q2: the play at 1700 is the first one that sees 7-0
+        pl.Series("start.homeScore", [0, 0, 0, 0, 0, 7, 7, 7]),
+        pl.Series("start.awayScore", [0, 0, 0, 0, 0, 0, 0, 0]),
+    )
+    drives = _clock_drives()
+    q2 = drive_summary.create_drive_summary(drives, frame, HOME, AWAY, periods={2})
+    q3 = drive_summary.create_drive_summary(drives, frame, HOME, AWAY, periods={3})
+    # Q2 was level throughout -- the score arrives after the quarter ends
+    assert q2["teams"][HOME]["time_leading_seconds"] == 0
+    assert q2["teams"][HOME]["time_tied_seconds"] == 900
+    assert q2["teams"][HOME]["largest_lead"] == 0
+    # Q3 carries the lead, and both windows still account for their full length
+    assert q3["teams"][HOME]["time_leading_seconds"] > 0
+    assert _accounted(q2) == 900 and _accounted(q3) == 900
+
+
+def test_gapped_window_skips_the_quarter_between():
+    """{1, 3} must charge Q1 and Q3 and nothing from Q2."""
+    q1 = drive_summary.create_drive_summary(_clock_drives(), _clock_frame(), HOME, AWAY, periods={1})
+    q3 = drive_summary.create_drive_summary(_clock_drives(), _clock_frame(), HOME, AWAY, periods={3})
+    both = drive_summary.create_drive_summary(_clock_drives(), _clock_frame(), HOME, AWAY, periods={1, 3})
+    for team in (HOME, AWAY):
+        assert (
+            both["teams"][team]["time_leading_seconds"]
+            == q1["teams"][team]["time_leading_seconds"] + q3["teams"][team]["time_leading_seconds"]
+        )
+    assert both["teams"][HOME]["time_tied_seconds"] == (
+        q1["teams"][HOME]["time_tied_seconds"] + q3["teams"][HOME]["time_tied_seconds"]
+    )

--- a/tests/cfb/test_cfb_drive_summary.py
+++ b/tests/cfb/test_cfb_drive_summary.py
@@ -178,8 +178,9 @@ def test_windowed_build_books_drives_to_start_quarter():
     # because the out-of-window context (running score, prev drive) is kept
     assert h["total_drives"] == 1 and a["total_drives"] == 1
     assert a["points_off_turnovers"] == 7
-    # game-level lines never ship on a windowed build
-    assert "largest_lead" not in h and "time_leading_seconds" not in h
+    # lead and clock state window too -- see the _clock_frame tests below for
+    # the bounds themselves; this fixture's clock does not match its periods
+    assert "largest_lead" in h and "time_leading_seconds" in h
     # chart holds only in-window drives
     assert [c["period"] for c in out["chart"]] == [2, 2]
     # first-down sources window with everything else (incl. penalty count)
@@ -211,3 +212,132 @@ def test_delegate_fails_open_on_unusable_frame():
 
     assert CFBPlayProcess.create_drive_summary(object(), pl.DataFrame(), _drives()) is None
     assert CFBPlayProcess.create_drive_summary(object(), None, _drives()) is None
+
+
+# --- windowed score-state clock ------------------------------------------
+# The shared _frame() fixture labels a play at 1500 game-seconds remaining as
+# Q2, which is really Q3 on the regulation axis. That is harmless for the
+# aggregates it was built for, but a clock-bounds test has to run on a frame
+# whose periods and clock agree, so this one does.
+
+
+def _clock_frame():
+    return pl.DataFrame(
+        {
+            "game_play_number": [1, 2, 3, 4, 5, 6, 7, 8],
+            "scrimmage_play": [True] * 8,
+            "pos_team": [10, 20, 10, 20, 20, 10, 20, 10],
+            "down": [1, 1, 1, 1, 1, 1, 1, 1],
+            "distance": [10] * 8,
+            "first_down_created": [False] * 8,
+            "firstD_by_penalty": [False] * 8,
+            "touchdown": [False] * 8,
+            "rush": [True, False] * 4,
+            "pass": [False, True] * 4,
+            "period": [1, 1, 2, 2, 3, 3, 4, 4],
+            # strictly inside each quarter: Q1 3600-2700, Q2 2700-1800,
+            # Q3 1800-900, Q4 900-0
+            "start.adj_TimeSecsRem": [3500.0, 3000.0, 2600.0, 2000.0, 1700.0, 1200.0, 800.0, 200.0],
+            "start.homeScore": [0, 0, 0, 0, 7, 7, 7, 7],
+            "start.awayScore": [0, 0, 0, 0, 0, 7, 7, 7],
+            "statYardage": [5] * 8,
+            "text": list("abcdefgh"),
+            "homeTeamId": [10] * 8,
+            "awayTeamId": [20] * 8,
+            "drive.id": ["c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8"],
+        }
+    )
+
+
+def _clock_drives():
+    return [
+        _drive(HOME, "c1", "PUNT", 10, 3, "1:40", 25, 1, last_score=(0, 0)),
+        _drive(AWAY, "c2", "PUNT", 10, 3, "1:40", 25, 1, last_score=(0, 0)),
+        _drive(HOME, "c3", "TD", 75, 8, "3:20", 25, 2, is_score=True, last_score=(7, 0)),
+        _drive(AWAY, "c4", "PUNT", 10, 3, "1:40", 25, 2, last_score=(7, 0)),
+        _drive(AWAY, "c5", "TD", 75, 8, "3:20", 25, 3, is_score=True, last_score=(7, 7)),
+        _drive(HOME, "c6", "PUNT", 10, 3, "1:40", 25, 3, last_score=(7, 7)),
+        _drive(AWAY, "c7", "FG", 40, 8, "3:20", 25, 4, is_score=True, last_score=(7, 10)),
+        _drive(HOME, "c8", "DOWNS", 9, 4, "0:50", 45, 4, last_score=(7, 10)),
+    ]
+
+
+def _accounted(out):
+    h, a = out["teams"][HOME], out["teams"][AWAY]
+    return h["time_leading_seconds"] + a["time_leading_seconds"] + h["time_tied_seconds"]
+
+
+def test_windowed_clock_accounts_for_exactly_the_window():
+    """Every second of the window is charged to somebody, and none outside it.
+
+    This is the regression that matters: before the bounds fix the last play's
+    remainder ran to 0:00 of the GAME, so a Q3 build silently swallowed the
+    fourth quarter. A quarter is 900 seconds and the accounting must say so.
+    """
+    for periods, length in (
+        ({1}, 900),
+        ({2}, 900),
+        ({3}, 900),
+        ({4}, 900),
+        ({1, 2}, 1800),
+        ({3, 4}, 1800),
+        (None, 3600),
+    ):
+        out = drive_summary.create_drive_summary(_clock_drives(), _clock_frame(), HOME, AWAY, periods=periods)
+        assert _accounted(out) == length, (periods, _accounted(out))
+
+
+def test_windowed_clock_uses_the_window_score_not_the_final():
+    # Q2: home goes ahead 7-0 and stays there; the game ends 7-10, and that
+    # final must not colour a second of this window.
+    out = drive_summary.create_drive_summary(_clock_drives(), _clock_frame(), HOME, AWAY, periods={2})
+    h, a = out["teams"][HOME], out["teams"][AWAY]
+    assert a["time_leading_seconds"] == 0
+    assert h["time_leading_seconds"] + h["time_tied_seconds"] == 900
+    # entering Q2 the game was level, so the tied share is real, not an artefact
+    assert h["time_tied_seconds"] > 0
+    # Q4 opens level at 7-7 and away's field goal lands late: the quarter is
+    # tied until then, and only the tail belongs to away. The tail is charged
+    # from the score at the WINDOW's end -- which here happens to equal the
+    # game's, so the sharper check is that it is neither 0 (the closing score
+    # ignored) nor 900 (the whole quarter mislabelled).
+    q4 = drive_summary.create_drive_summary(_clock_drives(), _clock_frame(), HOME, AWAY, periods={4})
+    assert q4["teams"][HOME]["time_leading_seconds"] == 0
+    assert q4["teams"][AWAY]["time_leading_seconds"] == 200
+    assert q4["teams"][HOME]["time_tied_seconds"] == 700
+
+
+def test_windowed_largest_lead_sees_the_window_edges():
+    # Home's 7-0 lead is established in Q2 and gone by the end of Q3. A Q3
+    # build must still report it: the window OPENS with home up seven, which no
+    # in-window snap after the tying score would show on its own.
+    q3 = drive_summary.create_drive_summary(_clock_drives(), _clock_frame(), HOME, AWAY, periods={3})
+    assert q3["teams"][HOME]["largest_lead"] == 7
+    assert q3["teams"][AWAY]["largest_lead"] == 0
+
+
+def test_ot_window_reports_lead_but_no_clock():
+    """OT has no clock axis to integrate over, so the time split must be absent.
+
+    ESPN files every OT play under one period number and adj_TimeSecsRem
+    collapses there -- see the sort note in cfb_pbp.
+    """
+    frame = _clock_frame().with_columns(period=pl.lit(5, dtype=pl.Int64))
+    drives = [
+        _drive(AWAY, "o1", "TD", 25, 3, "0:00", 25, 5, is_score=True, last_score=(7, 17)),
+        _drive(HOME, "o2", "DOWNS", 12, 4, "0:00", 25, 5, last_score=(7, 17)),
+    ]
+    out = drive_summary.create_drive_summary(drives, frame, HOME, AWAY, periods="ot")
+    h = out["teams"][HOME]
+    assert "largest_lead" in h
+    assert "time_leading_seconds" not in h and "time_tied_seconds" not in h
+
+
+def test_clock_bounds_table():
+    assert drive_summary._clock_bounds(None) == (3600, 0)
+    assert drive_summary._clock_bounds({1}) == (3600, 2700)
+    assert drive_summary._clock_bounds({3}) == (1800, 900)
+    assert drive_summary._clock_bounds({1, 2}) == (3600, 1800)
+    assert drive_summary._clock_bounds({4}) == (900, 0)
+    assert drive_summary._clock_bounds("ot") is None
+    assert drive_summary._clock_bounds({5, 6}) is None

--- a/tests/cfb/test_cfb_situational_stats.py
+++ b/tests/cfb/test_cfb_situational_stats.py
@@ -361,16 +361,33 @@ def test_situational_fails_open():
     assert situational_stats.create_situational_stats(pl.DataFrame({"x": [1]}), HOME, AWAY) is None
 
 
-def test_windowed_build_drops_window_inherent_sections():
+def test_windowed_build_drops_only_the_clock_named_sections():
     expr = pl.col("period").is_in([1, 2])
     out = situational_stats.create_situational_stats(_frame(), HOME, AWAY, window_expr=expr)
     h = out["teams"][HOME]
     # windowable sections present and windowed
     assert h["downs"]["down_1"]["plays"] == 1  # only the Q1 first-down play
     assert h["red_zone"]["trips"] == 1
-    # window-inherent sections absent
-    for k in ("two_minute", "middle_8", "pace", "non_garbage", "fourth_down_decisions"):
+    # two_minute and middle_8 name a clock window of their own; intersecting
+    # them with another window describes neither
+    for k in ("two_minute", "middle_8"):
         assert k not in h, k
+    # everything else reads the already-windowed frame and ships with it
+    for k in ("pace", "non_garbage", "fourth_down_decisions"):
+        assert k in h, k
+
+
+def test_windowed_pace_is_the_window_and_drops_the_half_split():
+    h1 = situational_stats.create_situational_stats(_frame(), HOME, AWAY, window_expr=pl.col("period") == 1)["teams"][
+        HOME
+    ]
+    # a window inside one half cannot split by half: both keys go, rather than
+    # shipping a permanently-null pair that would render as two blank rows
+    assert "first_half" not in h1["pace"] and "second_half" not in h1["pace"]
+    assert "seconds_per_play" in h1["pace"]
+    # the full-game build still splits, because there both halves have plays
+    full = situational_stats.create_situational_stats(_frame(), HOME, AWAY)["teams"][HOME]
+    assert "first_half" in full["pace"] and "second_half" in full["pace"]
 
 
 def test_windowed_build_empty_window_is_none():


### PR DESCRIPTION
Five situational/drive-summary sections were withheld from a windowed build as "window-inherent". Reading the implementation rather than the docstring, three of them never were — they were computed correctly per window and then discarded.

Raised while speccing how game-on-paper would render #470's payload: GOP wants per-quarter tempo and "led for 11:20 of the fourth", and both were reachable already.

## Tier 1 — computed on the window, then thrown away

`create_situational_stats` filters the entire frame at the top, so `mine` in every section already **is** the windowed slice. None of these three reaches outside it:

| section | why it was safe all along |
|---|---|
| `pace` | the delta loop requires `a["drive.id"] == b["drive.id"] and a["period"] == b["period"]`, so it never crosses a quarter boundary even on a full-game build |
| `non_garbage` | the garbage mask is a per-play test on `period` and `abs(margin)` |
| `fourth_down_decisions` | `fourth_down_recommendation` / `go_boost` are per-play model output |

They now ship on a windowed build. `two_minute` and `middle_8` keep their guard: both name a clock window of their own, so intersecting one with another window describes neither (middle-8 inside Q1 is empty).

One refinement: on a windowed build `pace.first_half` / `second_half` are dropped when the window does not straddle halftime, rather than shipping a permanently-null pair that renders as two blank rows. **The full-game build keeps both keys whatever the data, so its shape never moves.**

## Tier 3 — the score-state clock needed real work

`scrim` was already windowed, but `reg` was emptied with `scrim.head(0)` on any windowed build. Removing that guard alone would have produced three wrong answers:

1. the terminal interval charged `dt = adj_TimeSecsRem`, running to 0:00 of the **game** — a Q3 build would silently swallow the fourth quarter
2. it compared against `final_h/final_a`, the score after walking every drive, not the score at the window's end
3. the stretch from the period boundary to the first in-window snap went unattributed

New `_clock_bounds()` maps a window onto the `adj_TimeSecsRem` axis (Q1 3600→2700 … Q4 900→0; the same axis `middle_8` is defined against in `cfb_pbp`). The drive walk now records the score entering and leaving the window as it goes, and the opening and closing intervals are charged against those.

## Overtime keeps its guard, and that one is real

From 2023 ESPN files every OT play under one `period.number` and `adj_TimeSecsRem` collapses — `cfb_pbp` documents this and sorts OT plays by `sequenceNumber` instead. There is no axis to integrate time over. An `"ot"` window reports `largest_lead` and no time split.

## Tests

The regression test is an invariant rather than a hand-computed number: **every second of a window is charged to somebody and none outside it**, so each quarter sums to 900, each half to 1800, and the full game to 3600. That is exactly what the unclamped remainder violated.

Also covers: the window's own score colouring its intervals (not the game's final), `largest_lead` seeing the window's opening edge when the lead is gone by the end of it, OT reporting lead but no clock, and a `_clock_bounds` table.

The shared `_frame()` fixture labels a play at 1500 game-seconds remaining as Q2 — really Q3 on the regulation axis. Harmless for the aggregates it was built for, but a clock-bounds test needs periods and clock to agree, so those run on their own `_clock_frame()`.

`23 passed`. Full-game output is unchanged in shape and value — the two pre-existing full-game clock assertions pass untouched. `ruff check` / `ruff format` clean, `generate.py --check` reports all generated files current.

## Summary by Sourcery

Make CFB situational and drive summaries correctly support windowed builds, including accurate regulation score-state clock metrics and safe per-window statistics.

New Features:
- Expose pace, non-garbage, and fourth-down situational statistics for windowed builds, while retaining full-game-only clock-named sections.
- Provide window-aware largest-lead and time-state summaries for regulation quarters, halves, gapped quarter selections, and full games, with lead reporting for overtime.

Bug Fixes:
- Correct score-state clock accounting so windowed summaries charge only the selected regulation time and use scores at the window boundaries rather than the game's final score.
- Include opening and closing score intervals when calculating windowed lead, tied, and trailing time.

Enhancements:
- Preserve stable full-game pace output while omitting empty half splits for windows that do not span halftime.
- Document windowed drive-summary clock behavior and overtime limitations.

Documentation:
- Update CFB reference documentation to describe windowed situational sections and drive-summary score-state clock behavior.

Tests:
- Add regression coverage for exact time accounting across quarter, half, full-game, and gapped windows; boundary scores; largest-lead edges; overtime; clock bounds; and windowed situational-stat shapes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Windowed drive summaries now include lead duration and largest-lead metrics calculated within the selected time range.
  - Windowed situational statistics now include pace, non-garbage, and fourth-down decision data.
  - Pace results no longer show irrelevant half splits when a window falls entirely within one half.
  - Overtime windows correctly omit unsupported clock-based metrics.

- **Documentation**
  - Updated CFB helper documentation to clarify windowed and overtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->