### PR TITLE
fix(cfb): emit scalars from calculate_fourth_down, not a raw class distribution

### DIFF
--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -1289,7 +1289,7 @@ through untouched.
 
 **Returns**
 
-`df` with an `fg_prob` column appended. Input columns are preserved, so chaining two calculators is lossless.
+`df` with an `fg_make_prob` column appended. Named `fg_make_prob`, not `fg_prob`: `calculate_expected_points` emits `fg_prob` for the probability the NEXT SCORE is a field goal, which is a different quantity. Sharing the name made chaining the two silently lossy. Input columns are preserved, so chaining two calculators is lossless.
 
 **Example**
 
@@ -1317,7 +1317,7 @@ through untouched.
 
 **Returns**
 
-`df` with an `fd_prob` column appended. Input columns are preserved, so chaining two calculators is lossless.
+`df` with `fd_conversion_prob` (probability the gain reaches `distance`) and `fd_expected_yards` appended. Input columns are preserved, so chaining two calculators is lossless.
 
 **Example**
 

--- a/sportsdataverse/cfb/model_calculators.py
+++ b/sportsdataverse/cfb/model_calculators.py
@@ -442,7 +442,8 @@ def calculate_fourth_down(df, *, season=None, return_as_pandas=False):
         return_as_pandas: Return a pandas DataFrame instead of polars.
 
     Returns:
-        ``df`` with an ``fd_prob`` column appended. Input columns are preserved, so
+        ``df`` with ``fd_conversion_prob`` (probability the gain reaches
+        ``distance``) and ``fd_expected_yards`` appended. Input columns are preserved, so
         chaining two calculators is lossless.
 
     Raises:
@@ -455,7 +456,26 @@ def calculate_fourth_down(df, *, season=None, return_as_pandas=False):
             from sportsdataverse.cfb import calculate_fourth_down
             calculate_fourth_down(df, season=2024)
     """
-    return _calculate(df, "fd_model", "fd_prob", season=season, return_as_pandas=return_as_pandas)
+    from sportsdataverse.cfb.cfb_fourth_down import FD_NUM_CLASS
+
+    prepared = add_era_columns(normalize_pbp_columns(df, "fd_model"), "fd_model", season=season)
+    probs = np.asarray(predict_from_card(prepared, "fd_model", _booster_for("fd_model")))
+    if probs.ndim == 1:
+        probs = probs.reshape(-1, FD_NUM_CLASS)
+    # Class k is a gain of k - 10 yards, spanning -10..65 (FD_NUM_CLASS = 76).
+    gains = np.arange(FD_NUM_CLASS) - 10
+    expected_yards = probs @ gains.astype(float)
+    if "distance" not in prepared.columns:
+        raise ValueError("fd_model needs a 'distance' column to compute conversion probability")
+    needed = prepared["distance"].to_numpy()[:, None]
+    conversion = (probs * (gains[None, :] >= needed)).sum(axis=1)
+    # Cast explicitly: the booster returns Float32 and a public column's dtype
+    # should not be an artifact of the model's internal precision.
+    out = prepared.with_columns(
+        pl.Series("fd_conversion_prob", conversion, dtype=pl.Float64),
+        pl.Series("fd_expected_yards", expected_yards, dtype=pl.Float64),
+    )
+    return out.to_pandas() if return_as_pandas else out
 
 
 def calculate_qbr(df, *, season=None, return_as_pandas=False):

--- a/sportsdataverse/cfb/model_calculators.py
+++ b/sportsdataverse/cfb/model_calculators.py
@@ -349,7 +349,12 @@ def calculate_field_goal_probability(df, *, season=None, return_as_pandas=False)
         return_as_pandas: Return a pandas DataFrame instead of polars.
 
     Returns:
-        ``df`` with an ``fg_prob`` column appended. Input columns are preserved, so
+        ``df`` with an ``fg_make_prob`` column appended.
+
+        Named ``fg_make_prob``, not ``fg_prob``: ``calculate_expected_points``
+        emits ``fg_prob`` for the probability the NEXT SCORE is a field goal,
+        which is a different quantity. Sharing the name made chaining the two
+        silently lossy. Input columns are preserved, so
         chaining two calculators is lossless.
 
     Raises:
@@ -362,7 +367,7 @@ def calculate_field_goal_probability(df, *, season=None, return_as_pandas=False)
             from sportsdataverse.cfb import calculate_field_goal_probability
             calculate_field_goal_probability(df, season=2024)
     """
-    return _calculate(df, "fg_model", "fg_prob", season=season, return_as_pandas=return_as_pandas)
+    return _calculate(df, "fg_model", "fg_make_prob", season=season, return_as_pandas=return_as_pandas)
 
 
 def calculate_completion_probability(df, *, season=None, return_as_pandas=False):

--- a/tests/cfb/test_model_calculators.py
+++ b/tests/cfb/test_model_calculators.py
@@ -147,7 +147,7 @@ def test_xpass_returns_the_frame_plus_one_probability_column():
 def test_a_hand_built_row_scores_without_any_pbp_machinery():
     """The hypothetical case: someone types a situation and asks the model."""
     out = mc.calculate_field_goal_probability(pl.DataFrame({"season": [2024], "yards_to_goal": [25.0]}))
-    assert 0.0 <= out["fg_prob"][0] <= 1.0
+    assert 0.0 <= out["fg_make_prob"][0] <= 1.0
 
 
 def test_field_goal_probability_moves_with_the_era():
@@ -157,7 +157,7 @@ def test_field_goal_probability_moves_with_the_era():
 
     def fg(year):
         return mc.calculate_field_goal_probability(pl.DataFrame({"season": [year], "yards_to_goal": [25.0]}))[
-            "fg_prob"
+            "fg_make_prob"
         ][0]
 
     assert fg(2005) != fg(2024)
@@ -330,7 +330,7 @@ def test_the_frames_own_season_beats_the_season_argument():
     """
     multi = pl.DataFrame({"season": [2005, 2024], "yards_to_goal": [25.0, 25.0]})
     out = mc.calculate_field_goal_probability(multi, season=2024)
-    vals = out["fg_prob"].to_list()
+    vals = out["fg_make_prob"].to_list()
     assert vals[0] != vals[1], "one era was stamped across both rows"
     # and the per-row eras must match what each season maps to
     eras = mc.add_era_columns(multi, "fg_model", season=2024)
@@ -458,3 +458,26 @@ def test_fourth_down_needs_distance_for_the_conversion_probability():
     )
     with pytest.raises(ValueError, match="distance"):
         mc.calculate_fourth_down(df)
+
+
+def test_chaining_fg_and_ep_is_lossless():
+    """calculate_expected_points emits fg_prob for 'next score is a field goal';
+    the FG model emits the probability the KICK is made. Sharing the name meant
+    EP silently overwrote the FG output, breaking the documented guarantee that
+    chaining two calculators is lossless."""
+    df = pl.DataFrame(
+        {
+            "season": [2024],
+            "yards_to_goal": [25.0],
+            "TimeSecsRem": [1800.0],
+            "distance": [10.0],
+            "down_1": [1],
+            "down_2": [0],
+            "down_3": [0],
+            "down_4": [0],
+            "pos_score_diff_start": [0.0],
+        }
+    )
+    out = mc.calculate_expected_points(mc.calculate_field_goal_probability(df))
+    assert "fg_make_prob" in out.columns and "fg_prob" in out.columns
+    assert out["fg_make_prob"][0] != out["fg_prob"][0]

--- a/tests/cfb/test_model_calculators.py
+++ b/tests/cfb/test_model_calculators.py
@@ -425,3 +425,36 @@ def test_completion_probability_scores_a_raw_pbp_frame():
         }
     )
     assert 0.0 <= mc.calculate_completion_probability(pbp)["cp"][0] <= 1.0
+
+
+def test_fourth_down_emits_scalars_not_a_raw_class_distribution():
+    """fd_model is a 76-class yards-gained distribution (class k = k-10 yards),
+    not a probability. Appending the raw array gave a column that could not even
+    be written to CSV, while the returns table documented a scalar."""
+    df = pl.DataFrame(
+        {
+            "season": [2024, 2024],
+            "down": [4.0, 4.0],
+            "distance": [1.0, 15.0],
+            "yards_to_goal": [45.0, 45.0],
+            "posteam_total": [52.0, 52.0],
+            "posteam_spread": [-3.0, -3.0],
+        }
+    )
+    out = mc.calculate_fourth_down(df)
+    assert out.schema["fd_conversion_prob"] == pl.Float64
+    assert out.schema["fd_expected_yards"] == pl.Float64
+    # a short distance must convert more often than a long one
+    assert out["fd_conversion_prob"][0] > out["fd_conversion_prob"][1]
+    for v in out["fd_conversion_prob"].to_list():
+        assert 0.0 <= v <= 1.0
+
+
+def test_fourth_down_needs_distance_for_the_conversion_probability():
+    """Conversion is 'gain >= distance', so distance is not optional here even
+    though the card lists it among many features."""
+    df = pl.DataFrame(
+        {"season": [2024], "down": [4.0], "yards_to_goal": [45.0], "posteam_total": [52.0], "posteam_spread": [-3.0]}
+    )
+    with pytest.raises(ValueError, match="distance"):
+        mc.calculate_fourth_down(df)


### PR DESCRIPTION
Follow-up to [#475](https://github.com/sportsdataverse/sportsdataverse-py/pull/475).

`fd_model` is a **76-class yards-gained distribution** (class *k* is a gain of *k* − 10 yards, spanning −10..65), not a probability. `calculate_fourth_down()` appended that array verbatim while its returns table documented a scalar `fd_prob numeric`.

## How it surfaced

Building the cross-language parity fixture for the R port required serialising the calculator outputs, and polars refused:

```
ComputeError: datatype array[f32, 76] cannot be written to CSV
```

Every earlier test passed because they all asked *"is the column there?"* — and it was. Round-tripping through a real format asked a different question. A column that cannot be written is one no user can save, join, or ship.

## What it emits now

| column | meaning |
|---|---|
| `fd_conversion_prob` | probability the gain reaches `distance` |
| `fd_expected_yards` | expected yards gained |

| situation | conversion | expected yards |
|---|---|---|
| 4th & 1 | 0.7695 | 6.80 |
| 4th & 15 | 0.2512 | 8.24 |

Short distance converts far more often; longer distance yields more yards on the plays that work. A missing `distance` column is now a clear error rather than a silently meaningless conversion probability.

Both columns are cast to `Float64` — the booster returns `Float32`, and a public column's dtype should not be an artifact of the model's internal precision.

## Testing

- `pytest tests/cfb/test_model_calculators.py` — **40 passed**
- `ruff check` / `ruff format --check` / `mypy` — clean

## Summary by Sourcery

Return serializable, semantically distinct scalar outputs from the field-goal and fourth-down calculators.

New Features:
- Emit scalar fourth-down conversion probabilities and expected yards instead of the raw 76-class distribution.

Bug Fixes:
- Prevent fourth-down calculator outputs from producing non-serializable array columns and require distance for conversion calculations.

Enhancements:
- Rename the field-goal make probability output to fg_make_prob to preserve distinct outputs when chaining calculators.

Documentation:
- Update CFB calculator documentation for the renamed field-goal output and new fourth-down outputs.

Tests:
- Add coverage for scalar fourth-down outputs, distance validation, and lossless chaining of field-goal and expected-points calculators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fourth-down predictions now include conversion probability and expected yards gained.
  * Conversion probability reflects the required distance for the play.

* **Bug Fixes**
  * Added a clear error when fourth-down calculations are requested without distance information.

* **Tests**
  * Added coverage for scalar prediction outputs, probability ranges, distance sensitivity, and missing-distance handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->