### PR TITLE
feat(codegen): per-loader `notes:` caveat, rendered in the docstring and the reference page

### DIFF
--- a/tests/codegen/test_generate.py
+++ b/tests/codegen/test_generate.py
@@ -176,18 +176,29 @@ def test_loader_without_notes_emits_no_empty_caveat_block():
     from tools.codegen import spec
 
     ld = spec.Loader(
-        fn="load_demo_plain", league="mlb", base="sdv",
-        url="demo/demo_{season}.parquet", tag="demo",
+        fn="load_demo_plain",
+        league="mlb",
+        base="sdv",
+        url="demo/demo_{season}.parquet",
+        tag="demo",
     )
     assert "Note:" not in generate._build_loader_docstring(ld)
 
     template = generate.render.ENV.get_template("loaders_page.md.jinja")
     page = template.render(
-        prefix="mlb", sidebar_position=1,
-        loaders=[{
-            "fn": ld.fn, "notes": "", "tag": ld.tag, "tag_url": "", "url": "",
-            "automation": {"repo": "", "workflow": ""}, "return_table": "",
-            "example_seasons": 2024,
-        }],
+        prefix="mlb",
+        sidebar_position=1,
+        loaders=[
+            {
+                "fn": ld.fn,
+                "notes": "",
+                "tag": ld.tag,
+                "tag_url": "",
+                "url": "",
+                "automation": {"repo": "", "workflow": ""},
+                "return_table": "",
+                "example_seasons": 2024,
+            }
+        ],
     )
     assert ":::caution" not in page

--- a/tests/codegen/test_generate.py
+++ b/tests/codegen/test_generate.py
@@ -122,3 +122,72 @@ def test_autodoc_prune_keeps_in_scope_schema_whose_capture_failed(tmp_path, monk
 
     out = capsys.readouterr().out
     assert "1 pruned" in out and "1 kept (in scope, capture failed)" in out
+
+
+def test_loader_notes_reach_the_docstring_and_the_page():
+    """A `notes:` caveat must render in BOTH generated surfaces.
+
+    A coverage caveat is only useful where someone reads it. The docstring
+    serves help() and IDEs; the reference page serves the docs site. Wiring one
+    and not the other is the failure this guards -- the caveat looks documented
+    while the audience that would act on it never sees it.
+    """
+    from tools.codegen import spec
+
+    ld = spec.Loader(
+        fn="load_demo_thing",
+        league="mlb",
+        base="sdv",
+        url="demo/demo_{season}.parquet",
+        tag="demo",
+        min_season=1988,
+        notes="``demo_field`` is absent before 2008 and only 45.7% populated in 2007.",
+    )
+
+    doc = generate._build_loader_docstring(ld)
+    assert "Note:" in doc
+    assert "45.7% populated in 2007" in doc
+    # Note must precede Raises/Example so it is visible without scrolling.
+    assert doc.index("Note:") < doc.index("Raises:")
+
+    template = generate.render.ENV.get_template("loaders_page.md.jinja")
+    page = template.render(
+        prefix="mlb",
+        sidebar_position=1,
+        loaders=[
+            {
+                "fn": ld.fn,
+                "notes": ld.notes,
+                "tag": ld.tag,
+                "tag_url": "",
+                "url": "",
+                "automation": {"repo": "", "workflow": ""},
+                "return_table": "",
+                "example_seasons": 2024,
+            }
+        ],
+    )
+    assert ":::caution Coverage" in page
+    assert "45.7% populated in 2007" in page
+
+
+def test_loader_without_notes_emits_no_empty_caveat_block():
+    """No `notes:` must mean no Note section and no empty admonition."""
+    from tools.codegen import spec
+
+    ld = spec.Loader(
+        fn="load_demo_plain", league="mlb", base="sdv",
+        url="demo/demo_{season}.parquet", tag="demo",
+    )
+    assert "Note:" not in generate._build_loader_docstring(ld)
+
+    template = generate.render.ENV.get_template("loaders_page.md.jinja")
+    page = template.render(
+        prefix="mlb", sidebar_position=1,
+        loaders=[{
+            "fn": ld.fn, "notes": "", "tag": ld.tag, "tag_url": "", "url": "",
+            "automation": {"repo": "", "workflow": ""}, "return_table": "",
+            "example_seasons": 2024,
+        }],
+    )
+    assert ":::caution" not in page

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -1197,6 +1197,13 @@ def _build_loader_docstring(ld: spec.Loader) -> str:
         for c in cols:
             lines.append(f"    |{c['name'].ljust(width)} |{c['type'].ljust(twidth)} |")
     lines.append("")
+    if ld.notes:
+        # Before Raises/Example so it is visible in help() without scrolling. A
+        # coverage caveat that sits below the example is a caveat nobody reads.
+        lines.append("Note:")
+        for para in ld.notes.strip().split("\n"):
+            lines.append(f"    {para}".rstrip())
+        lines.append("")
     if ld.min_season:
         lines.append("Raises:")
         lines.append(f"    SeasonNotFoundError: if a requested season is below {ld.min_season}.")
@@ -2390,6 +2397,7 @@ def _loader_doc_views(prefix: str) -> list[dict]:
         out.append(
             {
                 "fn": ld.fn,
+                "notes": ld.notes or "",
                 "tag": ld.tag,
                 "tag_url": f"{tag_base}{ld.tag}",
                 "url": "" if ld.stub else f"{rel.bases[ld.base]}{ld.url}",

--- a/tools/codegen/spec.py
+++ b/tools/codegen/spec.py
@@ -129,6 +129,12 @@ class Loader:
     example_args: Dict[str, object] = field(default_factory=dict)
     automation: Dict[str, str] = field(default_factory=dict)
     notebook: Optional[str] = None
+    # Free-text caveat for this dataset -- coverage boundaries, partial
+    # seasons, fields that only populate after some date. Rendered into the
+    # generated docstring AND the loaders reference page, because a caveat
+    # only a maintainer can see does not stop anyone averaging a
+    # partly-empty column.
+    notes: Optional[str] = None
     stub: bool = False
     stub_message: Optional[str] = None
     # Name of the loader that supersedes this one. When set, the generated body is
@@ -295,6 +301,7 @@ def load_releases(path: Path) -> ReleasesConfig:
             example_args=ld.get("example_args", {}) or {},
             automation=ld.get("automation", {}) or {},
             notebook=ld.get("notebook"),
+            notes=ld.get("notes"),
             stub=ld.get("stub", False),
             stub_message=ld.get("stub_message"),
             deprecated_for=ld.get("deprecated_for"),

--- a/tools/codegen/templates/loaders_page.md.jinja
+++ b/tools/codegen/templates/loaders_page.md.jinja
@@ -22,6 +22,11 @@ flowchart LR
 ## `{{ ld.fn }}`
 
 Release: {% if ld.tag_url %}[{{ ld.tag }}]({{ ld.tag_url }}){% else %}`{{ ld.tag }}`{% endif %}{% if ld.url %} · asset `{{ ld.url }}`{% endif %}
+{% if ld.notes %}
+:::caution Coverage
+{{ ld.notes }}
+:::
+{% endif %}
 
 {% if ld.return_table %}### Returns
 


### PR DESCRIPTION
Adds the missing place to record a dataset's coverage boundary. Prompted by a CodeRabbit finding on #478 that could not be satisfied without it.

## The gap

A loader can accept seasons back to 1988 while one of its columns only populates from 2008 — and nothing in the generated docstring or `reference/loaders.md` could say so. The loaders page renders only Release, asset, Returns table, and an example; the docstring builder emits Args / Returns / Raises / Example. There was no field for "this column is absent before 2008".

So the caveat lived in a PR body, which no user reads. That is the *averages a partly-empty column* hazard: the call succeeds, the number is wrong, nothing warns.

## What this adds

An optional `notes:` on a loader in `releases.yaml`, wired to **both** surfaces that have an audience:

| Surface | Rendering | Audience |
|---|---|---|
| generated docstring | `Note:` section, before `Raises:`/`Example:` | `help()`, IDEs |
| `reference/loaders.md` | `:::caution Coverage` admonition | docs site |

Four coordinated points: the `spec.Loader` field and its YAML parsing, emission in `_build_loader_docstring()`, exposure via `_loader_doc_views()`, and rendering in `loaders_page.md.jinja`.

`Note:` sits before `Raises:`/`Example:` deliberately — a coverage caveat below the usage example is a caveat nobody reads.

## Tests

The failure mode worth guarding is **wiring one surface and not the other**: the caveat then looks documented in review while the audience that would act on it never sees it. So the test asserts both surfaces from one `Loader`, and a second test asserts that a loader *without* `notes:` emits neither a `Note:` section nor an empty admonition.

Verified the test actually discriminates rather than passing vacuously — deleting the template block fails it:

```
tests/codegen/test_generate.py:170: AssertionError
FAILED test_loader_notes_reach_the_docstring_and_the_page
1 failed, 1 passed
```

Restoring the block: `2 passed`.

## No output change

No loader declares `notes:` yet, so this commit changes no generated file:

```
codegen --check: all generated files current
```

## Follow-up

#478 can then declare `notes:` on `load_mlb_pbp` / `load_mlb_pitches` for the `pitchData` boundary (populated from 2008; 45.7% in 2007 as the PITCHf/x rollout finished mid-season; absent before), which satisfies that PR's open review thread properly rather than by hand-editing generated output.

## Summary by Sourcery

Add optional loader coverage notes to warn users about dataset boundaries across generated help and reference documentation.

New Features:
- Add optional per-loader coverage notes that appear in generated docstrings and the loaders reference page.

Enhancements:
- Place coverage caveats prominently before loader error and example documentation.

Tests:
- Verify loader notes are rendered on both documentation surfaces and omitted entirely when unset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Loader notes and dataset caveats now appear in generated API docstrings.
  - Loader documentation pages display available notes in a highlighted Coverage section.
  - Loaders without notes no longer show empty note or caution sections.
  - Notes from release metadata are carried through consistently to generated documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->