### PR TITLE
fix: retract the disproven nhl_xg cause, and let the live-tests cron close its own issues

### DIFF
--- a/.github/workflows/live-tests-cron.yml
+++ b/.github/workflows/live-tests-cron.yml
@@ -207,3 +207,45 @@ jobs:
               });
               core.info(`Opened new drift issue #${created.data.number}`);
             }
+
+      # Close the tracking issue when the run goes green. Without this the
+      # workflow only ever OPENS issues -- the body above promises "the next
+      # cron run that goes green will leave the issue closed", and nothing
+      # executed that, so a fixed drift stayed open indefinitely and the
+      # tracker filled with resolved issues (#416 sat open for a week after
+      # d7a8c7829 fixed it).
+      - name: Close drift tracking issue on green
+        if: success() && steps.run-pytest.outcome == 'success'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const label = 'live-tests:drift';
+            const today = new Date().toISOString().slice(0, 10);
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 20,
+            });
+            if (open.data.length === 0) {
+              core.info('No open drift issue to close.');
+              return;
+            }
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            for (const issue of open.data) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: issue.number,
+                body: `Live tests went green on ${today} — closing automatically.\n\nRun: ${runUrl}\n\nIf the drift returns, the next failing run reopens tracking by filing a fresh issue with the \`${label}\` label.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              core.info(`Closed drift issue #${issue.number}`);
+            }

--- a/.github/workflows/live-tests-cron.yml
+++ b/.github/workflows/live-tests-cron.yml
@@ -221,19 +221,24 @@ jobs:
           script: |
             const label = 'live-tests:drift';
             const today = new Date().toISOString().slice(0, 10);
-            const open = await github.rest.issues.listForRepo({
+            // paginate: listForRepo returns ONE page, so a plain call would
+            // leave every drift issue past the page size open.
+            const found = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo:  context.repo.repo,
               state: 'open',
               labels: label,
-              per_page: 20,
+              per_page: 100,
             });
-            if (open.data.length === 0) {
+            // The issues endpoint also returns pull requests. A PR carrying the
+            // drift label is not a tracking issue and must not be closed here.
+            const open = found.filter((i) => !i.pull_request);
+            if (open.length === 0) {
               core.info('No open drift issue to close.');
               return;
             }
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            for (const issue of open.data) {
+            for (const issue of open) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo:  context.repo.repo,

--- a/docs/docs/nhl/reference/additional.md
+++ b/docs/docs/nhl/reference/additional.md
@@ -1134,9 +1134,15 @@ release: observed goals / sum(`xg`) is **0.771** at 5v5 (n=1,724,290 shots) and
 **0.768** on special teams (n=349,232), where a correctly-levelled model gives 1.0 --
 i.e. `xg` is inflated by roughly 25-30% for every season from 2009-10 through
 2023-24. At 5v5 the two most recent seasons are much closer (2024-25 **0.949**,
-2025-26 **0.913**). The cause is the boosters' training corpus, which carried no
-`MISSED_SHOT` events for the affected seasons; it is not a defect in the feature
-frame this function builds.
+2025-26 **0.913**). The cause is **not identified**. It is not a defect in the
+feature frame this function builds, and it is not the missing-`MISSED_SHOT`
+training corpus recorded here previously: every season carries missed shots
+(27.7-34.8% of Fenwick events), the trainer's Fenwick selector takes
+`MISSED_SHOT` alongside `SHOT` and `GOAL`, and the published artifacts'
+`base_score` (0.07368 / 0.10533) matches the Fenwick goal rate (0.0695) rather
+than the shots-on-goal rate (0.0977). Leave-one-season-out refits land at
+goals / sum(`xg`) of 0.95-1.05 per season, so the miscalibration is a property
+of the published artifact rather than of the data it was trained on.
 Shot RANKING is far less affected (rank AUC 0.778 / 0.760), so `xg` is still usable
 for ordering chances -- but any SUM of `xg` (per game, per player, team totals,
 goals-above-expected, and `nhl_gsax` downstream) is inflated for pre-2024-25

--- a/sportsdataverse/nhl/nhl_xg.py
+++ b/sportsdataverse/nhl/nhl_xg.py
@@ -340,9 +340,15 @@ def nhl_xg(
     **0.768** on special teams (n=349,232), where a correctly-levelled model gives 1.0 --
     i.e. ``xg`` is inflated by roughly 25-30% for every season from 2009-10 through
     2023-24. At 5v5 the two most recent seasons are much closer (2024-25 **0.949**,
-    2025-26 **0.913**). The cause is the boosters' training corpus, which carried no
-    ``MISSED_SHOT`` events for the affected seasons; it is not a defect in the feature
-    frame this function builds.
+    2025-26 **0.913**). The cause is **not identified**. It is not a defect in the
+    feature frame this function builds, and it is not the missing-``MISSED_SHOT``
+    training corpus recorded here previously: every season carries missed shots
+    (27.7-34.8% of Fenwick events), the trainer's Fenwick selector takes
+    ``MISSED_SHOT`` alongside ``SHOT`` and ``GOAL``, and the published artifacts'
+    ``base_score`` (0.07368 / 0.10533) matches the Fenwick goal rate (0.0695) rather
+    than the shots-on-goal rate (0.0977). Leave-one-season-out refits land at
+    goals / sum(``xg``) of 0.95-1.05 per season, so the miscalibration is a property
+    of the published artifact rather than of the data it was trained on.
     Shot RANKING is far less affected (rank AUC 0.778 / 0.760), so ``xg`` is still usable
     for ordering chances -- but any SUM of ``xg`` (per game, per player, team totals,
     goals-above-expected, and ``nhl_gsax`` downstream) is inflated for pre-2024-25


### PR DESCRIPTION
Two independent fixes surfaced while triaging the open issue queue.

## 1. `nhl_xg()` docstring states a cause that was measured and retracted (#444)

The shipped known-issue note said the 25-30% over-prediction was caused by a training corpus that "carried no `MISSED_SHOT` events for the affected seasons". The measurements posted on #444 disprove that:

- every season carries missed shots — 27.7% to 34.8% of Fenwick events
- the trainer's Fenwick selector takes `MISSED_SHOT` alongside `SHOT` and `GOAL`
- the published artifacts' `base_score` (0.07368 / 0.10533) matches the **Fenwick** goal rate (0.0695), not the shots-on-goal rate (0.0977)
- leave-one-season-out refits land at goals/sum(`xg`) of 0.95-1.05 per season

So the miscalibration is a property of the published artifact, not of the data it trained on, and the cause is **not identified**.

Everything else in that note — the measured ratios, the "ranking is still usable" caveat, the self-check recipe — was correct and is unchanged. Only the causal claim is replaced. A confident wrong cause is worse than none, because it tells the reader not to look at the feature frame.

The retrain-and-republish of the `nhl_xg_models` boosters is separate work in fastRhockey-nhl-data and is not in scope here.

### One generated-output trap worth recording

My first draft wrote ``` ``_FENWICK = [...]`` ``` in the docstring. The RST-to-Markdown step reads a leading `` ``_ `` as an RST hyperlink marker, drops it, and emits `` FENWICK = [...]` `` — an **unbalanced backtick** in `docs/docs/nhl/reference/additional.md`. The docstring looked fine; the artifact was broken. Reworded to avoid a leading underscore inside inline code.

## 2. The live-tests cron never closes its tracking issue (#416)

The workflow only ever *opens* issues — the tracking step is `if: failure()`. The body it posts promises "The next cron run that goes green will leave the issue closed", and nothing executed that.

Not cosmetic: #416 sat open a week after `d7a8c7829` fixed it. A tracker that files but never closes trains you to skim it, which is how the eight genuine definitional ERRORs in #415 went unread for a week.

Adds a close-on-success step mirroring the existing open/update one — finds open issues with the `live-tests:drift` label, comments with the green run URL, closes them as `completed`. `issues: write` is already declared at workflow level. A later failure files a fresh issue, so the label dedup key still works.

## Verification

- `tools/codegen/generate.py` run; the only regenerated file is `docs/docs/nhl/reference/additional.md`
- generated block checked for balanced backticks
- workflow parses; the new step is last and gated on `success() && steps.run-pytest.outcome == 'success'`

## Note

This branch deliberately excludes unrelated in-progress work in the tree (`load_mlb_pbp` / `load_mlb_pitches` / `load_mlb_runners` in `mlb_loaders.py`, plus `releases.yaml`). Only NHL and workflow paths are staged.

## Summary by Sourcery

Correct the NHL expected-goals issue explanation and make successful live-test runs close their resolved tracking issues.

Bug Fixes:
- Correct the NHL expected-goals documentation to retract the disproven missing-`MISSED_SHOT` explanation and state that the artifact miscalibration remains unidentified.
- Automatically close open live-test drift tracking issues after a successful cron run, with a completion comment and run link.

Documentation:
- Update the generated NHL `nhl_xg` reference documentation to accurately describe the known calibration issue and supporting measurements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved monitoring reports are now automatically marked complete after successful live checks, preventing outdated drift reports from remaining open.

- **Documentation**
  - Corrected the explanation of known NHL expected-goals calibration issues.
  - Documentation now reflects that the cause of the published model’s over-prediction is currently unidentified and distinguishes artifact behavior from training-data coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->