### PR TITLE
fix(codegen): prune autodoc schemas only for names that left the set

### DIFF
--- a/tests/codegen/test_generate.py
+++ b/tests/codegen/test_generate.py
@@ -1,5 +1,7 @@
+import importlib
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from tools.codegen import generate
@@ -76,3 +78,47 @@ def test_standings_uses_alt_host():
     with patch("sportsdataverse._codegen_runtime.download", return_value=FakeResp()) as dl:
         mod.espn_nba_standings(season=2024)
     assert dl.call_args.kwargs["url"] == "https://site.api.espn.com/apis/v2/sports/basketball/nba/standings"
+
+
+# ===========================================================================
+# refresh_autodoc_schemas -- prune guard
+# ===========================================================================
+
+
+def _autodoc_tree(tmp_path: Path) -> Path:
+    """Three committed schemas: in-scope, removed, and hand-authored."""
+    d = tmp_path / "autodoc" / "nfl"
+    d.mkdir(parents=True)
+    (d / "boom.yaml").write_text("schema: boom\nkind: dataframe\ncolumns: []\n", encoding="utf-8")
+    (d / "removed.yaml").write_text("schema: removed\nkind: dataframe\ncolumns: []\n", encoding="utf-8")
+    (d / "handmade.yaml").write_text("schema: handmade\nhand_authored: true\ncolumns: []\n", encoding="utf-8")
+    return d
+
+
+def test_autodoc_prune_keeps_in_scope_schema_whose_capture_failed(tmp_path, monkeypatch, capsys):
+    """A failed capture must NOT delete a still-documented function's schema.
+
+    "Did not capture this run" is not "no longer exists" -- a rate limit, an
+    off-season endpoint or an unreachable host fails the call while the function
+    stays in the autodoc set. Deleting on that condition silently drops a
+    rendered Returns table, so only a name that left the set may be pruned.
+    """
+    d = _autodoc_tree(tmp_path)
+
+    def boom():
+        raise RuntimeError("simulated rate limit")
+
+    stub = SimpleNamespace(boom=boom)
+    monkeypatch.setattr(generate, "_AUTODOC_SCHEMA_DIR", tmp_path / "autodoc")
+    monkeypatch.setattr(generate, "_autodoc_names_by_scope", lambda: {"nfl": ["boom"]})
+    monkeypatch.setattr(generate, "_autodoc_example_args", lambda: {})
+    monkeypatch.setattr(importlib, "import_module", lambda name: stub)
+
+    assert generate.refresh_autodoc_schemas() == 0
+
+    assert (d / "boom.yaml").exists(), "in-scope function whose capture failed was pruned"
+    assert (d / "handmade.yaml").exists(), "hand-authored schema was pruned"
+    assert not (d / "removed.yaml").exists(), "schema for a name outside the set was not pruned"
+
+    out = capsys.readouterr().out
+    assert "1 pruned" in out and "1 kept (in scope, capture failed)" in out

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -3440,6 +3440,9 @@ def refresh_autodoc_schemas() -> int:
     captured = skipped = 0
     skip_reasons: list[str] = []
     written_paths: set = set()
+    # (scope_key, fn) for every name the autodoc set still resolves to a callable,
+    # whether or not its capture succeeds -- the prune guard below keys off this.
+    in_scope: set = set()
     args_by_scope = _autodoc_example_args()
     for scope, names in _autodoc_names_by_scope().items():
         scope_key = "global" if scope is None else scope
@@ -3449,6 +3452,7 @@ def refresh_autodoc_schemas() -> int:
             obj = getattr(mod, fn, None)
             if obj is None or not callable(obj):
                 continue
+            in_scope.add((scope_key, fn))
             kwargs = scope_args.get(fn, {})
             try:
                 df = obj(**kwargs)
@@ -3473,20 +3477,33 @@ def refresh_autodoc_schemas() -> int:
             dest.write_text(yaml.safe_dump(doc, sort_keys=False, width=120), encoding="utf-8", newline="\n")
             written_paths.add(dest.resolve())
             captured += 1
-    # Prune stale schema files (a function that no longer captures) so the
-    # committed artifact set stays in lockstep with what the renderer can read.
-    pruned = 0
+    # Prune ONLY what is genuinely gone from the autodoc set. "Did not capture
+    # this run" is NOT the same as "no longer exists": a rate limit, an
+    # off-season endpoint, an unreachable host, or a required positional arg all
+    # fail the call while the function stays documented. Deleting on that
+    # condition silently drops a rendered Returns table on a transient failure,
+    # which is what made this refresh unsafe to run -- and is why the committed
+    # set drifted. A schema whose function is still in scope is kept as-is.
+    pruned = kept_stale = 0
     if _AUTODOC_SCHEMA_DIR.exists():
         for f in _AUTODOC_SCHEMA_DIR.rglob("*.yaml"):
-            if f.resolve() not in written_paths:
-                # Hand-authored schemas (functions the capture step cannot call:
-                # frame-valued args or dict-of-frames returns) are kept, not pruned.
-                if (yaml.safe_load(f.read_text(encoding="utf-8")) or {}).get("hand_authored"):
-                    continue
-                f.unlink()
-                pruned += 1
+            if f.resolve() in written_paths:
+                continue
+            # Hand-authored schemas (functions the capture step cannot call:
+            # frame-valued args or dict-of-frames returns) are kept, not pruned.
+            if (yaml.safe_load(f.read_text(encoding="utf-8")) or {}).get("hand_authored"):
+                continue
+            if (f.parent.name, f.stem) in in_scope:
+                kept_stale += 1
+                continue
+            f.unlink()
+            pruned += 1
     _autodoc_return_columns.cache_clear()
-    print(f"autodoc schemas: {captured} captured, {skipped} skipped" + (f", {pruned} pruned" if pruned else ""))
+    print(
+        f"autodoc schemas: {captured} captured, {skipped} skipped"
+        + (f", {pruned} pruned" if pruned else "")
+        + (f", {kept_stale} kept (in scope, capture failed)" if kept_stale else "")
+    )
     if skip_reasons:
         print("  sample skips: " + "; ".join(skip_reasons[:5]))
     return 0


### PR DESCRIPTION
## The bug

`refresh_autodoc_schemas()` pruned on the wrong condition:

```python
if f.resolve() not in written_paths:   # ← only what captured THIS RUN
    f.unlink()
```

`written_paths` holds only captures that **succeeded in the current run**, so the deletion condition was never *"this function no longer exists"* — it was *"this function did not answer just now"*. A rate limit, an off-season endpoint, a host the runner can't reach, or a function needing a positional arg all fail the call while the function stays fully documented — and its committed schema was deleted, taking its rendered Returns table with it.

## Why it matters (measured, not theoretical)

A full `--autodoc-schemas` run against the committed set pruned **105** files. Classified by whether the function is still in the autodoc set:

| | count | examples |
|---|---:|---|
| **Capture failure** — still documented, would silently lose its Returns table | **72** | `cfb_advanced_stats`, `cfb_predict_games`, `cfb_resume`, `cfb_roster_talent`, `ahl_leaders`, `pwhl_team_roster`, `espn_*_schedule`, most `nfl_ngs_*` |
| Genuine removal | 33 | `baseball.college_baseball_re24` |

**69% of the deletions were wrong.** That is why this refresh has been unsafe to run — and therefore why the committed set drifted.

## Fix

Record every `(scope, fn)` the autodoc set resolves to a live callable **regardless of capture outcome**, prune only names absent from that set, and report the remainder as `N kept (in scope, capture failed)` — so a bad capture run is *visible* rather than destructive. Hand-authored schemas keep their existing exemption.

## Test plan

- [x] New `test_autodoc_prune_keeps_in_scope_schema_whose_capture_failed` — in-scope-but-failed kept, hand-authored kept, out-of-set pruned, counters reported
- [x] **Verified the test fails against the old logic** (stashed the fix, watched it fail, restored)
- [x] `tests/codegen/test_generate.py` + `test_docs.py`: 21 passed
- [x] `ruff format --check`, `ruff check`
- [x] `generate.py --check`: all generated files current (the prune runs only under `--autodoc-schemas`, so no generated output moves)

## Follow-up

The actual schema refresh lands **separately**, now that its diff is honest (adds + updates, prunes only genuine removals) instead of a 105-file silent deletion. Kept apart deliberately so this ~30-line logic change stays reviewable rather than buried under a 344-file data diff.

## Summary by Sourcery

Make autodoc schema refreshes non-destructive by pruning only functions removed from the autodoc set.

Bug Fixes:
- Prevent autodoc schema files from being deleted when their functions remain in scope but schema capture fails.
- Prune only schemas whose names have left the autodoc set while preserving hand-authored schemas.

Enhancements:
- Report in-scope schemas retained after capture failures to make incomplete refreshes visible.

Tests:
- Add coverage for retaining failed in-scope captures and hand-authored schemas while pruning removed functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented generated documentation schemas from being removed when their source functions remain available but schema capture temporarily fails.
  - Continued pruning schemas only when the associated functions are no longer part of the autodoc set.
  - Preserved hand-authored schemas during cleanup.
  - Added reporting for stale schemas retained after unsuccessful capture attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->