### PR TITLE
feat(cfb): one aggregate shape everywhere, unit splits, duration buckets

### DIFF
--- a/docs/docs/cfb/index.md
+++ b/docs/docs/cfb/index.md
@@ -16,7 +16,7 @@ description: "sdv-py CFB: endpoint references, dataset loaders and parsers for C
 | [247Sports Recruit Database (ipa.247sports.com)](reference/sports247) | 12 | `https://ipa.247sports.com` |
 | [247Sports Site Pages (247sports.com)](reference/sports247_site_pages) | 35 | `https://247sports.com` |
 | [Dataset loaders](reference/loaders) | 52 | sportsdataverse raw data / sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 99 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 100 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -2341,6 +2341,27 @@ moves = cfb_transfer_moves(2024)
 moves.filter(pl.col("direction") == "in").group_by("team_id").len()
 ```
 
+### `check_box_invariants(drive_summary: 'dict | None' = None, situational: 'dict | None' = None) -> 'list[str]'` {#check_box_invariants}
+
+Every identity the two aggregates must satisfy; violations as strings.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `drive_summary` | `dict \| None` | `None` | the dict from `create_drive_summary`, or None. |
+| `situational` | `dict \| None` | `None` | the dict from `create_situational_stats`, or None. |
+
+**Returns**
+
+one line per violation, `[]` when everything holds.
+
+**Example**
+
+```python
+assert check_box_invariants(summary, stats) == []
+```
+
 ### `create_drive_summary(drives: list[dict] | dict, frame: polars.dataframe.frame.DataFrame, home_id: str | int, away_id: str | int, periods: set[int] | str | None = None) -> dict | None` {#create_drive_summary}
 
 Build the StatBroadcast-style drive summary, chart, and long-play lists.

--- a/sportsdataverse/cfb/__init__.py
+++ b/sportsdataverse/cfb/__init__.py
@@ -13,6 +13,7 @@ from sportsdataverse.cfb.cfb_adjusted_epa import *
 from sportsdataverse.cfb.model_calculators import *
 from sportsdataverse.cfb.cfb_drive_summary import *
 from sportsdataverse.cfb.cfb_situational_stats import *
+from sportsdataverse.cfb.cfb_box_invariants import *
 from sportsdataverse.cfb.cfb_advanced_stats import *
 from sportsdataverse.cfb.cfb_field_position import *
 from sportsdataverse.cfb.cfb_tempo import *

--- a/sportsdataverse/cfb/cfb_box_invariants.py
+++ b/sportsdataverse/cfb/cfb_box_invariants.py
@@ -1,0 +1,155 @@
+"""Sanity checks over the drive-summary and situational-stats aggregates.
+
+The two builders slice one plays frame many ways, and every slice must agree
+with every other about the counts it shares -- a fumble can be lost only if it
+happened, a red-zone trip is also a scoring-opportunity trip, the unit split
+of a penalty count must sum back to the count. These are the identities a
+reader would notice if they broke, so they are checked as data, not assumed.
+
+``check_box_invariants`` returns the violations as strings; an empty list is
+a clean bill. It never raises, so a validation harness can report every
+failure in one pass rather than the first.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+__all__ = ["check_box_invariants"]
+
+_RATES = ("success_rate", "explosive_rate")
+_ST_PHASES = ("kickoff", "kickoff_return", "punt", "punt_return", "fg_xp")
+
+
+def _grp_ok(name: str, g: dict, out: list[str]) -> None:
+    """A ``_grp``-shaped node: counts non-negative, rates inside [0, 1], null only when empty."""
+    if not isinstance(g, dict) or "plays" not in g:
+        return
+    plays = g["plays"]
+    if plays < 0:
+        out.append(f"{name}: plays {plays} < 0")
+    for r in _RATES:
+        v = g.get(r)
+        if plays == 0 and v is not None:
+            out.append(f"{name}: {r} is {v} on an empty slice")
+        if v is not None and not (0.0 <= v <= 1.0):
+            out.append(f"{name}: {r} {v} outside [0, 1]")
+    if plays and g.get("epa_play") is not None and g.get("epa_total") is not None:
+        # total = mean * n, to rounding
+        if abs(g["epa_total"] - g["epa_play"] * plays) > 0.05 * plays + 0.05:
+            out.append(f"{name}: epa_total {g['epa_total']} != epa_play {g['epa_play']} x {plays}")
+
+
+def _walk_grps(prefix: str, node, out: list[str]) -> None:
+    if isinstance(node, dict):
+        _grp_ok(prefix, node, out)
+        for k, v in node.items():
+            _walk_grps(f"{prefix}.{k}", v, out)
+
+
+def _unit_sums(name: str, node: dict, key: str, total: int | None, out: list[str]) -> None:
+    """offense + defense + special_teams == total, and the phases sum to special_teams."""
+    st = node.get("special_teams") or {}
+    parts = [node.get("offense", {}).get(key, 0), node.get("defense", {}).get(key, 0), st.get(key, 0)]
+    if total is not None and sum(parts) != total:
+        out.append(f"{name}.by_unit: offense+defense+special_teams {key} = {sum(parts)} != {total}")
+    phases = sum((st.get(ph) or {}).get(key, 0) for ph in _ST_PHASES)
+    if phases != st.get(key, 0):
+        out.append(f"{name}.by_unit.special_teams: phases sum {phases} != {st.get(key, 0)}")
+
+
+def check_box_invariants(drive_summary: dict | None = None, situational: dict | None = None) -> list[str]:
+    """Every identity the two aggregates must satisfy; violations as strings.
+
+    Args:
+        drive_summary: the dict from :func:`create_drive_summary`, or None.
+        situational: the dict from :func:`create_situational_stats`, or None.
+
+    Returns:
+        list[str]: one line per violation, ``[]`` when everything holds.
+
+    Example:
+        Assert a processed game is internally consistent::
+
+            assert check_box_invariants(summary, stats) == []
+    """
+    out: list[str] = []
+
+    for tid, t in ((drive_summary or {}).get("teams") or {}).items():
+        n = t.get("total_drives", 0)
+        for k in (
+            "scoring_drives",
+            "td_drives",
+            "long_drives_70yds",
+            "long_drives_10plays",
+            "drives_over_5min",
+            "drives_under_1min",
+            "drives_under_2min",
+            "three_and_outs",
+        ):
+            if t.get(k, 0) > n:
+                out.append(f"drives[{tid}]: {k} {t[k]} > total_drives {n}")
+        if t.get("td_drives", 0) > t.get("scoring_drives", 0):
+            out.append(f"drives[{tid}]: td_drives > scoring_drives")
+        if t.get("drives_under_1min", 0) > t.get("drives_under_2min", 0):
+            out.append(f"drives[{tid}]: drives_under_1min > drives_under_2min")
+        if t.get("scoring_drives_under_2min", 0) > min(t.get("drives_under_2min", 0), t.get("scoring_drives", 0)):
+            out.append(f"drives[{tid}]: scoring_drives_under_2min exceeds its parents")
+        for k in ("third_downs", "fourth_downs"):
+            c = t.get(k) or {}
+            if c.get("made", 0) > c.get("att", 0):
+                out.append(f"drives[{tid}]: {k} made > att")
+
+    for tid, t in ((situational or {}).get("teams") or {}).items():
+        _walk_grps(f"situational[{tid}]", t, out)
+
+        tos = t.get("turnovers") or {}
+        if tos.get("fumbles_lost", 0) > tos.get("fumbles", 0):
+            out.append(f"situational[{tid}].turnovers: fumbles_lost > fumbles")
+        if "by_unit" in tos:
+            _unit_sums(f"situational[{tid}].turnovers", tos["by_unit"], "n", None, out)
+            for unit in ("offense", "defense"):
+                leaf = tos["by_unit"].get(unit) or {}
+                if leaf.get("interceptions", 0) + leaf.get("fumbles_lost", 0) > leaf.get("n", 0):
+                    out.append(f"situational[{tid}].turnovers.by_unit.{unit}: int + fumbles_lost > n")
+
+        pens = t.get("penalties_situational") or {}
+        if "by_unit" in pens:
+            _unit_sums(f"situational[{tid}].penalties", pens["by_unit"], "n", pens.get("accepted"), out)
+            for unit, leaf in _leaves(pens["by_unit"]):
+                if leaf.get("auto_first", 0) > leaf.get("n", 0):
+                    out.append(f"situational[{tid}].penalties.by_unit.{unit}: auto_first > n")
+
+        rz = t.get("red_zone") or {}
+        if rz.get("td_trips", 0) + rz.get("fg_trips", 0) > rz.get("trips", 0):
+            out.append(f"situational[{tid}].red_zone: td_trips + fg_trips > trips")
+        fin = t.get("finishing_drives") or {}
+        if rz.get("trips", 0) > fin.get("trips", 0):
+            out.append(
+                f"situational[{tid}]: red_zone.trips {rz.get('trips')} > finishing_drives.trips {fin.get('trips')}"
+            )
+
+        for dn, d in (t.get("downs") or {}).items():
+            conv = d.get("conversions")
+            if conv and conv.get("made", 0) > conv.get("att", 0):
+                out.append(f"situational[{tid}].downs.{dn}: conversions made > att")
+            bd = d.get("by_distance")
+            if conv and bd and sum(b.get("att", 0) for b in bd.values()) != conv.get("att", 0):
+                out.append(f"situational[{tid}].downs.{dn}: by_distance att does not sum to conversions att")
+            if d.get("pass_rate") is not None and not (0.0 <= d["pass_rate"] <= 1.0):
+                out.append(f"situational[{tid}].downs.{dn}: pass_rate outside [0, 1]")
+
+        rq = t.get("rushing_quality") or {}
+        if rq.get("plays") is not None and rq.get("attempts") is not None and rq["plays"] != rq["attempts"]:
+            out.append(f"situational[{tid}].rushing_quality: plays {rq['plays']} != attempts {rq['attempts']}")
+
+    return out
+
+
+def _leaves(by_unit: dict) -> Iterable[tuple[str, dict]]:
+    yield "offense", by_unit.get("offense") or {}
+    yield "defense", by_unit.get("defense") or {}
+    st = by_unit.get("special_teams") or {}
+    yield "special_teams", st
+    for ph in _ST_PHASES:
+        yield f"special_teams.{ph}", st.get(ph) or {}

--- a/sportsdataverse/cfb/cfb_drive_summary.py
+++ b/sportsdataverse/cfb/cfb_drive_summary.py
@@ -215,6 +215,11 @@ def create_drive_summary(
             "long_drives_10plays": 0,
             "drives_over_5min": 0,
             "drives_under_1min": 0,
+            # DURATION, not clock position: a drive that took under two minutes
+            # of game clock, whenever it happened. `under_2` on the plays frame
+            # is the other thing -- snaps inside the final two minutes of a half.
+            "drives_under_2min": 0,
+            "scoring_drives_under_2min": 0,
             "three_and_outs": 0,
             "forced_three_and_outs": 0,
             "points_off_turnovers": 0,
@@ -272,6 +277,10 @@ def create_drive_summary(
                 t["drives_over_5min"] += 1
             if top < 60:
                 t["drives_under_1min"] += 1
+            if top < 120:
+                t["drives_under_2min"] += 1
+                if d.get("isScore"):
+                    t["scoring_drives_under_2min"] += 1
         if yards >= 70:
             t["long_drives_70yds"] += 1
         if plays >= 10:

--- a/sportsdataverse/cfb/cfb_situational_stats.py
+++ b/sportsdataverse/cfb/cfb_situational_stats.py
@@ -27,13 +27,75 @@ def _num(v, digits=3):
 
 
 def _grp(df):
-    """plays / EPA per play / success rate for a slice."""
+    """The one aggregate shape every slice of plays reports.
+
+    ``plays`` / ``epa_total`` / ``epa_play`` / ``success_rate`` /
+    ``explosive_rate`` -- a count, the value it produced, and three rates. Every
+    section that slices plays spreads this, so a reader learns the columns once
+    and a consumer can join any two slices on the same keys. An empty slice
+    reports zero plays and null rates rather than raising or inventing a number.
+    """
     if df.height == 0:
-        return {"plays": 0, "epa_play": None, "success_rate": None}
+        return {"plays": 0, "epa_total": 0.0, "epa_play": None, "success_rate": None, "explosive_rate": None}
     return {
         "plays": df.height,
+        "epa_total": _num(df["EPA"].fill_null(0).sum(), 2),
         "epa_play": _num(df["EPA"].mean()),
         "success_rate": _num(df["EPA_success"].mean()),
+        "explosive_rate": _num(df["EPA_explosive"].cast(pl.Float64).mean()),
+    }
+
+
+_ST_PHASES = ("kickoff", "kickoff_return", "punt", "punt_return", "fg_xp")
+
+
+def _unit_of(df, tid):
+    """Label each play with the unit ``tid`` fielded on it.
+
+    A kick outranks possession: a hold on a punt return is a special-teams
+    flag even though the flagged team is nominally the defence. Within special
+    teams the side comes from ``kicking_team`` / ``return_team``, which the
+    pbp pipeline resolves from the play text, so the kicking team and the
+    return team are told apart rather than both filed under "kickoff".
+    """
+    t = pl.lit(str(tid))
+    is_kick = _TRUE("kickoff_play")
+    is_punt = _TRUE("punt_play")
+    is_fg = _TRUE("fg_attempt") | _TRUE("xp_attempt")
+    kicking = pl.col("kicking_team").cast(pl.Utf8) == t
+    return df.with_columns(
+        _unit=pl.when(is_fg)
+        .then(pl.lit("fg_xp"))
+        .when(is_kick & kicking)
+        .then(pl.lit("kickoff"))
+        .when(is_kick)
+        .then(pl.lit("kickoff_return"))
+        .when(is_punt & kicking)
+        .then(pl.lit("punt"))
+        .when(is_punt)
+        .then(pl.lit("punt_return"))
+        .when(pl.col("pos_team").cast(pl.Utf8) == t)
+        .then(pl.lit("offense"))
+        .otherwise(pl.lit("defense"))
+    )
+
+
+def _by_unit(df, leaf):
+    """``{offense, defense, special_teams: {phase: ...}}`` with ``leaf(slice)`` at each node.
+
+    ``special_teams`` also carries its own total so a reader who does not want
+    the phase split still gets one number. Every bucket is present even when
+    empty -- a consumer can rely on the keys.
+    """
+    u = pl.col("_unit")
+    st = df.filter(u.is_in(_ST_PHASES))
+    return {
+        "offense": leaf(df.filter(u == "offense")),
+        "defense": leaf(df.filter(u == "defense")),
+        "special_teams": {
+            **leaf(st),
+            **{ph: leaf(st.filter(u == ph)) for ph in _ST_PHASES},
+        },
     }
 
 
@@ -80,6 +142,7 @@ def create_situational_stats(
     # ColumnNotFoundError deep inside a section
     needed = {
         "EPA",
+        "EPA_explosive",
         "EPA_penalty",
         "EPA_success",
         "TFL",
@@ -101,7 +164,13 @@ def create_situational_stats(
         "goal_to_go",
         "havoc",
         "int",
+        "int_turnover",
+        "is_def_pos_team_turnover",
         "is_pos_team_turnover",
+        "is_st_turnover",
+        "is_turnover",
+        "kicking_team",
+        "kickoff_play",
         "line_yards",
         "middle_8",
         "open_field_yards",
@@ -133,9 +202,12 @@ def create_situational_stats(
         "statYardage",
         "stuffed_run",
         "touchdown",
+        "turnover_team",
         "under_2",
         "xp_attempt",
         "yards_after_catch",
+        "yds_penalty",
+        "def_fumble_lost",
     }
     if not needed.issubset(set(frame.columns)):
         return None
@@ -187,6 +259,7 @@ def create_situational_stats(
         so = mine.filter(_TRUE("scoring_opp"))
         so_trips = so["drive.id"].n_unique() if so.height else 0
         t["finishing_drives"] = {
+            **_grp(so),
             "trips": so_trips,
             "points": _points(so),
             "points_per_trip": _num(_points(so) / so_trips, 2) if so_trips else None,
@@ -244,6 +317,7 @@ def create_situational_stats(
         sack_yds = int(sacks["statYardage"].fill_null(0).sum())
         rush_yds = int(rushes["statYardage"].fill_null(0).sum())
         t["rushing_quality"] = {
+            **_grp(rushes),
             "attempts": rushes.height,
             "yards": rush_yds,
             # sack-adjusted by construction: the rush flag never covers sacks
@@ -300,14 +374,14 @@ def create_situational_stats(
 
         def _bp(df):
             return {
-                "plays": df.height,
+                **_grp(df),
                 "yards": int(df["statYardage"].fill_null(0).sum()),
                 "long": int(df["statYardage"].max()) if df.height else None,
                 "touchdowns": df.filter(_TRUE("touchdown")).height,
             }
 
         t["big_plays"] = {
-            "plays": bp_pass.height + bp_rush.height,
+            **_grp(pl.concat([bp_pass, bp_rush], how="vertical_relaxed")),
             "yards": int(bp_pass["statYardage"].fill_null(0).sum() + bp_rush["statYardage"].fill_null(0).sum()),
             "touchdowns": bp_pass.filter(_TRUE("touchdown")).height + bp_rush.filter(_TRUE("touchdown")).height,
             "pass": _bp(bp_pass),
@@ -358,6 +432,17 @@ def create_situational_stats(
             & (_TRUE("penalty_declined") == False)  # noqa: E712
             & (pl.col("penalty_team_id").cast(pl.Utf8) == tid)
         )
+
+        def _pen_leaf(df):
+            return {
+                "n": df.height,
+                "yards": int(df["yds_penalty"].cast(pl.Float64, strict=False).fill_null(0).abs().sum())
+                if df.height
+                else 0,
+                "auto_first": int(df.select(_TRUE("penalty_1st_conv").sum()).item()) if df.height else 0,
+                "epa_swing": _num(df["EPA_penalty"].fill_null(0).sum(), 2) if df.height else 0.0,
+            }
+
         t["penalties_situational"] = {
             "accepted": my_pens.height,
             "drive_extending_committed": int(
@@ -367,6 +452,7 @@ def create_situational_stats(
             ),
             "epa_swing": _num(my_pens["EPA_penalty"].fill_null(0).sum(), 2),
             "by_quarter": {int(k): int(v) for k, v in my_pens.group_by("period").len().iter_rows() if k is not None},
+            "by_unit": _by_unit(_unit_of(my_pens, tid), _pen_leaf),
         }
 
         # --- havoc created (defense = opponent offensive snaps) -------------
@@ -380,11 +466,27 @@ def create_situational_stats(
         # --- turnovers -------------------------------------------------------
         my_tos = mine.filter(_TRUE("is_pos_team_turnover"))
         my_fumbles = mine.filter(_TRUE("fumble_vec"))
+        # every turnover this team is charged with, whichever unit lost it:
+        # a giveaway on offence, a fumble back after a takeaway, or a muff on
+        # a return. `turnover_team` is the pipeline's single answer to "who".
+        all_tos = frame.filter(_TRUE("is_turnover") & (pl.col("turnover_team").cast(pl.Utf8) == tid))
+
+        def _to_leaf(df):
+            return {
+                "n": df.height,
+                "interceptions": int(df.select(_TRUE("int_turnover").sum()).item()) if df.height else 0,
+                "fumbles_lost": int(df.select((_TRUE("fumble_lost") | _TRUE("def_fumble_lost")).sum()).item())
+                if df.height
+                else 0,
+                "epa_swing": _num(df["EPA"].fill_null(0).sum(), 2) if df.height else 0.0,
+            }
+
         t["turnovers"] = {
             "committed": my_tos.height,
             "epa_swing": _num(my_tos["EPA"].fill_null(0).sum(), 2),
             "fumbles": my_fumbles.height,
             "fumbles_lost": int(mine.select(_TRUE("fumble_lost").sum()).item()),
+            "by_unit": _by_unit(_unit_of(all_tos, tid), _to_leaf),
         }
 
         # --- field-zone success ---------------------------------------------

--- a/sportsdataverse/parsed/cfb.py
+++ b/sportsdataverse/parsed/cfb.py
@@ -372,6 +372,7 @@ from sportsdataverse.cfb import cfb_standings as cfb_standings  # noqa: F401
 from sportsdataverse.cfb import cfb_teams_crosswalk as cfb_teams_crosswalk  # noqa: F401
 from sportsdataverse.cfb import cfb_transfer_impact as cfb_transfer_impact  # noqa: F401
 from sportsdataverse.cfb import cfb_transfer_moves as cfb_transfer_moves  # noqa: F401
+from sportsdataverse.cfb import check_box_invariants as check_box_invariants  # noqa: F401
 from sportsdataverse.cfb import create_drive_summary as create_drive_summary  # noqa: F401
 from sportsdataverse.cfb import create_situational_stats as create_situational_stats  # noqa: F401
 from sportsdataverse.cfb import download as download  # noqa: F401
@@ -541,6 +542,7 @@ __all__ = [
     "cfb_teams_crosswalk",
     "cfb_transfer_impact",
     "cfb_transfer_moves",
+    "check_box_invariants",
     "create_drive_summary",
     "create_situational_stats",
     "download",

--- a/tests/cfb/test_cfb_box_invariants.py
+++ b/tests/cfb/test_cfb_box_invariants.py
@@ -1,0 +1,63 @@
+import copy
+import sys
+
+from sportsdataverse.cfb import cfb_box_invariants as inv
+from sportsdataverse.cfb import cfb_drive_summary as drive_summary
+from sportsdataverse.cfb import cfb_situational_stats as situational_stats
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from test_cfb_drive_summary import _clock_drives, _clock_frame, _drives  # noqa: E402
+from test_cfb_drive_summary import _frame as _drive_frame  # noqa: E402
+from test_cfb_situational_stats import _frame as _sit_frame  # noqa: E402
+from test_cfb_situational_stats import _st_frame  # noqa: E402
+
+HOME, AWAY = "10", "20"
+
+
+def test_fixtures_satisfy_every_invariant():
+    """The shipped builders must agree with themselves on every fixture we have."""
+    cases = [
+        (drive_summary.create_drive_summary(_drives(), _drive_frame(), HOME, AWAY), None),
+        (drive_summary.create_drive_summary(_clock_drives(), _clock_frame(), HOME, AWAY), None),
+        (None, situational_stats.create_situational_stats(_sit_frame(), HOME, AWAY)),
+        (None, situational_stats.create_situational_stats(_st_frame(), HOME, AWAY)),
+    ]
+    for ds, sit in cases:
+        assert inv.check_box_invariants(ds, sit) == []
+    # and per window, where the slices get thin
+    for periods in ({1}, {2}, {3, 4}, "ot"):
+        ds = drive_summary.create_drive_summary(_clock_drives(), _clock_frame(), HOME, AWAY, periods=periods)
+        if ds is not None:
+            assert inv.check_box_invariants(ds, None) == []
+
+
+def test_checker_names_what_it_catches():
+    """A broken aggregate produces a specific line, never a silent pass."""
+    sit = situational_stats.create_situational_stats(_sit_frame(), HOME, AWAY)
+    bad = copy.deepcopy(sit)
+    t = bad["teams"][AWAY]
+    t["turnovers"]["fumbles_lost"] = t["turnovers"]["fumbles"] + 1  # lost more than happened
+    t["red_zone"]["td_trips"] = t["red_zone"]["trips"] + 5  # scored on more trips than taken
+    t["penalties_situational"]["by_unit"]["offense"]["n"] += 1  # units no longer sum to accepted
+    t["downs"]["down_3"]["explosive_rate"] = 1.7  # a rate outside [0, 1]
+    found = inv.check_box_invariants(None, bad)
+    for needle in (
+        "fumbles_lost > fumbles",
+        "td_trips + fg_trips > trips",
+        "offense+defense+special_teams",
+        "explosive_rate 1.7",
+    ):
+        assert any(needle in line for line in found), (needle, found)
+
+    ds = drive_summary.create_drive_summary(_drives(), _drive_frame(), HOME, AWAY)
+    bad = copy.deepcopy(ds)
+    bad["teams"][HOME]["td_drives"] = bad["teams"][HOME]["scoring_drives"] + 1
+    bad["teams"][HOME]["drives_under_1min"] = bad["teams"][HOME]["drives_under_2min"] + 1
+    found = inv.check_box_invariants(bad, None)
+    assert any("td_drives > scoring_drives" in x for x in found)
+    assert any("drives_under_1min > drives_under_2min" in x for x in found)
+
+
+def test_checker_is_quiet_on_nothing():
+    assert inv.check_box_invariants(None, None) == []
+    assert inv.check_box_invariants({}, {}) == []

--- a/tests/cfb/test_cfb_drive_summary.py
+++ b/tests/cfb/test_cfb_drive_summary.py
@@ -136,6 +136,21 @@ def test_drive_summary_frame_aggregates():
     assert all(p["yards"] > 0 for ps in out["longPlays"].values() for ps in [ps] for p in ps)
 
 
+def test_two_minute_buckets_are_duration_not_clock_position():
+    out = drive_summary.create_drive_summary(_drives(), _frame(), HOME, AWAY)
+    h, a = out["teams"][HOME], out["teams"][AWAY]
+    # elapsed under 2:00 -- home's 0:50 downs drive, away's 1:20 three-and-out;
+    # neither scored. The 2:00 INT drive is NOT under two minutes.
+    assert h["drives_under_2min"] == 1 and a["drives_under_2min"] == 1
+    assert h["scoring_drives_under_2min"] == 0 and a["scoring_drives_under_2min"] == 0
+    # nested: under-1:00 is a subset of under-2:00
+    assert h["drives_under_1min"] <= h["drives_under_2min"]
+    # a quick score counts in both the scoring and the duration bucket
+    quick = drive_summary.create_drive_summary(_clock_drives(), _clock_frame(), HOME, AWAY)
+    assert quick["teams"][AWAY]["scoring_drives_under_2min"] == 1
+    assert quick["teams"][AWAY]["drives_under_2min"] >= 1
+
+
 def test_drive_chart_obtained_and_scores():
     out = drive_summary.create_drive_summary(_drives(), _frame(), HOME, AWAY)
     chart = out["chart"]
@@ -257,7 +272,7 @@ def _clock_drives():
         _drive(AWAY, "c4", "PUNT", 10, 3, "1:40", 25, 2, last_score=(7, 0)),
         _drive(AWAY, "c5", "TD", 75, 8, "3:20", 25, 3, is_score=True, last_score=(7, 7)),
         _drive(HOME, "c6", "PUNT", 10, 3, "1:40", 25, 3, last_score=(7, 7)),
-        _drive(AWAY, "c7", "FG", 40, 8, "3:20", 25, 4, is_score=True, last_score=(7, 10)),
+        _drive(AWAY, "c7", "FG", 40, 8, "1:40", 25, 4, is_score=True, last_score=(7, 10)),
         _drive(HOME, "c8", "DOWNS", 9, 4, "0:50", 45, 4, last_score=(7, 10)),
     ]
 

--- a/tests/cfb/test_cfb_situational_stats.py
+++ b/tests/cfb/test_cfb_situational_stats.py
@@ -264,6 +264,23 @@ def _frame():
             400.0,
         ],
     }
+    # the aggregate contract widened (explosive rate, unit attribution): the
+    # shared fixture stays scrimmage-only, so every kick flag is off and the
+    # one away turnover (row 8) is an interception the offence threw
+    base.update(
+        {
+            "EPA_explosive": [False, True, False, True, False, False, False, False, True, False],
+            "kickoff_play": [False] * n,
+            "kicking_team": [None] * n,
+            "int_turnover": [False, False, False, False, False, False, False, True, False, False],
+            "def_fumble_lost": [False] * n,
+            "is_def_pos_team_turnover": [False] * n,
+            "is_st_turnover": [False] * n,
+            "is_turnover": base["is_pos_team_turnover"],
+            "turnover_team": [None, None, None, None, None, None, None, 20, None, None],
+            "yds_penalty": [None, None, None, None, None, None, None, None, None, 15],
+        }
+    )
     return pl.DataFrame(base, strict=False)
 
 
@@ -296,8 +313,10 @@ def test_situational_sections_and_values():
 
     assert h["two_minute"] == {
         "plays": 1,
+        "epa_total": -0.5,
         "epa_play": -0.5,
         "success_rate": 0.0,
+        "explosive_rate": 0.0,
         "points": 7,
     }
     assert h["red_zone"]["trips"] == 1 and h["red_zone"]["td_trips"] == 1
@@ -331,6 +350,10 @@ def test_situational_sections_and_values():
     assert h["big_plays"]["pass"]["long"] == 15
     assert h["big_plays"]["rush"] == {
         "plays": 2,
+        "epa_total": 0.7,
+        "epa_play": 0.35,
+        "success_rate": 1.0,
+        "explosive_rate": 0.0,
         "yards": 23,
         "long": 12,
         "touchdowns": 0,
@@ -414,3 +437,165 @@ def test_partially_enriched_frame_fails_open():
     # the five original core columns alone must NOT be enough to proceed
     f = _frame().select(["scrimmage_play", "pos_team", "EPA", "EPA_success", "pos_score_pts"])
     assert situational_stats.create_situational_stats(f, HOME, AWAY) is None
+
+
+# --- the five-field aggregate shape, everywhere -----------------------------
+
+
+def _grp_nodes(node, path="", out=None):
+    """Every dict carrying a `plays` key, with its path."""
+    out = [] if out is None else out
+    if isinstance(node, dict):
+        if "plays" in node:
+            out.append((path, node))
+        for k, v in node.items():
+            _grp_nodes(v, f"{path}.{k}" if path else k, out)
+    return out
+
+
+def test_every_slice_reports_the_same_five_fields():
+    out = situational_stats.create_situational_stats(_frame(), HOME, AWAY)
+    nodes = _grp_nodes(out["teams"][HOME])
+    assert len(nodes) >= 20, [p for p, _ in nodes]
+    for path, g in nodes:
+        for k in ("plays", "epa_total", "epa_play", "success_rate", "explosive_rate"):
+            assert k in g, (path, k)
+    # the three sections that used to lack it now carry it
+    h = out["teams"][HOME]
+    for sec in ("finishing_drives", "rushing_quality", "big_plays"):
+        assert "epa_play" in h[sec] and "explosive_rate" in h[sec], sec
+    # and the values are the slice's, not invented: the total is the fixture's
+    # own EPA over home rushes, whatever rows those happen to be
+    rq = h["rushing_quality"]
+    assert rq["plays"] == rq["attempts"]
+    f = _frame()
+    expect = f.filter((pl.col("rush") == True) & (pl.col("pos_team") == 10))["EPA"].sum()  # noqa: E712
+    assert rq["epa_total"] == round(expect, 2)
+
+
+def test_explosive_rate_is_the_share_of_explosive_plays():
+    h = situational_stats.create_situational_stats(_frame(), HOME, AWAY)["teams"][HOME]
+    # home scrimmage plays: rows 1-6, explosive on rows 2 and 4
+    assert h["downs"]["down_3"]["explosive_rate"] == 0.5  # rows 2 (T) and 3 (F)
+    assert h["field_zones"]["red_zone"]["plays"] > 0
+
+
+# --- unit attribution ----------------------------------------------------------
+
+
+def test_scrimmage_only_game_lands_everything_on_offense_or_defense():
+    out = situational_stats.create_situational_stats(_frame(), HOME, AWAY)
+    a = out["teams"][AWAY]
+    pu = a["penalties_situational"]["by_unit"]
+    # the one accepted flag is on team 20's own snap -> offence, 15 yards
+    assert pu["offense"] == {"n": 1, "yards": 15, "auto_first": 0, "epa_swing": -1.5}
+    assert pu["defense"]["n"] == 0 and pu["special_teams"]["n"] == 0
+    for ph in ("kickoff", "kickoff_return", "punt", "punt_return", "fg_xp"):
+        assert pu["special_teams"][ph]["n"] == 0, ph
+    tu = a["turnovers"]["by_unit"]
+    assert tu["offense"]["n"] == 1 and tu["offense"]["interceptions"] == 1
+    assert tu["defense"]["n"] == 0 and tu["special_teams"]["n"] == 0
+
+
+def _st_frame():
+    """Three special-teams plays, so the phase split has something to file.
+
+    row 0: team 10 punts, team 20 muffs the return and loses it   -> 20: ST punt_return turnover
+    row 1: team 10 kicks off, a hold on 10's coverage unit          -> 10: ST kickoff penalty
+    row 2: team 10 punts, a block in the back on 20's return        -> 20: ST punt_return penalty
+    """
+    n = 3
+    f = _frame()
+    cols = {c: [None] * n for c in f.columns}
+    cols.update(
+        {
+            "game_play_number": [1, 2, 3],
+            "scrimmage_play": [False] * n,
+            "pos_team": [10, 10, 10],
+            "period": [1, 2, 3],
+            "EPA": [-3.0, -0.4, -0.6],
+            "EPA_explosive": [False] * n,
+            "EPA_success": [False] * n,
+            "punt_play": [True, False, True],
+            "kickoff_play": [False, True, False],
+            "kicking_team": [10, 10, 10],
+            "fg_attempt": [False] * n,
+            "xp_attempt": [False] * n,
+            "penalty_flag": [False, True, True],
+            "penalty_declined": [False] * n,
+            "penalty_team_id": [None, 10, 20],
+            "penalty_1st_conv": [False] * n,
+            "EPA_penalty": [None, -0.4, -0.6],
+            "yds_penalty": [None, 10, 10],
+            "fumble_vec": [True, False, False],
+            "fumble_lost": [True, False, False],
+            "def_fumble_lost": [False] * n,
+            "int_turnover": [False] * n,
+            "int": [False] * n,
+            "is_pos_team_turnover": [False] * n,
+            "is_def_pos_team_turnover": [False] * n,
+            "is_st_turnover": [True, False, False],
+            "is_turnover": [True, False, False],
+            "turnover_team": [20, None, None],
+            "under_2": [False] * n,
+            "middle_8": [False] * n,
+            "rz_play": [False] * n,
+            "goal_to_go": [False] * n,
+            "scoring_opp": [False] * n,
+            "pos_score_pts": [0] * n,
+            "pos_score_diff": [0] * n,
+            "havoc": [False] * n,
+            "pass_breakup": [False] * n,
+            "rush": [False] * n,
+            "pass": [False] * n,
+            "sack": [False] * n,
+            "completion": [False] * n,
+            "touchdown": [False] * n,
+            "first_down_created": [False] * n,
+            "firstD_by_penalty": [False] * n,
+            "stuffed_run": [False] * n,
+            "opportunity_run": [False] * n,
+            "power_rush_attempt": [False] * n,
+            "power_rush_success": [False] * n,
+            "short_rush_attempt": [False] * n,
+            "short_rush_success": [False] * n,
+            "fg_made": [False] * n,
+            "TFL": [False] * n,
+            "drive.id": ["s1", "s2", "s3"],
+            "start.adj_TimeSecsRem": [3500.0, 2600.0, 1700.0],
+            "start.yardsToEndzone.touchback": [60, 65, 55],
+            "statYardage": [0, 0, 0],
+        }
+    )
+    return pl.DataFrame(cols, strict=False)
+
+
+def test_special_teams_phases_file_by_kicking_and_return_side():
+    out = situational_stats.create_situational_stats(_st_frame(), HOME, AWAY)
+    h, a = out["teams"][HOME], out["teams"][AWAY]
+    # team 20 lost a muffed punt: an ST turnover on the RETURN side, and the
+    # offence/defence buckets stay empty because it was never a scrimmage snap
+    tu = a["turnovers"]["by_unit"]
+    assert tu["special_teams"]["n"] == 1 and tu["special_teams"]["punt_return"]["n"] == 1
+    assert tu["special_teams"]["punt_return"]["fumbles_lost"] == 1
+    assert tu["special_teams"]["punt"]["n"] == 0 and tu["offense"]["n"] == 0
+    assert tu["special_teams"]["epa_swing"] == -3.0
+    # a hold on the kicking team's coverage files under kickoff, not kickoff_return
+    pu_h = h["penalties_situational"]["by_unit"]
+    assert pu_h["special_teams"]["kickoff"] == {"n": 1, "yards": 10, "auto_first": 0, "epa_swing": -0.4}
+    assert pu_h["special_teams"]["kickoff_return"]["n"] == 0
+    # a block in the back on the return files under punt_return for the returning team
+    pu_a = a["penalties_situational"]["by_unit"]
+    assert pu_a["special_teams"]["punt_return"]["n"] == 1 and pu_a["special_teams"]["punt"]["n"] == 0
+    # and the kick outranks possession: 20 had no possession on any of these
+    # plays, yet nothing of theirs landed in "defense"
+    assert pu_a["defense"]["n"] == 0 and pu_a["offense"]["n"] == 0
+    assert a["penalties_situational"]["accepted"] == pu_a["special_teams"]["n"] == 1
+
+
+def test_by_unit_keys_exist_even_when_empty():
+    a = situational_stats.create_situational_stats(_frame(), HOME, AWAY)["teams"][AWAY]
+    for section in ("penalties_situational", "turnovers"):
+        bu = a[section]["by_unit"]
+        assert set(bu) == {"offense", "defense", "special_teams"}
+        assert set(bu["special_teams"]) >= {"kickoff", "kickoff_return", "punt", "punt_return", "fg_xp", "n"}


### PR DESCRIPTION
Follows #470 and #476. Three requirements from speccing how game-on-paper renders the drive-summary / situational payload: EPA joined to every aggregate, penalties and turnovers attributable by unit and special-teams phase, and drive buckets by **duration** rather than clock position. Plus a checker that proves the aggregates agree with each other.

## One shape for every slice

`_grp()` now returns **`plays / epa_total / epa_play / success_rate / explosive_rate`** and is spread into every section that slices plays. Four sections lacked it — `finishing_drives`, `rushing_quality`, `big_plays`, and `big_plays.pass` / `.rush` — so a consumer could not join them to the other nine on shared keys. They carry it now. A reader learns the columns once; an empty slice reports zero plays and null rates rather than raising or inventing a number.

## `by_unit` on penalties and turnovers

```
offense | defense | special_teams: { n, ..., kickoff, kickoff_return, punt, punt_return, fg_xp }
```

Each bucket carries its count, its yards (penalties) or interceptions + fumbles lost (turnovers), and its EPA swing. Two rules worth stating:

- **A kick outranks possession.** A hold on a punt return files as special teams even though the flagged team is nominally the defence — the same rule GOP's `penalties.ts` already applies client-side.
- **Side comes from `kicking_team`**, so the coverage unit and the return unit are told apart rather than both filed under "kickoff". Turnovers are charged to `turnover_team`, the pipeline's single answer to who lost it, which is why a muffed punt lands on the returning team's ST bucket and never its offence.

Every bucket is present even when empty, so the keys can be relied on. The fail-open contract widens by the columns this reads (`kicking_team`, `turnover_team`, `is_turnover`, `int_turnover`, `def_fumble_lost`, `yds_penalty`, `EPA_explosive`, and the ST flags) — all already on the processed frame.

## Duration buckets

`drives_under_2min` and `scoring_drives_under_2min` in the drive summary. **Duration** — a drive that took under two minutes of game clock — as opposed to the existing `under_2` play flag, which is snaps inside the final two minutes of a half. `drives_under_1min` nests inside it.

## `check_box_invariants()`

New, exported. Every identity the two aggregates must satisfy, returned as strings and never raised, so a validation harness reports every failure in one pass:

- `fumbles_lost ≤ fumbles`; `td_trips + fg_trips ≤ trips`; `red_zone.trips ≤ finishing_drives.trips`
- unit buckets sum back to `accepted`; phases sum to `special_teams`; `int + fumbles_lost ≤ n` per unit
- every rate inside `[0, 1]`, null **only** on an empty slice; `epa_total ≈ epa_play × plays`
- `made ≤ att`; distance buckets sum to the conversion attempts; `drives_under_1min ≤ drives_under_2min`; every drive count ≤ `total_drives`

## Tests

34 pass. The shared fixture gains the new columns scrimmage-only so existing assertions hold. A purpose-built special-teams frame — a muffed punt return, a hold on the kickoff coverage unit, a block in the back on a punt return — proves each files to the correct phase **and** side, and that the returning team, which never had possession, lands nothing in `defense`. The invariant checker is run over every fixture and every window, and a deliberately broken aggregate is checked to produce the specific line, not a silent pass.

`ruff` / `ruff format` clean; the full `uv run mypy` ratchet passes (415 files); `generate.py --check` reports all generated files current — the docs diff is exactly one new function.

## Consumers

Two, both thin pass-throughs: the generated re-export in `parsed/cfb.py` and the `CFBPlayProcess.create_*` delegates, whose tests are in the 34. No call-site change is needed downstream — game-on-paper's `app.py` passes through whatever the module returns, so its span maps simply carry more keys.

## Summary by Sourcery

Standardize CFB aggregate outputs, attribute penalties and turnovers by unit, add duration-based drive metrics, and expose consistency validation.

New Features:
- Add consistent aggregate metrics across all situational-statistics play slices, including total EPA and explosive-play rates.
- Add offense, defense, and special-teams phase attribution for penalties and turnovers.
- Add drive-summary buckets for drives completed in under two minutes and scoring drives within that duration.

Enhancements:
- Export a non-raising invariant checker that reports inconsistencies across drive-summary and situational-statistics aggregates.

Documentation:
- Document the new box-score invariant checker in the CFB API reference.

Tests:
- Expand CFB fixtures and coverage to validate aggregate shapes, duration semantics, special-teams attribution, empty buckets, and invariant failures.